### PR TITLE
Inline UTxO and UTxOW `PredFailure` for `Conway`

### DIFF
--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.8.0.0
 
+* Make `utxoTransition` more general
 * Change the return type of `collAdaBalance` to `DeltaCoin`
 * Change the type of the provided collateral field in `IncorrectTotalCollateralField` to `DeltaCoin`
 * Change the type of `validateCollateralEqBalance`

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -456,7 +456,6 @@ instance
   , Environment (EraRule "UTXOS" era) ~ UtxoEnv era
   , State (EraRule "UTXOS" era) ~ UTxOState era
   , Signal (EraRule "UTXOS" era) ~ Tx era
-  , PredicateFailure (EraRule "UTXO" era) ~ BabbageUtxoPredFailure era
   ) =>
   STS (BabbageUTXO era)
   where

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -346,13 +346,17 @@ utxoTransition ::
   , BabbageEraTxBody era
   , AlonzoEraTxWits era
   , Tx era ~ AlonzoTx era
-  , EraRule "UTXO" era ~ BabbageUTXO era
   , InjectRuleFailure "UTXO" ShelleyUtxoPredFailure era
   , InjectRuleFailure "UTXO" AllegraUtxoPredFailure era
   , InjectRuleFailure "UTXO" AlonzoUtxoPredFailure era
   , InjectRuleFailure "UTXO" BabbageUtxoPredFailure era
+  , Environment (EraRule "UTXO" era) ~ UtxoEnv era
+  , State (EraRule "UTXO" era) ~ UTxOState era
+  , Signal (EraRule "UTXO" era) ~ AlonzoTx era
+  , BaseM (EraRule "UTXO" era) ~ ShelleyBase
+  , STS (EraRule "UTXO" era)
   , -- In this function we we call the UTXOS rule, so we need some assumptions
-    Embed (EraRule "UTXOS" era) (BabbageUTXO era)
+    Embed (EraRule "UTXOS" era) (EraRule "UTXO" era)
   , Environment (EraRule "UTXOS" era) ~ UtxoEnv era
   , State (EraRule "UTXOS" era) ~ UTxOState era
   , Signal (EraRule "UTXOS" era) ~ Tx era

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## 1.14.0 0
 
+* Add `ConwayUtxowPredFailure` era rule failure:
+  * Implement its `InjectRuleFailure` instances for:
+    * `BBODY`
+    * `LEDGER`
+    * `LEDGERS`
+    * `UTXOW`
+  * Implement instances:
+    * `Generic`
+    * `Show`
+    * `Eq`
+    * `EncCBOR`
+    * `DecCBOR`
+    * `NFData`
+  * Add mappings:
+    * `babbageToConwayUtxowPredFailure`
+    * `alonzoToConwayUtxowPredFailure`
+    * `shelleyToConwayUtxowPredFailure`
+  * Update `Embed (ConwayUTXO era) (ConwayUTXOW era)` instance
 * Add `ConwayUtxoPredFailure` era rule failure:
   * Implement its `InjectRuleFailure` instances for:
     * `BBODY`
@@ -31,6 +49,9 @@
 
 ### `testlib`
 
+* Implement `ConwayUtxowPredFailure` instances:
+  * `Arbitrary`
+  * `ToExpr`
 * Implement `ConwayUtxoPredFailure` instances:
   * `Arbitrary`
   * `ToExpr`

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,12 +2,38 @@
 
 ## 1.14.0 0
 
+* Add `ConwayUtxoPredFailure` era rule failure:
+  * Implement its `InjectRuleFailure` instances for:
+    * `BBODY`
+    * `LEDGER`
+    * `LEDGERS`
+    * `UTXO`
+    * `UTXOW`
+  * Implement instances:
+    * `Generic`
+    * `Show`
+    * `Eq`
+    * `EncCBOR`
+    * `DecCBOR`
+    * `NFData`
+  * Add mappings:
+    * `babbageToConwayUtxoPredFailure`
+    * `alonzoToConwayUtxoPredFailure`
+  * Update `allegraToConwayUtxoPredFailure` mapping
+* Add `ConwayUTXO` era rule:
+  * Implement instances:
+    * `STS`
+    * `Embed (ConwayUTXOS era) (ConwayUTXO era)`
+    * `Embed (ConwayUTXO era) (ConwayUTXOW era)`
 * Add `ucppPlutusV3CostModel` to `UpgradeConwayPParams`. #4252
   * Remove the `Default` instance for `ConwayGenesis`.
 * Add `foldrVotingProcedures`.
 
 ### `testlib`
 
