### PR TITLE
Start Conway Imp tests with an initial committee and constitution

### DIFF
--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -68,7 +68,7 @@ library
         cardano-crypto-class,
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-core ^>=1.12,
-        cardano-ledger-shelley ^>=1.10,
+        cardano-ledger-shelley ^>=1.11,
         cardano-strict-containers,
         cardano-slotting,
         cborg,

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
@@ -37,7 +37,7 @@ instance
   ) =>
   ShelleyEraImp (AllegraEra c)
   where
-  initImpNES = initShelleyImpNES
+  initImpTestState = pure ()
 
   impSatisfyNativeScript = impAllegraSatisfyNativeScript
 

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -81,7 +81,7 @@ library
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-core ^>=1.12,
         cardano-ledger-mary ^>=1.6.0,
-        cardano-ledger-shelley ^>=1.10,
+        cardano-ledger-shelley ^>=1.11,
         cardano-slotting,
         cardano-strict-containers,
         containers,
@@ -133,10 +133,10 @@ library testlib
         cardano-ledger-core:{cardano-ledger-core, testlib},
         cardano-strict-containers,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
-        data-default-class,
         plutus-ledger-api,
         generic-random,
         microlens,
+        microlens-mtl,
         text,
         tree-diff
 

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -58,7 +58,6 @@ import Cardano.Ledger.Plutus.Language (
  )
 import Cardano.Ledger.Shelley.LedgerState (
   NewEpochState,
-  StashedAVVMAddresses,
   curPParamsEpochStateL,
   esLStateL,
   lsUTxOStateL,
@@ -68,7 +67,6 @@ import Cardano.Ledger.Shelley.LedgerState (
 import Cardano.Ledger.Shelley.UTxO (EraUTxO (..), ScriptsProvided (..))
 import Cardano.Ledger.TxIn (TxIn)
 import Control.Monad (forM)
-import Data.Default.Class (Default)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.MapExtras (fromElems)
@@ -76,6 +74,7 @@ import Data.Maybe (catMaybes)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Lens.Micro
+import Lens.Micro.Mtl ((%=))
 import qualified PlutusLedgerApi.Common as P
 import Test.Cardano.Ledger.Alonzo.TreeDiff ()
 import Test.Cardano.Ledger.Core.Arbitrary ()
@@ -102,14 +101,12 @@ class
 initAlonzoImpNES ::
   forall era.
   ( AlonzoEraPParams era
-  , Default (StashedAVVMAddresses era)
   , ShelleyEraImp era
   , AlonzoEraScript era
   ) =>
+  NewEpochState era ->
   NewEpochState era
-initAlonzoImpNES =
-  initShelleyImpNES
-    & nesEsL . curPParamsEpochStateL %~ initPParams
+initAlonzoImpNES = nesEsL . curPParamsEpochStateL %~ initPParams
   where
     initPParams pp =
       pp
@@ -384,7 +381,7 @@ instance
   ) =>
   ShelleyEraImp (AlonzoEra c)
   where
-  initImpNES = initAlonzoImpNES
+  initImpTestState = impNESL %= initAlonzoImpNES
   impSatisfyNativeScript = impAllegraSatisfyNativeScript
   fixupTx = alonzoFixupTx
 

--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -48,7 +48,7 @@ library
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
         cardano-ledger-core:{cardano-ledger-core, testlib} >=1.11 && <1.13,
         cardano-ledger-allegra >=1.2,
-        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.6 && <1.11,
+        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.6 && <1.12,
         cardano-ledger-shelley-test >=1.2,
         cardano-ledger-shelley-ma-test ^>=1.2,
         cardano-ledger-mary >=1.4,

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -77,7 +77,7 @@ library
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-core ^>=1.12,
         cardano-ledger-mary ^>=1.6,
-        cardano-ledger-shelley ^>=1.10,
+        cardano-ledger-shelley ^>=1.11,
         cardano-strict-containers,
         containers,
         deepseq,
@@ -117,6 +117,7 @@ library testlib
         cardano-ledger-binary,
         cardano-ledger-core:{cardano-ledger-core, testlib},
         generic-random,
+        microlens-mtl,
         small-steps >=1.1,
         QuickCheck
 

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
@@ -17,6 +17,7 @@ import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto (..))
 import Cardano.Ledger.Plutus.Language (SLanguage (..))
+import Lens.Micro.Mtl ((%=))
 import Test.Cardano.Ledger.Alonzo.ImpTest
 import Test.Cardano.Ledger.Babbage.TreeDiff ()
 import Test.Cardano.Ledger.Common
@@ -30,7 +31,7 @@ instance
   ) =>
   ShelleyEraImp (BabbageEra c)
   where
-  initImpNES = initAlonzoImpNES
+  initImpTestState = impNESL %= initAlonzoImpNES
   impSatisfyNativeScript = impAllegraSatisfyNativeScript
   fixupTx = alonzoFixupTx
 

--- a/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
+++ b/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
@@ -41,7 +41,7 @@ library
         cardano-ledger-shelley-ma-test >=1.1,
         cardano-ledger-mary >=1.4,
         cardano-ledger-shelley-test >=1.1,
