### PR TITLE
Added UnitTestTools and IncrementalStakeTest

### DIFF
--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -105,10 +105,10 @@ library
         bytestring,
         cardano-crypto-class,
         cardano-crypto-wrapper,
-        cardano-data ^>=1.2,
+        cardano-data ^>=1.2.2,
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-byron,
-        cardano-ledger-core ^>=1.11,
+        cardano-ledger-core ^>=1.11.1,
         cardano-slotting,
         vector-map ^>=1.1,
         containers,
@@ -144,6 +144,7 @@ library testlib
         Test.Cardano.Ledger.Shelley.Imp.LedgerSpec
         Test.Cardano.Ledger.Shelley.Imp.UtxowSpec
         Test.Cardano.Ledger.Shelley.TreeDiff
+        Test.Cardano.Ledger.Shelley.UnitTests.IncrementalStakeTest
 
     visibility:       public
     hs-source-dirs:   testlib

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
@@ -13,6 +13,7 @@ import qualified Test.Cardano.Ledger.Shelley.Imp.EpochSpec as Epoch
 import qualified Test.Cardano.Ledger.Shelley.Imp.LedgerSpec as Ledger
 import qualified Test.Cardano.Ledger.Shelley.Imp.UtxowSpec as Utxow
 import Test.Cardano.Ledger.Shelley.ImpTest (ShelleyEraImp, withImpState)
+import qualified Test.Cardano.Ledger.Shelley.UnitTests.IncrementalStakeTest as Incremental
 
 spec ::
   forall era.
@@ -20,8 +21,10 @@ spec ::
   , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
   ) =>
   Spec
-spec =
+spec = do
   describe "ShelleyImpSpec" $ withImpState @era $ do
     Ledger.spec @era
     Epoch.spec @era
     Utxow.spec @era
