### PR TITLE
simplify foldMap interface to higher order syntax

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
@@ -138,21 +138,13 @@ utxoTxSpec env st =
                               ]
                         )
                         $ \totalValueConsumed ->
-                          [ -- TODO: the yuck here needs to be the selector Fn for the
-                            -- spending field in the outputs. Need to make selectors work!
-                            let outputSum =
+                          [ let outputSum =
                                   foldMap_
-                                    ( composeFn toGenericFn $
-                                        composeFn fstFn $
-                                          composeFn sndFn $
-                                            composeFn toGenericFn $
-                                              composeFn fstFn $
-                                                toGenericFn
-                                    )
+                                    (maryValueCoin_ . txOutVal_ . sizedValue_)
                                     outputList
                                 depositSum =
                                   foldMap_
-                                    (composeFn fstFn toGenericFn)
+                                    pProcDeposit_
                                     proposalsList
                              in outputSum + depositSum + ctbTxfee + ctbTreasuryDonation ==. totalValueConsumed
                           ]

--- a/libs/constrained-generators/bench/Constrained/Bench.hs
+++ b/libs/constrained-generators/bench/Constrained/Bench.hs
@@ -47,7 +47,7 @@ roseTreeMaybe = constrained $ \t ->
 
 listSumPair :: Specification BaseFn [(Int, Int)]
 listSumPair = constrained $ \xs ->
-  [ assert $ foldMap_ (composeFn fstFn toGenericFn) xs ==. 100
+  [ assert $ foldMap_ fst_ xs ==. 100
   , forAll' xs $ \x y -> [20 <. x, x <. 30, y <. 100]
   ]
 

--- a/libs/constrained-generators/src/Constrained/Examples/List.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/List.hs
@@ -65,7 +65,7 @@ listSumElemRange = constrained $ \xs ->
 
 listSumPair :: Numbery a => Specification BaseFn [(a, Int)]
 listSumPair = constrained $ \xs ->
-  [ assert $ foldMap_ (composeFn fstFn toGenericFn) xs ==. 100
+  [ assert $ foldMap_ fst_ xs ==. 100
   , forAll' xs $ \x y -> [20 <. x, x <. 30, y <. 100]
   ]
 


### PR DESCRIPTION
# Description

This is a tiny usability change

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