-        cardano-ledger-shelley >=1.6 && <1.11,
+        cardano-ledger-shelley >=1.6 && <1.12,
         cardano-strict-containers,
         cardano-slotting,
         containers,

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -52,6 +52,7 @@
 
 ### `testlib`
 
+* Add `registerInitialCommittee` and `getCommitteeMembers` to Conway ImpTest
 * Implement `ConwayUtxowPredFailure` instances:
   * `Arbitrary`
   * `ToExpr`

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -52,6 +52,7 @@
 
 ### `testlib`
 
+* Change return type of `setupSingleDRep` to Credential instead of KeyHash
 * Add `registerInitialCommittee` and `getCommitteeMembers` to Conway ImpTest
 * Implement `ConwayUtxowPredFailure` instances:
   * `Arbitrary`

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -52,6 +52,7 @@
 
 ### `testlib`
 
+* Add `getConstitution` to Conway ImpTest
 * Change return type of `setupSingleDRep` to Credential instead of KeyHash
 * Add `registerInitialCommittee` and `getCommitteeMembers` to Conway ImpTest
 * Implement `ConwayUtxowPredFailure` instances:

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -92,7 +92,7 @@ library
         cardano-ledger-babbage ^>=1.8,
         cardano-ledger-core ^>=1.12,
         cardano-ledger-mary ^>=1.6,
-        cardano-ledger-shelley ^>=1.10,
+        cardano-ledger-shelley ^>=1.11,
         cardano-slotting,
         cardano-strict-containers,
         containers,
@@ -157,6 +157,7 @@ library testlib
         cardano-strict-containers,
         data-default-class,
         generic-random,
+        microlens-mtl,
         mtl,
         text,
         small-steps >=1.1

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -66,4 +66,3 @@ spec = do
     Utxo.spec @era
     Utxos.spec @era
     Ratify.spec @era
-    GovCert.spec @era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
@@ -107,7 +107,6 @@ treasuryWithdrawalsSpec =
     it "Withdrawals exceeding treasury submitted in a single proposal" $ do
       (committeeC :| _) <- registerInitialCommittee
       (drepC, _, _) <- setupSingleDRep 1_000_000
-      modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
       initialTreasury <- getTreasury
       numWithdrawals <- choose (1, 10)
       withdrawals <- genWithdrawalsExceeding initialTreasury numWithdrawals
@@ -129,7 +128,6 @@ treasuryWithdrawalsSpec =
     it "Withdrawals exceeding maxBound Word64 submitted in a single proposal" $ do
       (committeeC :| _) <- registerInitialCommittee
       (drepC, _, _) <- setupSingleDRep 1_000_000
-      modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
       initialTreasury <- getTreasury
       numWithdrawals <- choose (1, 10)
       withdrawals <- genWithdrawalsExceeding (Coin (fromIntegral (maxBound :: Word64))) numWithdrawals
@@ -139,7 +137,6 @@ treasuryWithdrawalsSpec =
     it "Withdrawals exceeding treasury submitted in several proposals within the same epoch" $ do
       (committeeC :| _) <- registerInitialCommittee
       (drepC, _, _) <- setupSingleDRep 1_000_000
-      modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
       initialTreasury <- getTreasury
       numWithdrawals <- choose (1, 10)
       withdrawals <- genWithdrawalsExceeding initialTreasury numWithdrawals
@@ -347,7 +344,6 @@ actionPrioritySpec =
       $ do
         (drepC, _, _) <- setupSingleDRep 1_000_000
         (poolKH, _, _) <- setupPoolWithStake $ Coin 1_000_000
-        modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
         cc <- KeyHashObj <$> freshKeyHash
         gai1 <-
           submitGovAction $
@@ -379,7 +375,6 @@ actionPrioritySpec =
     it "proposals of same priority are enacted in order of submission" $ do
       (committeeC :| _) <- registerInitialCommittee
       (drepC, _, _) <- setupSingleDRep 1_000_000
-      modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
       pGai0 <-
         submitParameterChange
           SNothing
@@ -408,7 +403,6 @@ actionPrioritySpec =
     it "only the first action of a transaction gets enacted" $ do
       (committeeC :| _) <- registerInitialCommittee
       (drepC, _, _) <- setupSingleDRep 1_000_000
-      modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 5
       gaids <-
         submitGovActions $
           NE.fromList

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
@@ -281,6 +281,7 @@ constitutionSpec =
     (committeeMember :| _) <- registerInitialCommittee
     (dRep, _, _) <- setupSingleDRep 1_000_000
     (govActionId, constitution) <- submitConstitution SNothing
+    initialConstitution <- getConstitution
 
     proposalsBeforeVotes <- getsNES $ newEpochStateGovStateL . proposalsGovStateL
     pulserBeforeVotes <- getsNES newEpochStateDRepPulsingStateL
@@ -312,7 +313,7 @@ constitutionSpec =
 
     impAnn "New constitution is not enacted after one epoch" $ do
       constitutionAfterOneEpoch <- getsNES $ newEpochStateGovStateL . constitutionGovStateL
