### PR TITLE
Utxow Predicate failure tests

### DIFF
--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -85,6 +85,7 @@ library testlib
         Test.Cardano.Ledger.Allegra.Arbitrary
         Test.Cardano.Ledger.Allegra.Binary.Cddl
         Test.Cardano.Ledger.Allegra.Imp
+        Test.Cardano.Ledger.Allegra.Imp.UtxowSpec
         Test.Cardano.Ledger.Allegra.ImpTest
         Test.Cardano.Ledger.Allegra.TreeDiff
 
@@ -110,6 +111,7 @@ library testlib
         microlens,
         mtl,
         small-steps,
+        text,
         QuickCheck
 
 test-suite tests

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Imp.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Imp.hs
@@ -14,7 +14,8 @@ import Test.Cardano.Ledger.Shelley.ImpTest (ShelleyEraImp)
 
 spec ::
   forall era.
-  ( ShelleyEraImp era
+  ( Arbitrary (TxAuxData era)
+  , ShelleyEraImp era
   , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
   , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
   ) =>

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Imp.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Imp.hs
@@ -3,14 +3,16 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Test.Cardano.Ledger.Allegra.Imp (spec) where
 
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure, ShelleyUtxowPredFailure)
+import qualified Test.Cardano.Ledger.Allegra.Imp.UtxowSpec as UtxowSpec
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
-import Test.Cardano.Ledger.Shelley.ImpTest (ShelleyEraImp)
+import Test.Cardano.Ledger.Shelley.ImpTest
 
 spec ::
   forall era.
@@ -22,3 +24,5 @@ spec ::
   Spec
 spec = do
   ShelleyImp.spec @era
+  describe "AllegraImpSpec" . withImpState @era $ do
+    UtxowSpec.spec

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Imp/UtxowSpec.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Imp/UtxowSpec.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Test.Cardano.Ledger.Allegra.Imp.UtxowSpec (
+  spec,
+) where
+
+import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley.Rules (ShelleyUtxowPredFailure (..))
+import Cardano.Ledger.Shelley.TxAuxData (Metadatum (..))
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import Data.Word (Word64)
+import Lens.Micro
+import Test.Cardano.Ledger.Imp.Common
+import Test.Cardano.Ledger.Shelley.Arbitrary (genUtf8StringOfSize)
+import Test.Cardano.Ledger.Shelley.ImpTest
+
+spec ::
+  forall era.
+  ( ShelleyEraImp era
+  , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
+  ) =>
+  SpecWith (ImpTestState era)
+spec = describe "UTXOW" $ do
+  it "InvalidMetadata" $ do
+    invalidMetadatum <- genInvalidMetadata
+    let auxData = mkBasicTxAuxData & metadataTxAuxDataL .~ invalidMetadatum
+    let auxDataHash = hashTxAuxData auxData
+    let tx =
+          mkBasicTx mkBasicTxBody
+            & bodyTxL . auxDataHashTxBodyL .~ SJust auxDataHash
+            & auxDataTxL .~ SJust auxData
+    submitFailingTx tx [injectFailure InvalidMetadata]
+
+genInvalidMetadata :: ImpTestM era (Map.Map Word64 Metadatum)
+genInvalidMetadata = do
+  size <- choose (65, 1000)
+  let genM =
+        oneof
+          [ B . BS.pack <$> vectorOf size arbitrary
+          , S . T.pack <$> liftGen (genUtf8StringOfSize size)
+          ]
+  Map.fromList <$> listOf1 ((,) <$> arbitrary <*> genM)

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -132,7 +132,6 @@ library testlib
         cardano-ledger-binary,
         cardano-ledger-mary:testlib,
         cardano-ledger-core:{cardano-ledger-core, testlib},
-        cardano-strict-containers,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
         plutus-ledger-api,
         generic-random,

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -109,6 +109,7 @@ library testlib
         Test.Cardano.Ledger.Alonzo.Binary.TxWitsSpec
         Test.Cardano.Ledger.Alonzo.Imp
         Test.Cardano.Ledger.Alonzo.Imp.UtxosSpec
+        Test.Cardano.Ledger.Alonzo.Imp.UtxowSpec
         Test.Cardano.Ledger.Alonzo.ImpTest
         Test.Cardano.Ledger.Alonzo.TreeDiff
 
