### PR TITLE
`constrained-generators`: Fix bug in toPreds for maps + add additional tests

### DIFF
--- a/libs/constrained-generators/src/Constrained/Base.hs
+++ b/libs/constrained-generators/src/Constrained/Base.hs
@@ -2786,6 +2786,8 @@ instance BaseUniverse fn => Functions (SetFn fn) fn where
     | [a] <- Set.toList s = Just $ t ==. lit a
   rewriteRules Union (x :> Lit s :> Nil) | null s = Just x
   rewriteRules Union (Lit s :> x :> Nil) | null s = Just x
+  rewriteRules Subset (Lit s :> _ :> Nil) | null s = Just $ Lit True
+  rewriteRules Subset (x :> Lit s :> Nil) | null s = Just $ x ==. mempty
   rewriteRules _ _ = Nothing
 
   -- NOTE: this function over-approximates and returns a liberal spec.

--- a/libs/constrained-generators/src/Constrained/Properties.hs
+++ b/libs/constrained-generators/src/Constrained/Properties.hs
@@ -21,6 +21,9 @@ prop_sound spec =
       Result _ a -> QC.cover 80 True "successful" $ QC.counterexample (show a) $ conformsToSpecProp a spec
       _ -> QC.cover 80 False "successful" True
 
+prop_constrained_satisfies_sound :: HasSpec fn a => Specification fn a -> QC.Property
+prop_constrained_satisfies_sound spec = prop_sound (constrained $ \a -> satisfies a spec)
+
 -- | `prop_complete ps` assumes that `ps` is satisfiable
 prop_complete :: HasSpec fn a => Specification fn a -> QC.Property
 prop_complete s =
@@ -29,6 +32,9 @@ prop_complete s =
     -- Force the value to make sure we don't crash with `error` somewhere
     -- or fall into an inifinite loop
     pure $ length (show a) > 0
+
+prop_constrained_satisfies_complete :: HasSpec fn a => Specification fn a -> QC.Property
+prop_constrained_satisfies_complete spec = prop_complete (constrained $ \a -> satisfies a spec)
 
 prop_shrink_sound :: HasSpec fn a => Specification fn a -> QC.Property
 prop_shrink_sound s =

--- a/libs/constrained-generators/src/Constrained/Spec/Maps.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Maps.hs
@@ -138,13 +138,12 @@ instance
 
   toPreds m (MapSpec mustKeys mustVals size kvs foldSpec) =
     toPred
-      [ assert $ app (subsetFn @fn) (app (domFn @fn) m) (Lit mustKeys)
+      [ assert $ lit mustKeys `subset_` dom_ m
       , forAll (Lit mustVals) $ \val ->
-          app (elemFn @fn) val (app (rngFn @fn) m)
-      , -- TODO: make nice
-        satisfies (app (injectFn $ SizeOf @fn) $ app (rngFn @fn) m) size
+          val `elem_` rng_ m
+      , sizeOf_ (rng_ m) `satisfies` size
       , forAll m $ \kv -> satisfies kv kvs
-      , toPredsFoldSpec (app (rngFn @fn) m) foldSpec
+      , toPredsFoldSpec (rng_ m) foldSpec
       ]
 
 ------------------------------------------------------------------------

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -191,7 +191,14 @@ testSpecNoShrink = testSpec' False
 testSpec' :: HasSpec fn a => Bool -> String -> Specification fn a -> Spec
 testSpec' withShrink n s =
   describe n $ do
-    prop "prop_sound" $ within 10_000_000 $ checkCoverage $ prop_sound s
+    prop "prop_sound" $
+      within 10_000_000 $
+        checkCoverage $
+          prop_sound s
+    prop "prop_constrained_satisfies_sound" $
+      within 10_000_000 $
+        checkCoverage $
+          prop_constrained_satisfies_sound s
     when withShrink $
       prop "prop_shrink_sound" $
         within 10_000_000 $


### PR DESCRIPTION
# Description

There was a silly bug in toPreds whereby the required elements of the domain would become the universe of the domain when you do `toPreds`. This resulted in maps being constrained to be empty under unfortunate circumstances.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
