### PR TITLE
Revert to full formolu runs on CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -158,9 +158,7 @@ jobs:
         echo "$HOME/.local/bin" >> $GITHUB_PATH
 
     - name: Run fourmolu
-      run: |
-        git fetch --no-tags --prune --depth=1 origin +refs/heads/master:refs/remotes/origin/master
-        ./scripts/fourmolize.sh --changes
+      run: ./scripts/fourmolize.sh
 
   cabal-format:
     runs-on: ubuntu-latest

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Internal.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Internal.hs
@@ -456,7 +456,7 @@ isDRepVotingAllowed ::
 isDRepVotingAllowed =
   isVotingAllowed . votingDRepThresholdInternal pp isElectedCommittee
   where
-    -- Information about presence of committe or values in PParams are irrelevant for
+    -- Information about presence of committee or values in PParams are irrelevant for
     -- knowing if voting is allowed or not:
     pp = emptyPParams
     isElectedCommittee = False

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
@@ -301,13 +301,14 @@ mkProposals pgais omap = do
 --
 -- WARNING: Should only be used for testing!
 unsafeMkProposals ::
+  HasCallStack =>
   GovRelation StrictMaybe era ->
   OMap.OMap (GovActionId (EraCrypto era)) (GovActionState era) ->
   Proposals era
-unsafeMkProposals pgais omap = foldl' (flip unsafeProposalsAddAction) initialProposals omap
+unsafeMkProposals pgais omap = foldl' unsafeProposalsAddAction initialProposals omap
   where
     initialProposals = def & pRootsL .~ fromPrevGovActionIds pgais
-    unsafeProposalsAddAction gas ps =
+    unsafeProposalsAddAction ps gas =
       case runProposalsAddAction gas ps of
         Just p -> p
         Nothing -> error $ "unsafeMkProposals: runProposalsAddAction failed for " ++ show (gas ^. gasIdL)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
@@ -362,7 +362,7 @@ epochTransition = do
     accountState3 =
       accountState2
         -- Move donations and unclaimed rewards from proposals to treasury:
-        & asTreasuryL <>~ (utxoState0 ^. utxosDonationL <> mconcat (Map.elems unclaimed))
+        & asTreasuryL <>~ (utxoState0 ^. utxosDonationL <> fold unclaimed)
     utxoState2 =
       utxoState1
         & utxosDepositedL .~ totalObligation certState govState1

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
@@ -755,7 +755,7 @@ votingSpec =
       it
         "committee member can't vote on committee update when sandwiched between other votes"
         ccVoteOnConstitutionFailsWithMultipleVotes
-      it "CC cannot ratify if below quorum" $ do
+      it "CC cannot ratify if below threshold" $ do
         modifyPParams $ \pp ->
           pp
             & ppGovActionLifetimeL .~ EpochInterval 3

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -969,7 +969,6 @@ runImpRule stsEnv stsState stsSignal = do
   let ruleName = symbolVal (Proxy @rule)
   (res, ev) <-
     tryRunImpRule @rule stsEnv stsState stsSignal >>= \case
-      Left [] -> error "Impossible: STS rule failed without a predicate failure"
       Left fs ->
         assertFailure $
           unlines $


### PR DESCRIPTION
# Description

We neet to run fourmolu on all files on CI, not just the changed modules.

Consider a PR that updates a fourmolu version. In such case there will be no Haskell files that have been updated, but formatting of many modules could have very well changed.

Few other minor fixes.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