-      constitutionAfterOneEpoch `shouldBe` def
+      constitutionAfterOneEpoch `shouldBe` initialConstitution
 
     impAnn "Pulser should reflect the constitution to be enacted" $ do
       pulser <- getsNES newEpochStateDRepPulsingStateL

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
@@ -218,13 +218,13 @@ dRepSpec =
       gaidConstitutionProp <- submitGovAction constitutionAction
 
       (committeeHotCred :| _) <- registerInitialCommittee
-      (drepKh, _, _) <- setupSingleDRep 1_000_000
+      (dRepCred, _, _) <- setupSingleDRep 1_000_000
       passEpoch
       logRatificationChecks gaidConstitutionProp
       do
         isAccepted <- isDRepAccepted gaidConstitutionProp
         assertBool "Gov action should not be accepted" $ not isAccepted
-      submitYesVote_ (DRepVoter (KeyHashObj drepKh)) gaidConstitutionProp
+      submitYesVote_ (DRepVoter dRepCred) gaidConstitutionProp
       submitYesVote_ (CommitteeVoter committeeHotCred) gaidConstitutionProp
       logAcceptedRatio gaidConstitutionProp
       do
@@ -271,7 +271,7 @@ treasuryWithdrawalExpectation ::
   ImpTestM era ()
 treasuryWithdrawalExpectation extraWithdrawals = do
   (committeeHotCred :| _) <- registerInitialCommittee
-  (drepKh, _, _) <- setupSingleDRep 1_000_000
+  (dRepCred, _, _) <- setupSingleDRep 1_000_000
   treasuryStart <- getsNES $ nesEsL . esAccountStateL . asTreasuryL
   rewardAccount <- registerRewardAccount
   govPolicy <- getGovPolicy
@@ -280,7 +280,7 @@ treasuryWithdrawalExpectation extraWithdrawals = do
     submitGovActions $
       TreasuryWithdrawals (Map.singleton rewardAccount withdrawalAmount) govPolicy
         NE.:| extraWithdrawals
-  submitYesVote_ (DRepVoter (KeyHashObj drepKh)) govActionId
+  submitYesVote_ (DRepVoter dRepCred) govActionId
   submitYesVote_ (CommitteeVoter committeeHotCred) govActionId
   passEpoch -- 1st epoch crossing starts DRep pulser
   impAnn "Withdrawal should not be received yet" $
@@ -342,7 +342,7 @@ eventsSpec = describe "Events" $ do
   describe "emits event" $ do
     it "GovInfoEvent" $ do
       (ccCred :| _) <- registerInitialCommittee
-      (drepKh, _, _) <- setupSingleDRep 1_000_000
+      (dRepCred, _, _) <- setupSingleDRep 1_000_000
       let actionLifetime = 10
       modifyPParams $ \pp ->
         pp
@@ -381,7 +381,7 @@ eventsSpec = describe "Events" $ do
                            ]
       replicateM_ (fromIntegral actionLifetime) passEpochWithNoDroppedActions
       logAcceptedRatio proposalA
-      submitYesVote_ (DRepVoter (KeyHashObj drepKh)) proposalA
+      submitYesVote_ (DRepVoter dRepCred) proposalA
       submitYesVote_ (CommitteeVoter ccCred) proposalA
       gasA <- getGovActionState proposalA
       gasB <- getGovActionState proposalB

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
@@ -39,7 +39,7 @@ import Data.Maybe.Strict (StrictMaybe (..))
 import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
 import Data.Tree
-import Lens.Micro ((%~), (&), (.~))
+import Lens.Micro ((&), (.~))
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Core.Rational (IsRatio (..))
 import Test.Cardano.Ledger.Imp.Common
@@ -189,17 +189,6 @@ dRepSpec =
       logStakeDistr
       passEpoch
     it "constitution is accepted after two epochs" $ do
-      modifyPParams $ \pp ->
-        pp
-          & ppDRepVotingThresholdsL
-            %~ ( \dvt ->
-                  dvt
-                    { dvtCommitteeNormal = 1 %! 1
-                    , dvtCommitteeNoConfidence = 1 %! 2
-                    , dvtUpdateToConstitution = 1 %! 2
-                    }
-               )
-
       constitutionHash <- freshSafeHash
       let
         constitutionAction =
@@ -300,6 +289,7 @@ depositMovesToTreasuryWhenStakingAddressUnregisters = do
     pp
       & ppGovActionLifetimeL .~ EpochInterval 8
       & ppGovActionDepositL .~ Coin 100
+      & ppCommitteeMaxTermLengthL .~ EpochInterval 0
   returnAddr <- registerRewardAccount
   govActionDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppGovActionDepositL
   khCC <- KeyHashObj <$> freshKeyHash

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovCertSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovCertSpec.hs
@@ -67,13 +67,13 @@ spec = describe "GOVCERT" $ do
     "A CC that has resigned will need to be first voted out and then voted in to be considered active"
     $ do
       modifyPParams $ \pp -> pp & ppCommitteeMaxTermLengthL .~ EpochInterval 20