@@ -133,6 +134,7 @@ library testlib
         cardano-ledger-mary:testlib,
         cardano-ledger-core:{cardano-ledger-core, testlib},
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
+        cardano-strict-containers,
         plutus-ledger-api,
         generic-random,
         microlens,

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp.hs
@@ -8,22 +8,26 @@
 module Test.Cardano.Ledger.Alonzo.Imp where
 
 import Cardano.Ledger.Alonzo.Core
+import Cardano.Ledger.Alonzo.Rules (AlonzoUtxosPredFailure, AlonzoUtxowPredFailure)
 import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure, ShelleyUtxowPredFailure)
 import qualified Test.Cardano.Ledger.Alonzo.Imp.UtxosSpec as Utxos
-import Test.Cardano.Ledger.Alonzo.ImpTest (MaryEraImp, withImpState)
+import qualified Test.Cardano.Ledger.Alonzo.Imp.UtxowSpec as Utxow
+import Test.Cardano.Ledger.Alonzo.ImpTest (AlonzoEraImp, withImpState)
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Mary.Imp as MaryImp
 
 spec ::
   forall era.
   ( Arbitrary (TxAuxData era)
-  , MaryEraImp era
-  , AlonzoEraTx era
+  , AlonzoEraImp era
   , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
   , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
+  , InjectRuleFailure "LEDGER" AlonzoUtxowPredFailure era
+  , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
   ) =>
   Spec
 spec = do
   MaryImp.spec @era
   describe "AlonzoImpSpec" . withImpState @era $ do
     Utxos.spec @era
+    Utxow.spec @era

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp.hs
@@ -11,12 +11,13 @@ import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure, ShelleyUtxowPredFailure)
 import qualified Test.Cardano.Ledger.Alonzo.Imp.UtxosSpec as Utxos
 import Test.Cardano.Ledger.Alonzo.ImpTest (MaryEraImp, withImpState)
-import Test.Cardano.Ledger.Common (Spec, describe)
+import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Mary.Imp as MaryImp
 
 spec ::
   forall era.
