### PR TITLE
Implement POC of same number of argumetns for PlutusV3

### DIFF
--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Data.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Data.hs
@@ -24,6 +24,7 @@ module Cardano.Ledger.Plutus.Data (
   PlutusData (..),
   Data (Data),
   unData,
+  fromMaybeData,
   DataHash,
   upgradeData,
   hashData,
@@ -103,6 +104,12 @@ instance Typeable era => DecCBOR (Annotator (PlutusData era)) where
 newtype Data era = DataConstr (MemoBytes PlutusData era)
   deriving (Eq, Generic)
   deriving newtype (SafeToHash, ToCBOR, NFData)
+
+-- | Convert Maybe data to a List
+fromMaybeData :: Era era => Maybe (Data era) -> Data era
+fromMaybeData = \case
+  Nothing -> Data (PV1.List [])
+  Just (Data d) -> Data (PV1.List [d])
 
 -- | Encodes memoized bytes created upon construction.
 instance Typeable era => EncCBOR (Data era)


### PR DESCRIPTION
# Description

Proof-of-Concept: making the same number (three) of arguments for PlutusV3, regardless of plutus purpose.

CI is still failing because tests have not been adjusted to account for this change.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