-      (drepKh, _, _) <- setupSingleDRep 1_000_000
+      (drepCred, _, _) <- setupSingleDRep 1_000_000
       passNEpochs 2
       -- Add a fresh CC
       cc <- KeyHashObj <$> freshKeyHash
       let addCCAction = UpdateCommittee SNothing mempty (Map.singleton cc 10) (1 %! 2)
       addCCGaid <- submitGovAction addCCAction
-      submitYesVote_ (DRepVoter (KeyHashObj drepKh)) addCCGaid
+      submitYesVote_ (DRepVoter drepCred) addCCGaid
       passNEpochs 2
       -- Confirm that they are added
       SJust committee <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . committeeGovStateL
@@ -93,14 +93,14 @@ spec = describe "GOVCERT" $ do
       -- Re-add the same CC
       let reAddCCAction = UpdateCommittee (SJust $ GovPurposeId addCCGaid) mempty (Map.singleton cc 20) (1 %! 2)
       reAddCCGaid <- submitGovAction reAddCCAction
-      submitYesVote_ (DRepVoter (KeyHashObj drepKh)) reAddCCGaid
+      submitYesVote_ (DRepVoter drepCred) reAddCCGaid
       passNEpochs 2
       -- Confirm that they are still resigned
       ccShouldBeResigned cc
       -- Remove them
       let removeCCAction = UpdateCommittee (SJust $ GovPurposeId reAddCCGaid) (Set.singleton cc) mempty (1 %! 2)
       removeCCGaid <- submitGovAction removeCCAction
-      submitYesVote_ (DRepVoter (KeyHashObj drepKh)) removeCCGaid
+      submitYesVote_ (DRepVoter drepCred) removeCCGaid
       passNEpochs 2
       -- Confirm that they have been removed
       SJust committeeAfterRemove <-
@@ -109,7 +109,7 @@ spec = describe "GOVCERT" $ do
       -- Add the same CC back a second time
       let secondAddCCAction = UpdateCommittee (SJust $ GovPurposeId removeCCGaid) mempty (Map.singleton cc 20) (1 %! 2)
       secondAddCCGaid <- submitGovAction secondAddCCAction
-      submitYesVote_ (DRepVoter (KeyHashObj drepKh)) secondAddCCGaid
+      submitYesVote_ (DRepVoter drepCred) secondAddCCGaid
       passNEpochs 2
       -- Confirm that they have been added
       SJust committeeAfterRemoveAndAdd <-

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovCertSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovCertSpec.hs
@@ -11,7 +11,6 @@
 
 module Test.Cardano.Ledger.Conway.Imp.GovCertSpec (spec) where
 
