### PR TITLE
Shrinking for `constrained-generators`

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances.hs
@@ -261,6 +261,7 @@ instance (IsConwayUniv fn, Crypto c, Typeable index) => HasSpec fn (SafeHash c i
   emptySpec = ()
   combineSpec _ _ = TrueSpec
   genFromTypeSpec _ = pureGen arbitrary
+  shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
   toPreds _ _ = toPred True
 
@@ -275,6 +276,7 @@ instance (IsConwayUniv fn, Typeable r, Crypto c) => HasSpec fn (KeyHash r c) whe
   emptySpec = ()
   combineSpec _ _ = TrueSpec
   genFromTypeSpec _ = pureGen arbitrary
+  shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
   toPreds _ _ = toPred True
 
@@ -356,6 +358,7 @@ instance IsConwayUniv fn => HasSpec fn PV1.Data where
   emptySpec = ()
   combineSpec _ _ = TrueSpec
   genFromTypeSpec _ = pureGen arbitrary
+  shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
   toPreds _ _ = toPred True
 
@@ -443,6 +446,7 @@ instance (IsConwayUniv fn, Crypto (EraCrypto era), Era era) => HasSpec fn (Timel
   emptySpec = ()
   combineSpec _ _ = TrueSpec
   genFromTypeSpec _ = pureGen arbitrary
+  shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
   toPreds _ _ = toPred True
 
@@ -489,6 +493,7 @@ instance (IsConwayUniv fn, Typeable b) => HasSpec fn (AbstractHash Blake2b_224 b
   genFromTypeSpec _ = do
     bytes <- pureGen $ vectorOf 28 arbitrary
     pure $ fromJust $ abstractHashFromBytes (BS.pack bytes)
+  shrinkWithTypeSpec _ _ = []
   conformsTo _ _ = True
   toPreds _ _ = toPred True
 
@@ -523,6 +528,7 @@ instance (IsConwayUniv fn, HashAlgorithm a, Typeable b) => HasSpec fn (Hash a b)
   emptySpec = ()
   combineSpec _ _ = TrueSpec
   genFromTypeSpec _ = pureGen arbitrary
+  shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
   toPreds _ _ = toPred True
 
@@ -546,6 +552,7 @@ instance IsConwayUniv fn => HasSpec fn StakePoolRelay where
   emptySpec = ()
   combineSpec _ _ = TrueSpec
   genFromTypeSpec _ = pureGen arbitrary
+  shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
   toPreds _ _ = toPred True
 
@@ -559,6 +566,7 @@ instance IsConwayUniv fn => HasSpec fn UnitInterval where
   emptySpec = ()
   combineSpec _ _ = TrueSpec
   genFromTypeSpec _ = pureGen arbitrary
+  shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
   toPreds _ _ = toPred True
 
@@ -569,6 +577,7 @@ instance IsConwayUniv fn => HasSpec fn NonNegativeInterval where
   emptySpec = ()
   combineSpec _ _ = TrueSpec
   genFromTypeSpec _ = pureGen arbitrary
+  shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
   toPreds _ _ = toPred True
 
@@ -586,6 +595,7 @@ instance IsConwayUniv fn => HasSpec fn Text where
   emptySpec = ()
   combineSpec _ _ = TrueSpec
   genFromTypeSpec _ = pureGen arbitrary
+  shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
   toPreds _ _ = toPred True
 
@@ -606,6 +616,7 @@ instance IsConwayUniv fn => HasSpec fn ByteString where
   genFromTypeSpec (StringSpec ls) = do
     len <- genFromSpec ls
     BS.pack <$> vectorOfT len (pureGen arbitrary)
+  shrinkWithTypeSpec _ = shrink
   conformsTo bs (StringSpec ls) = BS.length bs `conformsToSpec` ls
   toPreds str (StringSpec len) = satisfies (strLen_ str) len
 
@@ -616,6 +627,7 @@ instance IsConwayUniv fn => HasSpec fn ShortByteString where
   genFromTypeSpec (StringSpec ls) = do
     len <- genFromSpec ls
     SBS.pack <$> vectorOfT len (pureGen arbitrary)
+  shrinkWithTypeSpec _ = shrink
   conformsTo bs (StringSpec ls) = SBS.length bs `conformsToSpec` ls
   toPreds str (StringSpec len) = satisfies (strLen_ str) len
 
@@ -730,12 +742,13 @@ instance IsConwayUniv fn => HasSpec fn ProtVer
 -- while ensuring that we don't have to add instances for e.g. `Num`
 -- to version.
 newtype VersionRep = VersionRep Word8
-  deriving (Show, Eq, Ord, Num, Random) via Word8
+  deriving (Show, Eq, Ord, Num, Random, Arbitrary) via Word8
 instance BaseUniverse fn => HasSpec fn VersionRep where
   type TypeSpec fn VersionRep = NumSpec VersionRep
   emptySpec = emptyNumSpec
   combineSpec = combineNumSpec
   genFromTypeSpec = genFromNumSpec
+  shrinkWithTypeSpec = shrinkWithNumSpec
   conformsTo = conformsToNumSpec
   toPreds = toPredsNumSpec
 instance Bounded VersionRep where
@@ -851,6 +864,7 @@ instance IsConwayUniv fn => HasSpec fn Char where
   emptySpec = ()
   combineSpec _ _ = TrueSpec
   genFromTypeSpec _ = pureGen arbitrary
+  shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
   toPreds _ _ = toPred True
 
@@ -859,6 +873,7 @@ instance IsConwayUniv fn => HasSpec fn CostModel where
   emptySpec = ()
   combineSpec _ _ = TrueSpec
   genFromTypeSpec _ = pureGen arbitrary
+  shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
   toPreds _ _ = toPred True
 
@@ -1256,6 +1271,7 @@ instance (IsConwayUniv fn, Crypto c, Typeable r) => HasSpec fn (WitVKey r c) whe
   emptySpec = ()
   combineSpec _ _ = TrueSpec
   genFromTypeSpec _ = pureGen arbitrary
+  shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
   toPreds _ _ = toPred True
 
@@ -1264,6 +1280,7 @@ instance (IsConwayUniv fn, Crypto c) => HasSpec fn (BootstrapWitness c) where
   emptySpec = ()
   combineSpec _ _ = TrueSpec
   genFromTypeSpec _ = pureGen arbitrary
+  shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
   toPreds _ _ = toPred True
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -45,7 +45,7 @@ import Test.Tasty.QuickCheck
 type GenShrink a = (Gen a, a -> [a])
 
 genShrinkFromSpec :: forall fn a. HasSpec fn a => Spec fn a -> GenShrink a
-genShrinkFromSpec spec = (genFromSpec_ @fn spec, const [])
+genShrinkFromSpec spec = (genFromSpec_ @fn spec, shrinkWithSpec @fn spec)
 
 stsPropertyV2 ::
   forall r fn era env st sig fail p.

--- a/libs/constrained-generators/src/Constrained.hs
+++ b/libs/constrained-generators/src/Constrained.hs
@@ -40,6 +40,7 @@ module Constrained (
   genFromSpec,
   genFromSpec_,
   genFromSpecWithSeed,
+  shrinkWithSpec,
   conformsToSpec,
   conformsToSpecProp,
   giveHint,
@@ -99,6 +100,7 @@ module Constrained (
   emptyNumSpec,
   combineNumSpec,
   genFromNumSpec,
+  shrinkWithNumSpec,
   conformsToNumSpec,
   toPredsNumSpec,
   -- TODO: this is super yucky, it would be good to implement

--- a/libs/constrained-generators/src/Constrained/Spec/Maps.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Maps.hs
@@ -27,6 +27,7 @@ import Data.Map qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Prettyprinter
+import Test.QuickCheck (shrinkList)
 
 ------------------------------------------------------------------------
 -- HasSpec
@@ -130,6 +131,8 @@ instance
               $ genFromSpec keySpec
           go (Map.insert k v m) restVals'
     go (Map.fromList mustMap) restVals
+
+  shrinkWithTypeSpec (MapSpec _ _ _ kvs _) m = map Map.fromList $ shrinkList (shrinkWithSpec kvs) (Map.toList m)
 
   toPreds m (MapSpec mustKeys mustVals size kvs foldSpec) =
     toPred

--- a/libs/constrained-generators/src/Constrained/Spec/Pairs.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Pairs.hs
@@ -49,6 +49,10 @@ instance (HasSpec fn a, HasSpec fn b) => HasSpec fn (Prod a b) where
 
   genFromTypeSpec (Cartesian sa sb) = Prod <$> genFromSpec sa <*> genFromSpec sb
 
+  shrinkWithTypeSpec (Cartesian sa sb) (Prod a b) =
+    [Prod a' b | a' <- shrinkWithSpec sa a]
+      ++ [Prod a b' | b' <- shrinkWithSpec sb b]
+
   toPreds x (Cartesian sf ss) =
     satisfies (app fstFn x) sf
       <> satisfies (app sndFn x) ss


### PR DESCRIPTION
# Description

This implements shrinking for `constrained-generators` by embedding it in the `HasSpec` class. There are still some TODOs that need to be covered but this should be relatively ready to look at.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