-  ( MaryEraImp era
+  ( Arbitrary (TxAuxData era)
+  , MaryEraImp era
   , AlonzoEraTx era
   , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
   , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxosSpec.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxosSpec.hs
@@ -7,54 +7,34 @@
 
 module Test.Cardano.Ledger.Alonzo.Imp.UtxosSpec (spec) where
 
-import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Alonzo.Core (
   AlonzoEraScript (..),
   AlonzoEraTx (..),
   AlonzoEraTxWits (..),
   AsIx (AsIx),
-  Era (..),
   ppMaxTxExUnitsL,
  )
 import Cardano.Ledger.Alonzo.Tx (IsValid (..))
 import Cardano.Ledger.Alonzo.TxWits (Redeemers (..))
-import Cardano.Ledger.BaseTypes (Inject (..), Network (..))
-import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Core (EraTx (..), EraTxBody (..), EraTxOut (..))
-import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
+import Cardano.Ledger.Core (EraTx (..), EraTxBody (..))
 import Cardano.Ledger.Plutus.Data (Data (..))
 import Cardano.Ledger.Plutus.Language (SLanguage (..), hashPlutusScript)
 import Cardano.Ledger.Shelley.LedgerState (curPParamsEpochStateL, nesEsL)
-import Cardano.Ledger.TxIn (TxIn)
 import qualified Data.Map.Strict as Map
-import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
 import Lens.Micro ((&), (.~))
 import qualified PlutusLedgerApi.Common as P
 import Test.Cardano.Ledger.Alonzo.ImpTest (
-  ImpTestM,
   ImpTestState,
   ShelleyEraImp,
   getsNES,
   impAnn,
-  submitTxAnn,
+  produceScript,
   submitTxAnn_,
   submitTx_,
  )
 import Test.Cardano.Ledger.Common
-import Test.Cardano.Ledger.Core.Utils (txInAt)
 import Test.Cardano.Ledger.Plutus.Examples (guessTheNumber3)
-
-submitProducingTx :: forall era. ShelleyEraImp era => ImpTestM era (TxIn (EraCrypto era))
-submitProducingTx =
-  fmap (txInAt (0 :: Int)) . submitTxAnn "Sumbit a transaction with a script output" $
-    mkBasicTx mkBasicTxBody
-      & bodyTxL . outputsTxBodyL
-        .~ SSeq.singleton
-          ( mkBasicTxOut
-              (Addr Testnet (ScriptHashObj $ hashPlutusScript (guessTheNumber3 SPlutusV1)) StakeRefNull)
-              (inject (Coin 100))
-          )
 
 spec ::
   forall era.
@@ -63,14 +43,15 @@ spec ::
   ) =>
   SpecWith (ImpTestState era)
 spec = describe "UTXOS" $ do
+  let scriptHash = hashPlutusScript (guessTheNumber3 SPlutusV1)
   it "Plutus script transactions are fixed up" $ do
-    txIn0 <- submitProducingTx
+    txIn0 <- produceScript scriptHash
     submitTxAnn_ "Submit a transaction that consumes the script output" $
       mkBasicTx mkBasicTxBody
         & bodyTxL . inputsTxBodyL
           .~ Set.singleton txIn0
   it "Invalid plutus script fails in phase 2" $ do
-    txIn0 <- submitProducingTx
+    txIn0 <- produceScript scriptHash
     exUnits <- getsNES $ nesEsL . curPParamsEpochStateL . ppMaxTxExUnitsL
     impAnn "Submitting consuming transaction" $
       submitTx_

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec.hs
@@ -1,0 +1,162 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Test.Cardano.Ledger.Alonzo.Imp.UtxowSpec (spec) where
+
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Alonzo.Core (
+  AlonzoEraTxWits (..),
+  scriptIntegrityHashTxBodyL,
+ )
+import Cardano.Ledger.Alonzo.Plutus.Evaluate (CollectError (..))
+import Cardano.Ledger.Alonzo.Rules (AlonzoUtxosPredFailure (..), AlonzoUtxowPredFailure (..))
+import Cardano.Ledger.Alonzo.Scripts
+import Cardano.Ledger.Alonzo.TxOut (dataHashTxOutL)
+import Cardano.Ledger.Alonzo.TxWits (Redeemers (..), TxDats (..))
+import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Core
+import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
+import Cardano.Ledger.Plutus
+import Cardano.Ledger.Shelley.Rules (ShelleyUtxowPredFailure (..))
+import qualified Data.Map as Map
+import Data.Sequence.Strict (StrictSeq ((:<|)))
+import Lens.Micro
+import qualified PlutusLedgerApi.Common as P
+import Test.Cardano.Ledger.Alonzo.Arbitrary ()
+import Test.Cardano.Ledger.Alonzo.ImpTest (AlonzoEraImp, fixupPPHash)
+import Test.Cardano.Ledger.Core.Utils (txInAt)
+import Test.Cardano.Ledger.Imp.Common
+import Test.Cardano.Ledger.Plutus.Examples (guessTheNumber3)
+import Test.Cardano.Ledger.Shelley.ImpTest
+
+spec ::
+  forall era.
+  ( AlonzoEraImp era
+  , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
+  , InjectRuleFailure "LEDGER" AlonzoUtxowPredFailure era
+  , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
+  ) =>
+  SpecWith (ImpTestState era)
+spec = describe "UTXOW" $ do
+  let resetAddrWits tx = updateAddrTxWits $ tx & witsTxL . addrTxWitsL .~ []
+  let fixupResetAddrWits = fixupPPHash >=> resetAddrWits
+
+  it "MissingRedeemers" $ do
+    let lang = eraMaxLanguage @era
+    let scriptHash = withSLanguage lang (hashPlutusScript . guessTheNumber3)
+    txIn <- produceScript scriptHash
+    let missingRedeemer = mkSpendingPurpose $ AsItem txIn
+    let tx = mkBasicTx mkBasicTxBody & bodyTxL . inputsTxBodyL .~ [txIn]
+    withPostFixup (fixupResetAddrWits . (witsTxL . rdmrsTxWitsL .~ Redeemers mempty)) $
+      submitFailingTx
+        tx
+        [ injectFailure $
+            MissingRedeemers [(missingRedeemer, scriptHash)]
+        , injectFailure $
+            CollectErrors [NoRedeemer missingRedeemer]
+        ]
+
+  it "MissingRequiredDatums" $ do
+    let lang = eraMaxLanguage @era
+    let scriptHash = withSLanguage lang (hashPlutusScript . guessTheNumber3)
+    txIn <- produceScript scriptHash
+    let tx = mkBasicTx mkBasicTxBody & bodyTxL . inputsTxBodyL .~ [txIn]
+    let missingDatum = hashData @era (Data (P.I 3))
+    withPostFixup (fixupResetAddrWits . (witsTxL . datsTxWitsL .~ mempty)) $
+      submitFailingTx
+        tx
+        [ injectFailure $
+            MissingRequiredDatums [missingDatum] []
+        ]
+
+  it "NotAllowedSupplementalDatums" $ do
+    let lang = eraMaxLanguage @era
+    let scriptHash = withSLanguage lang (hashPlutusScript . guessTheNumber3)
+    txIn <- produceScript scriptHash
+    let extraDatumHash = hashData @era (Data (P.I 30))
+    let extraDatum = Data (P.I 30)
+    let tx =
+          mkBasicTx mkBasicTxBody
+            & bodyTxL . inputsTxBodyL .~ [txIn]
+            & witsTxL . datsTxWitsL .~ TxDats (Map.singleton extraDatumHash extraDatum)
+    submitFailingTx
+      tx
+      [ injectFailure $
+          NotAllowedSupplementalDatums [extraDatumHash] []
+      ]
+
+  it "PPViewHashesDontMatch" $ do
+    let lang = eraMaxLanguage @era
+    let scriptHash = withSLanguage lang (hashPlutusScript . guessTheNumber3)
+    txIn <- produceScript scriptHash
+    tx <- fixupTx $ mkBasicTx mkBasicTxBody & bodyTxL . inputsTxBodyL .~ [txIn]
+
+    impAnn "Mismatched " $ do
+      wrongIntegrityHash <- arbitrary
+      wrongIntegrityHashTx <-
+        resetAddrWits $ tx & bodyTxL . scriptIntegrityHashTxBodyL .~ SJust wrongIntegrityHash
+      withNoFixup $
+        submitFailingTx
+          wrongIntegrityHashTx
+          [ injectFailure $
+              PPViewHashesDontMatch
+                (SJust wrongIntegrityHash)
+                (tx ^. bodyTxL . scriptIntegrityHashTxBodyL)
+          ]
+    impAnn "Missing" $ do
+      missingIntegrityHashTx <-
+        resetAddrWits $ tx & bodyTxL . scriptIntegrityHashTxBodyL .~ SNothing
+      withNoFixup $
+        submitFailingTx
+          missingIntegrityHashTx
+          [ injectFailure $
+              PPViewHashesDontMatch SNothing (tx ^. bodyTxL . scriptIntegrityHashTxBodyL)
+          ]
+
+  it "UnspendableUTxONoDatumHash" $ do
+    let lang = eraMaxLanguage @era
+    let scriptHash = withSLanguage lang (hashPlutusScript . guessTheNumber3)
+
+    txIn <- impAnn "Produce script at a txout with a missing datahash" $ do
+      let addr = Addr Testnet (ScriptHashObj scriptHash) StakeRefNull
+      let tx =
+            mkBasicTx mkBasicTxBody
+              & bodyTxL . outputsTxBodyL .~ [mkBasicTxOut addr (inject (Coin 10))]
+      let resetDataHash = dataHashTxOutL .~ SNothing
+      let resetTxOutDataHash =
+            bodyTxL . outputsTxBodyL
+              %~ ( \case
+                    h :<| r -> resetDataHash h :<| r
+                    _ -> error "Expected non-empty outputs"
+                 )
+
+      txInAt (0 :: Int)
+        <$> withPostFixup
+          (fixupResetAddrWits <$> resetTxOutDataHash)
+          (submitTx tx)
+
+    submitFailingTx
+      (mkBasicTx mkBasicTxBody & bodyTxL . inputsTxBodyL .~ [txIn])
+      [injectFailure $ UnspendableUTxONoDatumHash [txIn]]
+
+  it "ExtraRedeemers" $ do
+    let scriptHash = withSLanguage PlutusV1 (hashPlutusScript . guessTheNumber3)
+    txIn <- produceScript scriptHash
+    let prp = MintingPurpose (AsIx 2)
+    dt <- arbitrary
+    let tx =
+          mkBasicTx mkBasicTxBody
+            & bodyTxL . inputsTxBodyL .~ [txIn]
+            & witsTxL . rdmrsTxWitsL <>~ Redeemers (Map.singleton prp (dt, ExUnits 0 0))
+    let submit = submitFailingTx tx [injectFailure $ ExtraRedeemers [prp]]
+    if eraProtVerLow @era < natVersion @9
+      then -- PlutusPurpose serialization was fixed in Conway
+        withCborRoundTripFailures submit
+      else submit

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
@@ -16,6 +17,7 @@ module Test.Cardano.Ledger.Alonzo.ImpTest (
   AlonzoEraImp (..),
   initAlonzoImpNES,
   impLookupPlutusScriptMaybe,
+  malformedPlutus,
   addCollateralInput,
   impGetPlutusContexts,
   alonzoFixupTx,
@@ -53,7 +55,8 @@ import Cardano.Ledger.Plutus (SLanguage (..), hashPlutusScript)
 import Cardano.Ledger.Plutus.Data (Data (..), Datum (..), hashData)
 import Cardano.Ledger.Plutus.Language (
   Language (..),
-  Plutus,
+  Plutus (..),
+  PlutusBinary (..),
   PlutusLanguage,
  )
 import Cardano.Ledger.Shelley.LedgerState (
@@ -351,6 +354,7 @@ mkScriptTestEntry script args =
   )
 
 plutusTestScripts ::
+  forall c l.
   (Crypto c, PlutusLanguage l) =>
   SLanguage l ->
   Map.Map (ScriptHash c) ScriptTestContext
@@ -370,7 +374,11 @@ plutusTestScripts lang =
     , mkScriptTestEntry (oddRedeemer2 lang) $ PlutusArgs (P.I 0) Nothing
     , mkScriptTestEntry (evenRedeemer2 lang) $ PlutusArgs (P.I 0) Nothing
     , mkScriptTestEntry (redeemerIs102 lang) $ PlutusArgs (P.I 0) Nothing
+    , mkScriptTestEntry (malformedPlutus @l) $ PlutusArgs (P.I 0) (Just $ P.I 0)
     ]
+
+malformedPlutus :: Plutus l
+malformedPlutus = Plutus (PlutusBinary "invalid")
 
 instance
   ( Crypto c

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -95,6 +95,7 @@ library testlib
         Test.Cardano.Ledger.Babbage.Arbitrary
         Test.Cardano.Ledger.Babbage.Binary.Cddl
         Test.Cardano.Ledger.Babbage.Imp
+        Test.Cardano.Ledger.Babbage.Imp.UtxowSpec
         Test.Cardano.Ledger.Babbage.ImpTest
         Test.Cardano.Ledger.Babbage.TreeDiff
 
@@ -117,6 +118,7 @@ library testlib
         cardano-ledger-binary,
         cardano-ledger-core:{cardano-ledger-core, testlib},
         generic-random,
+        microlens,
         microlens-mtl,
         small-steps >=1.1,
         QuickCheck

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
@@ -7,6 +7,7 @@
 
 module Test.Cardano.Ledger.Babbage.Imp (spec) where
 
+import Cardano.Ledger.Alonzo.Rules (AlonzoUtxosPredFailure, AlonzoUtxowPredFailure)
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure, ShelleyUtxowPredFailure)
 import qualified Test.Cardano.Ledger.Alonzo.Imp as AlonzoImp
@@ -18,6 +19,8 @@ spec ::
   ( Arbitrary (TxAuxData era)
   , AlonzoEraImp era
   , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
+  , InjectRuleFailure "LEDGER" AlonzoUtxowPredFailure era
+  , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
   , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
   ) =>
   Spec

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
@@ -15,7 +15,8 @@ import Test.Cardano.Ledger.Common
 
 spec ::
   forall era.
-  ( AlonzoEraImp era
+  ( Arbitrary (TxAuxData era)
+  , AlonzoEraImp era
   , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
   , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
   ) =>

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
@@ -9,20 +9,26 @@ module Test.Cardano.Ledger.Babbage.Imp (spec) where
 
 import Cardano.Ledger.Alonzo.Rules (AlonzoUtxosPredFailure, AlonzoUtxowPredFailure)
 import Cardano.Ledger.Babbage.Core
+import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure (..))
 import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure, ShelleyUtxowPredFailure)
 import qualified Test.Cardano.Ledger.Alonzo.Imp as AlonzoImp
