### PR TITLE
Remove duplicate certificates from conway.cddl

### DIFF
--- a/eras/conway/impl/cddl-files/conway.cddl
+++ b/eras/conway/impl/cddl-files/conway.cddl
@@ -307,10 +307,6 @@ pool_retirement = (4, pool_keyhash, epoch)
 reg_cert = (7, stake_credential, coin)
 unreg_cert = (8, stake_credential, coin)
 vote_deleg_cert = (9, stake_credential, drep)
-stake_vote_deleg_cert = (10, stake_credential, pool_keyhash, drep)
-stake_reg_deleg_cert = (11, stake_credential, pool_keyhash, coin)
-vote_reg_deleg_cert = (12, stake_credential, drep, coin)
-stake_vote_reg_deleg_cert = (13, stake_credential, pool_keyhash, drep, coin)
 
 ; GOVCERT
 auth_committee_hot_cert = (14, committee_cold_credential, committee_hot_credential)


### PR DESCRIPTION
# Description

Previously, if you wanted to do multiple things at once, you had to submit multiple certificates as part of the transaction

However, in Conway, there is now a combinatorial explosion of certificates that do multiple things at the same time (they're just combinations of `stake_delegation`, `reg_cert`, `unreg_cert`, `vote_deleg_cert`

I feel this is wrong because:
1. It increases protocol complexity despite this being easily handled on the wallet layer
2. This doesn't scale if we add more certificates because every new certificate requires more combinations
3. Trezor, Ledger, Eternl and dcSpark have already said they will not support this feature. This is on-track to be another "pointer address" which is a feature designed to save a few bytes that nobody wants to support and just ends up making everything more complex for no reason

Feel free to let me know if you think differently, but otherwise I propose we just remove these