### PR TITLE
`constrained-generators`: refactor `reify` to reduce the number of binding sites + delay simplification more to avoid variable capture in higher order syntax

### DIFF
--- a/libs/constrained-generators/src/Constrained.hs
+++ b/libs/constrained-generators/src/Constrained.hs
@@ -37,6 +37,7 @@ module Constrained (
   NumSpec (..),
   MapSpec (..),
   FoldSpec (..),
+  simplifySpec,
   genFromSpec,
   genFromSpec_,
   genFromSpecWithSeed,

--- a/libs/constrained-generators/src/Constrained/Base.hs
+++ b/libs/constrained-generators/src/Constrained/Base.hs
@@ -205,7 +205,7 @@ exists $ \ x ->
   tm == x
   preds
 
--- Reify ----------------------------------------------------------------
+-- Reifies ----------------------------------------------------------------
 
 Sometimes it's important to be able to perform complex calculations on data
 to obtain values that further constrain later variables. For this purpose
@@ -303,15 +303,15 @@ data Pred (fn :: [Type] -> Type -> Type) where
     [String] ->
     Term fn Bool ->
     Pred fn
-  Reify ::
+  Reifies ::
     ( HasSpec fn a
     , HasSpec fn b
     ) =>
+    -- | This depends on the `a` term
+    Term fn b ->
     Term fn a ->
     -- | Recover a useable value from the `a` term.
     (a -> b) ->
-    -- | Everything in here depends on the `a` term.
-    Binder fn b ->
     Pred fn
   DependsOn ::
     ( HasSpec fn a
@@ -449,9 +449,10 @@ checkPred env = \case
   Assert [] t -> runTerm env t
   Assert es t -> explain ("assert:" : map ("  " ++) es) $ runTerm env t
   GenHint {} -> pure True
-  Reify t f (x :-> p) -> do
+  p@(Reifies t' t f) -> do
     val <- runTerm env t
-    checkPred (extendEnv x (f val) env) p
+    val' <- runTerm env t'
+    explain ["Reification:", "  " ++ show p] $ pure (f val == val')
   ForAll t (x :-> p) -> do
     set <- runTerm env t
     and
@@ -903,9 +904,7 @@ computeDependencies :: Pred fn -> DependGraph fn
 computeDependencies = \case
   Subst x t p -> computeDependencies (substitutePred x t p)
   Assert _ t -> computeTermDependencies t
-  Reify t _ b ->
-    let innerG = computeBinderDependencies b
-     in innerG <> nodes innerG `irreflexiveDependencyOn` t
+  Reifies t' t _ -> t' `irreflexiveDependencyOn` t
   ForAll set b ->
     let innerG = computeBinderDependencies b
      in innerG <> set `irreflexiveDependencyOn` nodes innerG
@@ -1026,11 +1025,11 @@ computeSpecSimplified x p = fromGE ErrorSpec $ case p of
   Case t branches ->
     let branchSpecs = mapList computeSpecBinderSimplified branches
      in propagateSpec (caseSpec branchSpecs) <$> toCtx x t
-  Reify (Lit val) f (x' :-> p) ->
-    pure $ computeSpec x (substPred (singletonEnv x' (f val)) p)
+  Reifies t' (Lit val) f ->
+    propagateSpec (equalSpec (f val)) <$> toCtx x t'
   -- Impossible cases that should be ruled out by the dependency analysis and linearizer
   DependsOn {} -> fatalError ["The impossible happened in computeSpec: DependsOn"]
-  Reify {} -> fatalError ["The impossible happened in computeSpec: Reify", show x, show p]
+  Reifies {} -> fatalError ["The impossible happened in computeSpec: Reifies", show x, show p]
 
 -- | Precondition: the `Pred fn` defines the `Var a`
 computeSpec :: forall fn a. (HasSpec fn a, HasCallStack) => Var a -> Pred fn -> Specification fn a
@@ -1266,7 +1265,7 @@ instance HasVariables fn (Pred fn) where
     Let t b -> freeVars t <> freeVars b
     Exists _ b -> freeVars b
     Assert _ t -> freeVars t
-    Reify tm _ b -> freeVars tm <> freeVars b
+    Reifies t' t _ -> freeVars t' <> freeVars t
     DependsOn x y -> freeVars x <> freeVars y
     ForAll set b -> freeVars set <> freeVars b
     Case t bs -> freeVars t <> freeVars bs
@@ -1279,7 +1278,7 @@ instance HasVariables fn (Pred fn) where
     Let t b -> freeVarSet t <> freeVarSet b
     Exists _ b -> freeVarSet b
     Assert _ t -> freeVarSet t
-    Reify tm _ b -> freeVarSet tm <> freeVarSet b
+    Reifies t' t _ -> freeVarSet t' <> freeVarSet t
     DependsOn x y -> freeVarSet x <> freeVarSet y
     ForAll set b -> freeVarSet set <> freeVarSet b
     Case t bs -> freeVarSet t <> freeVarSet bs
@@ -1294,7 +1293,7 @@ instance HasVariables fn (Pred fn) where
     Let t b -> countOf n t + countOf n b
     Exists _ b -> countOf n b
     Assert _ t -> countOf n t
-    Reify tm _ b -> countOf n tm + countOf n b
+    Reifies t' t _ -> countOf n t' + countOf n t
     DependsOn x y -> countOf n x + countOf n y
     ForAll set b -> countOf n set + countOf n b
     Case t bs -> countOf n t + countOf n bs
@@ -1309,7 +1308,7 @@ instance HasVariables fn (Pred fn) where
     Let t b -> appearsIn n t || appearsIn n b
     Exists _ b -> appearsIn n b
     Assert _ t -> appearsIn n t
-    Reify tm _ b -> appearsIn n tm || appearsIn n b
+    Reifies t' t _ -> appearsIn n t' || appearsIn n t
     DependsOn x y -> appearsIn n x || appearsIn n y
     ForAll set b -> appearsIn n set || appearsIn n b
     Case t bs -> appearsIn n t || appearsIn n bs
@@ -1432,7 +1431,7 @@ substitutePred x tm = \case
   Let t b -> Let (substituteTerm [x := tm] t) (substituteBinder x tm b)
   ForAll t b -> ForAll (substituteTerm [x := tm] t) (substituteBinder x tm b)
   Case t bs -> Case (substituteTerm [x := tm] t) (mapList (substituteBinder x tm) bs)
-  Reify t f b -> Reify (substituteTerm [x := tm] t) f (substituteBinder x tm b)
+  Reifies t' t f -> Reifies (substituteTerm [x := tm] t') (substituteTerm [x := tm] t) f
   DependsOn t t' -> DependsOn (substituteTerm [x := tm] t) (substituteTerm [x := tm] t')
   TruePred -> TruePred
   FalsePred es -> FalsePred es
@@ -1457,7 +1456,7 @@ instance Rename (Pred fn) where
         Block ps -> Block (rename v v' ps)
         Exists k b -> Exists (\eval -> k $ eval . rename v v') (rename v v' b)
         Let t b -> Let (rename v v' t) (rename v v' b)
-        Reify t f b -> Reify (rename v v' t) f (rename v v' b)
+        Reifies t' t f -> Reifies (rename v v' t') (rename v v' t) f
         Assert es t -> Assert es (rename v v' t)
         DependsOn x y -> DependsOn (rename v v' x) (rename v v' y)
         ForAll set b -> ForAll (rename v v' set) (rename v v' b)
@@ -1489,7 +1488,7 @@ substPred env = \case
   GenHint h t -> GenHint h (substTerm env t)
   Subst x t p -> substPred env $ substitutePred x t p
   Assert es t -> assertExplain es (substTerm env t)
-  Reify t f b -> Reify (substTerm env t) f (substBinder env b)
+  Reifies t' t f -> Reifies (substTerm env t') (substTerm env t) f
   ForAll set b -> ForAll (substTerm env set) (substBinder env b)
   Case t bs -> Case (substTerm env t) (mapList (substBinder env) bs)
   DependsOn x y -> DependsOn (substTerm env x) (substTerm env y)
@@ -1536,7 +1535,7 @@ simplifyPred = \case
     t' -> GenHint h t'
   Subst x t p -> simplifyPred $ substitutePred x t p
   Assert es t -> assertExplain es (simplifyTerm t)
-  Reify tm f b -> mkReify (simplifyTerm tm) f (simplifyBinder b)
+  Reifies t' t f -> Reifies (simplifyTerm t') (simplifyTerm t) f
   ForAll set b -> case simplifyTerm set of
     Lit as -> foldMap (`unBind` b) (forAllToList as)
     set' -> ForAll set' (simplifyBinder b)
@@ -1613,7 +1612,7 @@ letSubexpressionElimination = go []
       Exists k b -> Exists k (goBinder sub b)
       Subst x t p -> go sub (substitutePred x t p)
       Assert es t -> Assert es (backwardsSubstitution sub t)
-      Reify t k b -> Reify (backwardsSubstitution sub t) k (goBinder sub b)
+      Reifies t' t f -> Reifies (backwardsSubstitution sub t') (backwardsSubstitution sub t) f
       -- TODO: this is almost certainly not the right thing to do!
       DependsOn t t' ->
         DependsOn t t'
@@ -1658,8 +1657,7 @@ letFloating = fold . go []
       Let t (x :-> p) -> goBlock ctx [Let t (x :-> letFloating p)]
       Exists k (x :-> p) -> goExists ctx (Exists k) x (letFloating p)
       Subst x t p -> go ctx (substitutePred x t p)
-      -- TODO: float let through reify if possible
-      Reify t k (x :-> p) -> Reify t k (x :-> letFloating p) : ctx
+      Reifies t' t f -> Reifies t' t f : ctx
       -- TODO: float let through forall if possible
       ForAll t (x :-> p) -> ForAll t (x :-> letFloating p) : ctx
       -- TODO: float let through the cases if possible
@@ -1693,12 +1691,12 @@ aggressiveInlining p
 
     go fvs sub p = case p of
       Subst x t p -> go fvs sub (substitutePred x t p)
-      Reify tm f b
-        | not (isLit tm)
-        , Lit a <- substituteAndSimplifyTerm sub tm -> do
+      Reifies t' t f
+        | not (isLit t)
+        , Lit a <- substituteAndSimplifyTerm sub t -> do
             tell $ Any True
-            pure $ mkReify (Lit a) f b
-        | otherwise -> Reify tm f <$> goBinder fvs sub b
+            pure $ Reifies t' (Lit a) f
+        | otherwise -> pure $ Reifies t' t f
       ForAll set b
         | not (isLit set)
         , Lit a <- substituteAndSimplifyTerm sub set -> do
@@ -3763,8 +3761,14 @@ reify ::
   (a -> b) ->
   (Term fn b -> p) ->
   Pred fn
-reify tm f body =
-  mkReify tm f (bind body)
+reify t f body =
+  exists (\eval -> pure $ f (eval t)) $ \x ->
+    [ reifies x t f
+    , toPred $ body x
+    ]
+
+reifies :: (HasSpec fn a, HasSpec fn b) => Term fn b -> Term fn a -> (a -> b) -> Pred fn
+reifies = Reifies
 
 dependsOn :: (HasSpec fn a, HasSpec fn b) => Term fn a -> Term fn b -> Pred fn
 dependsOn = DependsOn
@@ -3804,16 +3808,12 @@ bind body = x :-> p
     bound (Let _ b) = boundBinder b
     bound (ForAll _ b) = boundBinder b
     bound (Case _ cs) = getMax $ foldMapList (Max . boundBinder) cs
-    bound (Reify _ _ b) = boundBinder b
+    bound Reifies {} = -1
     bound GenHint {} = -1
     bound Assert {} = -1
     bound DependsOn {} = -1
     bound TruePred = -1
     bound FalsePred {} = -1
-
-mkReify :: (HasSpec fn a, HasSpec fn b) => Term fn a -> (a -> b) -> Binder fn b -> Pred fn
-mkReify (Lit a) f b = unBind (f a) b
-mkReify t f b = Reify t f b
 
 mkCase :: HasSpec fn (SumOver as) => Term fn (SumOver as) -> List (Binder fn) as -> Pred fn
 mkCase tm cs
@@ -3908,7 +3908,7 @@ instance Pretty (Pred fn) where
     Let t (x :-> p) -> align $ sep ["let" <+> viaShow x <+> "=" /> pretty t <+> "in", pretty p]
     Block ps -> braces $ vsep' $ map pretty ps
     Assert _err t -> "assert $" <+> pretty t
-    Reify t _ b -> "reify" <+> pretty (WithPrec 11 t) <+> "$ \\" <+> pretty b
+    Reifies t' t _ -> "reifies" <+> pretty (WithPrec 11 t') <+> pretty (WithPrec 11 t)
     DependsOn a b -> pretty a <+> "<-" /> pretty b
     ForAll t (x :-> p) -> "forall" <+> viaShow x <+> "in" <+> pretty t <+> "$" /> pretty p
     Case t bs -> "case" <+> pretty t <+> "of" /> vsep' (ppList_ pretty bs)

--- a/libs/constrained-generators/src/Constrained/Examples/Basic.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Basic.hs
@@ -145,19 +145,8 @@ reifyYucky = constrained' $ \x y z ->
   , z `dependsOn` y
   ]
 
--- TODO: these are all fucked up right now!! Something is very wrong here!
-
-basicSpec :: Term BaseFn Int -> Specification BaseFn Int
-basicSpec t = constrained $ \x ->
-  exists (\eval -> pure $ eval x + eval t) $ \y ->
-    x + t <=. y
-
-basicSpec' :: Specification BaseFn (Int, Int)
-basicSpec' = constrained' $ \x y ->
-  y `satisfies` basicSpec x
-
-reifySatisfies :: Specification BaseFn (Int, Int)
-reifySatisfies = constrained' $ \x y ->
-  [ x `satisfies` basicSpec (lit 0)
-  , reify x id $ \x' -> y `satisfies` basicSpec x'
-  ]
+basicSpec :: Specification BaseFn Int
+basicSpec = constrained $ \x ->
+  unsafeExists $ \y ->
+    satisfies x $ constrained $ \x' ->
+      x' <=. 1 + y

--- a/libs/constrained-generators/src/Constrained/Examples/Basic.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Basic.hs
@@ -135,3 +135,29 @@ parallelLetPair = constrained $ \p ->
 
 existsUnfree :: Specification BaseFn Int
 existsUnfree = constrained $ \_ -> exists (\_ -> pure 1) $ \y -> y `elem_` lit [1, 2 :: Int]
+
+reifyYucky :: Specification BaseFn (Int, Int, Int)
+reifyYucky = constrained' $ \x y z ->
+  [ reify x id $ \w ->
+      [ y ==. w
+      , z ==. w
+      ]
+  , z `dependsOn` y
+  ]
+
+-- TODO: these are all fucked up right now!! Something is very wrong here!
+
+basicSpec :: Term BaseFn Int -> Specification BaseFn Int
+basicSpec t = constrained $ \x ->
+  exists (\eval -> pure $ eval x + eval t) $ \y ->
+    x + t <=. y
+
+basicSpec' :: Specification BaseFn (Int, Int)
+basicSpec' = constrained' $ \x y ->
+  y `satisfies` basicSpec x
+
+reifySatisfies :: Specification BaseFn (Int, Int)
+reifySatisfies = constrained' $ \x y ->
+  [ x `satisfies` basicSpec (lit 0)
+  , reify x id $ \x' -> y `satisfies` basicSpec x'
+  ]

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -111,6 +111,8 @@ tests =
     testSpec "sumListBad" sumListBad
     testSpec "listExistsUnfree" listExistsUnfree
     testSpec "existsUnfree" existsUnfree
+    -- TODO: double shrinking
+    testSpecNoShrink "reifyYucky" reifyYucky
     testSpec "fixedRangeElements" fixedRange
     numberyTests
     sizeTests


### PR DESCRIPTION
# Description

This should unblock @TimSheard 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
