### PR TITLE
Restrict gov actions during bootstrap

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -59,10 +59,11 @@
 
 ### `testlib`
 
+* Add `withImpStateWithProtVer` to Conway ImpTest
 * Add the following utilities. #4273
   * to `Conway.ImpTest`
     * `setupDRepWithoutStake`
-    * `setupPoolWithoutStake` 
+    * `setupPoolWithoutStake`
     * `submitAndExpireProposalToMakeReward`
   * to `Shelley.ImpTest`
     * `getRewardAccountFor`

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.14.0 0
 
+* Add lenses:
+  * `dvtHardForkInitiationL`
+  * `dvtMotionNoConfidenceL`
+  * `dvtTreasuryWithdrawalL`
 * Add`DisallowedProposalDuringBootstrap` and `DisallowedVotesDuringBootstrap` to `ConwayGovPredFailure`
 * Make `DRepDistr` calculation include rewards when no UTxO stake is delegated. #4273
   * Rename `computeDrepPulser` to `computeDRepPulser`.

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -59,6 +59,7 @@
 
 ### `testlib`
 
+* Add `withPostBootstrap` to Conway ImpTest
 * Add `withImpStateWithProtVer` to Conway ImpTest
 * Add the following utilities. #4273
   * to `Conway.ImpTest`

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.14.0 0
 
