### PR TITLE
`constrained-generators`: add new test to test suite

### DIFF
--- a/libs/constrained-generators/src/Constrained/Examples/Map.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Map.hs
@@ -51,3 +51,9 @@ mapSizeConstrained = constrained $ \m -> size_ (dom_ m) <=. 3
 
 sumRange :: Specification BaseFn (Map Word64 Word64)
 sumRange = constrained $ \m -> sum_ (rng_ m) ==. lit 10
+
+fixedRange :: Specification BaseFn (Map Int Int)
+fixedRange = constrained $ \m ->
+  [ forAll (rng_ m) (\x -> x ==. 5)
+  , assert $ (sizeOf_ m) ==. 1
+  ]

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -111,6 +111,7 @@ tests =
     testSpec "sumListBad" sumListBad
     testSpec "listExistsUnfree" listExistsUnfree
     testSpec "existsUnfree" existsUnfree
+    testSpec "fixedRangeElements" fixedRange
     numberyTests
     sizeTests
     numNumSpecTree


### PR DESCRIPTION
# Description

@TimSheard had a failure in this test on an old branch. It was fixed recently but I think it's none the less a nice minimal test for an old bug so we should keep it around to avoid regressions.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