-import Test.Cardano.Ledger.Alonzo.ImpTest (AlonzoEraImp)
+import Test.Cardano.Ledger.Alonzo.ImpTest (AlonzoEraImp, withImpState)
+import qualified Test.Cardano.Ledger.Babbage.Imp.UtxowSpec as Utxow
 import Test.Cardano.Ledger.Common
 
 spec ::
   forall era.
   ( Arbitrary (TxAuxData era)
   , AlonzoEraImp era
+  , BabbageEraTxOut era
   , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
   , InjectRuleFailure "LEDGER" AlonzoUtxowPredFailure era
   , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
   , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
+  , InjectRuleFailure "LEDGER" BabbageUtxowPredFailure era
   ) =>
   Spec
 spec = do
   AlonzoImp.spec @era
+  describe "BabbageImpSpec" . withImpState @era $ do
+    Utxow.spec @era

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxowSpec.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxowSpec.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Babbage.Imp.UtxowSpec (spec) where
+
+import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure (..))
+import Cardano.Ledger.Babbage.TxOut (BabbageEraTxOut, referenceScriptTxOutL)
+import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Core
+import Cardano.Ledger.Plutus
+import Lens.Micro
+import Test.Cardano.Ledger.Alonzo.Arbitrary (mkPlutusScript')
+import Test.Cardano.Ledger.Alonzo.ImpTest
+import Test.Cardano.Ledger.Imp.Common
+
+spec ::
+  forall era.
+  ( AlonzoEraImp era
+  , BabbageEraTxOut era
+  , InjectRuleFailure "LEDGER" BabbageUtxowPredFailure era
+  ) =>
+  SpecWith (ImpTestState era)
+spec = describe "UTXOW" $ do
+  it "MalformedScriptWitnesses" $ do
+    let scriptHash = hashPlutusScript @'PlutusV2 malformedPlutus
+    txIn <- produceScript scriptHash
+    let tx = mkBasicTx mkBasicTxBody & bodyTxL . inputsTxBodyL .~ [txIn]
+    submitFailingTx
+      tx
+      [ injectFailure $
+          MalformedScriptWitnesses [scriptHash]
+      ]
+
+  it "MalformedReferenceScripts" $ do
+    let script = mkPlutusScript' @era (malformedPlutus @'PlutusV2)
+    let scriptHash = hashScript script
+    addr <- snd <$> freshKeyAddr
+    let tx =
+          mkBasicTx mkBasicTxBody
+            & bodyTxL . outputsTxBodyL
+              .~ [ mkBasicTxOut addr (inject (Coin 10)) & referenceScriptTxOutL .~ SJust script
+                 ]
+    submitFailingTx
+      tx
+      [ injectFailure $
+          MalformedReferenceScripts [scriptHash]
+      ]

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -39,7 +39,8 @@ import Test.Cardano.Ledger.Conway.ImpTest (ConwayEraImp, withImpState, withImpSt
 
 spec ::
   forall era.
-  ( ConwayEraImp era
+  ( Arbitrary (TxAuxData era)
+  , ConwayEraImp era
   , GovState era ~ ConwayGovState era
   , PParamsHKD Identity era ~ ConwayPParams Identity era
   , InjectRuleFailure "LEDGER" ConwayGovPredFailure era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -9,8 +9,8 @@
 module Test.Cardano.Ledger.Conway.Imp (spec) where
 
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext (..))
-import Cardano.Ledger.Alonzo.Rules (AlonzoUtxosPredFailure)
-import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure)
+import Cardano.Ledger.Alonzo.Rules (AlonzoUtxosPredFailure, AlonzoUtxowPredFailure)
+import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure, BabbageUtxowPredFailure)
 import Cardano.Ledger.Babbage.TxInfo (BabbageContextError)
 import Cardano.Ledger.BaseTypes (Inject, natVersion)
 import Cardano.Ledger.Conway.Core