+* Add`DisallowedProposalDuringBootstrap` and `DisallowedVotesDuringBootstrap` to `ConwayGovPredFailure`
 * Make `DRepDistr` calculation include rewards when no UTxO stake is delegated. #4273
   * Rename `computeDrepPulser` to `computeDRepPulser`.
 * Implement `NoThunks` instance for:

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -48,10 +48,13 @@ module Cardano.Ledger.Conway.PParams (
   DRepVotingThresholds (..),
   dvtCommitteeNoConfidenceL,
   dvtCommitteeNormalL,
+  dvtHardForkInitiationL,
+  dvtMotionNoConfidenceL,
   dvtPPNetworkGroupL,
   dvtPPGovGroupL,
   dvtPPTechnicalGroupL,
   dvtPPEconomicGroupL,
+  dvtTreasuryWithdrawalL,
   dvtUpdateToConstitutionL,
   ConwayPParams (..),
   getLanguageView,
@@ -360,6 +363,15 @@ dvtCommitteeNoConfidenceL = lens dvtCommitteeNoConfidence (\x y -> x {dvtCommitt
 
 dvtCommitteeNormalL :: Lens' DRepVotingThresholds UnitInterval
 dvtCommitteeNormalL = lens dvtCommitteeNormal (\x y -> x {dvtCommitteeNormal = y})
+
+dvtMotionNoConfidenceL :: Lens' DRepVotingThresholds UnitInterval
+dvtMotionNoConfidenceL = lens dvtMotionNoConfidence (\x y -> x {dvtMotionNoConfidence = y})
+
+dvtHardForkInitiationL :: Lens' DRepVotingThresholds UnitInterval
+dvtHardForkInitiationL = lens dvtHardForkInitiation (\x y -> x {dvtHardForkInitiation = y})
+
+dvtTreasuryWithdrawalL :: Lens' DRepVotingThresholds UnitInterval
+dvtTreasuryWithdrawalL = lens dvtTreasuryWithdrawal (\x y -> x {dvtTreasuryWithdrawal = y})
 
 instance EncCBOR DRepVotingThresholds where
   encCBOR DRepVotingThresholds {..} =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -163,6 +163,9 @@ data ConwayGovPredFailure era
       (StrictMaybe (ScriptHash (EraCrypto era)))
       -- | The policy script hash of the current constitution
       (StrictMaybe (ScriptHash (EraCrypto era)))
+  | DisallowedProposalDuringBootstrap (ProposalProcedure era)
+  | DisallowedVotesDuringBootstrap
+      (NonEmpty (Voter (EraCrypto era), GovActionId (EraCrypto era)))
   deriving (Eq, Show, Generic)
 
 type instance EraRuleFailure "GOV" (ConwayEra c) = ConwayGovPredFailure (ConwayEra c)
@@ -189,6 +192,8 @@ instance EraPParams era => DecCBOR (ConwayGovPredFailure era) where
     9 -> SumD VotingOnExpiredGovAction <! From
     10 -> SumD ProposalCantFollow <! From <! From <! From
     11 -> SumD InvalidPolicyHash <! From <! From
+    12 -> SumD DisallowedProposalDuringBootstrap <! From
+    13 -> SumD DisallowedVotesDuringBootstrap <! From
     k -> Invalid k
 
 instance EraPParams era => EncCBOR (ConwayGovPredFailure era) where
@@ -221,6 +226,10 @@ instance EraPParams era => EncCBOR (ConwayGovPredFailure era) where
         Sum InvalidPolicyHash 11
           !> To got
           !> To expected
+      DisallowedProposalDuringBootstrap proposal ->
+        Sum DisallowedProposalDuringBootstrap 12 !> To proposal
+      DisallowedVotesDuringBootstrap votes ->
+        Sum DisallowedVotesDuringBootstrap 13 !> To votes
 
 instance EraPParams era => ToCBOR (ConwayGovPredFailure era) where
   toCBOR = toEraCBOR @era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -104,7 +104,6 @@ import Control.State.Transition.Extended (
   tellEvent,
   (?!),
  )
-import Data.Bifunctor (Bifunctor (..))
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as Map
 import qualified Data.OSet.Strict as OSet
@@ -266,10 +265,9 @@ checkVotesAreNotForExpiredActions ::
   EpochNo ->
   [(Voter (EraCrypto era), GovActionState era)] ->
   Test (ConwayGovPredFailure era)
-checkVotesAreNotForExpiredActions curEpoch voters =
-  let votesOnExpiredActions = filter (\(_, GovActionState {gasExpiresAfter}) -> curEpoch > gasExpiresAfter) voters
-   in failureOnNonEmpty votesOnExpiredActions $
-        VotingOnExpiredGovAction . fmap (second gasId)
+checkVotesAreNotForExpiredActions curEpoch votes =
+  checkDisallowedVotes votes VotingOnExpiredGovAction $ \GovActionState {gasExpiresAfter} _ ->
+    curEpoch <= gasExpiresAfter
 
 checkVotersAreValid ::
   forall era.
@@ -278,17 +276,12 @@ checkVotersAreValid ::
   CommitteeState era ->
   [(Voter (EraCrypto era), GovActionState era)] ->
   Test (ConwayGovPredFailure era)
-checkVotersAreValid currentEpoch committeeState voters =
-  let canVoteOn voter govAction = case voter of
-        CommitteeVoter {} -> isCommitteeVotingAllowed currentEpoch committeeState govAction
-        DRepVoter {} -> isDRepVotingAllowed govAction
-        StakePoolVoter {} -> isStakePoolVotingAllowed govAction
-      disallowedVoters =
-        filter
-          (\(voter, action) -> not $ voter `canVoteOn` gasAction action)
-          voters
-   in failureOnNonEmpty disallowedVoters $
-        DisallowedVoters . fmap (second gasId)
+checkVotersAreValid currentEpoch committeeState votes =
+  checkDisallowedVotes votes DisallowedVoters $ \gas ->
+    \case
+      CommitteeVoter {} -> isCommitteeVotingAllowed currentEpoch committeeState (gasAction gas)
+      DRepVoter {} -> isDRepVotingAllowed (gasAction gas)
+      StakePoolVoter {} -> isStakePoolVotingAllowed (gasAction gas)
 
 actionWellFormed :: ConwayEraPParams era => GovAction era -> Test (ConwayGovPredFailure era)
 actionWellFormed ga = failureUnless isWellFormed $ MalformedProposal ga
@@ -467,6 +460,18 @@ isBootstrapAction =
     HardForkInitiation {} -> True
     InfoAction -> True
     _ -> False
+
+checkDisallowedVotes ::
+  [(Voter (EraCrypto era), GovActionState era)] ->
+  (NonEmpty (Voter (EraCrypto era), GovActionId (EraCrypto era)) -> ConwayGovPredFailure era) ->
+  (GovActionState era -> Voter (EraCrypto era) -> Bool) ->
+  Test (ConwayGovPredFailure era)
+checkDisallowedVotes votes failure canBeVotedOnBy =
+  failureOnNonEmpty disallowedVotes failure
+  where
+    disallowedVotes =
+      [(voter, gasId gas) | (voter, gas) <- votes, not (gas `canBeVotedOnBy` voter)]
+
 
 -- | If the GovAction is a HardFork, then return 3 things (if they exist)
 -- 1) The (StrictMaybe GovPurposeId), pointed to by the HardFork proposal

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
@@ -187,20 +187,9 @@ hardForkInitiationSpec =
     (committeeMember :| _) <- registerInitialCommittee
     modifyPParams $ \pp ->
       pp
-        & ppDRepVotingThresholdsL
-          %~ ( \dvt ->
-                dvt
-                  { dvtHardForkInitiation = 2 %! 3
-                  }
-             )
-        & ppPoolVotingThresholdsL
-          %~ ( \pvt ->
-                pvt
-                  { pvtHardForkInitiation = 2 %! 3
-                  }
-             )
-        & ppGovActionLifetimeL
-          .~ EpochInterval 20
+        & ppDRepVotingThresholdsL . dvtHardForkInitiationL .~ 2 %! 3
+        & ppPoolVotingThresholdsL . pvtHardForkInitiationL .~ 2 %! 3
+        & ppGovActionLifetimeL .~ EpochInterval 20
     _ <- setupPoolWithStake $ Coin 22_000_000
     (stakePoolId1, _, _) <- setupPoolWithStake $ Coin 22_000_000
     (stakePoolId2, _, _) <- setupPoolWithStake $ Coin 22_000_000

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovCertSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovCertSpec.hs
@@ -9,7 +9,10 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Test.Cardano.Ledger.Conway.Imp.GovCertSpec (spec) where
+module Test.Cardano.Ledger.Conway.Imp.GovCertSpec (
+  spec,
+  relevantDuringBootstrapSpec,
+) where
 
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core (
@@ -60,9 +63,11 @@ spec ::
   , InjectRuleFailure "LEDGER" ConwayGovCertPredFailure era
   ) =>
   SpecWith (ImpTestState era)
-spec = describe "GOVCERT" $ do
-  it
-    "A CC that has resigned will need to be first voted out and then voted in to be considered active"
+spec = do
+  relevantDuringBootstrapSpec
+  describe "GOVCERT"
+    $ it
+      "A CC that has resigned will need to be first voted out and then voted in to be considered active"
     $ do
       (drepCred, _, _) <- setupSingleDRep 1_000_000
       passNEpochs 2
@@ -115,6 +120,14 @@ spec = describe "GOVCERT" $ do
       -- Confirm that after registering a hot key, they are active
       _hotKey <- registerCommitteeHotKey cc
       ccShouldNotBeResigned cc
+
+relevantDuringBootstrapSpec ::
+  forall era.
+  ( ConwayEraImp era
+  , InjectRuleFailure "LEDGER" ConwayGovCertPredFailure era
+  ) =>
+  SpecWith (ImpTestState era)
+relevantDuringBootstrapSpec = do
   describe "succeeds for" $ do
     it "registering and unregistering a DRep" $ do
       modifyPParams $ ppDRepDepositL .~ Coin 100

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
@@ -8,7 +8,10 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Test.Cardano.Ledger.Conway.Imp.GovSpec (spec) where
+module Test.Cardano.Ledger.Conway.Imp.GovSpec (
+  spec,
+  relevantDuringBootstrapSpec,
+) where
 
 import Cardano.Ledger.Address (RewardAccount (..))
 import Cardano.Ledger.Allegra.Scripts (
@@ -29,7 +32,6 @@ import Cardano.Ledger.Val (zero, (<->))
 import Data.Default.Class (Default (..))
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as Map
-import Data.Maybe
 import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
 import Data.Tree
@@ -49,15 +51,26 @@ spec ::
   SpecWith (ImpTestState era)
 spec =
   describe "GOV" $ do
-    hardForkSpec
-    pparamUpdateSpec
-    proposalsSpec
-    votingSpec
+    relevantDuringBootstrapSpec
     constitutionSpec
+    proposalsWithVotingSpec
+    votingSpec
     policySpec
-    networkIdSpec
+    networkIdWithdrawalsSpec
     predicateFailuresSpec
     unknownCostModelsSpec
+
+relevantDuringBootstrapSpec ::
+  forall era.
+  ( ConwayEraImp era
+  , InjectRuleFailure "LEDGER" ConwayGovPredFailure era
+  ) =>
+  SpecWith (ImpTestState era)
+relevantDuringBootstrapSpec = do
+  hardForkSpec
+  pparamUpdateSpec
+  proposalsSpec
+  networkIdSpec
 
 unknownCostModelsSpec ::
   forall era.
@@ -247,92 +260,19 @@ pparamUpdateSpec =
           )
           [injectFailure $ MalformedProposal ga]
 
-proposalsSpec ::
+proposalsWithVotingSpec ::
   forall era.
-  ( ConwayEraImp era
-  , InjectRuleFailure "LEDGER" ConwayGovPredFailure era
-  ) =>
+  ConwayEraImp era =>
   SpecWith (ImpTestState era)
-proposalsSpec =
+proposalsWithVotingSpec =
   describe "Proposals" $ do
     describe "Consistency" $ do
-      it "Proposals submitted without proper parent fail" $ do
-        let mkCorruptGovActionId :: GovActionId c -> GovActionId c
-            mkCorruptGovActionId (GovActionId txi (GovActionIx gaix)) =
-              GovActionId txi $ GovActionIx $ gaix + 999
-        Node p1 [Node _p11 []] <-
-          submitConstitutionGovActionTree
-            SNothing
-            $ Node
-              ()
-              [ Node () []
-              ]
-        constitutionHash <- freshSafeHash
-        pp <- getsNES $ nesEsL . curPParamsEpochStateL
-        khPropRwd <- freshKeyHash
-        let constitutionAction =
-              NewConstitution
-                (SJust $ GovPurposeId $ mkCorruptGovActionId p1)
-                ( Constitution
-                    ( Anchor
-                        (fromJust $ textToUrl 64 "constitution.after.0")
-                        constitutionHash
-                    )
-                    SNothing
-                )
-            constitutionProposal =
-              ProposalProcedure
-                { pProcDeposit = pp ^. ppGovActionDepositL
-                , pProcReturnAddr = RewardAccount Testnet (KeyHashObj khPropRwd)
-                , pProcGovAction = constitutionAction
-                , pProcAnchor = def
-                }
-        submitFailingProposal
-          constitutionProposal
-          [ injectFailure $ InvalidPrevGovActionId constitutionProposal
-          ]
-      it "Subtrees are pruned when proposals expire" $ do
-        modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 4
-        p1 <- submitInitConstitutionGovAction
-        passNEpochs 3
-        a <-
-          submitConstitutionGovActionTree
-            (SJust p1)
-            $ Node
-              ()
-              [ Node () []
-              , Node () []
-              ]
-        b <-
-          submitConstitutionGovActionTree
-            SNothing
-            $ Node
-              ()
-              [ Node () []
-              ]
-        getProposalsForest
-          `shouldReturn` [ Node SNothing []
-                         , Node SNothing []
-                         , Node SNothing []
-                         , Node
-                            SNothing
-                            [ Node (SJust p1) [SJust <$> a]
-                            , SJust <$> b
-                            ]
-                         ]
-        passNEpochs 3
-        getProposalsForest
-          `shouldReturn` [ Node SNothing []
-                         , Node SNothing []
-                         , Node SNothing []
-                         , Node SNothing [SJust <$> b]
-                         ]
       it "Subtrees are pruned when competing proposals are enacted" $ do
         (dRep, committeeMember, GovPurposeId committeeGovActionId) <- electBasicCommittee
         a@[ _
             , b@(Node p2 _)
             ] <-
-          submitConstitutionGovActionForest
+          submitConstitutionForest
             SNothing
             [ Node
                 ()
@@ -364,177 +304,6 @@ proposalsSpec =
                          , Node (SJust committeeGovActionId) []
                          , SJust <$> b
                          ]
-      it "Subtrees are pruned when proposals expire over multiple rounds" $ do
-        modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 4
-        p1 <- submitInitConstitutionGovAction
-        getProposalsForest
-          `shouldReturn` [ Node SNothing []
-                         , Node SNothing []
-                         , Node SNothing []
-                         , Node
-                            SNothing
-                            [ Node (SJust p1) []
-                            ]
-                         ]
-        passEpoch
-        p2 <- submitInitConstitutionGovAction
-        p11 <- submitChildConstitutionGovAction p1
-        getProposalsForest
-          `shouldReturn` [ Node SNothing []
-                         , Node SNothing []
-                         , Node SNothing []
-                         , Node
-                            SNothing
-                            [ Node (SJust p1) [Node (SJust p11) []]
-                            , Node (SJust p2) []
-                            ]
-                         ]
-
-        passEpoch
-        p3 <- submitInitConstitutionGovAction
-        p21 <- submitChildConstitutionGovAction p2
-        a <-
-          submitConstitutionGovActionForest
-            (SJust p11)
-            [ Node () []
-            , Node () []
-            ]
-        getProposalsForest
-          `shouldReturn` [ Node SNothing []
-                         , Node SNothing []
-                         , Node SNothing []
-                         , Node
-                            SNothing
-                            [ Node
-                                (SJust p1)
-                                [ Node
-                                    (SJust p11)
-                                    (fmap SJust <$> a)
-                                ]
-                            , Node (SJust p2) [Node (SJust p21) []]
-                            , Node (SJust p3) []
-                            ]
-                         ]
-        passEpoch
-        p4 <- submitInitConstitutionGovAction
-        p31 <- submitChildConstitutionGovAction p3
-        p211 <- submitChildConstitutionGovAction p21
-        getProposalsForest
-          `shouldReturn` [ Node SNothing []
-                         , Node SNothing []
-                         , Node SNothing []
-                         , Node
-                            SNothing
-                            [ Node
-                                (SJust p1)
-                                [ Node
-                                    (SJust p11)
-                                    (fmap SJust <$> a)
-                                ]
-                            , Node (SJust p2) [Node (SJust p21) [Node (SJust p211) []]]
-                            , Node (SJust p3) [Node (SJust p31) []]
-                            , Node (SJust p4) []
-                            ]
-                         ]
-        passNEpochs 3
-        getProposalsForest
-          `shouldReturn` [ Node SNothing []
-                         , Node SNothing []
-                         , Node SNothing []
-                         , Node
-                            SNothing
-                            [ Node (SJust p2) [Node (SJust p21) [Node (SJust p211) []]]
-                            , Node (SJust p3) [Node (SJust p31) []]
-                            , Node (SJust p4) []
-                            ]
-                         ]
-        p5 <- submitInitConstitutionGovAction
-        p41 <- submitChildConstitutionGovAction p4
-        p311 <- submitChildConstitutionGovAction p31
-        p212 <- submitChildConstitutionGovAction p21
-        getProposalsForest
-          `shouldReturn` [ Node SNothing []
-                         , Node SNothing []
-                         , Node SNothing []
-                         , Node
-                            SNothing
-                            [ Node
-                                (SJust p2)
-                                [ Node
-                                    (SJust p21)
-                                    [ Node (SJust p211) []
-                                    , Node (SJust p212) []
-                                    ]
-                                ]
-                            , Node (SJust p3) [Node (SJust p31) [Node (SJust p311) []]]
-                            , Node (SJust p4) [Node (SJust p41) []]
-                            , Node (SJust p5) []
-                            ]
-                         ]
-        passEpoch
-        p6 <- submitInitConstitutionGovAction
-        p51 <- submitChildConstitutionGovAction p5
-        p411 <- submitChildConstitutionGovAction p41
-        p312 <- submitChildConstitutionGovAction p31
-        getProposalsForest
-          `shouldReturn` [ Node SNothing []
-                         , Node SNothing []
-                         , Node SNothing []
-                         , Node
-                            SNothing
-                            [ Node
-                                (SJust p3)
-                                [ Node
-                                    (SJust p31)
-                                    [ Node (SJust p311) []
-                                    , Node (SJust p312) []
-                                    ]
-                                ]
-                            , Node (SJust p4) [Node (SJust p41) [Node (SJust p411) []]]
-                            , Node (SJust p5) [Node (SJust p51) []]
-                            , Node (SJust p6) []
-                            ]
-                         ]
-        passEpoch
-        getProposalsForest
-          `shouldReturn` [ Node SNothing []
-                         , Node SNothing []
-                         , Node SNothing []
-                         , Node
-                            SNothing
-                            [ Node (SJust p4) [Node (SJust p41) [Node (SJust p411) []]]
-                            , Node (SJust p5) [Node (SJust p51) []]
-                            , Node (SJust p6) []
-                            ]
-                         ]
-        passEpoch
-        getProposalsForest
-          `shouldReturn` [ Node SNothing []
-                         , Node SNothing []
-                         , Node SNothing []
-                         , Node
-                            SNothing
-                            [ Node (SJust p5) [Node (SJust p51) []]
-                            , Node (SJust p6) []
-                            ]
-                         ]
-        passNEpochs 3
-        getProposalsForest
-          `shouldReturn` [ Node SNothing []
-                         , Node SNothing []
-                         , Node SNothing []
-                         , Node
-                            SNothing
-                            [ Node (SJust p6) []
-                            ]
-                         ]
-        passEpoch
-        getProposalsForest
-          `shouldReturn` [ Node SNothing []
-                         , Node SNothing []
-                         , Node SNothing []
-                         , Node SNothing []
-                         ]
       it "Subtrees are pruned when competing proposals are enacted over multiple rounds" $ do
         (committeeMember :| _) <- registerInitialCommittee
         (drepC, _, _) <- setupSingleDRep 1_000_000
@@ -546,7 +315,7 @@ proposalsSpec =
                   ]
             , Node p3 []
             ] <-