-import Cardano.Ledger.BaseTypes (EpochInterval (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core (
   EraGov (..),
@@ -26,7 +25,6 @@ import Cardano.Ledger.Conway.Governance (
   Voter (..),
   committeeMembersL,
  )
-import Cardano.Ledger.Conway.PParams (ppCommitteeMaxTermLengthL)
 import Cardano.Ledger.Conway.Rules (ConwayGovCertPredFailure (..))
 import Cardano.Ledger.Conway.TxCert (
   pattern AuthCommitteeHotKeyTxCert,
@@ -66,7 +64,6 @@ spec = describe "GOVCERT" $ do
   it
     "A CC that has resigned will need to be first voted out and then voted in to be considered active"
     $ do
-      modifyPParams $ \pp -> pp & ppCommitteeMaxTermLengthL .~ EpochInterval 20
       (drepCred, _, _) <- setupSingleDRep 1_000_000
       passNEpochs 2
       -- Add a fresh CC

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovCertSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovCertSpec.hs
@@ -1,20 +1,21 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
 module Test.Cardano.Ledger.Conway.Imp.GovCertSpec (spec) where
 
-import Cardano.Ledger.BaseTypes (EpochInterval (..), EpochNo (..))
+import Cardano.Ledger.BaseTypes (EpochInterval (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core (
   EraGov (..),
   InjectRuleFailure (..),
-  ppCommitteeMaxTermLengthL,
   ppDRepDepositL,
  )
 import Cardano.Ledger.Conway.Governance (
@@ -23,9 +24,9 @@ import Cardano.Ledger.Conway.Governance (
   GovAction (..),
   GovPurposeId (..),
   Voter (..),
-  committeeMembers,
   committeeMembersL,
  )
+import Cardano.Ledger.Conway.PParams (ppCommitteeMaxTermLengthL)
 import Cardano.Ledger.Conway.Rules (ConwayGovCertPredFailure (..))
 import Cardano.Ledger.Conway.TxCert (
   pattern AuthCommitteeHotKeyTxCert,
@@ -33,9 +34,8 @@ import Cardano.Ledger.Conway.TxCert (
   pattern ResignCommitteeColdTxCert,
   pattern UnRegDRepTxCert,
  )
-import Cardano.Ledger.Core (Era (..), EraTx (..), EraTxBody (..))
+import Cardano.Ledger.Core (EraTx (..), EraTxBody (..))
 import Cardano.Ledger.Credential (Credential (..))
-import Cardano.Ledger.Keys (KeyRole (..))
 import Cardano.Ledger.Shelley.LedgerState (
   curPParamsEpochStateL,
   esLStateL,
@@ -55,22 +55,6 @@ import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Core.Rational (IsRatio (..))
 import Test.Cardano.Ledger.Imp.Common
 
-electCommittee1 :: ConwayEraImp era => ImpTestM era (Credential 'ColdCommitteeRole (EraCrypto era))
-electCommittee1 = do
-  modifyPParams $ ppCommitteeMaxTermLengthL .~ EpochInterval 100
-  drep <- registerDRep
-  EpochInterval ccTerm <- getsNES $ nesEsL . curPParamsEpochStateL . ppCommitteeMaxTermLengthL
-  ccCred <- KeyHashObj <$> freshKeyHash
-  let
-    committee = Map.singleton ccCred (EpochNo $ fromIntegral ccTerm)
-  _ <- electCommittee SNothing drep mempty committee
-  passNEpochs 3
-  newCommittee <-
-    getsNES $
-      nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . committeeGovStateL
-  fmap committeeMembers newCommittee `shouldBe` SJust committee
-  pure ccCred
-
 spec ::
   forall era.
   ( ConwayEraImp era
@@ -82,13 +66,14 @@ spec = describe "GOVCERT" $ do
   it
     "A CC that has resigned will need to be first voted out and then voted in to be considered active"
     $ do
-      (dRep, _, gaidCC) <- electBasicCommittee
+      modifyPParams $ \pp -> pp & ppCommitteeMaxTermLengthL .~ EpochInterval 20
+      (drepKh, _, _) <- setupSingleDRep 1_000_000
       passNEpochs 2
       -- Add a fresh CC
       cc <- KeyHashObj <$> freshKeyHash
-      let addCCAction = UpdateCommittee (SJust gaidCC) mempty (Map.singleton cc 20) (1 %! 2)
+      let addCCAction = UpdateCommittee SNothing mempty (Map.singleton cc 10) (1 %! 2)
       addCCGaid <- submitGovAction addCCAction
-      submitYesVote_ (DRepVoter dRep) addCCGaid
+      submitYesVote_ (DRepVoter (KeyHashObj drepKh)) addCCGaid
       passNEpochs 2
       -- Confirm that they are added
       SJust committee <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . committeeGovStateL
@@ -108,14 +93,14 @@ spec = describe "GOVCERT" $ do
       -- Re-add the same CC
       let reAddCCAction = UpdateCommittee (SJust $ GovPurposeId addCCGaid) mempty (Map.singleton cc 20) (1 %! 2)
       reAddCCGaid <- submitGovAction reAddCCAction
-      submitYesVote_ (DRepVoter dRep) reAddCCGaid
+      submitYesVote_ (DRepVoter (KeyHashObj drepKh)) reAddCCGaid
       passNEpochs 2
       -- Confirm that they are still resigned
       ccShouldBeResigned cc
       -- Remove them
       let removeCCAction = UpdateCommittee (SJust $ GovPurposeId reAddCCGaid) (Set.singleton cc) mempty (1 %! 2)
       removeCCGaid <- submitGovAction removeCCAction
-      submitYesVote_ (DRepVoter dRep) removeCCGaid
+      submitYesVote_ (DRepVoter (KeyHashObj drepKh)) removeCCGaid
       passNEpochs 2
       -- Confirm that they have been removed
       SJust committeeAfterRemove <-
@@ -124,7 +109,7 @@ spec = describe "GOVCERT" $ do
       -- Add the same CC back a second time
       let secondAddCCAction = UpdateCommittee (SJust $ GovPurposeId removeCCGaid) mempty (Map.singleton cc 20) (1 %! 2)
       secondAddCCGaid <- submitGovAction secondAddCCAction
-      submitYesVote_ (DRepVoter dRep) secondAddCCGaid
+      submitYesVote_ (DRepVoter (KeyHashObj drepKh)) secondAddCCGaid
       passNEpochs 2
       -- Confirm that they have been added
       SJust committeeAfterRemoveAndAdd <-
@@ -154,13 +139,15 @@ spec = describe "GOVCERT" $ do
               .~ SSeq.singleton (ResignCommitteeColdTxCert someCred SNothing)
         )
     it "re-registering a CC hot key" $ do
-      ccCred <- electCommittee1
-      replicateM_ 10 $ do
-        ccHotCred <- KeyHashObj <$> freshKeyHash
-        submitTx_ $
-          mkBasicTx mkBasicTxBody
-            & bodyTxL . certsTxBodyL
-              .~ SSeq.singleton (AuthCommitteeHotKeyTxCert ccCred ccHotCred)
+      void registerInitialCommittee
+      initialCommittee <- getCommitteeMembers
+      forM_ initialCommittee $ \kh ->
+        replicateM_ 10 $ do
+          ccHotCred <- KeyHashObj <$> freshKeyHash
+          submitTx_ $
+            mkBasicTx mkBasicTxBody
+              & bodyTxL . certsTxBodyL
+                .~ SSeq.singleton (AuthCommitteeHotKeyTxCert kh ccHotCred)
   describe "fails for" $ do
     it "invalid deposit provided with DRep registration cert" $ do
       modifyPParams $ ppDRepDepositL .~ Coin 100
@@ -220,18 +207,20 @@ spec = describe "GOVCERT" $ do
         )
         (pure . injectFailure $ ConwayDRepNotRegistered drepCred)
     it "registering a resigned CC member hotkey" $ do
-      ccCred <- electCommittee1
-      ccHotCred <- KeyHashObj <$> freshKeyHash
-      let
-        registerHotKeyTx =
+      void registerInitialCommittee
+      initialCommittee <- getCommitteeMembers
+      forM_ initialCommittee $ \ccCred -> do
+        ccHotCred <- KeyHashObj <$> freshKeyHash
+        let
+          registerHotKeyTx =
+            mkBasicTx mkBasicTxBody
+              & bodyTxL . certsTxBodyL
+                .~ SSeq.singleton (AuthCommitteeHotKeyTxCert ccCred ccHotCred)
+        submitTx_ registerHotKeyTx
+        submitTx_ $
           mkBasicTx mkBasicTxBody
             & bodyTxL . certsTxBodyL
-              .~ SSeq.singleton (AuthCommitteeHotKeyTxCert ccCred ccHotCred)
-      submitTx_ registerHotKeyTx
-      submitTx_ $
-        mkBasicTx mkBasicTxBody
-          & bodyTxL . certsTxBodyL
-            .~ SSeq.singleton (ResignCommitteeColdTxCert ccCred SNothing)
-      submitFailingTx
-        registerHotKeyTx
-        (pure . injectFailure $ ConwayCommitteeHasPreviouslyResigned ccCred)
+              .~ SSeq.singleton (ResignCommitteeColdTxCert ccCred SNothing)
+        submitFailingTx
+          registerHotKeyTx
+          (pure . injectFailure $ ConwayCommitteeHasPreviouslyResigned ccCred)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
@@ -260,7 +260,6 @@ proposalsSpec =
         let mkCorruptGovActionId :: GovActionId c -> GovActionId c
             mkCorruptGovActionId (GovActionId txi (GovActionIx gaix)) =
               GovActionId txi $ GovActionIx $ gaix + 999
-        modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 4
         Node p1 [Node _p11 []] <-
           submitConstitutionGovActionTree
             SNothing
@@ -789,7 +788,6 @@ votingSpec =
                 { dvtUpdateToConstitution = 1 %! 2
                 }
             & ppCommitteeMinSizeL .~ 2
-            & ppCommitteeMaxTermLengthL .~ EpochInterval 10
         (dRepCred, _, _) <- setupSingleDRep 1_000_000
         ccColdCred0 <- KeyHashObj <$> freshKeyHash
         ccColdCred1 <- KeyHashObj <$> freshKeyHash

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -186,7 +186,6 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromJust, isJust)
-import Data.Maybe.Strict (isSJust)
 import Data.Sequence.Strict (StrictSeq (..))
 import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
@@ -927,7 +926,7 @@ getRatifyEnvAndState = do
   pure (ratifyEnv, ratifyState)
 
 -- | Checks whether the governance action has enough DRep votes to be accepted in the next
--- epoch. (Note that no other checks execept DRep votes is used)
+-- epoch. (Note that no other checks except DRep votes are used)
 isDRepAccepted ::
   (HasCallStack, ConwayEraGov era, ConwayEraPParams era) =>
   GovActionId (EraCrypto era) ->
@@ -1095,26 +1094,8 @@ electBasicCommittee = do
       , UpdateCommittee SNothing mempty mempty (1 %! 10)
       ]
   submitYesVote_ (DRepVoter $ KeyHashObj drepKH) gaidCommitteeProp
-
-  let
-    assertNoCommittee = do
-      committee <-
-        getsNES $
-          nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . committeeGovStateL
-      impAnn "There should not be a committee" $ committee `shouldBe` SNothing
-  logRatificationChecks gaidCommitteeProp
-  assertNoCommittee
-
   passEpoch
-  logRatificationChecks gaidCommitteeProp
-  assertNoCommittee
   passEpoch
-  do
-    committee <-
-      getsNES $
-        nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . committeeGovStateL
-    impAnn "There should be a committee" $ committee `shouldSatisfy` isSJust
-
   hotCommitteeC <- registerCommitteeHotKey coldCommitteeC
   pure (KeyHashObj drepKH, hotCommitteeC, GovPurposeId gaidCommitteeProp)
 

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -236,6 +236,17 @@ instance
               (initAlonzoImpNES nes)
                 & nesEsL . curPParamsEpochStateL . ppDRepActivityL .~ EpochInterval 100
                 & nesEsL . curPParamsEpochStateL . ppGovActionLifetimeL .~ EpochInterval 30
+                & nesEsL . curPParamsEpochStateL . ppGovActionDepositL .~ Coin 123
+                & nesEsL . curPParamsEpochStateL . ppCommitteeMaxTermLengthL .~ EpochInterval 20
+                & nesEsL . curPParamsEpochStateL . ppCommitteeMinSizeL .~ 1
+                & nesEsL . curPParamsEpochStateL . ppDRepVotingThresholdsL
+                  %~ ( \dvt ->
+                        dvt
+                          { dvtCommitteeNormal = 1 %! 1
+                          , dvtCommitteeNoConfidence = 1 %! 2
+                          , dvtUpdateToConstitution = 1 %! 2
+                          }
+                     )
                 & nesEsL . epochStateGovStateL . committeeGovStateL .~ SJust committee
             epochState = newNes ^. nesEsL
             ratifyState =
@@ -1063,20 +1074,7 @@ electBasicCommittee ::
     , GovPurposeId 'CommitteePurpose era
     )
 electBasicCommittee = do
-  logEntry "Setting up PParams and DRep"
-  modifyPParams $ \pp ->
-    pp
-      & ppDRepVotingThresholdsL
-        %~ ( \dvt ->
-              dvt
-                { dvtCommitteeNormal = 1 %! 1
-                , dvtCommitteeNoConfidence = 1 %! 2
-                , dvtUpdateToConstitution = 1 %! 2
-                }
-           )
-      & ppCommitteeMaxTermLengthL .~ EpochInterval 20
-      & ppGovActionLifetimeL .~ EpochInterval 2
-      & ppGovActionDepositL .~ Coin 123
+  logEntry "Setting up a DRep"
   (drep, _, _) <- setupSingleDRep 1_000_000
 
   logEntry "Registering committee member"

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -192,6 +192,7 @@ import qualified Data.Text as T
 import Data.Tree
 import qualified GHC.Exts as GHC (fromList)
 import Lens.Micro
+import Lens.Micro.Mtl ((%=))
 import Test.Cardano.Ledger.Babbage.ImpTest
 import Test.Cardano.Ledger.Conway.Arbitrary ()
 import Test.Cardano.Ledger.Conway.TreeDiff ()
@@ -224,16 +225,19 @@ instance
   ) =>
   ShelleyEraImp (ConwayEra c)
   where
-  initImpNES =
-    let nes =
-          initAlonzoImpNES
-            & nesEsL . curPParamsEpochStateL . ppDRepActivityL .~ EpochInterval 100
-            & nesEsL . curPParamsEpochStateL . ppGovActionLifetimeL .~ EpochInterval 30
-        epochState = nes ^. nesEsL
-        ratifyState =
-          def
-            & rsEnactStateL .~ mkEnactState (epochState ^. epochStateGovStateL)
-     in nes & nesEsL .~ setCompleteDRepPulsingState def ratifyState epochState
+  initImpTestState =
+    impNESL %= initConwayNES
+    where
+      initConwayNES nes =
+        let newNes =
+              (initAlonzoImpNES nes)
+                & nesEsL . curPParamsEpochStateL . ppDRepActivityL .~ EpochInterval 100
+                & nesEsL . curPParamsEpochStateL . ppGovActionLifetimeL .~ EpochInterval 30
+            epochState = newNes ^. nesEsL
+            ratifyState =
+              def
+                & rsEnactStateL .~ mkEnactState (epochState ^. epochStateGovStateL)
+         in newNes & nesEsL .~ setCompleteDRepPulsingState def ratifyState epochState
 
   impSatisfyNativeScript = impAllegraSatisfyNativeScript
 

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -77,7 +77,7 @@ library
         cardano-ledger-allegra ^>=1.4.1,
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-core ^>=1.12,
-        cardano-ledger-shelley ^>=1.10,
+        cardano-ledger-shelley ^>=1.11,
         containers,
         deepseq,
         groups,

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
@@ -30,7 +30,7 @@ instance
   ) =>
   ShelleyEraImp (MaryEra c)
   where
-  initImpNES = initShelleyImpNES
+  initImpTestState = pure ()
   impSatisfyNativeScript = impAllegraSatisfyNativeScript
   fixupTx = shelleyFixupTx
 

--- a/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
+++ b/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-shelley-ma-test
-version:       1.2.2.0
+version:       1.2.2.1
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK
@@ -49,7 +49,7 @@ library
         containers,
         hashable,
         cardano-ledger-shelley-test >=1.1,
-        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} ^>=1.10,
+        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} ^>=1.11,
         cardano-strict-containers,
         microlens,
         mtl,

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Version history for `cardano-ledger-shelley`
 
-## 1.10.1.0
+## 1.11.0.0
 
 *
 
 ### `testlib`
 
+* Export `impNESL` instead of of `impNESG` from `ImpTest`
+* Replace `initImpNES` with `initImpTestState` and change its return type to MonadState
 * Add functions to Shelley `ImpTest`:
   * `withFixup`
   * `withCustomFixup`

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-shelley
-version:            1.10.1.0
+version:            1.11.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -79,7 +79,7 @@ library
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.3,
         cardano-ledger-byron,
         cardano-ledger-core:{cardano-ledger-core, testlib} >=1.11 && <1.13,
-        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} ^>=1.10,
+        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} ^>=1.11,
         cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib} >=1.0.1,
         cardano-slotting:{cardano-slotting, testlib},
         cborg,

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -61,7 +61,7 @@ library
         cardano-ledger-conway >=1.13 && <1.15,
         cardano-ledger-core ^>=1.12,
         cardano-ledger-mary >=1.5 && <1.7,