@@ -47,7 +47,9 @@ spec ::
   , Inject (BabbageContextError era) (ContextError era)
   , Inject (ConwayContextError era) (ContextError era)
   , InjectRuleFailure "LEDGER" BabbageUtxoPredFailure era
+  , InjectRuleFailure "LEDGER" BabbageUtxowPredFailure era
   , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
+  , InjectRuleFailure "LEDGER" AlonzoUtxowPredFailure era
   , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
   , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
   , InjectRuleFailure "LEDGER" ConwayGovCertPredFailure era

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Imp.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Imp.hs
@@ -18,7 +18,8 @@ import Test.Cardano.Ledger.Shelley.ImpTest (withImpState)
 
 spec ::
   forall era.
-  ( MaryEraImp era
+  ( Arbitrary (TxAuxData era)
+  , MaryEraImp era
   , AllegraEraScript era
   , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
   , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -14,6 +14,7 @@
   * replace `MultiSig` with `NativeScript`
 
 ### testlib
+* Add `withCborRoundTripFailures`
 * Change signatures of `Arbitrary` instances for `MultiSig`:
   * replace `Era` constraint with `ShelleyEraScript`
   * add `NativeScript era ~ MultiSig era` constraint

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -20,6 +20,7 @@ module Test.Cardano.Ledger.Shelley.Arbitrary (
   metadataMaxSize,
   genMetadata,
   genMetadata',
+  genUtf8StringOfSize,
   RawSeed (..),
   ASC (..),
   StakeProportion (..),

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
@@ -18,7 +18,8 @@ import qualified Test.Cardano.Ledger.Shelley.UnitTests.IncrementalStakeTest as I
 
 spec ::
   forall era.
-  ( ShelleyEraImp era
+  ( Arbitrary (TxAuxData era)
+  , ShelleyEraImp era
   , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
   , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
   ) =>

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/UtxowSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/UtxowSpec.hs
@@ -1,23 +1,36 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Cardano.Ledger.Shelley.Imp.UtxowSpec (spec) where
 
 import qualified Cardano.Chain.Common as Byron
 import Cardano.Ledger.Address (Addr (..), BootstrapAddress (..))
+import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
+import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
+import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
+import Cardano.Ledger.Keys (asWitness, witVKeyHash)
 import Cardano.Ledger.Keys.Bootstrap
 import Cardano.Ledger.SafeHash (extractHash, hashAnnotated)
 import Cardano.Ledger.Shelley.Rules (ShelleyUtxowPredFailure (..))
+import Cardano.Ledger.Shelley.Scripts (
+  pattern RequireSignature,
+ )
+import qualified Data.Set as Set
 import Lens.Micro
 import Test.Cardano.Ledger.Core.KeyPair (ByronKeyPair (..))
 import Test.Cardano.Ledger.Imp.Common
 import Test.Cardano.Ledger.Shelley.ImpTest
 
 spec ::
+  forall era.
   ( ShelleyEraImp era
+  , Arbitrary (TxAuxData era)
   , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
   ) =>
   SpecWith (ImpTestState era)
@@ -49,3 +62,76 @@ spec = describe "UTXOW" $ do
             mkBasicTx txBody
               & (witsTxL %~ (bootAddrTxWitsL .~ [aliceBadWitness]))
       submitFailingTx txBad [injectFailure $ InvalidWitnessesUTXOW [aliceVKey]]
+
+  it "MissingVKeyWitnessesUTXOW" $ do
+    aliceKh <- freshKeyHash
+    txIn <- sendCoinTo (Addr Testnet (KeyHashObj aliceKh) StakeRefNull) (Coin 99)
+    let tx = mkBasicTx $ mkBasicTxBody & inputsTxBodyL <>~ [txIn]
+    let isAliceWitness wit = witVKeyHash wit == asWitness aliceKh
+    withPostFixup (pure . (witsTxL . addrTxWitsL %~ Set.filter (not . isAliceWitness))) $
+      submitFailingTx
+        tx
+        [ injectFailure $
+            MissingVKeyWitnessesUTXOW [asWitness aliceKh]
+        ]
+
+  it "MissingScriptWitnessesUTXOW" $ do
+    requiredKh <- freshKeyHash
+    let scriptHash = hashScript @era $ fromNativeScript $ RequireSignature requiredKh
+    txIn <- produceScript scriptHash
+    let tx = mkBasicTx $ mkBasicTxBody & inputsTxBodyL <>~ [txIn]
+    submitFailingTx
+      tx
+      [ injectFailure $
+          MissingScriptWitnessesUTXOW [scriptHash]
+      ]
+
+  it "MissingTxBodyMetadataHash" $ do
+    auxData <- arbitrary @(TxAuxData era)
+    let auxDataHash = hashTxAuxData auxData
+    let tx = mkBasicTx mkBasicTxBody & auxDataTxL .~ SJust auxData
+    submitFailingTx
+      tx
+      [ injectFailure $
+          MissingTxBodyMetadataHash auxDataHash
+      ]
+
+  it "MissingTxMetadata" $ do
+    auxData <- arbitrary @(TxAuxData era)
+    let auxDataHash = hashTxAuxData auxData
+    let tx = mkBasicTx mkBasicTxBody & bodyTxL . auxDataHashTxBodyL .~ SJust auxDataHash
+    submitFailingTx
+      tx
+      [ injectFailure $
+          MissingTxMetadata auxDataHash
+      ]
+
+  it "ConflictingMetadataHash" $ do
+    auxData <- arbitrary @(TxAuxData era)
+    let auxDataHash = hashTxAuxData auxData
+    wrongAuxDataHash <- arbitrary @(AuxiliaryDataHash (EraCrypto era))
+    let tx =
+          mkBasicTx mkBasicTxBody
+            & bodyTxL . auxDataHashTxBodyL .~ SJust wrongAuxDataHash
+            & auxDataTxL .~ SJust auxData
+    submitFailingTx
+      tx
+      [ injectFailure $
+          ConflictingMetadataHash wrongAuxDataHash auxDataHash
+      ]
+
+  it "ExtraneousScriptWitnessesUTXOW" $ do
+    requiredKh <- freshKeyHash
+    let script = fromNativeScript $ RequireSignature (asWitness requiredKh)
+    let scriptHash = hashScript @era script
+    let tx = mkBasicTx mkBasicTxBody & witsTxL . scriptTxWitsL .~ [(scriptHash, script)]
+    submitFailingTx tx $
+      -- We dropped validating scripts when they are not needed, starting with Babbage
+      if eraProtVerLow @era >= natVersion @6
+        then
+          [ injectFailure $ ExtraneousScriptWitnessesUTXOW [scriptHash]
+          ]
+        else
+          [ injectFailure $ ScriptWitnessNotValidatingUTXOW [scriptHash]
+          , injectFailure $ ExtraneousScriptWitnessesUTXOW [scriptHash]
+          ]

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -318,6 +318,7 @@ class
   , EraTxOut era
   , EraPParams era
   , ShelleyEraTxCert era
+  , ShelleyEraScript era
   , ToExpr (Tx era)
   , NFData (Tx era)
   , ToExpr (TxBody era)

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -105,6 +105,7 @@ module Test.Cardano.Ledger.Shelley.ImpTest (
   impLastTickG,
   impKeyPairsG,
   impNativeScriptsG,
+  produceScript,
 ) where
 
 import qualified Cardano.Chain.Common as Byron
@@ -1473,3 +1474,14 @@ impLookupUTxO txIn = impAnn "Looking up TxOut" $ do
   case txinLookup txIn utxo of
     Just txOut -> pure txOut
     Nothing -> error $ "Failed to get TxOut for " <> show txIn
+
+produceScript ::
+  ShelleyEraImp era =>
+  ScriptHash (EraCrypto era) ->
+  ImpTestM era (TxIn (EraCrypto era))
+produceScript scriptHash = do
+  let addr = Addr Testnet (ScriptHashObj scriptHash) StakeRefNull
+  let tx =
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . outputsTxBodyL .~ SSeq.singleton (mkBasicTxOut addr (inject (Coin 10)))
+  txInAt (0 :: Int) <$> submitTx tx

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/RulesTests.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/RulesTests.hs
@@ -91,7 +91,6 @@ multisigExamples =
     [ testCase "Alice uses SingleSig script" testAliceSignsAlone
     , testCase "FAIL: Alice doesn't sign in multi-sig" testAliceDoesntSign
     , testCase "Everybody signs in multi-sig" testEverybodySigns
-    , testCase "FAIL: Wrong script for correct signatures" testWrongScript
     , testCase "Alice || Bob, Alice signs" testAliceOrBob
     , testCase "Alice || Bob, Bob signs" testAliceOrBob'
     , testCase "Alice && Bob, both sign" testAliceAndBob
@@ -165,22 +164,6 @@ testEverybodySigns =
         , asWitness Cast.dariaPay
         ]
     s = "problem: " ++ show utxoSt'
-
-testWrongScript :: Assertion
-testWrongScript =
-  utxoSt' @?= Left (pure extraneous <> pure missing)
-  where
-    utxoSt' =
-      applyTxWithScript
-        @C_Crypto
-        [(aliceOnly, Coin 11000)]
-        [aliceOrBob]
-        (Withdrawals Map.empty)
-        (Coin 0)
-        [asWitness Cast.alicePay, asWitness Cast.bobPay]
-    asHashes = Set.singleton . hashScript @C
-    extraneous = ExtraneousScriptWitnessesUTXOW $ asHashes aliceOrBob
-    missing = MissingScriptWitnessesUTXOW $ asHashes aliceOnly
 
 testAliceOrBob :: Assertion
 testAliceOrBob =


### PR DESCRIPTION
# Description

Tests for UTXOW Predicate failures, part of https://github.com/IntersectMBO/cardano-ledger/issues/4185

 InvalidWitnessesUTXOW
 MissingVKeyWitnessesUTXOW
 MissingScriptWitnessesUTXOW
 ScriptWitnessNotValidatingUTXOW
 MissingTxBodyMetadataHash
 MissingTxMetadata
 ConflictingMetadataHash
 InvalidMetadata
 ExtraneousScriptWitnessesUTXOW
 MissingRedeemers
 MissingRequiredDatums
 NotAllowedSupplementalDatums
 PPViewHashesDontMatch
 UnspendableUTxONoDatumHash
 ExtraRedeemers
 MalformedScriptWitnesses
 MalformedReferenceScripts

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