-          submitConstitutionGovActionForest
+          submitConstitutionForest
             SNothing
             [ Node
                 ()
@@ -572,9 +341,9 @@ proposalsSpec =
         fmap (!! 3) getProposalsForest
           `shouldReturn` Node SNothing (fmap SJust <$> a)
         passEpoch
-        p4 <- submitInitConstitutionGovAction
-        p31 <- submitChildConstitutionGovAction p3
-        p211 <- submitChildConstitutionGovAction p21
+        p4 <- submitConstitutionGovAction SNothing
+        p31 <- submitConstitutionGovAction $ SJust p3
+        p211 <- submitConstitutionGovAction $ SJust p21
         fmap (!! 3) getProposalsForest
           `shouldReturn` Node
             SNothing
@@ -598,14 +367,14 @@ proposalsSpec =
           , Node p213 []
           , Node p214 []
           ] <-
-          submitConstitutionGovActionForest
+          submitConstitutionForest
             (SJust p21)
             [ Node () []
             , Node () []
             , Node () []
             ]
-        p2131 <- submitChildConstitutionGovAction p213
-        p2141 <- submitChildConstitutionGovAction p214
+        p2131 <- submitConstitutionGovAction $ SJust p213
+        p2141 <- submitConstitutionGovAction $ SJust p214
         submitYesVote_ (DRepVoter drepC) p212
         submitYesVote_ (CommitteeVoter committeeMember) p212
         fmap (!! 3) getProposalsForest