-        cardano-ledger-shelley ^>=1.10,
+        cardano-ledger-shelley ^>=1.11,
         cardano-slotting,
         containers,
         FailT,

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
@@ -17,21 +17,11 @@ import Cardano.Ledger.Api.State.Query (
   queryCommitteeMembersState,
  )
 import Cardano.Ledger.BaseTypes
-import Cardano.Ledger.Coin (Coin (Coin))
 import Cardano.Ledger.Conway.Governance (
   Committee (..),
   ConwayEraGov (..),
   ConwayGovState,
   EraGov (..),
- )
-import Cardano.Ledger.Conway.PParams (
-  dvtCommitteeNoConfidence,
-  dvtCommitteeNormal,
-  dvtUpdateToConstitution,
-  ppCommitteeMaxTermLengthL,
-  ppDRepVotingThresholdsL,
-  ppGovActionDepositL,
-  ppGovActionLifetimeL,
  )
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (KeyHashObj))
@@ -39,14 +29,11 @@ import Cardano.Ledger.Keys (
   KeyRole (..),
  )
 import Cardano.Ledger.Shelley.LedgerState
-import Data.Default.Class (Default (..))
 import Data.Foldable (Foldable (..))
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-import Lens.Micro ((&), (.~))
 import Lens.Micro.Mtl
 import Test.Cardano.Ledger.Conway.ImpTest
