### PR TITLE
Remove missingScriptsSymmetricDifference

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -362,7 +362,7 @@ alonzoStyleWitness = do
   let scriptsNeeded = getScriptsNeeded utxo txBody
       scriptsHashesNeeded = getScriptsHashesNeeded scriptsNeeded
       shelleyScriptsNeeded = ShelleyScriptsNeeded scriptsHashesNeeded
-  runTest $ Shelley.validateMissingScripts pp shelleyScriptsNeeded scriptsProvided
+  runTest $ Shelley.validateMissingScripts shelleyScriptsNeeded scriptsProvided
 
   {- inputHashes := { h | (_ → (a,_,h)) ∈ txins tx ◁ utxo, isTwoPhaseScriptAddress tx a} -}
   {-  inputHashes ⊆ dom(txdats txw)  -}

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.10.0.0
 
+* Remove the `PParams` param from `validateMissingScripts`
+* Remove the `missingScriptsSymmetricDifference` function
 * Add `NFData` instance for `AdaPots`, `ShelleyDelegEvent`
 * Add `Generic`, `Eq` and `NFData` instances for:
   * `ShelleyDelegsEvent`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
@@ -6,7 +6,6 @@ module Cardano.Ledger.Shelley.HardForks (
   aggregatedRewards,
   allowMIRTransfer,
   validatePoolRewardAccountNetID,
-  missingScriptsSymmetricDifference,
   forgoRewardPrefilter,
   translateUpperBoundForPlutusScripts,
   forgoPointerAddressResolution,
@@ -38,13 +37,6 @@ validatePoolRewardAccountNetID ::
   ProtVer ->
   Bool
 validatePoolRewardAccountNetID pv = pvMajor pv > natVersion @4
-
--- | Starting with protocol version 7, the UTXO rule predicate failure
--- MissingScriptWitnessesUTXOW will not be used for extraneous scripts
-missingScriptsSymmetricDifference ::
-  ProtVer ->
-  Bool
-missingScriptsSymmetricDifference pv = pvMajor pv > natVersion @6
 
 -- | Starting with protocol version 7, the reward calculation no longer
 -- filters out unregistered stake addresses at the moment the calculation begins.

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/RulesTests.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/RulesTests.hs
@@ -168,7 +168,7 @@ testEverybodySigns =
 
 testWrongScript :: Assertion
 testWrongScript =
-  utxoSt' @?= (Left . pure . MissingScriptWitnessesUTXOW) wits
+  utxoSt' @?= Left (pure extraneous <> pure missing)
   where
     utxoSt' =
       applyTxWithScript
@@ -178,7 +178,9 @@ testWrongScript =
         (Withdrawals Map.empty)
         (Coin 0)
         [asWitness Cast.alicePay, asWitness Cast.bobPay]
-    wits = Set.singleton $ hashScript @C aliceOnly
+    asHashes = Set.singleton . hashScript @C
+    extraneous = ExtraneousScriptWitnessesUTXOW $ asHashes aliceOrBob
+    missing = MissingScriptWitnessesUTXOW $ asHashes aliceOnly
 
 testAliceOrBob :: Assertion
 testAliceOrBob =


### PR DESCRIPTION
Closes #3796

# Description

Extraneous scripts have had a specific predicate failure since Babbage and we no longer wish to support the backwards compatibility that this function enables.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
