### PR TITLE
Stop generating Haddocks for internal modules

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -75,7 +75,7 @@ jobs:
         git commit -qm "Updated from ${GITHUB_SHA} via ${GITHUB_EVENT_NAME}"
 
     - name: Push to gh-pages
-      uses: ad-m/github-push-action@v0.6.0
+      uses: ad-m/github-push-action@v0.8.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: gh-pages

--- a/scripts/haddocks.sh
+++ b/scripts/haddocks.sh
@@ -32,7 +32,6 @@ HADDOCK_OPTS=(
   --haddock-all
   --haddock-html
   --haddock-hyperlink-source
-  --haddock-internal
   --haddock-option "--show-all"
   --haddock-option "--use-unicode"
   --haddock-option="--base-url=.."


### PR DESCRIPTION
# Description

It doesn't make sense to generate haddock for modules that can't be imported from outside of the package.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