-import Test.Cardano.Ledger.Core.Rational (IsRatio (..))
 import Test.Cardano.Ledger.Imp.Common
 
 spec ::
@@ -59,8 +46,6 @@ spec ::
 spec = do
   describe "Committee members hot key pre-authorization" $ do
     it "authorized members not elected get removed in the next epoch" $ do
-      setPParams
-
       c1 <- KeyHashObj <$> freshKeyHash
       hk1 <- registerCommitteeHotKey c1
       expectQueryResult (Set.singleton c1) mempty mempty $
@@ -69,7 +54,6 @@ spec = do
       expectQueryResult (Set.singleton c1) mempty mempty Map.empty
 
     it "members should remain authorized if authorized during the epoch after their election" $ do
-      setPParams
       (drep, _, _) <- setupSingleDRep 1_000_000
 
       c1 <- KeyHashObj <$> freshKeyHash
@@ -83,7 +67,6 @@ spec = do
         [(c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just 12) NoChangeExpected)]
 
   it "Committee queries" $ do
-    setPParams
     (drep, _, _) <- setupSingleDRep 1_000_000
     c1 <- KeyHashObj <$> freshKeyHash
     c2 <- KeyHashObj <$> freshKeyHash
@@ -288,22 +271,3 @@ spec = do
       ImpTestM era ()
     expectNoFilterQueryResult =
       expectQueryResult mempty mempty mempty
