### PR TITLE
Undeprecate redeemerPointer and expose it in cardano-ledger-api

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.7.1.0
 
 * Add `ToJSON` instances for `FailureDescription` and `TagMismatchDescription`
+* Undeprecate `redeemerPointer`.
 
 ## 1.7.0.0
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -173,7 +173,6 @@ class (MaryEraTxBody era, AlonzoEraTxOut era) => AlonzoEraTxBody era where
     TxBody era ->
     PlutusPurpose AsIx era ->
     StrictMaybe (PlutusPurpose AsIxItem era)
-{-# DEPRECATED redeemerPointer "As no longer needed" #-}
 
 -- ======================================
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-api`
 
-## 1.9.0.1
+## 1.9.1.0
 
-*
+* Add `redeemerPointer` and `redeemerPointerInverse`.
 
 ## 1.9.0.0
 

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-api
-version:            1.9.0.0
+version:            1.9.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Body.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Body.hs
@@ -47,6 +47,8 @@ module Cardano.Ledger.Api.Tx.Body (
   reqSignerHashesTxBodyL,
   scriptIntegrityHashTxBodyL,
   networkIdTxBodyL,
+  redeemerPointer,
+  redeemerPointerInverse,
 
   -- * Babbage Era
   BabbageEraTxBody,


### PR DESCRIPTION
# Description

User code may still rely on this as there is no other "off-the-shelf" conversion from an AsItem -> AsIx. As the alternative would be to implement this index lookup (e.g. for AlonzoSpending purpose) in user applications, we decide to rather keep it and expose it on the cardano-ledger-api.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
