### PR TITLE
Fixes for 8.10 release

### DIFF
--- a/eras/byron/crypto/cardano-crypto-wrapper.cabal
+++ b/eras/byron/crypto/cardano-crypto-wrapper.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-crypto-wrapper
-version:            1.5.1.1
+version:            1.5.1.2
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -81,7 +81,7 @@ library
         binary,
         bytestring,
         canonical-json,
-        cardano-ledger-binary >=1.0,
+        cardano-ledger-binary >=1.3.1,
         cardano-crypto,
         cardano-prelude >=0.1.0.1,
         heapwords,

--- a/eras/byron/crypto/test/cardano-crypto-test.cabal
+++ b/eras/byron/crypto/test/cardano-crypto-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-crypto-test
-version:       1.5.0.1
+version:       1.5.0.2
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK
@@ -53,7 +53,7 @@ library
     build-depends:
         base >=4.14 && <5,
         bytestring,
-        cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.3.1,
         cardano-crypto,
         cardano-crypto-wrapper ^>=1.5,
         cardano-prelude,

--- a/eras/byron/ledger/impl/cardano-ledger-byron.cabal
+++ b/eras/byron/ledger/impl/cardano-ledger-byron.cabal
@@ -236,7 +236,7 @@ library
         canonical-json,
         cardano-crypto,
         cardano-crypto-wrapper,
-        cardano-ledger-binary >=1.0,
+        cardano-ledger-binary >=1.3.1,
         cardano-prelude,
         cborg,
         containers,

--- a/libs/cardano-protocol-tpraos/CHANGELOG.md
+++ b/libs/cardano-protocol-tpraos/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Version history for `cardano-protocol-tpraos`
 
-## 1.1.0.0
-
+## 1.2.0.0
 * Change `FutureLedgerViewError` and `ChainTransitionError`
   to use `NonEmpty (PredicateFailure _)` instead of `[PredicateFailure _]`
+
+## 1.1.0.0
 * Change the type of `bsize` and `hBbsize` to `Word32`
 
 ## 1.0.3.7
@@ -67,4 +68,3 @@
 ## 1.0.0.0
 
 * First properly versioned release.
-

--- a/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
+++ b/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-protocol-tpraos
-version:       1.1.0.0
+version:       1.2.0.0
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK


### PR DESCRIPTION
Some fixes  needed in order for the ChAP build to pass: 

* update of cardano-protocol-tpraos version to reflect the breaking change
* updating of cardano-ledger-binary version in byron packages - without which it's pulling in an ancient plutus-core version which it can't compile (for reasons passing my understanding)

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