-
-setPParams ::
-  forall era.
-  ( HasCallStack
-  , ConwayEraImp era
-  ) =>
-  ImpTestM era ()
-setPParams = do
-  modifyPParams $ \pp ->
-    pp
-      & ppDRepVotingThresholdsL
-        .~ def
-          { dvtCommitteeNormal = 1 %! 1
-          , dvtCommitteeNoConfidence = 1 %! 2
-          , dvtUpdateToConstitution = 1 %! 2
-          }
-      & ppCommitteeMaxTermLengthL .~ EpochInterval 100
-      & ppGovActionLifetimeL .~ EpochInterval 2
-      & ppGovActionDepositL .~ Coin 123

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
@@ -271,7 +271,7 @@ spec = do
       Map.Map (Credential 'ColdCommitteeRole (EraCrypto era)) (CommitteeMemberState (EraCrypto era)) ->
       ImpTestM era ()
     expectQueryResult ckFilter hkFilter statusFilter expResult = do
-      nes <- use impNESG
+      nes <- use impNESL
       let CommitteeMembersState {csCommittee} =
             queryCommitteeMembersState
               ckFilter


### PR DESCRIPTION
# Description

This PR is setting an initial committee and constitution for Conway (emulating the ones that  will be defined in genesis). 
For this, it was necessary to slightly modify the initialization of the NewEpochState in the Imp framework, to allow initialization actions before returning the state. 

Tests were adjusted to only elect a committee if this action is actually meaningful to the test (relying on the initial committee otherwise). 
Going through many tests was an opportunity to make some small  improvements: 
 * an attempt to be more disciplined with setting pparams. I have consolidated a few of them 
 * updating some functions to reduce the noise of converting between KeyHash and Credential
 * removing the duplicated inclusion of a test 
 
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
