### PR TITLE
Avoid thunks in the `Arbitrary` instance of `RewardSnapShot`

### DIFF
--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -221,7 +221,10 @@ instance Arbitrary PerformanceEstimate where
   arbitrary = PerformanceEstimate <$> arbitrary
 
 instance Crypto c => Arbitrary (NonMyopic c) where
-  arbitrary = NonMyopic <$> arbitrary <*> arbitrary
+  arbitrary =
+    NonMyopic
+      <$> arbitraryStrictMap
+      <*> arbitrary
   shrink = genericShrink
 
 ------------------------------------------------------------------------------------------
@@ -281,8 +284,8 @@ instance Crypto c => Arbitrary (RewardSnapShot c) where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary
-      <*> arbitrary
+      <*> arbitraryStrictMap
+      <*> arbitraryStrictMap
   shrink = genericShrink
 
 instance Crypto c => Arbitrary (FreeVars c) where

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -37,6 +37,7 @@
 
 ### `testlib`
 
+* Add `arbitraryStrictMap`
 * Add `shouldContainExpr`
 * Add `EraRuleProof`, `UnliftRules`, `roundTripAllPredicateFailures`
 * Add `Test.Cardano.Ledger.Plutus.ScriptTestContext`

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Common.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Common.hs
@@ -31,11 +31,15 @@ module Test.Cardano.Ledger.Common (
   expectLeftDeep,
   expectLeftDeep_,
   expectLeftDeepExpr,
+
+  -- * Support for defining Arbitrary instances
+  arbitraryStrictMap,
 )
 where
 
 import Control.DeepSeq (NFData)
 import Control.Monad as X (forM_, replicateM, replicateM_, unless, void, when, (>=>))
+import qualified Data.Map.Strict as Map
 import System.IO (
   BufferMode (LineBuffering),
   hSetBuffering,
@@ -141,3 +145,12 @@ shouldBeLeft e x = expectLeft e >>= (`shouldBe` x)
 -- | Same as `shouldBeExpr`, except it checks that the value is `Left`
 shouldBeLeftExpr :: (HasCallStack, ToExpr a, ToExpr b, Eq a) => Either a b -> a -> Expectation
 shouldBeLeftExpr e x = expectLeftExpr e >>= (`shouldBeExpr` x)
+
+-- | A workaround for the standard `Arbitrary` instance for Maps.
+--
+-- Strict and lazy Maps share the same type so it's not possible to have separate instances for
+-- them. The standard instance (from `Test.QuickCheck`) uses the lazy interface and thus produces
+-- lazy values. This function uses the strict `fromList` to ensure that all the generated values are
+-- strict.
+arbitraryStrictMap :: (Ord k, Arbitrary k, Arbitrary v) => Gen (Map.Map k v)
+arbitraryStrictMap = Map.fromList <$> arbitrary


### PR DESCRIPTION
# Description

The `Arbitrary` instance for `RewardSnapShot` produces values containing thunks. These values are used in the `arbitrary` values of `MockChainState`. Sometimes the thunks are never forced (for unknown reasons) and in the nightly tests we specifically check that `MockChainState` contains no thunks.

The thunks arise because `RewardSnapShot` contains a (strict) `Map` and the `Arbitrary` instance for `Map` doesn't ensure that the generated map contains no lazy values. This in turn is because strict and lazy Maps share the same type so it's not possible to have separate instances for them. The single instance (which comes from `Test.QuickCheck`) uses the lazy interface and thus produces lazy values.

This PR introduces a new function, `arbitraryStrictMap`, that uses the strict `Map.fromList` to ensure that the `Map`'s values are strict (ie WHNF). The function is used instead of `arbitrary` in the places where `RewardSnapShot` uses a `Map`.

There are no doubt many other places where we could and probably should be using `arbitraryStrictMap` instead of `arbitrary`, but finding and fixing them all would be a lot of work. We could instead create our own `newtype` of `Map`, similar to `StrictSeq`, but that too would be a lot of work. Since the problem can occur only in testing (because `arbitrary` is never used in production) we need to worry about it only in tests that use `noThunks`, and we can fix the affected instances whenever we get new test failures.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [ ] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [ ] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