+* Implement `ConwayUtxoPredFailure` instances:
+  * `Arbitrary`
+  * `ToExpr`
 * Updated `exampleConwayGenesis` to `conway-genesis.json`. #4252
 
 ## 1.13.1.0

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
@@ -11,6 +11,7 @@ module Cardano.Ledger.Conway.Era (
   ConwayNEWEPOCH,
   ConwayEPOCH,
   ConwayENACT,
+  ConwayUTXO,
   ConwayUTXOS,
   ConwayUTXOW,
   ConwayTICKF,
@@ -20,7 +21,6 @@ module Cardano.Ledger.Conway.Era (
 
 import Cardano.Ledger.Alonzo.Rules (AlonzoBBODY)
 import Cardano.Ledger.Babbage (BabbageEra)
-import Cardano.Ledger.Babbage.Rules (BabbageUTXO)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Mary.Value (MaryValue)
@@ -127,9 +127,9 @@ data ConwayUTXOW era
 
 type instance EraRule "UTXOW" (ConwayEra c) = ConwayUTXOW (ConwayEra c)
 
--- Rules inherited from Babbage
+data ConwayUTXO era
 
-type instance EraRule "UTXO" (ConwayEra c) = BabbageUTXO (ConwayEra c)
+type instance EraRule "UTXO" (ConwayEra c) = ConwayUTXO (ConwayEra c)
 
 -- Rules inherited from Alonzo
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules.hs
@@ -15,6 +15,7 @@ module Cardano.Ledger.Conway.Rules (
   module Cardano.Ledger.Conway.Rules.Tickf,
   module Cardano.Ledger.Conway.Rules.Ratify,
   module Cardano.Ledger.Conway.Rules.Gov,
+  module Cardano.Ledger.Conway.Rules.Utxo,
   module Cardano.Ledger.Conway.Rules.Utxos,
   module Cardano.Ledger.Conway.Rules.Utxow,
 )
@@ -36,7 +37,7 @@ import Cardano.Ledger.Conway.Rules.NewEpoch
 import Cardano.Ledger.Conway.Rules.Pool ()
 import Cardano.Ledger.Conway.Rules.Ratify
 import Cardano.Ledger.Conway.Rules.Tickf
-import Cardano.Ledger.Conway.Rules.Utxo ()
+import Cardano.Ledger.Conway.Rules.Utxo
 import Cardano.Ledger.Conway.Rules.Utxos
 import Cardano.Ledger.Conway.Rules.Utxow
 import Cardano.Ledger.Shelley.Rules (ShelleyTickEvent (..))

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
@@ -35,6 +35,7 @@ import Cardano.Ledger.Conway.Rules.Ledger (ConwayLedgerPredFailure)
 import Cardano.Ledger.Conway.Rules.Ledgers ()
 import Cardano.Ledger.Conway.Rules.Utxo (ConwayUtxoPredFailure)
 import Cardano.Ledger.Conway.Rules.Utxos (ConwayUtxosPredFailure)
+import Cardano.Ledger.Conway.Rules.Utxow (ConwayUtxowPredFailure)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Rules (
   ShelleyBbodyPredFailure (..),
@@ -57,6 +58,9 @@ instance InjectRuleFailure "BBODY" ShelleyLedgersPredFailure (ConwayEra c) where
   injectFailure = ShelleyInAlonzoBbodyPredFailure . LedgersFailure
 
 instance InjectRuleFailure "BBODY" ConwayLedgerPredFailure (ConwayEra c) where
+  injectFailure = ShelleyInAlonzoBbodyPredFailure . LedgersFailure . injectFailure
+
+instance InjectRuleFailure "BBODY" ConwayUtxowPredFailure (ConwayEra c) where
   injectFailure = ShelleyInAlonzoBbodyPredFailure . LedgersFailure . injectFailure
 
 instance InjectRuleFailure "BBODY" BabbageUtxowPredFailure (ConwayEra c) where

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
@@ -33,6 +33,7 @@ import Cardano.Ledger.Conway.Rules.Gov (ConwayGovPredFailure)
 import Cardano.Ledger.Conway.Rules.GovCert (ConwayGovCertPredFailure)
 import Cardano.Ledger.Conway.Rules.Ledger (ConwayLedgerPredFailure)
 import Cardano.Ledger.Conway.Rules.Ledgers ()
+import Cardano.Ledger.Conway.Rules.Utxo (ConwayUtxoPredFailure)
 import Cardano.Ledger.Conway.Rules.Utxos (ConwayUtxosPredFailure)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Rules (
@@ -65,6 +66,9 @@ instance InjectRuleFailure "BBODY" AlonzoUtxowPredFailure (ConwayEra c) where
   injectFailure = ShelleyInAlonzoBbodyPredFailure . LedgersFailure . injectFailure
 
 instance InjectRuleFailure "BBODY" ShelleyUtxowPredFailure (ConwayEra c) where
+  injectFailure = ShelleyInAlonzoBbodyPredFailure . LedgersFailure . injectFailure
+
+instance InjectRuleFailure "BBODY" ConwayUtxoPredFailure (ConwayEra c) where
   injectFailure = ShelleyInAlonzoBbodyPredFailure . LedgersFailure . injectFailure
 
 instance InjectRuleFailure "BBODY" BabbageUtxoPredFailure (ConwayEra c) where

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -67,6 +67,7 @@ import Cardano.Ledger.Conway.Rules.Gov (
   GovEnv (..),
  )
 import Cardano.Ledger.Conway.Rules.GovCert (ConwayGovCertPredFailure)
+import Cardano.Ledger.Conway.Rules.Utxo (ConwayUtxoPredFailure)
 import Cardano.Ledger.Conway.Rules.Utxos (ConwayUtxosPredFailure)
 import Cardano.Ledger.Conway.Rules.Utxow ()
 import Cardano.Ledger.Credential (Credential)
@@ -146,6 +147,9 @@ instance InjectRuleFailure "LEDGER" AlonzoUtxowPredFailure (ConwayEra c) where
   injectFailure = ConwayUtxowFailure . injectFailure
 
 instance InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure (ConwayEra c) where
+  injectFailure = ConwayUtxowFailure . injectFailure
+
+instance InjectRuleFailure "LEDGER" ConwayUtxoPredFailure (ConwayEra c) where
   injectFailure = ConwayUtxowFailure . injectFailure
 
 instance InjectRuleFailure "LEDGER" BabbageUtxoPredFailure (ConwayEra c) where

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -69,7 +69,7 @@ import Cardano.Ledger.Conway.Rules.Gov (
 import Cardano.Ledger.Conway.Rules.GovCert (ConwayGovCertPredFailure)
 import Cardano.Ledger.Conway.Rules.Utxo (ConwayUtxoPredFailure)
 import Cardano.Ledger.Conway.Rules.Utxos (ConwayUtxosPredFailure)
-import Cardano.Ledger.Conway.Rules.Utxow ()
+import Cardano.Ledger.Conway.Rules.Utxow (ConwayUtxowPredFailure)
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Crypto (Crypto (..))
 import Cardano.Ledger.Keys (KeyRole (..))
@@ -140,8 +140,11 @@ type instance EraRuleEvent "LEDGER" (ConwayEra c) = ConwayLedgerEvent (ConwayEra
 
 instance InjectRuleFailure "LEDGER" ConwayLedgerPredFailure (ConwayEra c)
 
-instance InjectRuleFailure "LEDGER" BabbageUtxowPredFailure (ConwayEra c) where
+instance InjectRuleFailure "LEDGER" ConwayUtxowPredFailure (ConwayEra c) where
   injectFailure = ConwayUtxowFailure
+
+instance InjectRuleFailure "LEDGER" BabbageUtxowPredFailure (ConwayEra c) where
+  injectFailure = ConwayUtxowFailure . injectFailure
 
 instance InjectRuleFailure "LEDGER" AlonzoUtxowPredFailure (ConwayEra c) where
   injectFailure = ConwayUtxowFailure . injectFailure
@@ -426,10 +429,10 @@ instance
   , TxOut era ~ BabbageTxOut era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , Signal (EraRule "UTXO" era) ~ Tx era
-  , PredicateFailure (EraRule "UTXOW" era) ~ BabbageUtxowPredFailure era
+  , PredicateFailure (EraRule "UTXOW" era) ~ ConwayUtxowPredFailure era
   , Event (EraRule "UTXOW" era) ~ AlonzoUtxowEvent era
   , STS (ConwayUTXOW era)
-  , PredicateFailure (ConwayUTXOW era) ~ BabbageUtxowPredFailure era
+  , PredicateFailure (ConwayUTXOW era) ~ ConwayUtxowPredFailure era
   , Event (ConwayUTXOW era) ~ AlonzoUtxowEvent era
   ) =>
   Embed (ConwayUTXOW era) (ConwayLEDGER era)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledgers.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledgers.hs
@@ -21,6 +21,7 @@ import Cardano.Ledger.Conway.Rules.GovCert (ConwayGovCertPredFailure)
 import Cardano.Ledger.Conway.Rules.Ledger (ConwayLedgerPredFailure)
 import Cardano.Ledger.Conway.Rules.Utxo (ConwayUtxoPredFailure)
 import Cardano.Ledger.Conway.Rules.Utxos (ConwayUtxosPredFailure)
+import Cardano.Ledger.Conway.Rules.Utxow (ConwayUtxowPredFailure)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Rules (
   ShelleyLedgersEvent,
@@ -38,6 +39,9 @@ instance InjectRuleFailure "LEDGERS" ShelleyLedgersPredFailure (ConwayEra c)
 
 instance InjectRuleFailure "LEDGERS" ConwayLedgerPredFailure (ConwayEra c) where
   injectFailure = LedgerFailure
+
+instance InjectRuleFailure "LEDGERS" ConwayUtxowPredFailure (ConwayEra c) where
+  injectFailure = LedgerFailure . injectFailure
 
 instance InjectRuleFailure "LEDGERS" BabbageUtxowPredFailure (ConwayEra c) where
   injectFailure = LedgerFailure . injectFailure

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledgers.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledgers.hs
@@ -19,6 +19,7 @@ import Cardano.Ledger.Conway.Rules.Deleg (ConwayDelegPredFailure)
 import Cardano.Ledger.Conway.Rules.Gov (ConwayGovPredFailure)
 import Cardano.Ledger.Conway.Rules.GovCert (ConwayGovCertPredFailure)
 import Cardano.Ledger.Conway.Rules.Ledger (ConwayLedgerPredFailure)
+import Cardano.Ledger.Conway.Rules.Utxo (ConwayUtxoPredFailure)
 import Cardano.Ledger.Conway.Rules.Utxos (ConwayUtxosPredFailure)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Rules (
@@ -45,6 +46,9 @@ instance InjectRuleFailure "LEDGERS" AlonzoUtxowPredFailure (ConwayEra c) where
   injectFailure = LedgerFailure . injectFailure
 
 instance InjectRuleFailure "LEDGERS" ShelleyUtxowPredFailure (ConwayEra c) where
+  injectFailure = LedgerFailure . injectFailure
+
+instance InjectRuleFailure "LEDGERS" ConwayUtxoPredFailure (ConwayEra c) where
   injectFailure = LedgerFailure . injectFailure
 
 instance InjectRuleFailure "LEDGERS" BabbageUtxoPredFailure (ConwayEra c) where

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -1,58 +1,402 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Cardano.Ledger.Conway.Rules.Utxo (allegraToConwayUtxoPredFailure) where
+module Cardano.Ledger.Conway.Rules.Utxo (
+  allegraToConwayUtxoPredFailure,
+  babbageToConwayUtxoPredFailure,
+  alonzoToConwayUtxoPredFailure,
+  ConwayUtxoPredFailure (..),
+) where
 
-import Cardano.Ledger.Allegra.Rules (shelleyToAllegraUtxoPredFailure)
+import Cardano.Ledger.Address (Addr, RewardAccount)
+import Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure, shelleyToAllegraUtxoPredFailure)
 import qualified Cardano.Ledger.Allegra.Rules as Allegra (AllegraUtxoPredFailure (..))
 import Cardano.Ledger.Alonzo.Rules (
   AlonzoUtxoEvent,
-  AlonzoUtxoPredFailure (..),
+  AlonzoUtxoPredFailure,
   AlonzoUtxosPredFailure,
  )
-import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure (..))
-import Cardano.Ledger.Conway.Era (ConwayEra)
-import Cardano.Ledger.Conway.Rules.Utxos (ConwayUtxosPredFailure)
-import Cardano.Ledger.Core
+import qualified Cardano.Ledger.Alonzo.Rules as Alonzo (
+  AlonzoUtxoEvent (UtxosEvent),
+  AlonzoUtxoPredFailure (..),
+ )
+import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..))
+import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure)
+import qualified Cardano.Ledger.Babbage.Rules as Babbage (
+  BabbageUtxoPredFailure (..),
+  utxoTransition,
+ )
+import Cardano.Ledger.BaseTypes (Network, ShelleyBase, SlotNo)
+import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
+import Cardano.Ledger.Binary.Coders (
+  Decode (..),
+  Encode (..),
+  decode,
+  encode,
+  (!>),
+  (<!),
+ )
+import Cardano.Ledger.Coin (Coin, DeltaCoin)
+import Cardano.Ledger.Conway.Core
+import Cardano.Ledger.Conway.Era (ConwayEra, ConwayUTXO, ConwayUTXOS)
+import Cardano.Ledger.Conway.Rules.Utxos (
+  ConwayUtxosPredFailure (..),
+ )
+import Cardano.Ledger.Plutus (ExUnits)
+import qualified Cardano.Ledger.Shelley.LedgerState as Shelley (UTxOState)
 import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure)
+import qualified Cardano.Ledger.Shelley.Rules as Shelley (UtxoEnv)
+import Cardano.Ledger.TxIn (TxIn)
+import Cardano.Ledger.UTxO (EraUTxO, UTxO (..))
+import Control.DeepSeq (NFData)
+import Control.State.Transition.Extended (
+  Embed (..),
+  STS (..),
+ )
+import Data.List.NonEmpty (NonEmpty)
+import Data.Set (Set)
+import GHC.Generics (Generic)
+import GHC.Natural (Natural)
 
-type instance EraRuleFailure "UTXO" (ConwayEra c) = BabbageUtxoPredFailure (ConwayEra c)
+-- ======================================================
+
+-- | Predicate failure for the Conway Era
+data ConwayUtxoPredFailure era
+  = -- | Subtransition Failures
+    UtxosFailure (PredicateFailure (EraRule "UTXOS" era))
+  | -- | The bad transaction inputs
+    BadInputsUTxO
+      !(Set (TxIn (EraCrypto era)))
+  | OutsideValidityIntervalUTxO
+      -- | transaction's validity interval
+      !ValidityInterval
+      -- | current slot
+      !SlotNo
+  | MaxTxSizeUTxO
+      -- | the actual transaction size
+      !Integer
+      -- | the max transaction size
+      !Integer
+  | InputSetEmptyUTxO
+  | FeeTooSmallUTxO
+      -- | the minimum fee for this transaction
+      !Coin
+      -- | the fee supplied in this transaction
+      !Coin
+  | ValueNotConservedUTxO
+      -- | the Coin consumed by this transaction
+      !(Value era)
+      -- | the Coin produced by this transaction
+      !(Value era)
+  | -- | the set of addresses with incorrect network IDs
+    WrongNetwork
+      -- | the expected network id
+      !Network
+      -- | the set of addresses with incorrect network IDs
+      !(Set (Addr (EraCrypto era)))
+  | WrongNetworkWithdrawal
+      -- | the expected network id
+      !Network
+      -- | the set of reward addresses with incorrect network IDs
+      !(Set (RewardAccount (EraCrypto era)))
+  | -- | list of supplied transaction outputs that are too small
+    OutputTooSmallUTxO
+      ![TxOut era]
+  | -- | list of supplied bad transaction outputs
+    OutputBootAddrAttrsTooBig
+      ![TxOut era]
+  | -- | list of supplied bad transaction output triples (actualSize,PParameterMaxValue,TxOut)
+    OutputTooBigUTxO
+      ![(Int, Int, TxOut era)]
+  | InsufficientCollateral
+      -- | balance computed
+      !DeltaCoin
+      -- | the required collateral for the given fee
+      !Coin
+  | -- | The UTxO entries which have the wrong kind of script
+    ScriptsNotPaidUTxO
+      !(UTxO era)
+  | ExUnitsTooBigUTxO
+      -- | Max EXUnits from the protocol parameters
+      !ExUnits
+      -- | EXUnits supplied
+      !ExUnits
+  | -- | The inputs marked for use as fees contain non-ADA tokens
+    CollateralContainsNonADA !(Value era)
+  | -- | Wrong Network ID in body
+    WrongNetworkInTxBody
+      -- | Actual Network ID
+      !Network
+      -- | Network ID in transaction body
+      !Network
+  | -- | slot number outside consensus forecast range
+    OutsideForecast
+      !SlotNo
+  | -- | There are too many collateral inputs
+    TooManyCollateralInputs
+      -- | Max allowed collateral inputs
+      !Natural
+      -- | Number of collateral inputs
+      !Natural
+  | NoCollateralInputs
+  | -- | The collateral is not equivalent to the total collateral asserted by the transaction
+    IncorrectTotalCollateralField
+      -- | collateral provided
+      !DeltaCoin
+      -- | collateral amount declared in transaction body
+      !Coin
+  | -- | list of supplied transaction outputs that are too small,
+    -- together with the minimum value for the given output.
+    BabbageOutputTooSmallUTxO
+      ![(TxOut era, Coin)]
+  | -- | TxIns that appear in both inputs and reference inputs
+    BabbageNonDisjointRefInputs
+      !(NonEmpty (TxIn (EraCrypto era)))
+  deriving (Generic)
+
+type instance EraRuleFailure "UTXO" (ConwayEra c) = ConwayUtxoPredFailure (ConwayEra c)
 
 type instance EraRuleEvent "UTXO" (ConwayEra c) = AlonzoUtxoEvent (ConwayEra c)
 
-instance InjectRuleFailure "UTXO" BabbageUtxoPredFailure (ConwayEra c)
+instance InjectRuleFailure "UTXO" ConwayUtxoPredFailure (ConwayEra c)
+
+instance InjectRuleFailure "UTXO" BabbageUtxoPredFailure (ConwayEra c) where
+  injectFailure = babbageToConwayUtxoPredFailure
 
 instance InjectRuleFailure "UTXO" AlonzoUtxoPredFailure (ConwayEra c) where
-  injectFailure = AlonzoInBabbageUtxoPredFailure
+  injectFailure = alonzoToConwayUtxoPredFailure
 
 instance InjectRuleFailure "UTXO" ShelleyUtxoPredFailure (ConwayEra c) where
   injectFailure =
-    AlonzoInBabbageUtxoPredFailure
-      . allegraToConwayUtxoPredFailure
+    allegraToConwayUtxoPredFailure
       . shelleyToAllegraUtxoPredFailure
 
 instance InjectRuleFailure "UTXO" Allegra.AllegraUtxoPredFailure (ConwayEra c) where
-  injectFailure = AlonzoInBabbageUtxoPredFailure . allegraToConwayUtxoPredFailure
+  injectFailure = allegraToConwayUtxoPredFailure
 
 instance InjectRuleFailure "UTXO" ConwayUtxosPredFailure (ConwayEra c) where
-  injectFailure = AlonzoInBabbageUtxoPredFailure . UtxosFailure
+  injectFailure = UtxosFailure
 
 instance InjectRuleFailure "UTXO" AlonzoUtxosPredFailure (ConwayEra c) where
-  injectFailure = AlonzoInBabbageUtxoPredFailure . UtxosFailure . injectFailure
+  injectFailure =
+    alonzoToConwayUtxoPredFailure
+      . Alonzo.UtxosFailure
+      . injectFailure
+
+deriving instance
+  ( Era era
+  , Show (Value era)
+  , Show (PredicateFailure (EraRule "UTXOS" era))
+  , Show (TxOut era)
+  , Show (Script era)
+  , Show (TxIn (EraCrypto era))
+  ) =>
+  Show (ConwayUtxoPredFailure era)
+
+deriving instance
+  ( Era era
+  , Eq (Value era)
+  , Eq (PredicateFailure (EraRule "UTXOS" era))
+  , Eq (TxOut era)
+  , Eq (Script era)
+  , Eq (TxIn (EraCrypto era))
+  ) =>
+  Eq (ConwayUtxoPredFailure era)
+
+instance
+  ( Era era
+  , NFData (Value era)
+  , NFData (TxOut era)
+  , NFData (PredicateFailure (EraRule "UTXOS" era))
+  ) =>
+  NFData (ConwayUtxoPredFailure era)
+
+--------------------------------------------------------------------------------
+-- ConwayUTXO STS
+--------------------------------------------------------------------------------
+
+instance
+  forall era.
+  ( EraTx era
+  , EraUTxO era
+  , ConwayEraTxBody era
+  , AlonzoEraTxWits era
+  , Tx era ~ AlonzoTx era
+  , EraRule "UTXO" era ~ ConwayUTXO era
+  , InjectRuleFailure "UTXO" ShelleyUtxoPredFailure era
+  , InjectRuleFailure "UTXO" AllegraUtxoPredFailure era
+  , InjectRuleFailure "UTXO" AlonzoUtxoPredFailure era
+  , InjectRuleFailure "UTXO" BabbageUtxoPredFailure era
+  , InjectRuleFailure "UTXO" ConwayUtxoPredFailure era
+  , Embed (EraRule "UTXOS" era) (ConwayUTXO era)
+  , Environment (EraRule "UTXOS" era) ~ Shelley.UtxoEnv era
+  , State (EraRule "UTXOS" era) ~ Shelley.UTxOState era
+  , Signal (EraRule "UTXOS" era) ~ Tx era
+  , PredicateFailure (EraRule "UTXO" era) ~ ConwayUtxoPredFailure era
+  ) =>
+  STS (ConwayUTXO era)
+  where
+  type State (ConwayUTXO era) = Shelley.UTxOState era
+  type Signal (ConwayUTXO era) = AlonzoTx era
+  type Environment (ConwayUTXO era) = Shelley.UtxoEnv era
+  type BaseM (ConwayUTXO era) = ShelleyBase
+  type PredicateFailure (ConwayUTXO era) = ConwayUtxoPredFailure era
+  type Event (ConwayUTXO era) = AlonzoUtxoEvent era
+
+  initialRules = []
+
+  transitionRules = [Babbage.utxoTransition @era]
+
+instance
+  ( Era era
+  , STS (ConwayUTXOS era)
+  , PredicateFailure (EraRule "UTXOS" era) ~ ConwayUtxosPredFailure era
+  , Event (EraRule "UTXOS" era) ~ Event (ConwayUTXOS era)
+  ) =>
+  Embed (ConwayUTXOS era) (ConwayUTXO era)
+  where
+  wrapFailed = UtxosFailure
+  wrapEvent = Alonzo.UtxosEvent
+
+--------------------------------------------------------------------------------
+-- Serialisation
+--------------------------------------------------------------------------------
+
+instance
+  ( Era era
+  , EncCBOR (TxOut era)
+  , EncCBOR (Value era)
+  , EncCBOR (PredicateFailure (EraRule "UTXOS" era))
+  ) =>
+  EncCBOR (ConwayUtxoPredFailure era)
+  where
+  encCBOR =
+    encode . \case
+      UtxosFailure a -> Sum (UtxosFailure @era) 0 !> To a
+      BadInputsUTxO ins -> Sum (BadInputsUTxO @era) 1 !> To ins
+      OutsideValidityIntervalUTxO a b -> Sum OutsideValidityIntervalUTxO 2 !> To a !> To b
+      MaxTxSizeUTxO a b -> Sum MaxTxSizeUTxO 3 !> To a !> To b
+      InputSetEmptyUTxO -> Sum InputSetEmptyUTxO 4
+      FeeTooSmallUTxO a b -> Sum FeeTooSmallUTxO 5 !> To a !> To b
+      ValueNotConservedUTxO a b -> Sum (ValueNotConservedUTxO @era) 6 !> To a !> To b
+      WrongNetwork right wrongs -> Sum (WrongNetwork @era) 7 !> To right !> To wrongs
+      WrongNetworkWithdrawal right wrongs -> Sum (WrongNetworkWithdrawal @era) 8 !> To right !> To wrongs
+      OutputTooSmallUTxO outs -> Sum (OutputTooSmallUTxO @era) 9 !> To outs
+      OutputBootAddrAttrsTooBig outs -> Sum (OutputBootAddrAttrsTooBig @era) 10 !> To outs
+      OutputTooBigUTxO outs -> Sum (OutputTooBigUTxO @era) 11 !> To outs
+      InsufficientCollateral a b -> Sum InsufficientCollateral 12 !> To a !> To b
+      ScriptsNotPaidUTxO a -> Sum ScriptsNotPaidUTxO 13 !> To a
+      ExUnitsTooBigUTxO a b -> Sum ExUnitsTooBigUTxO 14 !> To a !> To b
+      CollateralContainsNonADA a -> Sum CollateralContainsNonADA 15 !> To a
+      WrongNetworkInTxBody a b -> Sum WrongNetworkInTxBody 16 !> To a !> To b
+      OutsideForecast a -> Sum OutsideForecast 17 !> To a
+      TooManyCollateralInputs a b -> Sum TooManyCollateralInputs 18 !> To a !> To b
+      NoCollateralInputs -> Sum NoCollateralInputs 19
+      IncorrectTotalCollateralField c1 c2 -> Sum IncorrectTotalCollateralField 20 !> To c1 !> To c2
+      BabbageOutputTooSmallUTxO x -> Sum BabbageOutputTooSmallUTxO 21 !> To x
+      BabbageNonDisjointRefInputs x -> Sum BabbageNonDisjointRefInputs 22 !> To x
+
+instance
+  ( Era era
+  , DecCBOR (TxOut era)
+  , DecCBOR (Value era)
+  , DecCBOR (PredicateFailure (EraRule "UTXOS" era))
+  ) =>
+  DecCBOR (ConwayUtxoPredFailure era)
+  where
+  decCBOR = decode . Summands "ConwayUtxoPred" $ \case
+    0 -> SumD UtxosFailure <! From
+    1 -> SumD BadInputsUTxO <! From
+    2 -> SumD OutsideValidityIntervalUTxO <! From <! From
+    3 -> SumD MaxTxSizeUTxO <! From <! From
+    4 -> SumD InputSetEmptyUTxO
+    5 -> SumD FeeTooSmallUTxO <! From <! From
+    6 -> SumD ValueNotConservedUTxO <! From <! From
+    7 -> SumD WrongNetwork <! From <! From
+    8 -> SumD WrongNetworkWithdrawal <! From <! From
+    9 -> SumD OutputTooSmallUTxO <! From
+    10 -> SumD OutputBootAddrAttrsTooBig <! From
+    11 -> SumD OutputTooBigUTxO <! From
+    12 -> SumD InsufficientCollateral <! From <! From
+    13 -> SumD ScriptsNotPaidUTxO <! D (UTxO <$> decCBOR)
+    14 -> SumD ExUnitsTooBigUTxO <! From <! From
+    15 -> SumD CollateralContainsNonADA <! From
+    16 -> SumD WrongNetworkInTxBody <! From <! From
+    17 -> SumD OutsideForecast <! From
+    18 -> SumD TooManyCollateralInputs <! From <! From
+    19 -> SumD NoCollateralInputs
+    20 -> SumD IncorrectTotalCollateralField <! From <! From
+    21 -> SumD BabbageOutputTooSmallUTxO <! From
+    22 -> SumD BabbageNonDisjointRefInputs <! From
+    n -> Invalid n
+
+-- =====================================================
+-- Injecting from one PredicateFailure to another
+
+babbageToConwayUtxoPredFailure ::
+  forall era.
+  BabbageUtxoPredFailure era ->
+  ConwayUtxoPredFailure era
+babbageToConwayUtxoPredFailure = \case
+  Babbage.AlonzoInBabbageUtxoPredFailure a -> alonzoToConwayUtxoPredFailure a
+  Babbage.IncorrectTotalCollateralField c1 c2 -> IncorrectTotalCollateralField c1 c2
+  Babbage.BabbageOutputTooSmallUTxO ts -> BabbageOutputTooSmallUTxO ts
+  Babbage.BabbageNonDisjointRefInputs ts -> BabbageNonDisjointRefInputs ts
+
+alonzoToConwayUtxoPredFailure ::
+  forall era.
+  AlonzoUtxoPredFailure era ->
+  ConwayUtxoPredFailure era
+alonzoToConwayUtxoPredFailure = \case
+  Alonzo.BadInputsUTxO x -> BadInputsUTxO x
+  Alonzo.OutsideValidityIntervalUTxO vi slotNo -> OutsideValidityIntervalUTxO vi slotNo
+  Alonzo.MaxTxSizeUTxO x y -> MaxTxSizeUTxO x y
+  Alonzo.InputSetEmptyUTxO -> InputSetEmptyUTxO
+  Alonzo.FeeTooSmallUTxO c1 c2 -> FeeTooSmallUTxO c1 c2
+  Alonzo.ValueNotConservedUTxO vc vp -> ValueNotConservedUTxO vc vp
+  Alonzo.WrongNetwork x y -> WrongNetwork x y
+  Alonzo.WrongNetworkWithdrawal x y -> WrongNetworkWithdrawal x y
+  Alonzo.OutputTooSmallUTxO x -> OutputTooSmallUTxO x
+  Alonzo.UtxosFailure x -> UtxosFailure x
+  Alonzo.OutputBootAddrAttrsTooBig xs -> OutputBootAddrAttrsTooBig xs
+  Alonzo.TriesToForgeADA ->
+    error
+      "Impossible case, soon to be removed. See: https://github.com/IntersectMBO/cardano-ledger/issues/4085"
+  Alonzo.OutputTooBigUTxO xs ->
+    let
+      -- TODO: Remove this once the other eras will make the switch from Integer to Int
+      -- as per #4015.
+      -- https://github.com/IntersectMBO/cardano-ledger/issues/4085
+      toRestricted :: (Integer, Integer, TxOut era) -> (Int, Int, TxOut era)
+      toRestricted (sz, mv, out) = (fromIntegral sz, fromIntegral mv, out)
+     in
+      OutputTooBigUTxO $ map toRestricted xs
+  Alonzo.InsufficientCollateral c1 c2 -> InsufficientCollateral c1 c2
+  Alonzo.ScriptsNotPaidUTxO u -> ScriptsNotPaidUTxO u
+  Alonzo.ExUnitsTooBigUTxO e1 e2 -> ExUnitsTooBigUTxO e1 e2
+  Alonzo.CollateralContainsNonADA v -> CollateralContainsNonADA v
+  Alonzo.WrongNetworkInTxBody nid nidb -> WrongNetworkInTxBody nid nidb
+  Alonzo.OutsideForecast sno -> OutsideForecast sno
+  Alonzo.TooManyCollateralInputs n1 n2 -> TooManyCollateralInputs n1 n2
+  Alonzo.NoCollateralInputs -> NoCollateralInputs
 
 allegraToConwayUtxoPredFailure ::
   forall era.
   EraRuleFailure "PPUP" era ~ VoidEraRule "PPUP" era =>
   Allegra.AllegraUtxoPredFailure era ->
-  AlonzoUtxoPredFailure era
+  ConwayUtxoPredFailure era
 allegraToConwayUtxoPredFailure = \case
   Allegra.BadInputsUTxO x -> BadInputsUTxO x
   Allegra.OutsideValidityIntervalUTxO vi slotNo -> OutsideValidityIntervalUTxO vi slotNo
@@ -65,5 +409,7 @@ allegraToConwayUtxoPredFailure = \case
   Allegra.OutputTooSmallUTxO x -> OutputTooSmallUTxO x
   Allegra.UpdateFailure x -> absurdEraRule @"PPUP" @era x
   Allegra.OutputBootAddrAttrsTooBig xs -> OutputBootAddrAttrsTooBig xs
-  Allegra.TriesToForgeADA -> TriesToForgeADA
+  Allegra.TriesToForgeADA ->
+    error
+      "Impossible case, soon to be removed. See: https://github.com/IntersectMBO/cardano-ledger/issues/4085"
   Allegra.OutputTooBigUTxO xs -> OutputTooBigUTxO (map (0,0,) xs)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
@@ -1,10 +1,14 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -12,12 +16,16 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Conway.Rules.Utxow (
+  alonzoToConwayUtxowPredFailure,
+  babbageToConwayUtxowPredFailure,
   ConwayUTXOW,
+  ConwayUtxowPredFailure (..),
   conwayWitsVKeyNeeded,
+  shelleyToConwayUtxowPredFailure,
 )
 where
 
-import Cardano.Crypto.DSIGN.Class (Signable)
+import Cardano.Crypto.DSIGN.Class (DSIGNAlgorithm (..), Signable)
 import Cardano.Crypto.Hash.Class (Hash)
 import Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure)
 import Cardano.Ledger.Alonzo.Rules (
@@ -25,32 +33,51 @@ import Cardano.Ledger.Alonzo.Rules (
   AlonzoUtxoPredFailure,
   AlonzoUtxosPredFailure,
   AlonzoUtxowEvent (WrappedShelleyEraEvent),
-  AlonzoUtxowPredFailure (..),
+  AlonzoUtxowPredFailure,
  )
+import qualified Cardano.Ledger.Alonzo.Rules as Alonzo (AlonzoUtxowPredFailure (..))
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
+import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.Babbage.Rules (
   BabbageUtxoPredFailure,
-  BabbageUtxowPredFailure (..),
+  BabbageUtxowPredFailure,
   babbageUtxowTransition,
  )
+import qualified Cardano.Ledger.Babbage.Rules as Babbage (BabbageUtxowPredFailure (..))
 import Cardano.Ledger.BaseTypes (ShelleyBase)
+import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
+import Cardano.Ledger.Binary.Coders (
+  Decode (..),
+  Encode (..),
+  decode,
+  encode,
+  (!>),
+  (<!),
+ )
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Era (ConwayEra, ConwayUTXO, ConwayUTXOW)
 import Cardano.Ledger.Conway.Rules.Utxo (ConwayUtxoPredFailure)
 import Cardano.Ledger.Conway.Rules.Utxos (ConwayUtxosPredFailure)
 import Cardano.Ledger.Conway.UTxO (getConwayWitsVKeyNeeded)
 import Cardano.Ledger.Crypto (DSIGN, HASH)
-import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
-import Cardano.Ledger.Shelley.LedgerState (UTxOState (..))
+import Cardano.Ledger.Keys (KeyHash, KeyRole (..), VKey)
+import qualified Cardano.Ledger.Shelley.LedgerState as Shelley (UTxOState)
 import Cardano.Ledger.Shelley.Rules (
   ShelleyUtxoPredFailure,
   ShelleyUtxowEvent (UtxoEvent),
   ShelleyUtxowPredFailure,
-  UtxoEnv (..),
  )
+import qualified Cardano.Ledger.Shelley.Rules as Shelley (
+  ShelleyUtxowPredFailure (..),
+  UtxoEnv,
+ )
+import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Ledger.UTxO (EraUTxO (..), UTxO)
+import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended (Embed (..), STS (..))
+import Data.Maybe.Strict (StrictMaybe)
 import Data.Set (Set)
+import GHC.Generics (Generic)
 
 conwayWitsVKeyNeeded ::
   (EraTx era, ConwayEraTxBody era) =>
@@ -62,17 +89,81 @@ conwayWitsVKeyNeeded = getConwayWitsVKeyNeeded
 
 -- ================================
 
-type instance EraRuleFailure "UTXOW" (ConwayEra c) = BabbageUtxowPredFailure (ConwayEra c)
+-- | Predicate failure type for the Conway Era
+data ConwayUtxowPredFailure era
+  = UtxoFailure (PredicateFailure (EraRule "UTXO" era))
+  | InvalidWitnessesUTXOW
+      ![VKey 'Witness (EraCrypto era)]
+  | -- | witnesses which failed in verifiedWits function
+    MissingVKeyWitnessesUTXOW
+      -- | witnesses which were needed and not supplied
+      !(Set (KeyHash 'Witness (EraCrypto era)))
+  | -- | missing scripts
+    MissingScriptWitnessesUTXOW
+      !(Set (ScriptHash (EraCrypto era)))
+  | -- | failed scripts
+    ScriptWitnessNotValidatingUTXOW
+      !(Set (ScriptHash (EraCrypto era)))
+  | -- | hash of the full metadata
+    MissingTxBodyMetadataHash
+      !(AuxiliaryDataHash (EraCrypto era))
+  | -- | hash of the metadata included in the transaction body
+    MissingTxMetadata
+      !(AuxiliaryDataHash (EraCrypto era))
+  | ConflictingMetadataHash
+      -- | hash of the metadata included in the transaction body
+      !(AuxiliaryDataHash (EraCrypto era))
+      -- | expected hash of the full metadata
+      !(AuxiliaryDataHash (EraCrypto era))
+  | -- | Contains out of range values (string`s too long)
+    InvalidMetadata
+  | -- | extraneous scripts
+    ExtraneousScriptWitnessesUTXOW
+      !(Set (ScriptHash (EraCrypto era)))
+  | MissingRedeemers
+      ![(PlutusPurpose AsItem era, ScriptHash (EraCrypto era))]
+  | MissingRequiredDatums
+      -- | Set of missing data hashes
+      !(Set (DataHash (EraCrypto era)))
+      -- | Set of received data hashes
+      !(Set (DataHash (EraCrypto era)))
+  | NotAllowedSupplementalDatums
+      -- | Set of unallowed data hashes
+      !(Set (DataHash (EraCrypto era)))
+      -- | Set of acceptable supplemental data hashes
+      !(Set (DataHash (EraCrypto era)))
+  | PPViewHashesDontMatch
+      -- | The PPHash in the TxBody
+      !(StrictMaybe (ScriptIntegrityHash (EraCrypto era)))
+      -- | Computed from the current Protocol Parameters
+      !(StrictMaybe (ScriptIntegrityHash (EraCrypto era)))
+  | -- | Set of transaction inputs that are TwoPhase scripts, and should have a DataHash but don't
+    UnspendableUTxONoDatumHash
+      (Set (TxIn (EraCrypto era)))
+  | -- | List of redeemers not needed
+    ExtraRedeemers ![PlutusPurpose AsIx era]
+  | -- | Embed UTXO rule failures
+    MalformedScriptWitnesses
+      !(Set (ScriptHash (EraCrypto era)))
+  | -- | the set of malformed script witnesses
+    MalformedReferenceScripts
+      !(Set (ScriptHash (EraCrypto era)))
+  deriving (Generic)
+
+type instance EraRuleFailure "UTXOW" (ConwayEra c) = ConwayUtxowPredFailure (ConwayEra c)
 
 type instance EraRuleEvent "UTXOW" (ConwayEra c) = AlonzoUtxowEvent (ConwayEra c)
 
-instance InjectRuleFailure "UTXOW" BabbageUtxowPredFailure (ConwayEra c)
+instance InjectRuleFailure "UTXOW" ConwayUtxowPredFailure (ConwayEra c)
+
+instance InjectRuleFailure "UTXOW" BabbageUtxowPredFailure (ConwayEra c) where
+  injectFailure = babbageToConwayUtxowPredFailure
 
 instance InjectRuleFailure "UTXOW" AlonzoUtxowPredFailure (ConwayEra c) where
-  injectFailure = AlonzoInBabbageUtxowPredFailure
+  injectFailure = alonzoToConwayUtxowPredFailure
 
 instance InjectRuleFailure "UTXOW" ShelleyUtxowPredFailure (ConwayEra c) where
-  injectFailure = AlonzoInBabbageUtxowPredFailure . ShelleyInAlonzoUtxowPredFailure
+  injectFailure = shelleyToConwayUtxowPredFailure
 
 instance InjectRuleFailure "UTXOW" ConwayUtxoPredFailure (ConwayEra c) where
   injectFailure = UtxoFailure . injectFailure
@@ -95,6 +186,30 @@ instance InjectRuleFailure "UTXOW" ShelleyUtxoPredFailure (ConwayEra c) where
 instance InjectRuleFailure "UTXOW" AllegraUtxoPredFailure (ConwayEra c) where
   injectFailure = UtxoFailure . injectFailure
 
+deriving instance
+  ( ConwayEraScript era
+  , Show (PredicateFailure (EraRule "UTXO" era))
+  ) =>
+  Show (ConwayUtxowPredFailure era)
+
+deriving instance
+  ( ConwayEraScript era
+  , Eq (PredicateFailure (EraRule "UTXO" era))
+  ) =>
+  Eq (ConwayUtxowPredFailure era)
+
+instance
+  ( ConwayEraScript era
+  , NFData (TxCert era)
+  , NFData (PredicateFailure (EraRule "UTXO" era))
+  , NFData (VerKeyDSIGN (DSIGN (EraCrypto era)))
+  ) =>
+  NFData (ConwayUtxowPredFailure era)
+
+--------------------------------------------------------------------------------
+-- ConwayUTXOW STS
+--------------------------------------------------------------------------------
+
 instance
   forall era.
   ( AlonzoEraTx era
@@ -108,19 +223,19 @@ instance
   , InjectRuleFailure "UTXOW" BabbageUtxowPredFailure era
   , -- Allow UTXOW to call UTXO
     Embed (EraRule "UTXO" era) (ConwayUTXOW era)
-  , Environment (EraRule "UTXO" era) ~ UtxoEnv era
-  , State (EraRule "UTXO" era) ~ UTxOState era
+  , Environment (EraRule "UTXO" era) ~ Shelley.UtxoEnv era
+  , State (EraRule "UTXO" era) ~ Shelley.UTxOState era
   , Signal (EraRule "UTXO" era) ~ Tx era
   , Eq (PredicateFailure (EraRule "UTXOS" era))
   , Show (PredicateFailure (EraRule "UTXOS" era))
   ) =>
   STS (ConwayUTXOW era)
   where
-  type State (ConwayUTXOW era) = UTxOState era
+  type State (ConwayUTXOW era) = Shelley.UTxOState era
   type Signal (ConwayUTXOW era) = Tx era
-  type Environment (ConwayUTXOW era) = UtxoEnv era
+  type Environment (ConwayUTXOW era) = Shelley.UtxoEnv era
   type BaseM (ConwayUTXOW era) = ShelleyBase
-  type PredicateFailure (ConwayUTXOW era) = BabbageUtxowPredFailure era
+  type PredicateFailure (ConwayUTXOW era) = ConwayUtxowPredFailure era
   type Event (ConwayUTXOW era) = AlonzoUtxowEvent era
   transitionRules = [babbageUtxowTransition @era]
   initialRules = []
@@ -131,10 +246,111 @@ instance
   , PredicateFailure (EraRule "UTXO" era) ~ ConwayUtxoPredFailure era
   , Event (EraRule "UTXO" era) ~ AlonzoUtxoEvent era
   , BaseM (ConwayUTXOW era) ~ ShelleyBase
-  , PredicateFailure (ConwayUTXOW era) ~ BabbageUtxowPredFailure era
+  , PredicateFailure (ConwayUTXOW era) ~ ConwayUtxowPredFailure era
   , Event (ConwayUTXOW era) ~ AlonzoUtxowEvent era
   ) =>
   Embed (ConwayUTXO era) (ConwayUTXOW era)
   where
   wrapFailed = UtxoFailure
   wrapEvent = WrappedShelleyEraEvent . UtxoEvent
+
+--------------------------------------------------------------------------------
+-- Serialisation
+--------------------------------------------------------------------------------
+
+instance
+  ( ConwayEraScript era
+  , EncCBOR (PredicateFailure (EraRule "UTXO" era))
+  ) =>
+  EncCBOR (ConwayUtxowPredFailure era)
+  where
+  encCBOR =
+    encode . \case
+      UtxoFailure x -> Sum UtxoFailure 0 !> To x
+      InvalidWitnessesUTXOW xs -> Sum InvalidWitnessesUTXOW 1 !> To xs
+      MissingVKeyWitnessesUTXOW xs -> Sum MissingVKeyWitnessesUTXOW 2 !> To xs
+      MissingScriptWitnessesUTXOW xs -> Sum MissingScriptWitnessesUTXOW 3 !> To xs
+      ScriptWitnessNotValidatingUTXOW xs -> Sum ScriptWitnessNotValidatingUTXOW 4 !> To xs
+      MissingTxBodyMetadataHash xs -> Sum MissingTxBodyMetadataHash 5 !> To xs
+      MissingTxMetadata xs -> Sum MissingTxMetadata 6 !> To xs
+      ConflictingMetadataHash a b -> Sum ConflictingMetadataHash 7 !> To a !> To b
+      InvalidMetadata -> Sum InvalidMetadata 8
+      ExtraneousScriptWitnessesUTXOW xs -> Sum ExtraneousScriptWitnessesUTXOW 9 !> To xs
+      MissingRedeemers x -> Sum MissingRedeemers 10 !> To x
+      MissingRequiredDatums x y -> Sum MissingRequiredDatums 11 !> To x !> To y
+      NotAllowedSupplementalDatums x y -> Sum NotAllowedSupplementalDatums 12 !> To x !> To y
+      PPViewHashesDontMatch x y -> Sum PPViewHashesDontMatch 13 !> To x !> To y
+      UnspendableUTxONoDatumHash x -> Sum UnspendableUTxONoDatumHash 14 !> To x
+      ExtraRedeemers x -> Sum ExtraRedeemers 15 !> To x
+      MalformedScriptWitnesses x -> Sum MalformedScriptWitnesses 16 !> To x
+      MalformedReferenceScripts x -> Sum MalformedReferenceScripts 17 !> To x
+
+instance
+  ( ConwayEraScript era
+  , DecCBOR (PredicateFailure (EraRule "UTXO" era))
+  ) =>
+  DecCBOR (ConwayUtxowPredFailure era)
+  where
+  decCBOR = decode . Summands "ConwayUtxowPred" $ \case
+    0 -> SumD UtxoFailure <! From
+    1 -> SumD InvalidWitnessesUTXOW <! From
+    2 -> SumD MissingVKeyWitnessesUTXOW <! From
+    3 -> SumD MissingScriptWitnessesUTXOW <! From
+    4 -> SumD ScriptWitnessNotValidatingUTXOW <! From
+    5 -> SumD MissingTxBodyMetadataHash <! From
+    6 -> SumD MissingTxMetadata <! From
+    7 -> SumD ConflictingMetadataHash <! From <! From
+    8 -> SumD InvalidMetadata
+    9 -> SumD ExtraneousScriptWitnessesUTXOW <! From
+    10 -> SumD MissingRedeemers <! From
+    11 -> SumD MissingRequiredDatums <! From <! From
+    12 -> SumD NotAllowedSupplementalDatums <! From <! From
+    13 -> SumD PPViewHashesDontMatch <! From <! From
+    14 -> SumD UnspendableUTxONoDatumHash <! From
+    15 -> SumD ExtraRedeemers <! From
+    16 -> SumD MalformedScriptWitnesses <! From
+    17 -> SumD MalformedReferenceScripts <! From
+    n -> Invalid n
+
+-- =====================================================
+-- Injecting from one PredicateFailure to another
+
+babbageToConwayUtxowPredFailure ::
+  forall era.
+  BabbageUtxowPredFailure era ->
+  ConwayUtxowPredFailure era
+babbageToConwayUtxowPredFailure = \case
+  Babbage.AlonzoInBabbageUtxowPredFailure x -> alonzoToConwayUtxowPredFailure x
+  Babbage.UtxoFailure x -> UtxoFailure x
+  Babbage.MalformedScriptWitnesses xs -> MalformedScriptWitnesses xs
+  Babbage.MalformedReferenceScripts xs -> MalformedReferenceScripts xs
+
+alonzoToConwayUtxowPredFailure ::
+  forall era.
+  AlonzoUtxowPredFailure era ->
+  ConwayUtxowPredFailure era
+alonzoToConwayUtxowPredFailure = \case
+  Alonzo.ShelleyInAlonzoUtxowPredFailure f -> shelleyToConwayUtxowPredFailure f
+  Alonzo.MissingRedeemers rs -> MissingRedeemers rs
+  Alonzo.MissingRequiredDatums mds rds -> MissingRequiredDatums mds rds
+  Alonzo.NotAllowedSupplementalDatums uds ads -> NotAllowedSupplementalDatums uds ads
+  Alonzo.PPViewHashesDontMatch a b -> PPViewHashesDontMatch a b
+  Alonzo.MissingRequiredSigners _xs ->
+    error "Impossible case. It will be removed once we are in Conway. See #3972"
+  Alonzo.UnspendableUTxONoDatumHash ins -> UnspendableUTxONoDatumHash ins
+  Alonzo.ExtraRedeemers xs -> ExtraRedeemers xs
+
+shelleyToConwayUtxowPredFailure :: ShelleyUtxowPredFailure era -> ConwayUtxowPredFailure era
+shelleyToConwayUtxowPredFailure = \case
+  Shelley.InvalidWitnessesUTXOW xs -> InvalidWitnessesUTXOW xs
+  Shelley.MissingVKeyWitnessesUTXOW xs -> MissingVKeyWitnessesUTXOW xs
+  Shelley.MissingScriptWitnessesUTXOW xs -> MissingScriptWitnessesUTXOW xs
+  Shelley.ScriptWitnessNotValidatingUTXOW xs -> ScriptWitnessNotValidatingUTXOW xs
+  Shelley.UtxoFailure x -> UtxoFailure x
+  Shelley.MIRInsufficientGenesisSigsUTXOW _xs ->
+    error "Impossible: MIR has been removed in Conway"
+  Shelley.MissingTxBodyMetadataHash x -> MissingTxBodyMetadataHash x
+  Shelley.MissingTxMetadata x -> MissingTxMetadata x
+  Shelley.ConflictingMetadataHash a b -> ConflictingMetadataHash a b
+  Shelley.InvalidMetadata -> InvalidMetadata
+  Shelley.ExtraneousScriptWitnessesUTXOW xs -> ExtraneousScriptWitnessesUTXOW xs

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -205,6 +205,16 @@ instance
       <*> arbitrary
       <*> arbitrary
 
+instance
+  ( EraTxOut era
+  , Arbitrary (Value era)
+  , Arbitrary (TxOut era)
+  , Arbitrary (PredicateFailure (EraRule "UTXOS" era))
+  ) =>
+  Arbitrary (ConwayUtxoPredFailure era)
+  where
+  arbitrary = genericArbitraryU
+
 _uniqueIdGovActions ::
   (Era era, Arbitrary (PParamsUpdate era)) =>
   Gen (SSeq.StrictSeq (GovActionState era))

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -215,6 +215,17 @@ instance
   where
   arbitrary = genericArbitraryU
 
+instance
+  ( Era era
+  , Arbitrary (PredicateFailure (EraRule "UTXO" era))
+  , Arbitrary (TxCert era)
+  , Arbitrary (PlutusPurpose AsItem era)
+  , Arbitrary (PlutusPurpose AsIx era)
+  ) =>
+  Arbitrary (ConwayUtxowPredFailure era)
+  where
+  arbitrary = genericArbitraryU
+
 _uniqueIdGovActions ::
   (Era era, Arbitrary (PParamsUpdate era)) =>
   Gen (SSeq.StrictSeq (GovActionState era))

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Regression.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Regression.hs
@@ -10,7 +10,6 @@
 
 module Test.Cardano.Ledger.Conway.Binary.Regression where
 
-import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure (..))
 import Cardano.Ledger.BaseTypes (Inject (..), StrictMaybe (..), TxIx (..))
 import Cardano.Ledger.Binary (
   EncCBOR (..),
@@ -32,7 +31,11 @@ import Cardano.Ledger.Conway.Core (
   eraProtVerLow,
   txIdTx,
  )
-import Cardano.Ledger.Conway.Rules (ConwayLedgerPredFailure (..), ConwayUtxoPredFailure (..))
+import Cardano.Ledger.Conway.Rules (
+  ConwayLedgerPredFailure (..),
+  ConwayUtxoPredFailure (..),
+  ConwayUtxowPredFailure (..),
+ )
 import Cardano.Ledger.Plutus.Language (SLanguage (..), hashPlutusScript)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Control.Monad ((<=<))

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Regression.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Regression.hs
@@ -10,8 +10,7 @@
 
 module Test.Cardano.Ledger.Conway.Binary.Regression where
 
-import Cardano.Ledger.Alonzo.Rules (AlonzoUtxoPredFailure (..))
-import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure (..), BabbageUtxowPredFailure (..))
+import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure (..))
 import Cardano.Ledger.BaseTypes (Inject (..), StrictMaybe (..), TxIx (..))
 import Cardano.Ledger.Binary (
   EncCBOR (..),
@@ -33,7 +32,7 @@ import Cardano.Ledger.Conway.Core (
   eraProtVerLow,
   txIdTx,
  )
-import Cardano.Ledger.Conway.Rules (ConwayLedgerPredFailure (..))
+import Cardano.Ledger.Conway.Rules (ConwayLedgerPredFailure (..), ConwayUtxoPredFailure (..))
 import Cardano.Ledger.Plutus.Language (SLanguage (..), hashPlutusScript)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Control.Monad ((<=<))
@@ -134,7 +133,7 @@ spec = describe "Regression" $ do
         pFailure <- impAnn "Expecting failure" $ expectLeftDeepExpr res
         let
           hasInsufficientCollateral
-            (ConwayUtxowFailure (UtxoFailure (AlonzoInBabbageUtxoPredFailure (InsufficientCollateral _ _)))) = True
+            (ConwayUtxowFailure (UtxoFailure (InsufficientCollateral _ _))) = True
           hasInsufficientCollateral _ = False
         impAnn "Fails with InsufficientCollateral" $
           pFailure `shouldSatisfyExpr` any hasInsufficientCollateral

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
@@ -233,3 +233,10 @@ instance
   ToExpr (GovProcedures era)
 
 instance ToExpr (PParamsHKD Identity era) => ToExpr (GovEnv era)
+
+instance
+  ( ToExpr (Value era)
+  , ToExpr (TxOut era)
+  , ToExpr (PredicateFailure (EraRule "UTXOS" era))
+  ) =>
+  ToExpr (ConwayUtxoPredFailure era)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
@@ -240,3 +240,12 @@ instance
   , ToExpr (PredicateFailure (EraRule "UTXOS" era))
   ) =>
   ToExpr (ConwayUtxoPredFailure era)
+
+instance
+  ( Era era
+  , ToExpr (PredicateFailure (EraRule "UTXO" era))
+  , ToExpr (PlutusPurpose AsIx era)
+  , ToExpr (PlutusPurpose AsItem era)
+  , ToExpr (TxCert era)
+  ) =>
+  ToExpr (ConwayUtxowPredFailure era)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway.hs
@@ -33,7 +33,6 @@ import Cardano.Ledger.Alonzo.PParams (OrdExUnits (OrdExUnits))
 import Cardano.Ledger.Alonzo.Scripts (AlonzoPlutusPurpose (..))
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..))
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), Redeemers (..), TxDats (..))
-import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure)
 import Cardano.Ledger.Babbage.TxOut (BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes (
   Anchor,
@@ -76,7 +75,11 @@ import Cardano.Ledger.Conway.Governance (
   pPropsL,
  )
 import Cardano.Ledger.Conway.PParams (ConwayPParams (..), THKD (..))
-import Cardano.Ledger.Conway.Rules (ConwayGovPredFailure, GovEnv (..))
+import Cardano.Ledger.Conway.Rules (
+  ConwayGovPredFailure,
+  ConwayUtxoPredFailure,
+  GovEnv (..),
+ )
 import Cardano.Ledger.Conway.Scripts (ConwayPlutusPurpose (..))
 import Cardano.Ledger.Conway.TxCert (
   ConwayDelegCert (..),
@@ -636,9 +639,9 @@ instance
   , ToExpr (TxOut era)
   , ToExpr (PredicateFailure (EraRule "UTXOS" era))
   ) =>
-  SpecTranslate ctx (BabbageUtxoPredFailure era)
+  SpecTranslate ctx (ConwayUtxoPredFailure era)
   where
-  type SpecRep (BabbageUtxoPredFailure era) = OpaqueErrorString
+  type SpecRep (ConwayUtxoPredFailure era) = OpaqueErrorString
 
   toSpecRep e = pure . OpaqueErrorString . show $ toExpr e
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/BabbageFeatures.hs
@@ -55,6 +55,7 @@ import Cardano.Ledger.BaseTypes (
   mkTxIxPartial,
  )
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
+import qualified Cardano.Ledger.Conway.Rules as Conway (ConwayUtxoPredFailure (..))
 import Cardano.Ledger.Conway.TxInfo (ConwayContextError (..))
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import Cardano.Ledger.Crypto
@@ -1449,7 +1450,7 @@ babbageFeatures =
         testExpectUTXOFailure
           Conway
           (commonReferenceScript Conway)
-          (BabbageNonDisjointRefInputs (pure commonTxIn))
+          (Conway.BabbageNonDisjointRefInputs (pure commonTxIn))
     ]
 
 testExpectUTXOFailure ::

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
@@ -465,7 +465,7 @@ findMismatch Alonzo (ShelleyInAlonzoUtxowPredFailure (Shelley.UtxoFailure (Utxos
 findMismatch Babbage (Babbage.UtxoFailure (AlonzoInBabbageUtxoPredFailure (UtxosFailure x@(ValidationTagMismatch _ _)))) = Just $ injectFailure x
 findMismatch
   Conway
-  ( Babbage.UtxoFailure
+  ( Conway.UtxoFailure
       (Conway.UtxosFailure x@(Conway.ValidationTagMismatch _ _))
     ) = Just $ injectFailure x
 findMismatch _ _ = Nothing

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
@@ -466,7 +466,7 @@ findMismatch Babbage (Babbage.UtxoFailure (AlonzoInBabbageUtxoPredFailure (Utxos
 findMismatch
   Conway
   ( Babbage.UtxoFailure
-      (AlonzoInBabbageUtxoPredFailure (UtxosFailure x@(Conway.ValidationTagMismatch _ _)))
+      (Conway.UtxosFailure x@(Conway.ValidationTagMismatch _ _))
     ) = Just $ injectFailure x
 findMismatch _ _ = Nothing
 


### PR DESCRIPTION
# Description
Resolves #4170 
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
