### PR TITLE
Disable CC ratification when number of members is below `ppCommitteeMinSize`

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.0.0
 
+* Add `geCommitteeState`
 * Remove `ConwayDelegEvent`, `ConwayGovCertEvent`
 * Add `GovInfoEvent`
 * Add `ConwayUtxosEvent`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -78,7 +78,9 @@ import Cardano.Ledger.Shelley.LedgerState (
   LedgerState (..),
   UTxOState (..),
   asTreasuryL,
+  certVStateL,
   utxosGovStateL,
+  vsCommitteeStateL,
  )
 import Cardano.Ledger.Shelley.Rules (
   LedgerEnv (..),
@@ -383,6 +385,7 @@ ledgerTransition = do
                   pp
                   (utxoState ^. utxosGovStateL . proposalsGovStateL . pRootsL . L.to toPrevGovActionIds)
                   (utxoState ^. utxosGovStateL . constitutionGovStateL . constitutionScriptL)
+                  (certState ^. certVStateL . vsCommitteeStateL)
               , utxoState ^. utxosGovStateL . proposalsGovStateL
               , govProcedures
               )

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
@@ -128,7 +128,7 @@ committeeAccepted ::
   GovActionState era ->
   Bool
 committeeAccepted RatifyEnv {reCommitteeState, reCurrentEpoch} rs gas =
-  case votingCommitteeThreshold rs (gasAction gas) of
+  case votingCommitteeThreshold rs reCommitteeState (gasAction gas) of
     SNothing -> False -- this happens if we have no committee, or if the committee is too small,
     -- in which case the committee vote is `no`
     SJust r ->

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -559,6 +559,7 @@ instance (Era era, Arbitrary (PParamsHKD Identity era)) => Arbitrary (GovEnv era
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary
 
 instance Era era => Arbitrary (VotingProcedure era) where
   arbitrary = VotingProcedure <$> arbitrary <*> arbitrary

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/V2/Conway/GOV.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/V2/Conway/GOV.hs
@@ -28,7 +28,7 @@ govEnvSpec ::
   IsConwayUniv fn =>
   Spec fn (GovEnv (ConwayEra StandardCrypto))
 govEnvSpec = constrained $ \ge ->
-  match ge $ \_ _ pp _ _ ->
+  match ge $ \_ _ pp _ _ _ ->
     satisfies pp pparamsSpec
 
 -- TODO:
@@ -258,7 +258,7 @@ govProceduresSpec ge@GovEnv {..} ps =
         , f (gasAction act)
         ]
       committeeVotableActionIds =
-        actions isCommitteeVotingAllowed
+        actions (isCommitteeVotingAllowed geCommitteeState)
       drepVotableActionIds =
         actions isDRepVotingAllowed
       stakepoolVotableActionIds =


### PR DESCRIPTION
# Description

This PR fixes the voting thresholds so that if the size of active CC members is below `ccMinSize`, then the CC cannot pass any proposals. The previous implementation did not check how many CC members have resigned, thus counting all of the CC members as active members.

resolves #4204

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