+  describe "ShelleyPureTests" $ do
+    Incremental.spec @era

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/UnitTests/IncrementalStakeTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/UnitTests/IncrementalStakeTest.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Shelley.UnitTests.IncrementalStakeTest (spec) where
+
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.BaseTypes (Network (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Compactible (fromCompact)
+import Cardano.Ledger.Core (Era (..), EraTxOut, emptyPParams, mkCoinTxOut)
+import Cardano.Ledger.Credential (Credential, StakeReference (..))
+import Cardano.Ledger.EpochBoundary (SnapShot (..), Stake (..))
+import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
+import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.Shelley.LedgerState (
+  IncrementalStake (..),
+  dsUnifiedL,
+  incrementalStakeDistr,
+  psStakePoolParamsL,
+  updateStakeDistribution,
+ )
+import Cardano.Ledger.TxIn (TxIn)
+import Cardano.Ledger.UMap (RDPair (..), rdRewardCoin)
+import qualified Cardano.Ledger.UMap as UM
+import Cardano.Ledger.UTxO (UTxO (..))
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.MonoTuple (TupleN)
+import qualified Data.VMap as VMap
+import Lens.Micro
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Core.Arbitrary ()
+
+ppIdL :: Lens' (PoolParams c) (KeyHash 'StakePool c)
+ppIdL = lens ppId (\x y -> x {ppId = y})
+
+address :: Credential 'Payment c -> Maybe (Credential 'Staking c) -> Addr c
+address pc Nothing = Addr Testnet pc StakeRefNull
+address pc (Just sc) = Addr Testnet pc (StakeRefBase sc)
+
+arbitraryLens :: Arbitrary a => Lens' a b -> b -> Gen a
+arbitraryLens l b = do a <- arbitrary; pure (a & l .~ b)
+
+-- ===========================================
+
+stakeDistrIncludesRewards :: forall era. EraTxOut era => Gen Property
+stakeDistrIncludesRewards = do
+  (tom, john, ann, ron, mary) <- arbitrary @(TupleN 5 (Credential 'Staking (EraCrypto era)))
+  (tomPay, johnPay, annPay, ronPay) <- arbitrary @(TupleN 4 (Credential 'Payment (EraCrypto era)))
+
+  (pool1, pool2) <- arbitrary @(TupleN 2 (KeyHash 'StakePool (EraCrypto era)))
+  pool1Params <- arbitraryLens ppIdL pool1
+  pool2Params <- arbitraryLens ppIdL pool2
+
+  (tomRD, johnRD, annRD, ronRD, maryRD) <- arbitrary @(TupleN 5 RDPair)
+
+  let tomAddr = address tomPay Nothing -- Nothing means tomAddr does not have a StakeReference
+      johnAddr = address johnPay (Just john)
+      annAddr = address annPay (Just ann)
+      ronAddr = address ronPay (Just ron)
+      -- maryAddr is omitted on purpose. Mary will not have a UTxO entry
+
+      rewards :: Map (Credential 'Staking (EraCrypto era)) RDPair
+      rewards =
+        Map.fromList
+          [ (tom, tomRD)
+          , (john, johnRD)
+          , (ann, annRD)
+          , (ron, ronRD)
+          , (mary, maryRD)
+          ]
+
+      delegations :: Map (Credential 'Staking (EraCrypto era)) (KeyHash 'StakePool (EraCrypto era))
+      delegations =
+        Map.fromList
+          [ (tom, pool1) -- since every one is delegated
+          , (ann, pool2) -- no one's stake should be left out
+          , (ron, pool1)
+          , (john, pool2)
+          , (mary, pool2)
+          ]
+
+  -- Again mary is not included, because she will not have an UTxO entry, but tom will have 2
+  (tomCoin1, tomCoin2, johnCoin, annCoin, ronCoin) <- arbitrary @(TupleN 5 Coin)
+
+  (tomTxIn1, tomTxIn2, johnTxIn, annTxIn, ronTxIn) <- arbitrary @(TupleN 5 (TxIn (EraCrypto era)))
+
+  let
+    -- Each wallet (except mary) has one or more UTxO entries
+    -- Since tom uses a StakeRefNull those entries will not be distributed
+    utxo1 =
+      UTxO @era
+        ( Map.fromList
+            [ (tomTxIn1, mkCoinTxOut tomAddr tomCoin1) -- Not distrubuted, see tomAddr
+            , (tomTxIn2, mkCoinTxOut tomAddr tomCoin2) -- Not distributed, see tomAddr
+            , (annTxIn, mkCoinTxOut annAddr annCoin)
+            , (ronTxIn, mkCoinTxOut ronAddr ronCoin)
+            , (johnTxIn, mkCoinTxOut johnAddr johnCoin)
+            -- Note Mary does not have a UTxO entry, but her rewards are still counted
+            ]
+        )
+
+    pparams = emptyPParams @era
+
+    incrementalStake = updateStakeDistribution pparams (IStake mempty mempty) mempty utxo1
+    umap = UM.unify rewards Map.empty delegations Map.empty
+    poolparamMap = Map.fromList [(pool1, pool1Params), (pool2, pool2Params)]
+  -- We can either use an emptyDstate with just the umap, like this
+  -- dState = (emptyDState {dsUnified = umap}) :: DState era
+  -- Or an arbitrary one, where we overwrite the umap, with the one we need.
+  dState <- arbitraryLens dsUnifiedL umap
+  pState <- arbitraryLens psStakePoolParamsL poolparamMap
+  let computedStakeDistr = Map.map fromCompact (VMap.toMap (unStake (ssStake snap)))
+        where
+          snap =
+            incrementalStakeDistr -- This computes the actual Incremental Stake
+              pparams
+              incrementalStake
+              dState
+              pState
+
+      expectedStakeDistr :: Map (Credential 'Staking (EraCrypto era)) Coin
+      expectedStakeDistr =
+        Map.fromList -- Coin Part is (rdRewardCoin <> utxoCoin)
+          [ (tom, rdRewardCoin tomRD <> Coin 0) -- tom uxtxoCoin is zero because his address has StakeRefNull
+          , (ann, rdRewardCoin annRD <> annCoin)
+          , (ron, rdRewardCoin ronRD <> ronCoin)
+          , (john, rdRewardCoin johnRD <> johnCoin)
+          , (mary, rdRewardCoin maryRD <> Coin 0) -- mary uxtxoCoin is zero because she has no UtxO entry
+          ]
+
+  pure $ (computedStakeDistr === expectedStakeDistr)
+
+spec :: forall era. EraTxOut era => Spec
+spec = prop "StakeDistrIncludesRewards" (stakeDistrIncludesRewards @era)

--- a/libs/cardano-data/CHANGELOG.md
+++ b/libs/cardano-data/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2.2.0
 
 * Add `assocList`
+* Add module Data.MonoTuple
 
 ## 1.2.1.0
 

--- a/libs/cardano-data/cardano-data.cabal
+++ b/libs/cardano-data/cardano-data.cabal
@@ -24,6 +24,7 @@ library
         Data.Universe
         Data.OSet.Strict
         Data.OMap.Strict
+        Data.MonoTuple
 
     hs-source-dirs:   src
     default-language: Haskell2010

--- a/libs/cardano-data/src/Data/MonoTuple.hs
+++ b/libs/cardano-data/src/Data/MonoTuple.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Supports creating tuples (where all components have the same type) as Fixed length lists.
+module Data.MonoTuple (
+  TupleN,
+) where
+
+import GHC.TypeNats (Nat)
+
+-- =========================================
+
+type family TupleN (n :: Nat) a where
+  TupleN 0 a = ()
+  TupleN 1 a = a
+  TupleN 2 a = (a, a)
+  TupleN 3 a = (a, a, a)
+  TupleN 4 a = (a, a, a, a)
+  TupleN 5 a = (a, a, a, a, a)
+  TupleN 6 a = (a, a, a, a, a, a)
+  TupleN 7 a = (a, a, a, a, a, a, a)
+  TupleN 8 a = (a, a, a, a, a, a, a, a)
+  TupleN 9 a = (a, a, a, a, a, a, a, a, a)
+  TupleN 10 a = (a, a, a, a, a, a, a, a, a, a)

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Add trivial `Inject` instances for `()` and `Void`
 * Add `byteStringToNum`
+* Add functions `rdRewardCoin`, `rdDepositCoin` in UMap.hs
+* Add function `mkCoinTxOut` in Core.hs
 
 ## 1.11.0.0
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -39,6 +39,7 @@ module Cardano.Ledger.Core (
   hashScriptTxWitsL,
   Value,
   EraPParams (..),
+  mkCoinTxOut,
 
   -- * Era
   module Cardano.Ledger.Core.Era,
@@ -104,7 +105,7 @@ import Cardano.Ledger.MemoBytes
 import Cardano.Ledger.Rewards (Reward (..), RewardType (..))
 import Cardano.Ledger.SafeHash (HashAnnotated (..), SafeToHash (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
-import Cardano.Ledger.Val (Val (..))
+import Cardano.Ledger.Val (Val (..), inject)
 import Control.DeepSeq (NFData)
 import Data.Aeson (ToJSON)
 import qualified Data.ByteString as BS
@@ -424,6 +425,10 @@ isAdaOnlyTxOutF = to $ \txOut ->
 toCompactPartial :: (HasCallStack, Val a) => a -> CompactForm a
 toCompactPartial v =
   fromMaybe (error $ "Illegal value in TxOut: " <> show v) $ toCompact v
+
+-- A version of mkBasicTxOut, which has only a Coin (no multiAssets) for every EraTxOut era.
+mkCoinTxOut :: EraTxOut era => Addr (EraCrypto era) -> Coin -> TxOut era
+mkCoinTxOut addr = mkBasicTxOut addr . inject
 
 -- | A value is something which quantifies a transaction output.
 type family Value era :: Type

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/UMap.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/UMap.hs
@@ -25,6 +25,8 @@
 module Cardano.Ledger.UMap (
   -- * Constructing a `UMap`
   RDPair (..),
+  rdRewardCoin,
+  rdDepositCoin,
   UMElem (UMElem),
   umElemRDPair,
   umElemRDActive,
@@ -140,6 +142,14 @@ data RDPair = RDPair
   , rdDeposit :: {-# UNPACK #-} !(CompactForm Coin)
   }
   deriving (Show, Eq, Ord, Generic, NoThunks, NFData)
+
+-- rdReward and rdDeposit return a (CompactForm Coin), These return a Coin.
+
+rdRewardCoin :: RDPair -> Coin
+rdRewardCoin rdp = fromCompact (rdReward rdp)
+
+rdDepositCoin :: RDPair -> Coin
+rdDepositCoin rdp = fromCompact (rdDeposit rdp)
 
 instance EncCBOR RDPair where
   encCBOR RDPair {rdReward, rdDeposit} =


### PR DESCRIPTION
This is a second try at addressing #4171.
It replaces PR #4211, which has been abandoned.

Issue #4171 identified some potential problems with the code in [eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/IncrementalStake.hs]. It suggested some tests to resolve the issue. Such a test need specific values with types such as Credential, StakeReference, UtxO, IncrementalStake, PParams, Rewards, Deposits, all with complex interrelation-ships.

Test.Cardano.Ledger.UnitTestTools makes it easy to express such relationships
Test.Cardano.Ledger.Shelley.UnitTests.IncrementalStakeTest exhibits a test, that resolves the issue.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