@@ -630,7 +399,7 @@ proposalsSpec =
         (committeeMember :| _) <- registerInitialCommittee
         (dRep, _, _) <- setupSingleDRep 1_000_000
         [Node p1 []] <-
-          submitConstitutionGovActionForest
+          submitConstitutionForest
             SNothing
             [Node () []]
         fmap (!! 3) getProposalsForest
@@ -662,7 +431,7 @@ proposalsSpec =
                 ]
           , Node p3 []
           ] <-
-          submitConstitutionGovActionForest
+          submitConstitutionForest
             SNothing
             [ Node
                 ()
@@ -700,7 +469,7 @@ proposalsSpec =
         c@[ Node _p113 []
             , Node _p114 []
             ] <-
-          submitConstitutionGovActionForest
+          submitConstitutionForest
             (SJust p11)
             [ Node () []
             , Node () []
@@ -711,7 +480,7 @@ proposalsSpec =
         d@[ Node _p115 []
             , Node p116 []
             ] <-
-          submitConstitutionGovActionForest
+          submitConstitutionForest
             (SJust p11)
             [ Node () []
             , Node () []
@@ -726,6 +495,264 @@ proposalsSpec =
         passNEpochs 3
         fmap (!! 3) getProposalsForest
           `shouldReturn` Node (SJust p116) []
+  where
+    submitConstitutionForest = submitGovActionForest submitConstitutionGovAction
+
+proposalsSpec ::
+  forall era.
+  ( ConwayEraImp era
+  , InjectRuleFailure "LEDGER" ConwayGovPredFailure era
+  ) =>
+  SpecWith (ImpTestState era)
+proposalsSpec =
+  describe "Proposals" $ do
+    describe "Consistency" $ do
+      it "Proposals submitted without proper parent fail" $ do
+        let mkCorruptGovActionId :: GovActionId c -> GovActionId c
+            mkCorruptGovActionId (GovActionId txi (GovActionIx gaix)) =
+              GovActionId txi $ GovActionIx $ gaix + 999
+        Node p1 [Node _p11 []] <-
+          submitParameterChangeTree
+            SNothing
+            $ Node
+              ()
+              [ Node () []
+              ]
+        pp <- getsNES $ nesEsL . curPParamsEpochStateL
+        khPropRwd <- freshKeyHash
+        let parameterChangeAction =
+              ParameterChange
+                (SJust $ GovPurposeId $ mkCorruptGovActionId p1)
+                (def & ppuMinFeeAL .~ SJust (Coin 3000))
+                SNothing
+            parameterChangeProposal =
+              ProposalProcedure
+                { pProcDeposit = pp ^. ppGovActionDepositL
+                , pProcReturnAddr = RewardAccount Testnet (KeyHashObj khPropRwd)
+                , pProcGovAction = parameterChangeAction
+                , pProcAnchor = def
+                }
+        submitFailingProposal
+          parameterChangeProposal
+          [ injectFailure $ InvalidPrevGovActionId parameterChangeProposal
+          ]
+      it "Subtrees are pruned when proposals expire" $ do
+        modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 4
+        p1 <- submitParameterChange SNothing (def & ppuMinFeeAL .~ SJust (Coin 3000))
+        passNEpochs 3
+        a <-
+          submitParameterChangeTree
+            (SJust p1)
+            $ Node
+              ()
+              [ Node () []
+              , Node () []
+              ]
+        b <-
+          submitParameterChangeTree
+            SNothing
+            $ Node
+              ()
+              [ Node () []
+              ]
+        getProposalsForest
+          `shouldReturn` [ Node
+                            SNothing
+                            [ Node (SJust p1) [SJust <$> a]
+                            , SJust <$> b
+                            ]
+                         , Node SNothing []
+                         , Node SNothing []
+                         , Node SNothing []
+                         ]
+        passNEpochs 3
+        getProposalsForest
+          `shouldReturn` [ Node SNothing [SJust <$> b]
+                         , Node SNothing []
+                         , Node SNothing []
+                         , Node SNothing []
+                         ]
+      it "Subtrees are pruned when proposals expire over multiple rounds" $ do
+        let ppupdate = def & ppuMinFeeAL .~ SJust (Coin 3000)
+        let submitInitialProposal = submitParameterChange SNothing ppupdate
+        let submitChildProposal parent = submitParameterChange (SJust parent) ppupdate
+        modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 4
+        p1 <- submitInitialProposal
+        getProposalsForest
+          `shouldReturn` [ Node
+                            SNothing
+                            [ Node (SJust p1) []
+                            ]
+                         , Node SNothing []
+                         , Node SNothing []
+                         , Node SNothing []
+                         ]
+
+        passEpoch
+        p2 <- submitInitialProposal
+        p11 <- submitChildProposal p1
+        getProposalsForest
+          `shouldReturn` [ Node
+                            SNothing
+                            [ Node (SJust p1) [Node (SJust p11) []]
+                            , Node (SJust p2) []
+                            ]
+                         , Node SNothing []
+                         , Node SNothing []
+                         , Node SNothing []
+                         ]
+
+        passEpoch
+        p3 <- submitInitialProposal
+        p21 <- submitChildProposal p2
+        a <-
+          submitParameterChangeForest
+            (SJust p11)
+            [ Node () []
+            , Node () []
+            ]
+        getProposalsForest
+          `shouldReturn` [ Node
+                            SNothing
+                            [ Node
+                                (SJust p1)
+                                [ Node
+                                    (SJust p11)
+                                    (fmap SJust <$> a)
+                                ]
+                            , Node (SJust p2) [Node (SJust p21) []]
+                            , Node (SJust p3) []
+                            ]
+                         , Node SNothing []
+                         , Node SNothing []
+                         , Node SNothing []
+                         ]
+
+        passEpoch
+        p4 <- submitInitialProposal
+        p31 <- submitChildProposal p3
+        p211 <- submitChildProposal p21
+        getProposalsForest
+          `shouldReturn` [ Node
+                            SNothing
+                            [ Node
+                                (SJust p1)
+                                [ Node
+                                    (SJust p11)
+                                    (fmap SJust <$> a)
+                                ]
+                            , Node (SJust p2) [Node (SJust p21) [Node (SJust p211) []]]
+                            , Node (SJust p3) [Node (SJust p31) []]
+                            , Node (SJust p4) []
+                            ]
+                         , Node SNothing []
+                         , Node SNothing []
+                         , Node SNothing []
+                         ]
+        passNEpochs 3
+        getProposalsForest
+          `shouldReturn` [ Node
+                            SNothing
+                            [ Node (SJust p2) [Node (SJust p21) [Node (SJust p211) []]]
+                            , Node (SJust p3) [Node (SJust p31) []]
+                            , Node (SJust p4) []
+                            ]
+                         , Node SNothing []
+                         , Node SNothing []
+                         , Node SNothing []
+                         ]
+        p5 <- submitInitialProposal
+        p41 <- submitChildProposal p4
+        p311 <- submitChildProposal p31
+        p212 <- submitChildProposal p21
+        getProposalsForest
+          `shouldReturn` [ Node
+                            SNothing
+                            [ Node
+                                (SJust p2)
+                                [ Node
+                                    (SJust p21)
+                                    [ Node (SJust p211) []
+                                    , Node (SJust p212) []
+                                    ]
+                                ]
+                            , Node (SJust p3) [Node (SJust p31) [Node (SJust p311) []]]
+                            , Node (SJust p4) [Node (SJust p41) []]
+                            , Node (SJust p5) []
+                            ]
+                         , Node SNothing []
+                         , Node SNothing []
+                         , Node SNothing []
+                         ]
+        passEpoch
+        p6 <- submitInitialProposal
+        p51 <- submitChildProposal p5
+        p411 <- submitChildProposal p41
+        p312 <- submitChildProposal p31
+        getProposalsForest
+          `shouldReturn` [ Node
+                            SNothing
+                            [ Node
+                                (SJust p3)
+                                [ Node
+                                    (SJust p31)
+                                    [ Node (SJust p311) []
+                                    , Node (SJust p312) []
+                                    ]
+                                ]
+                            , Node (SJust p4) [Node (SJust p41) [Node (SJust p411) []]]
+                            , Node (SJust p5) [Node (SJust p51) []]
+                            , Node (SJust p6) []
+                            ]
+                         , Node SNothing []
+                         , Node SNothing []
+                         , Node SNothing []
+                         ]
+        passEpoch
+        getProposalsForest
+          `shouldReturn` [ Node
+                            SNothing
+                            [ Node (SJust p4) [Node (SJust p41) [Node (SJust p411) []]]
+                            , Node (SJust p5) [Node (SJust p51) []]
+                            , Node (SJust p6) []
+                            ]
+                         , Node SNothing []
+                         , Node SNothing []
+                         , Node SNothing []
+                         ]
+        passEpoch
+        getProposalsForest
+          `shouldReturn` [ Node
+                            SNothing
+                            [ Node (SJust p5) [Node (SJust p51) []]
+                            , Node (SJust p6) []
+                            ]
+                         , Node SNothing []
+                         , Node SNothing []
+                         , Node SNothing []
+                         ]
+        passNEpochs 3
+        getProposalsForest
+          `shouldReturn` [ Node
+                            SNothing
+                            [ Node (SJust p6) []
+                            ]
+                         , Node SNothing []
+                         , Node SNothing []
+                         , Node SNothing []
+                         ]
+        passEpoch
+        getProposalsForest
+          `shouldReturn` [ Node SNothing []
+                         , Node SNothing []
+                         , Node SNothing []
+                         , Node SNothing []
+                         ]
+  where
+    submitParameterChangeForest = submitGovActionForest $ submitGovAction . paramAction
+    submitParameterChangeTree = submitGovActionTree $ submitGovAction . paramAction
+    paramAction p =
+      ParameterChange (GovPurposeId <$> p) (def & ppuMinFeeAL .~ SJust (Coin 10)) SNothing
 
 votingSpec ::
   forall era.
@@ -1062,6 +1089,15 @@ networkIdSpec =
               badRewardAccount
               Testnet
         ]
+
+networkIdWithdrawalsSpec ::
+  forall era.
+  ( ConwayEraImp era
+  , InjectRuleFailure "LEDGER" ConwayGovPredFailure era
+  ) =>
+  SpecWith (ImpTestState era)
+networkIdWithdrawalsSpec =
+  describe "Network ID" $ do
     it "Fails with invalid network ID in withdrawal addresses" $ do
       rewardAccount <- registerRewardAccount
       rewardCredential <- KeyHashObj <$> freshKeyHash
@@ -1114,7 +1150,7 @@ firstHardForkFollows ::
   (ProtVer -> ProtVer) ->
   ImpTestM era ()
 firstHardForkFollows computeNewFromOld = do
-  protVer <- getsNES $ nesEsL . curPParamsEpochStateL . ppProtocolVersionL
+  protVer <- getProtVer
   submitGovAction_ $ HardForkInitiation SNothing (computeNewFromOld protVer)
 
 -- | Negative (deliberatey failing) first hardfork in the Conway era where the PrevGovActionID is SNothing
@@ -1148,7 +1184,7 @@ secondHardForkFollows ::
   (ProtVer -> ProtVer) ->
   ImpTestM era ()
 secondHardForkFollows computeNewFromOld = do
-  protver0 <- getsNES $ nesEsL . curPParamsEpochStateL . ppProtocolVersionL
+  protver0 <- getProtVer
   let protver1 = minorFollow protver0
       protver2 = computeNewFromOld protver1
   gaid1 <- submitGovAction $ HardForkInitiation SNothing protver1

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -106,6 +106,7 @@ module Test.Cardano.Ledger.Conway.ImpTest (
   currentProposalsShouldContain,
   setupDRepWithoutStake,
   withImpStateWithProtVer,
+  whenPostBootstrap,
 ) where
 
 import Cardano.Crypto.DSIGN (DSIGNAlgorithm (..), Ed25519DSIGN, Signable)
@@ -162,6 +163,7 @@ import Cardano.Ledger.Crypto (Crypto (..))
 import Cardano.Ledger.DRep
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
 import Cardano.Ledger.Plutus.Language (SLanguage (..))
+import qualified Cardano.Ledger.Shelley.HardForks as HardForks (bootstrapPhase)
 import Cardano.Ledger.Shelley.LedgerState (
   IncrementalStake (..),
   asTreasuryL,
@@ -1472,3 +1474,8 @@ majorFollow pv@(ProtVer x _) = case succVersion x of
 -- | An illegal ProtVer that skips 3 minor versions
 cantFollow :: ProtVer -> ProtVer
 cantFollow (ProtVer x y) = ProtVer x (y + 3)
+
+whenPostBootstrap :: EraGov era => ImpTestM era () -> ImpTestM era ()
+whenPostBootstrap a = do
+  pv <- getsNES $ nesEsL . curPParamsEpochStateL . ppProtocolVersionL
+  unless (HardForks.bootstrapPhase pv) a

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
@@ -5,6 +5,7 @@
 module Cardano.Ledger.Shelley.HardForks (
   aggregatedRewards,
   allowMIRTransfer,
+  bootstrapPhase,
   validatePoolRewardAccountNetID,
   forgoRewardPrefilter,
   translateUpperBoundForPlutusScripts,
@@ -64,3 +65,9 @@ forgoPointerAddressResolution ::
   ProtVer ->
   Bool
 forgoPointerAddressResolution pv = pvMajor pv > natVersion @8
+
+-- | Bootstrap phase
+bootstrapPhase ::
+  ProtVer ->
+  Bool
+bootstrapPhase pv = pvMajor pv == natVersion @9

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -59,6 +59,7 @@ module Test.Cardano.Ledger.Shelley.ImpTest (
   submitFailingTx,
   trySubmitTx,
   modifyNES,
+  getProtVer,
   getsNES,
   getUTxO,
   impAddNativeScript,
@@ -1270,6 +1271,9 @@ getsNES l = gets . view $ impNESL . l
 
 getUTxO :: ImpTestM era (UTxO era)
 getUTxO = getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosUtxoL
+
+getProtVer :: EraGov era => ImpTestM era ProtVer
+getProtVer = getsNES $ nesEsL . curPParamsEpochStateL . ppProtocolVersionL
 
 submitTxAnn ::
   (HasCallStack, ShelleyEraImp era) =>

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -72,6 +72,7 @@ module Test.Cardano.Ledger.Shelley.ImpTest (
   registerAndRetirePoolToMakeReward,
   getRewardAccountAmount,
   withImpState,
+  withImpStateModified,
   shelleyFixupTx,
   lookupImpRootTxOut,
   sendValueTo,
@@ -1106,13 +1107,19 @@ logToExpr :: (HasCallStack, ToExpr a) => a -> ImpTestM era ()
 logToExpr e = logEntry (showExpr e)
 
 withImpState ::
-  forall era.
   ShelleyEraImp era =>
   SpecWith (ImpTestState era) ->
   Spec
-withImpState =
+withImpState = withImpStateModified id
+
+withImpStateModified ::
+  ShelleyEraImp era =>
+  (ImpTestState era -> ImpTestState era) ->
+  SpecWith (ImpTestState era) ->
+  Spec
+withImpStateModified f =
   beforeAll $
-    execImpTestM Nothing impTestState0 $
+    execImpTestM Nothing (f impTestState0) $
       addRootTxOut >> initImpTestState
   where
     impTestState0 =

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
@@ -53,20 +53,21 @@ spec = do
       passEpoch
       expectQueryResult (Set.singleton c1) mempty mempty Map.empty
 
-    it "members should remain authorized if authorized during the epoch after their election" $ do
-      (drep, _, _) <- setupSingleDRep 1_000_000
+    it "members should remain authorized if authorized during the epoch after their election" $
+      whenPostBootstrap $ do
+        (drep, _, _) <- setupSingleDRep 1_000_000
 
-      c1 <- KeyHashObj <$> freshKeyHash
-      _ <- electCommittee SNothing drep Set.empty [(c1, EpochNo 12)]
-      passEpoch
-      hk1 <- registerCommitteeHotKey c1
-      expectQueryResult (Set.singleton c1) mempty mempty $
-        [(c1, CommitteeMemberState (MemberAuthorized hk1) Unrecognized Nothing ToBeEnacted)]
-      passEpoch
-      expectQueryResult (Set.singleton c1) mempty mempty $
-        [(c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just 12) NoChangeExpected)]
+        c1 <- KeyHashObj <$> freshKeyHash
+        _ <- electCommittee SNothing drep Set.empty [(c1, EpochNo 12)]
+        passEpoch
+        hk1 <- registerCommitteeHotKey c1
+        expectQueryResult (Set.singleton c1) mempty mempty $
+          [(c1, CommitteeMemberState (MemberAuthorized hk1) Unrecognized Nothing ToBeEnacted)]
+        passEpoch
+        expectQueryResult (Set.singleton c1) mempty mempty $
+          [(c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just 12) NoChangeExpected)]
 
-  it "Committee queries" $ do
+  it "Committee queries" $ whenPostBootstrap $ do
     (drep, _, _) <- setupSingleDRep 1_000_000
     c1 <- KeyHashObj <$> freshKeyHash
     c2 <- KeyHashObj <$> freshKeyHash

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1489,7 +1489,7 @@ instance Reflect era => PrettyA (ConwayCertsPredFailure era) where
 ppConwayGovPredFailure :: ConwayGovPredFailure era -> PDoc
 ppConwayGovPredFailure x = case x of
   GovActionsDoNotExist c -> ppSexp "GovActionsDoNotExist" [prettyA c]
-  MalformedProposal ga -> ppSexp " MalformedProposal" [pcGovAction ga] -- (GovAction era)
+  MalformedProposal ga -> ppSexp "MalformedProposal" [pcGovAction ga]
   ProposalProcedureNetworkIdMismatch racnt nw ->
     ppSexp "ProposalProcedureNetworkIdMismatch" [pcRewardAccount racnt, pcNetwork nw]
   TreasuryWithdrawalsNetworkIdMismatch sr nw ->
@@ -1498,7 +1498,7 @@ ppConwayGovPredFailure x = case x of
   DisallowedVoters m -> ppSexp "DisallowedVoters" [prettyA m]
   ConflictingCommitteeUpdate s ->
     ppSexp "ConflictingCommitteeUpdate" [ppSet pcCredential s]
-  ExpirationEpochTooSmall m -> ppSexp " ExpirationEpochTooSmall" [ppMap pcCredential ppEpochNo m]
+  ExpirationEpochTooSmall m -> ppSexp "ExpirationEpochTooSmall" [ppMap pcCredential ppEpochNo m]
   InvalidPrevGovActionId p -> ppSexp "InvalidPrevGovActionId" [pcProposalProcedure p]
   VotingOnExpiredGovAction m ->
     ppSexp "VotingOnExpiredGovAction" [prettyA m]
@@ -1506,6 +1506,9 @@ ppConwayGovPredFailure x = case x of
     ppSexp "ProposalCantFollow" [ppStrictMaybe pcGovPurposeId s1, ppProtVer p1, ppProtVer p2]
   InvalidPolicyHash a b ->
     ppSexp "InvalidPolicyHash" [ppStrictMaybe prettyA a, ppStrictMaybe prettyA b]
+  DisallowedProposalDuringBootstrap p ->
+    ppSexp "DisallowedProposalDuringBootstrap" [pcProposalProcedure p]
+  DisallowedVotesDuringBootstrap m -> ppSexp "DisallowedVotesDuringBootstrap" [prettyA m]
 
 instance PrettyA (ConwayGovPredFailure era) where
   prettyA = ppConwayGovPredFailure


### PR DESCRIPTION
# Description

Resolves: #3451 

Implement bootstrap phase, which means, allowing only proposals of type: ParameterChange, HardForkInitiation and Info 
and restricting DRep voting to proposals of type Info. 

The biggest part of the PR is adjusting the tests, namely, 
 *  running all existing tests with protocol version 10 and 
 *  running tests that are relevant (or permitted) during bootstrap phase only with protocol version 9   

I have tried to maximize the number of test we can run for the bootstrap phase, so in some places i have replaced the type of proposal tested (eg: new constitution with parameter update). 
Where this was too complicated (Eg: if drep voting was involved) or the tested proposal is not relevant for bootstrap by the nature of  the proposal, I have separated the tests in two, and ran them with their appropriate protocol version. 
   
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
