### PR TITLE
Fix generation bug for sums of positive member spec

### DIFF
--- a/libs/constrained-generators/src/Constrained/Instances.hs
+++ b/libs/constrained-generators/src/Constrained/Instances.hs
@@ -67,6 +67,10 @@ instance BaseUniverse fn => Functions (EqFn fn) fn where
         True -> equalSpec a
         False -> notEqualSpec a
 
+  rewriteRules Equal (t :> t' :> Nil)
+    | t == t' = Just $ lit True
+    | otherwise = Nothing
+
   mapTypeSpec f _ = case f of {}
 
 instance BaseUniverse fn => Functions (BoolFn fn) fn where

--- a/libs/constrained-generators/src/Constrained/Spec/Maps.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Maps.hs
@@ -112,14 +112,16 @@ instance
             Nothing
             mustVals'
             size'
-            (constrained $ \v -> unsafeExists $ \p -> p `satisfies` kvs <> assert (v ==. snd_ p))
+            (constrained $ \v -> unsafeExists $ \k -> pair_ k v `satisfies` kvs)
             foldSpec'
 
     restVals <-
-      explain ["Make the restVals"] $
-        explain [show $ "size' = " <> pretty size'] $
-          genFromTypeSpec $
-            valsSpec
+      explain
+        [ "Make the restVals"
+        , "  valsSpec = " ++ show valsSpec
+        ]
+        $ genFromTypeSpec
+        $ valsSpec
     let go m [] = pure m
         go m (v : restVals') = do
           let keySpec = notMemberSpec (Map.keysSet m) <> constrained (\k -> pair_ k (lit v) `satisfies` kvs)

--- a/libs/constrained-generators/src/Constrained/Test.hs
+++ b/libs/constrained-generators/src/Constrained/Test.hs
@@ -188,6 +188,10 @@ tests =
     , testSpec "roseTreePairs" roseTreePairs
     , testSpec "roseTreeMaybe" roseTreeMaybe
     , testSpec "badTreeInteraction" badTreeInteraction
+    , testSpec "sumRange" sumRange
+    , testSpec "sumListBad" sumListBad
+    , testSpec "listExistsUnfree" listExistsUnfree
+    , testSpec "existsUnfree" existsUnfree
     , numberyTests
     , sizeTests
     , numNumSpecTree
@@ -744,6 +748,24 @@ roseTreeMaybe = constrained $ \t ->
   , forAll' t $ \mp _ -> isJust mp
   , genHint (Nothing, 10) t
   ]
+
+sumRange :: Spec BaseFn (Map Word64 Word64)
+sumRange = constrained $ \m -> sum_ (rng_ m) ==. lit 10
+
+sumListBad :: Spec BaseFn [Word64]
+sumListBad = constrained $ \xs ->
+  [ forAll xs $ \x -> unsafeExists $ \y -> y ==. x
+  , assert $ sum_ xs ==. lit 10
+  ]
+
+listExistsUnfree :: Spec BaseFn [Int]
+listExistsUnfree = constrained $ \xs ->
+  [ forAll xs $ \x -> x `satisfies` existsUnfree
+  , assert $ sizeOf_ xs ==. 3
+  ]
+
+existsUnfree :: Spec BaseFn Int
+existsUnfree = constrained $ \_ -> exists (\_ -> pure 1) $ \y -> y `elem_` lit [1, 2 :: Int]
 
 badTreeInteraction :: Spec RoseFn (RoseTree (Either Int Int))
 badTreeInteraction = constrained $ \t ->


### PR DESCRIPTION
# Description

This unblocks @TimSheard 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
