### PR TITLE
Fix burning tokens predicate failure

### DIFF
--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -84,6 +84,7 @@ library testlib
     exposed-modules:
         Test.Cardano.Ledger.Allegra.Arbitrary
         Test.Cardano.Ledger.Allegra.Binary.Cddl
+        Test.Cardano.Ledger.Allegra.Imp
         Test.Cardano.Ledger.Allegra.ImpTest
         Test.Cardano.Ledger.Allegra.TreeDiff
 

--- a/eras/allegra/impl/test/Main.hs
+++ b/eras/allegra/impl/test/Main.hs
@@ -5,9 +5,9 @@ module Main where
 import Cardano.Ledger.Allegra (Allegra)
 import qualified Test.Cardano.Ledger.Allegra.Binary.CddlSpec as CddlSpec
 import qualified Test.Cardano.Ledger.Allegra.BinarySpec as BinarySpec
+import qualified Test.Cardano.Ledger.Allegra.Imp as Imp
 import Test.Cardano.Ledger.Allegra.ImpTest ()
 import Test.Cardano.Ledger.Common
-import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 
 main :: IO ()
 main =
@@ -16,4 +16,4 @@ main =
       BinarySpec.spec
       CddlSpec.spec
       describe "Imp" $ do
-        ShelleyImp.spec @Allegra
+        Imp.spec @Allegra

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Imp.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Imp.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Allegra.Imp (spec) where
+
+import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure, ShelleyUtxowPredFailure)
+import Test.Cardano.Ledger.Common
+import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
+import Test.Cardano.Ledger.Shelley.ImpTest (ShelleyEraImp)
+
+spec ::
+  forall era.
+  ( ShelleyEraImp era
+  , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
+  , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
+  ) =>
+  Spec
+spec = do
+  ShelleyImp.spec @era

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
@@ -6,7 +6,10 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Cardano.Ledger.Allegra.ImpTest (impAllegraSatisfyNativeScript) where
+module Test.Cardano.Ledger.Allegra.ImpTest (
+  impAllegraSatisfyNativeScript,
+  module Test.Cardano.Ledger.Shelley.ImpTest,
+) where
 
 import Cardano.Crypto.DSIGN (DSIGNAlgorithm (..), Ed25519DSIGN)
 import Cardano.Crypto.Hash.Class (Hash)

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -80,7 +80,7 @@ library
         cardano-crypto-class,
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-core ^>=1.12,
-        cardano-ledger-mary ^>=1.5,
+        cardano-ledger-mary ^>=1.5.2,
         cardano-ledger-shelley ^>=1.10,
         cardano-slotting,
         cardano-strict-containers,
@@ -127,7 +127,6 @@ library testlib
         containers,
         cardano-crypto-class,
         cardano-data,
-        cardano-ledger-allegra:testlib,
         cardano-ledger-alonzo,
         cardano-ledger-binary,
         cardano-ledger-mary:testlib,
@@ -161,5 +160,4 @@ test-suite tests
         cardano-ledger-alonzo,
         cardano-ledger-binary:testlib,
         cardano-ledger-core:{cardano-ledger-core, testlib},
-        cardano-ledger-shelley:testlib,
         testlib

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -80,7 +80,7 @@ library
         cardano-crypto-class,
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-core ^>=1.12,
-        cardano-ledger-mary ^>=1.5.2,
+        cardano-ledger-mary ^>=1.6.0,
         cardano-ledger-shelley ^>=1.10,
         cardano-slotting,
         cardano-strict-containers,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -46,14 +46,13 @@ import Cardano.Ledger.CertState (CertState)
 import Cardano.Ledger.Credential (credScriptHash)
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Keys (KeyHash, KeyRole (Witness))
-import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue)
+import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue, getProducedMaryValue)
 import Cardano.Ledger.Mary.Value (PolicyID (..))
 import Cardano.Ledger.Plutus.Data (Data, Datum (..))
 import Cardano.Ledger.Shelley.TxBody (raCredential)
 import Cardano.Ledger.Shelley.UTxO (
   getShelleyMinFeeTxUtxo,
   getShelleyWitsVKeyNeeded,
-  shelleyProducedValue,
  )
 import Cardano.Ledger.TxIn
 import Cardano.Ledger.UTxO (
@@ -84,7 +83,7 @@ instance Crypto c => EraUTxO (AlonzoEra c) where
 
   getConsumedValue = getConsumedMaryValue
 
-  getProducedValue = shelleyProducedValue
+  getProducedValue = getProducedMaryValue
 
   getScriptsProvided _ tx = ScriptsProvided (tx ^. witsTxL . scriptTxWitsL)
 

--- a/eras/alonzo/impl/test/Main.hs
+++ b/eras/alonzo/impl/test/Main.hs
@@ -7,11 +7,10 @@ import qualified Test.Cardano.Ledger.Alonzo.Binary.CddlSpec as CddlSpec
 import qualified Test.Cardano.Ledger.Alonzo.Binary.CostModelsSpec as CostModelsSpec
 import qualified Test.Cardano.Ledger.Alonzo.Binary.TxWitsSpec as TxWitsSpec
 import qualified Test.Cardano.Ledger.Alonzo.BinarySpec as BinarySpec
-import qualified Test.Cardano.Ledger.Alonzo.Imp as AlonzoImp
+import qualified Test.Cardano.Ledger.Alonzo.Imp as Imp
 import Test.Cardano.Ledger.Alonzo.ImpTest ()
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.JSON (roundTripJsonEraSpec)
-import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 
 main :: IO ()
 main =
@@ -21,8 +20,7 @@ main =
       CddlSpec.spec
       roundTripJsonEraSpec @Alonzo
       describe "Imp" $ do
-        ShelleyImp.spec @Alonzo
-        AlonzoImp.spec @Alonzo
+        Imp.spec @Alonzo
       describe "CostModels" $ do
         CostModelsSpec.spec @Alonzo
       describe "TxWits" $ do

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp.hs
@@ -7,17 +7,22 @@
 
 module Test.Cardano.Ledger.Alonzo.Imp where
 
-import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx)
+import Cardano.Ledger.Alonzo.Core
+import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure, ShelleyUtxowPredFailure)
 import qualified Test.Cardano.Ledger.Alonzo.Imp.UtxosSpec as Utxos
-import Test.Cardano.Ledger.Alonzo.ImpTest (ShelleyEraImp, withImpState)
+import Test.Cardano.Ledger.Alonzo.ImpTest (MaryEraImp, withImpState)
 import Test.Cardano.Ledger.Common (Spec, describe)
+import qualified Test.Cardano.Ledger.Mary.Imp as MaryImp
 
 spec ::
   forall era.
-  ( ShelleyEraImp era
+  ( MaryEraImp era
   , AlonzoEraTx era
+  , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
+  , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
   ) =>
   Spec
-spec =
-  describe "AlonzoImpTest" . withImpState @era $ do
+spec = do
+  MaryImp.spec @era
+  describe "AlonzoImpSpec" . withImpState @era $ do
     Utxos.spec @era

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -12,7 +12,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Alonzo.ImpTest (
-  module ImpTest,
+  module Test.Cardano.Ledger.Mary.ImpTest,
   AlonzoEraImp (..),
   initAlonzoImpNES,
   impLookupPlutusScriptMaybe,
@@ -77,22 +77,19 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Lens.Micro
 import qualified PlutusLedgerApi.Common as P
-import Test.Cardano.Ledger.Allegra.ImpTest (
-  impAllegraSatisfyNativeScript,
- )
 import Test.Cardano.Ledger.Alonzo.TreeDiff ()
 import Test.Cardano.Ledger.Core.Arbitrary ()
 import Test.Cardano.Ledger.Imp.Common
+import Test.Cardano.Ledger.Mary.ImpTest
 import Test.Cardano.Ledger.Plutus (
   PlutusArgs (..),
   ScriptTestContext (..),
   testingCostModels,
  )
 import Test.Cardano.Ledger.Plutus.Examples
-import Test.Cardano.Ledger.Shelley.ImpTest as ImpTest
 
 class
-  ( ShelleyEraImp era
+  ( MaryEraImp era
   , AlonzoEraScript era
   , AlonzoEraTxWits era
   , AlonzoEraTx era
@@ -391,7 +388,16 @@ instance
   impSatisfyNativeScript = impAllegraSatisfyNativeScript
   fixupTx = alonzoFixupTx
 
-instance ShelleyEraImp (AlonzoEra c) => AlonzoEraImp (AlonzoEra c) where
+instance
+  ( Crypto c
+  , NFData (SigDSIGN (DSIGN c))
+  , NFData (VerKeyDSIGN (DSIGN c))
+  , DSIGN c ~ Ed25519DSIGN
+  , Signable (DSIGN c) (Hash (HASH c) EraIndependentTxBody)
+  ) =>
+  MaryEraImp (AlonzoEra c)
+
+instance MaryEraImp (AlonzoEra c) => AlonzoEraImp (AlonzoEra c) where
   scriptTestContexts = plutusTestScripts SPlutusV1
 
 impGetScriptContextMaybe ::

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -94,6 +94,7 @@ library testlib
     exposed-modules:
         Test.Cardano.Ledger.Babbage.Arbitrary
         Test.Cardano.Ledger.Babbage.Binary.Cddl
+        Test.Cardano.Ledger.Babbage.Imp
         Test.Cardano.Ledger.Babbage.ImpTest
         Test.Cardano.Ledger.Babbage.TreeDiff
 
@@ -109,9 +110,8 @@ library testlib
     build-depends:
         base,
         bytestring,
-        cardano-ledger-allegra:testlib,
         cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
-        cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
+        cardano-ledger-shelley,
         cardano-crypto-class,
         cardano-ledger-babbage,
         cardano-ledger-binary,
@@ -141,7 +141,6 @@ test-suite tests
         cardano-ledger-babbage,
         cardano-ledger-core,
         cardano-ledger-binary:testlib,
-        cardano-ledger-shelley:testlib,
         cardano-ledger-core:testlib,
         cardano-ledger-alonzo:testlib,
         data-default-class,

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -76,7 +76,7 @@ library
         cardano-ledger-alonzo ^>=1.8,
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-core ^>=1.12,
-        cardano-ledger-mary ^>=1.5,
+        cardano-ledger-mary ^>=1.6,
         cardano-ledger-shelley ^>=1.10,
         cardano-strict-containers,
         containers,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
@@ -24,9 +24,9 @@ import Cardano.Ledger.Babbage.Era (BabbageEra)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..), strictMaybeToMaybe)
 import Cardano.Ledger.Binary (sizedValue)
 import Cardano.Ledger.Crypto
-import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue)
+import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue, getProducedMaryValue)
 import Cardano.Ledger.Plutus.Data (Data)
-import Cardano.Ledger.Shelley.UTxO (getShelleyMinFeeTxUtxo, shelleyProducedValue)
+import Cardano.Ledger.Shelley.UTxO (getShelleyMinFeeTxUtxo)
 import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Ledger.UTxO (EraUTxO (..), ScriptsProvided (..), UTxO (..))
 import Control.Applicative
@@ -43,7 +43,7 @@ instance Crypto c => EraUTxO (BabbageEra c) where
 
   getConsumedValue = getConsumedMaryValue
 
-  getProducedValue = shelleyProducedValue
+  getProducedValue = getProducedMaryValue
 
   getScriptsProvided = getBabbageScriptsProvided
 

--- a/eras/babbage/impl/test/Main.hs
+++ b/eras/babbage/impl/test/Main.hs
@@ -5,13 +5,12 @@ module Main where
 import Cardano.Ledger.Babbage (Babbage)
 import qualified Test.Cardano.Ledger.Alonzo.Binary.CostModelsSpec as CostModelsSpec
 import qualified Test.Cardano.Ledger.Alonzo.Binary.TxWitsSpec as TxWitsSpec
-import qualified Test.Cardano.Ledger.Alonzo.Imp as AlonzoImp
 import qualified Test.Cardano.Ledger.Babbage.Binary.CddlSpec as CddlSpec
 import qualified Test.Cardano.Ledger.Babbage.BinarySpec as BinarySpec
+import qualified Test.Cardano.Ledger.Babbage.Imp as Imp
 import Test.Cardano.Ledger.Babbage.ImpTest ()
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.JSON (roundTripJsonEraSpec)
-import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 
 main :: IO ()
 main =
@@ -21,8 +20,7 @@ main =
       CddlSpec.spec
       roundTripJsonEraSpec @Babbage
       describe "Imp" $ do
-        AlonzoImp.spec @Babbage
-        ShelleyImp.spec @Babbage
+        Imp.spec @Babbage
       describe "CostModels" $ do
         CostModelsSpec.spec @Babbage
       describe "TxWits" $ do

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Test.Cardano.Ledger.Babbage.Imp (spec) where
+
+import Cardano.Ledger.Babbage.Core
+import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure, ShelleyUtxowPredFailure)
+import qualified Test.Cardano.Ledger.Alonzo.Imp as AlonzoImp
+import Test.Cardano.Ledger.Alonzo.ImpTest (AlonzoEraImp)
+import Test.Cardano.Ledger.Common
+
+spec ::
+  forall era.
+  ( AlonzoEraImp era
+  , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
+  , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
+  ) =>
+  Spec
+spec = do
+  AlonzoImp.spec @era

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
@@ -7,7 +7,9 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Cardano.Ledger.Babbage.ImpTest () where
+module Test.Cardano.Ledger.Babbage.ImpTest (
+  module Test.Cardano.Ledger.Alonzo.ImpTest,
+) where
 
 import Cardano.Crypto.DSIGN (DSIGNAlgorithm (..), Ed25519DSIGN)
 import Cardano.Crypto.Hash (Hash)
@@ -15,16 +17,9 @@ import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (Crypto (..))
 import Cardano.Ledger.Plutus.Language (SLanguage (..))
-import Test.Cardano.Ledger.Allegra.ImpTest (impAllegraSatisfyNativeScript)
-import Test.Cardano.Ledger.Alonzo.ImpTest (
-  AlonzoEraImp (..),
-  alonzoFixupTx,
-  initAlonzoImpNES,
-  plutusTestScripts,
- )
+import Test.Cardano.Ledger.Alonzo.ImpTest
 import Test.Cardano.Ledger.Babbage.TreeDiff ()
 import Test.Cardano.Ledger.Common
-import Test.Cardano.Ledger.Shelley.ImpTest (ShelleyEraImp (..))
 
 instance
   ( Crypto c
@@ -38,6 +33,8 @@ instance
   initImpNES = initAlonzoImpNES
   impSatisfyNativeScript = impAllegraSatisfyNativeScript
   fixupTx = alonzoFixupTx
+
+instance ShelleyEraImp (BabbageEra c) => MaryEraImp (BabbageEra c)
 
 instance ShelleyEraImp (BabbageEra c) => AlonzoEraImp (BabbageEra c) where
   scriptTestContexts = plutusTestScripts SPlutusV1 <> plutusTestScripts SPlutusV2

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -146,7 +146,7 @@ library testlib
         deepseq,
         microlens,
         cardano-crypto-class,
-        cardano-ledger-allegra:{cardano-ledger-allegra, testlib},
+        cardano-ledger-allegra,
         cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
         cardano-ledger-binary,
         cardano-ledger-babbage:{cardano-ledger-babbage, testlib},

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -91,7 +91,7 @@ library
         cardano-ledger-alonzo ^>=1.8,
         cardano-ledger-babbage ^>=1.8,
         cardano-ledger-core ^>=1.12,
-        cardano-ledger-mary ^>=1.5,
+        cardano-ledger-mary ^>=1.6,
         cardano-ledger-shelley ^>=1.10,
         cardano-slotting,
         cardano-strict-containers,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
@@ -45,9 +45,10 @@ import Cardano.Ledger.Conway.Governance.Procedures (
 import Cardano.Ledger.Credential (credKeyHashWitness, credScriptHash)
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..), asWitness)
-import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue)
+import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue, getProducedMaryValue)
+import Cardano.Ledger.Mary.Value (MaryValue)
 import Cardano.Ledger.SafeHash (SafeToHash (..))
-import Cardano.Ledger.Shelley.UTxO (getShelleyWitsVKeyNeededNoGov, shelleyProducedValue)
+import Cardano.Ledger.Shelley.UTxO (getShelleyWitsVKeyNeededNoGov)
 import Cardano.Ledger.UTxO (EraUTxO (..), UTxO (..))
 import Cardano.Ledger.Val (Val (..), inject)
 import qualified Data.Map.Strict as Map
@@ -102,13 +103,13 @@ getConwayScriptsNeeded utxo txBody =
             _ -> Nothing
 
 conwayProducedValue ::
-  ConwayEraTxBody era =>
+  (ConwayEraTxBody era, Value era ~ MaryValue (EraCrypto era)) =>
   PParams era ->
   (KeyHash 'StakePool (EraCrypto era) -> Bool) ->
   TxBody era ->
   Value era
 conwayProducedValue pp isStakePool txBody =
-  shelleyProducedValue pp isStakePool txBody
+  getProducedMaryValue pp isStakePool txBody
     <+> inject (txBody ^. treasuryDonationTxBodyL)
 
 instance Crypto c => EraUTxO (ConwayEra c) where

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -22,8 +22,9 @@ import Cardano.Ledger.Conway.Rules (
   ConwayNewEpochEvent,
  )
 import Cardano.Ledger.Conway.TxInfo (ConwayContextError)
-import Cardano.Ledger.Shelley.Rules (Event, ShelleyUtxowPredFailure (..))
+import Cardano.Ledger.Shelley.Rules (Event, ShelleyUtxoPredFailure, ShelleyUtxowPredFailure)
 import Data.Typeable (Typeable)
+import qualified Test.Cardano.Ledger.Babbage.Imp as BabbageImp
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Conway.Imp.EnactSpec as Enact
 import qualified Test.Cardano.Ledger.Conway.Imp.EpochSpec as Epoch
@@ -43,6 +44,7 @@ spec ::
   , Inject (ConwayContextError era) (ContextError era)
   , InjectRuleFailure "LEDGER" BabbageUtxoPredFailure era
   , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
+  , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
   , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
   , InjectRuleFailure "LEDGER" ConwayGovCertPredFailure era
   , NFData (Event (EraRule "ENACT" era))
@@ -55,6 +57,7 @@ spec ::
   ) =>
   Spec
 spec = do
+  BabbageImp.spec @era
   describe "ConwayImpSpec" $ withImpState @era $ do
     Enact.spec @era
     Epoch.spec @era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxosSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxosSpec.hs
@@ -30,6 +30,7 @@ import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import Cardano.Ledger.DRep
 import Cardano.Ledger.Keys (KeyRole (..))
 import Cardano.Ledger.Mary.Value (
+  MaryValue (..),
   MultiAsset (..),
   PolicyID (..),
  )
@@ -739,7 +740,11 @@ mintingTokenTx tx sh = do
   count <- choose (0, 10)
   let policyId = PolicyID sh
   let ma = MultiAsset $ Map.singleton policyId [(name, count)]
-  pure $ tx & bodyTxL . mintTxBodyL .~ ma
+  (_, addr) <- freshKeyAddr
+  pure $
+    tx
+      & bodyTxL . mintTxBodyL .~ ma
+      & bodyTxL . outputsTxBodyL <>~ [mkBasicTxOut addr (MaryValue (Coin 12345) ma)]
 
 enactCostModels ::
   ConwayEraImp era =>

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -318,9 +318,8 @@ setupSingleDRep ::
     )
 setupSingleDRep stake = do
   drepKH <- registerDRep
-  delegatorKH <- freshKeyHash
-  delegatorKP <- lookupKeyPair delegatorKH
-  spendingKP <- lookupKeyPair =<< freshKeyHash
+  (delegatorKH, delegatorKP) <- freshKeyPair
+  (_, spendingKP) <- freshKeyPair
   submitTxAnn_ "Delegate to DRep" $
     mkBasicTx mkBasicTxBody
       & bodyTxL . outputsTxBodyL

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -18,7 +18,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Conway.ImpTest (
-  module ImpTest,
+  module Test.Cardano.Ledger.Babbage.ImpTest,
   ConwayEraImp,
   enactConstitution,
   enactTreasuryWithdrawals,
@@ -192,8 +192,7 @@ import qualified Data.Text as T
 import Data.Tree
 import qualified GHC.Exts as GHC (fromList)
 import Lens.Micro
-import Test.Cardano.Ledger.Allegra.ImpTest (impAllegraSatisfyNativeScript)
-import Test.Cardano.Ledger.Alonzo.ImpTest as ImpTest
+import Test.Cardano.Ledger.Babbage.ImpTest
 import Test.Cardano.Ledger.Conway.Arbitrary ()
 import Test.Cardano.Ledger.Conway.TreeDiff ()
 import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..), mkAddr)
@@ -241,6 +240,15 @@ instance
   modifyPParams = conwayModifyPParams
 
   fixupTx = alonzoFixupTx
+
+instance
+  ( Crypto c
+  , NFData (SigDSIGN (DSIGN c))
+  , NFData (VerKeyDSIGN (DSIGN c))
+  , DSIGN c ~ Ed25519DSIGN
+  , Signable (DSIGN c) (Hash (HASH c) EraIndependentTxBody)
+  ) =>
+  MaryEraImp (ConwayEra c)
 
 instance ShelleyEraImp (ConwayEra c) => AlonzoEraImp (ConwayEra c) where
   scriptTestContexts =

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Version history for `cardano-ledger-mary`
 
-## 1.5.2.0
+## 1.6.0.0
 
-*
+* Change how we report tokens burned in `ValueNotConservedUTxO`: #4288
+* Add `getProducedMaryValue`, `pruneZeroMultiAsset`, `filterMultiAsset` and `mapMaybeMultiAsset`
+* Deprecate `prune`
 
 ### `testlib`
 

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Version history for `cardano-ledger-mary`
 
-## 1.5.1.1
+## 1.5.2.0
 
 *
+
+### `testlib`
+
+* Add `MaryEraImp`
 
 ## 1.5.1.0
 

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Change how we report tokens burned in `ValueNotConservedUTxO`: #4288
 * Add `getProducedMaryValue`, `pruneZeroMultiAsset`, `filterMultiAsset` and `mapMaybeMultiAsset`
 * Deprecate `prune`
+* Rename `assetName` to `assetNameBytes`
 
 ### `testlib`
 

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-mary
-version:            1.5.2.0
+version:            1.6.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-mary
-version:            1.5.1.1
+version:            1.5.2.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -94,7 +94,9 @@ library testlib
     exposed-modules:
         Test.Cardano.Ledger.Mary.Arbitrary
         Test.Cardano.Ledger.Mary.Binary.Cddl
+        Test.Cardano.Ledger.Mary.Imp
         Test.Cardano.Ledger.Mary.ImpTest
+        Test.Cardano.Ledger.Mary.Imp.UtxoSpec
         Test.Cardano.Ledger.Mary.TreeDiff
 
     visibility:       public
@@ -115,9 +117,10 @@ library testlib
         cardano-ledger-binary:testlib,
         cardano-ledger-core:{cardano-ledger-core, testlib},
         cardano-ledger-mary,
-        cardano-ledger-allegra:testlib,
+        cardano-ledger-allegra:{cardano-ledger-allegra, testlib},
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
-        cardano-strict-containers
+        cardano-strict-containers,
+        microlens
 
 test-suite tests
     type:             exitcode-stdio-1.0

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Value.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Value.hs
@@ -113,7 +113,7 @@ import NoThunks.Class (NoThunks (..), OnlyCheckWhnfNamed (..))
 import Prelude hiding (lookup)
 
 -- | Asset Name
-newtype AssetName = AssetName {assetName :: SBS.ShortByteString}
+newtype AssetName = AssetName {assetNameBytes :: SBS.ShortByteString}
   deriving newtype
     ( Eq
     , EncCBOR
@@ -126,7 +126,7 @@ instance Show AssetName where
   show = show . assetNameToBytesAsHex
 
 assetNameToBytesAsHex :: AssetName -> BS.ByteString
-assetNameToBytesAsHex = BS16.encode . SBS.fromShort . assetName
+assetNameToBytesAsHex = BS16.encode . SBS.fromShort . assetNameBytes
 
 assetNameToTextAsHex :: AssetName -> Text
 assetNameToTextAsHex = decodeLatin1 . assetNameToBytesAsHex
@@ -650,7 +650,7 @@ to v@(MaryValue _ ma) = do
     -- is last, so the associated offset is pointing to the end of the array
     assetNames = Set.toDescList $ Set.fromList $ (\(_, an, _) -> an) <$> triples
 
-    assetNameLengths = fromIntegral . SBS.length . assetName <$> assetNames
+    assetNameLengths = fromIntegral . SBS.length . assetNameBytes <$> assetNames
 
     assetNameOffsetMap :: Map AssetName Word16
     assetNameOffsetMap =
@@ -698,7 +698,7 @@ representationSize xs = abcRegionSize + pidBlockSize + anameBlockSize
 
     assetNames = Set.fromList $ (\(_, an, _) -> an) <$> xs
     anameBlockSize =
-      Semigroup.getSum $ foldMap' (Semigroup.Sum . SBS.length . assetName) assetNames
+      Semigroup.getSum $ foldMap' (Semigroup.Sum . SBS.length . assetNameBytes) assetNames
 
 from :: forall c. Crypto c => CompactValue c -> MaryValue c
 from (CompactValueAdaOnly c) = MaryValue (fromCompact c) (MultiAsset Map.empty)

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Value.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Value.hs
@@ -24,7 +24,9 @@ module Cardano.Ledger.Mary.Value (
   lookupMultiAsset,
   multiAssetFromList,
   policies,
-  prune,
+  mapMaybeMultiAsset,
+  filterMultiAsset,
+  pruneZeroMultiAsset,
   representationSize,
   showValue,
   flattenMultiAsset,
@@ -33,6 +35,9 @@ module Cardano.Ledger.Mary.Value (
   CompactForm (CompactValue),
   isMultiAssetSmallEnough,
   assetNameToTextAsHex,
+
+  -- * Deprecated
+  prune,
 )
 where
 
@@ -67,7 +72,7 @@ import Cardano.Ledger.Shelley.Scripts (ScriptHash (..))
 import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData (..), deepseq, rwhnf)
 import Control.Exception (assert)
-import Control.Monad (forM_, unless, when)
+import Control.Monad (forM_, guard, unless, when)
 import Control.Monad.ST (runST)
 import Data.Aeson (FromJSON, FromJSONKey, ToJSON (..), object, (.=))
 import qualified Data.Aeson as Aeson
@@ -320,21 +325,20 @@ decodeValuePair decodeMultiAssetAmount =
 decodeMultiAsset :: Crypto c => (forall t. Decoder t Integer) -> Decoder s (MultiAsset c)
 decodeMultiAsset decodeAmount = do
   ma <-
-    MultiAsset
-      <$> ifDecoderVersionAtLeast
-        (natVersion @9)
-        decodeWithEnforcing
-        decodeWithPrunning
+    ifDecoderVersionAtLeast
+      (natVersion @9)
+      decodeWithEnforcing
+      decodeWithPrunning
   ma <$ unless (isMultiAssetSmallEnough ma) (fail "MultiAsset is too big to compact")
   where
     decodeWithEnforcing =
-      decodeMap decCBOR $ do
+      fmap MultiAsset $ decodeMap decCBOR $ do
         m <- decodeMap decCBOR $ do
           amount <- decodeAmount
           amount <$ when (amount == 0) (fail "MultiAsset cannot contain zeros")
         m <$ when (Map.null m) (fail "Empty Assets are not allowed")
     decodeWithPrunning =
-      prune <$> decodeMap decCBOR (decodeMap decCBOR decodeAmount)
+      pruneZeroMultiAsset . MultiAsset <$> decodeMap decCBOR (decodeMap decCBOR decodeAmount)
 
 instance Crypto c => EncCBOR (MaryValue c) where
   encCBOR (MaryValue c ma@(MultiAsset m)) =
@@ -853,12 +857,49 @@ insertMultiAsset combine pid aid new (MultiAsset m1) =
 
 -- ========================================================
 
--- | Remove 0 assets from a map
+-- | Remove 0 assets from a `MultiAsset`
 prune ::
   Map (PolicyID c) (Map AssetName Integer) ->
   Map (PolicyID c) (Map AssetName Integer)
 prune assets =
   Map.filter (not . null) $ Map.filter (/= 0) <$> assets
+{-# DEPRECATED prune "In favor of `pruneZeroMultiAsset`" #-}
+
+-- | Remove all assets with that have zero amount specified
+pruneZeroMultiAsset :: MultiAsset c -> MultiAsset c
+pruneZeroMultiAsset = filterMultiAsset (\_ _ -> (/= 0))
+
+-- | Filter multi assets. Canonical form is preserved.
+filterMultiAsset ::
+  -- | Predicate that needs to return `True` whenever an asset should be retained.
+  (PolicyID c -> AssetName -> Integer -> Bool) ->
+  MultiAsset c ->
+  MultiAsset c
+filterMultiAsset f (MultiAsset ma) =
+  MultiAsset $ Map.mapMaybeWithKey modifyAsset ma
+  where
+    modifyAsset policyId assetMap = do
+      let newAssetMap = Map.filterWithKey (f policyId) assetMap
+      guard (not (null newAssetMap))
+      Just newAssetMap
+
+-- | Map a function over each multi asset value while optionally filtering values
+-- out. Canonical form is preserved.
+mapMaybeMultiAsset ::
+  (PolicyID c -> AssetName -> Integer -> Maybe Integer) ->
+  MultiAsset c ->
+  MultiAsset c
+mapMaybeMultiAsset f (MultiAsset ma) =
+  MultiAsset $ Map.mapMaybeWithKey modifyAsset ma
+  where
+    modifyAsset policyId assetMap = do
+      let newAssetMap = Map.mapMaybeWithKey (modifyValue policyId) assetMap
+      guard (not (null newAssetMap))
+      Just newAssetMap
+    modifyValue policyId assetName assetValue = do
+      newAssetValue <- f policyId assetName assetValue
+      guard (newAssetValue /= 0)
+      Just newAssetValue
 
 -- | Rather than using prune to remove 0 assets, when can avoid adding them in the
 --   first place by using valueFromList to construct a MultiAsset

--- a/eras/mary/impl/test/Main.hs
+++ b/eras/mary/impl/test/Main.hs
@@ -6,9 +6,9 @@ import Cardano.Ledger.Mary (Mary)
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Mary.Binary.CddlSpec as CddlSpec
 import qualified Test.Cardano.Ledger.Mary.BinarySpec as BinarySpec
+import qualified Test.Cardano.Ledger.Mary.Imp as Imp
 import Test.Cardano.Ledger.Mary.ImpTest ()
 import qualified Test.Cardano.Ledger.Mary.ValueSpec as ValueSpec
-import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 
 main :: IO ()
 main =
@@ -18,4 +18,4 @@ main =
       BinarySpec.spec
       CddlSpec.spec
       describe "Imp" $ do
-        ShelleyImp.spec @Mary
+        Imp.spec @Mary

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Imp.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Imp.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Test.Cardano.Ledger.Mary.Imp (spec) where
+
+import Cardano.Ledger.Mary.Core
+import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure, ShelleyUtxowPredFailure)
+import qualified Test.Cardano.Ledger.Allegra.Imp as AllegraImp
+import Test.Cardano.Ledger.Common
+import qualified Test.Cardano.Ledger.Mary.Imp.UtxoSpec as Utxo
+import Test.Cardano.Ledger.Mary.ImpTest (MaryEraImp)
+import Test.Cardano.Ledger.Shelley.ImpTest (withImpState)
+
+spec ::
+  forall era.
+  ( MaryEraImp era
+  , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
+  , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
+  ) =>
+  Spec
+spec = do
+  AllegraImp.spec @era
+  describe "MaryImpSpec" $ withImpState @era $ do
+    Utxo.spec @era

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Imp/UtxoSpec.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Imp/UtxoSpec.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Test.Cardano.Ledger.Mary.Imp.UtxoSpec (spec) where
@@ -11,28 +12,64 @@ import Cardano.Ledger.Allegra.Scripts
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Mary.Core
 import Cardano.Ledger.Mary.Value
+import Cardano.Ledger.Shelley.Rules
+import Cardano.Ledger.Val
+import Data.Sequence.Strict (StrictSeq (..))
+
+-- import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure (..))
+
 import qualified Data.Map.Strict as Map
 import Lens.Micro
+import Test.Cardano.Ledger.Core.Utils (txInAt)
 import Test.Cardano.Ledger.Imp.Common
-import Test.Cardano.Ledger.Shelley.ImpTest
+import Test.Cardano.Ledger.Mary.ImpTest
+
+mintBasicToken :: forall era. MaryEraImp era => ImpTestM era (Tx era)
+mintBasicToken = do
+  (_, addr) <- freshKeyAddr
+  keyHash <- freshKeyHash
+  scriptHash <- impAddNativeScript $ RequireSignature keyHash
+  Positive amount <- arbitrary
+  let txCoin = Coin 1000000
+      txAsset = MultiAsset $ Map.singleton (PolicyID scriptHash) $ Map.singleton (AssetName "testAsset") amount
+      txValue :: MaryValue (EraCrypto era)
+      txValue = MaryValue txCoin txAsset
+      txBody =
+        mkBasicTxBody
+          & outputsTxBodyL .~ [mkBasicTxOut addr txValue]
+          & mintTxBodyL .~ txAsset
+  submitTx $ mkBasicTx txBody
 
 spec ::
-  ( ShelleyEraImp era
-  , MaryEraTxBody era
-  , NativeScript era ~ Timelock era
-  , Value era ~ MaryValue (EraCrypto era)
+  ( MaryEraImp era
+  , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
   ) =>
   SpecWith (ImpTestState era)
 spec = describe "UTXO" $ do
-  it "Mint a Token" $ do
-    (_, addr) <- freshKeyAddr
-    (keyHash, _) <- freshKeyPair
-    scriptHash <- impAddNativeScript $ RequireSignature keyHash
-    let txCoin = Coin 1000000
-        txAsset = MultiAsset $ Map.singleton (PolicyID scriptHash) $ Map.singleton (AssetName "testAsset") 100
-        txValue = MaryValue txCoin txAsset
-        txBody =
-          mkBasicTxBody
-            & outputsTxBodyL .~ [mkBasicTxOut addr txValue]
-            & mintTxBodyL .~ txAsset
-    submitTx_ $ mkBasicTx txBody
+  it "Mint a Token" $ void mintBasicToken
+  describe "ShelleyUtxoPredFailure" $ do
+    it "ValueNotConservedUTxO" $ do
+      -- Burn too much
+      txMinted <- mintBasicToken
+      let MaryValue c (MultiAsset mintedMultiAsset) =
+            case txMinted ^. bodyTxL . outputsTxBodyL of
+              Empty -> error "Empty outputs was unexpected"
+              txOut :<| _ ->
+                case txOut ^. valueTxOutL of
+                  MaryValue negCoin (MultiAsset ma) ->
+                    MaryValue negCoin $ MultiAsset ma
+          burnTooMuchMultiAsset = MultiAsset (Map.map (Map.map (subtract 1 . negate)) mintedMultiAsset)
+          txBody =
+            mkBasicTxBody
+              & inputsTxBodyL .~ [txInAt (0 :: Int) txMinted]
+              & mintTxBodyL .~ burnTooMuchMultiAsset
+      (_, rootTxOut) <- lookupImpRootTxOut
+      let rootTxOutValue = rootTxOut ^. valueTxOutL
+      predFailures <- expectLeftDeep =<< trySubmitTx (mkBasicTx txBody)
+      predFailures
+        `shouldBe` [ injectFailure $
+                      ValueNotConservedUTxO
+                        (rootTxOutValue <> MaryValue c (MultiAsset (Map.map (Map.map (const (-1))) mintedMultiAsset)))
+                        (rootTxOutValue <> inject c)
+                   ]
+      pure ()

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Imp/UtxoSpec.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Imp/UtxoSpec.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Test.Cardano.Ledger.Mary.Imp.UtxoSpec (spec) where
+
+import Cardano.Ledger.Allegra.Scripts
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Mary.Core
+import Cardano.Ledger.Mary.Value
+import qualified Data.Map.Strict as Map
+import Lens.Micro
+import Test.Cardano.Ledger.Imp.Common
+import Test.Cardano.Ledger.Shelley.ImpTest
+
+spec ::
+  ( ShelleyEraImp era
+  , MaryEraTxBody era
+  , NativeScript era ~ Timelock era
+  , Value era ~ MaryValue (EraCrypto era)
+  ) =>
+  SpecWith (ImpTestState era)
+spec = describe "UTXO" $ do
+  it "Mint a Token" $ do
+    (_, addr) <- freshKeyAddr
+    (keyHash, _) <- freshKeyPair
+    scriptHash <- impAddNativeScript $ RequireSignature keyHash
+    let txCoin = Coin 1000000
+        txAsset = MultiAsset $ Map.singleton (PolicyID scriptHash) $ Map.singleton (AssetName "testAsset") 100
+        txValue = MaryValue txCoin txAsset
+        txBody =
+          mkBasicTxBody
+            & outputsTxBodyL .~ [mkBasicTxOut addr txValue]
+            & mintTxBodyL .~ txAsset
+    submitTx_ $ mkBasicTx txBody

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Imp/UtxoSpec.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Imp/UtxoSpec.hs
@@ -12,19 +12,15 @@ import Cardano.Ledger.Allegra.Scripts
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Mary.Core
 import Cardano.Ledger.Mary.Value
-import Cardano.Ledger.Shelley.Rules
-import Cardano.Ledger.Val
-import Data.Sequence.Strict (StrictSeq (..))
-
--- import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure (..))
-
+import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure (..))
 import qualified Data.Map.Strict as Map
+import Data.Sequence.Strict (StrictSeq (..))
 import Lens.Micro
 import Test.Cardano.Ledger.Core.Utils (txInAt)
 import Test.Cardano.Ledger.Imp.Common
 import Test.Cardano.Ledger.Mary.ImpTest
 
-mintBasicToken :: forall era. MaryEraImp era => ImpTestM era (Tx era)
+mintBasicToken :: forall era. (HasCallStack, MaryEraImp era) => ImpTestM era (Tx era)
 mintBasicToken = do
   (_, addr) <- freshKeyAddr
   keyHash <- freshKeyHash
@@ -41,7 +37,8 @@ mintBasicToken = do
   submitTx $ mkBasicTx txBody
 
 spec ::
-  ( MaryEraImp era
+  ( HasCallStack
+  , MaryEraImp era
   , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
   ) =>
   SpecWith (ImpTestState era)
@@ -50,15 +47,16 @@ spec = describe "UTXO" $ do
   describe "ShelleyUtxoPredFailure" $ do
     it "ValueNotConservedUTxO" $ do
       -- Burn too much
+      Positive tooMuch <- arbitrary
       txMinted <- mintBasicToken
       let MaryValue c (MultiAsset mintedMultiAsset) =
             case txMinted ^. bodyTxL . outputsTxBodyL of
               Empty -> error "Empty outputs was unexpected"
-              txOut :<| _ ->
-                case txOut ^. valueTxOutL of
-                  MaryValue negCoin (MultiAsset ma) ->
-                    MaryValue negCoin $ MultiAsset ma
-          burnTooMuchMultiAsset = MultiAsset (Map.map (Map.map (subtract 1 . negate)) mintedMultiAsset)
+              txOut :<| _ -> txOut ^. valueTxOutL
+          burnTooMuchMultiAsset@(MultiAsset burnTooMuch) =
+            MultiAsset (Map.map (Map.map (subtract tooMuch . negate)) mintedMultiAsset)
+          -- Produced should contain positive value that was atttempted to be burned
+          burnTooMuchProducedMultiAsset = MultiAsset (Map.map (Map.map negate) burnTooMuch)
           txBody =
             mkBasicTxBody
               & inputsTxBodyL .~ [txInAt (0 :: Int) txMinted]
@@ -69,7 +67,6 @@ spec = describe "UTXO" $ do
       predFailures
         `shouldBe` [ injectFailure $
                       ValueNotConservedUTxO
-                        (rootTxOutValue <> MaryValue c (MultiAsset (Map.map (Map.map (const (-1))) mintedMultiAsset)))
-                        (rootTxOutValue <> inject c)
+                        (rootTxOutValue <> MaryValue c (MultiAsset mintedMultiAsset))
+                        (rootTxOutValue <> MaryValue c burnTooMuchProducedMultiAsset)
                    ]
-      pure ()

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
@@ -2,23 +2,24 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Cardano.Ledger.Mary.ImpTest () where
+module Test.Cardano.Ledger.Mary.ImpTest (
+  MaryEraImp,
+  module Test.Cardano.Ledger.Allegra.ImpTest,
+) where
 
 import Cardano.Crypto.DSIGN (DSIGNAlgorithm (..), Ed25519DSIGN)
 import Cardano.Crypto.Hash (Hash)
-import Cardano.Ledger.Core (EraIndependentTxBody)
+import Cardano.Ledger.Allegra.Scripts
 import Cardano.Ledger.Crypto (Crypto (..))
 import Cardano.Ledger.Mary (MaryEra)
-import Test.Cardano.Ledger.Allegra.ImpTest (impAllegraSatisfyNativeScript)
+import Cardano.Ledger.Mary.Core
+import Cardano.Ledger.Mary.Value
+import Test.Cardano.Ledger.Allegra.ImpTest
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Mary.TreeDiff ()
-import Test.Cardano.Ledger.Shelley.ImpTest (
-  ShelleyEraImp (..),
-  initShelleyImpNES,
-  shelleyFixupTx,
- )
 
 instance
   ( Crypto c
@@ -32,3 +33,20 @@ instance
   initImpNES = initShelleyImpNES
   impSatisfyNativeScript = impAllegraSatisfyNativeScript
   fixupTx = shelleyFixupTx
+
+class
+  ( ShelleyEraImp era
+  , MaryEraTxBody era
+  , NativeScript era ~ Timelock era
+  , Value era ~ MaryValue (EraCrypto era)
+  ) =>
+  MaryEraImp era
+
+instance
+  ( Crypto c
+  , NFData (SigDSIGN (DSIGN c))
+  , NFData (VerKeyDSIGN (DSIGN c))
+  , DSIGN c ~ Ed25519DSIGN
+  , Signable (DSIGN c) (Hash (HASH c) EraIndependentTxBody)
+  ) =>
+  MaryEraImp (MaryEra c)

--- a/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
+++ b/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
@@ -44,7 +44,7 @@ library
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.2,
         cardano-ledger-core:{cardano-ledger-core, testlib} >=1.11,
         cardano-ledger-allegra:{cardano-ledger-allegra, testlib} ^>=1.4,
-        cardano-ledger-mary:{cardano-ledger-mary, testlib} ^>=1.5,
+        cardano-ledger-mary:{cardano-ledger-mary, testlib} >=1.5 && <1.7,
         cardano-slotting,
         containers,
         hashable,

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -12,6 +12,7 @@
   * `withPreFixup`
   * `withPostFixup`
 * Add `ToExpr` and `NFData` instances for `UtxoEnv`
+* Stop fixing up multi assets in the transaction.
 
 ## 1.10.0.0
 

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -142,6 +142,7 @@ library testlib
         Test.Cardano.Ledger.Shelley.Imp
         Test.Cardano.Ledger.Shelley.Imp.EpochSpec
         Test.Cardano.Ledger.Shelley.Imp.LedgerSpec
+        Test.Cardano.Ledger.Shelley.Imp.UtxoSpec
         Test.Cardano.Ledger.Shelley.Imp.UtxowSpec
         Test.Cardano.Ledger.Shelley.TreeDiff
         Test.Cardano.Ledger.Shelley.UnitTests.IncrementalStakeTest

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -556,11 +556,11 @@ validateValueNotConservedUTxO ::
   CertState era ->
   TxBody era ->
   Test (ShelleyUtxoPredFailure era)
-validateValueNotConservedUTxO pp utxo dpstate txb =
+validateValueNotConservedUTxO pp utxo certState txBody =
   failureUnless (consumedValue == producedValue) $ ValueNotConservedUTxO consumedValue producedValue
   where
-    consumedValue = consumed pp dpstate utxo txb
-    producedValue = produced pp dpstate txb
+    consumedValue = consumed pp certState utxo txBody
+    producedValue = produced pp certState txBody
 
 -- | Ensure there are no `TxOut`s that have less than @minUTxOValue@
 --

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
@@ -7,10 +7,11 @@
 module Test.Cardano.Ledger.Shelley.Imp (spec) where
 
 import Cardano.Ledger.Core
-import Cardano.Ledger.Shelley.Rules (ShelleyUtxowPredFailure)
+import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure, ShelleyUtxowPredFailure)
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Shelley.Imp.EpochSpec as Epoch
 import qualified Test.Cardano.Ledger.Shelley.Imp.LedgerSpec as Ledger
+import qualified Test.Cardano.Ledger.Shelley.Imp.UtxoSpec as Utxo
 import qualified Test.Cardano.Ledger.Shelley.Imp.UtxowSpec as Utxow
 import Test.Cardano.Ledger.Shelley.ImpTest (ShelleyEraImp, withImpState)
 import qualified Test.Cardano.Ledger.Shelley.UnitTests.IncrementalStakeTest as Incremental
@@ -18,6 +19,7 @@ import qualified Test.Cardano.Ledger.Shelley.UnitTests.IncrementalStakeTest as I
 spec ::
   forall era.
   ( ShelleyEraImp era
+  , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
   , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
   ) =>
   Spec
@@ -26,5 +28,6 @@ spec = do
     Ledger.spec @era
     Epoch.spec @era
     Utxow.spec @era
+    Utxo.spec @era
   describe "ShelleyPureTests" $ do
     Incremental.spec @era

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/UtxoSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/UtxoSpec.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLists #-}
+
+module Test.Cardano.Ledger.Shelley.Imp.UtxoSpec (spec) where
+
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure (..))
+import Cardano.Ledger.Val (inject)
+import Data.Sequence.Strict (StrictSeq (..))
+import Lens.Micro
+import Test.Cardano.Ledger.Imp.Common
+import Test.Cardano.Ledger.Shelley.ImpTest
+
+spec ::
+  ( ShelleyEraImp era
+  , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
+  ) =>
+  SpecWith (ImpTestState era)
+spec = describe "UTXO" $ do
+  describe "ShelleyUtxoPredFailure" $ do
+    it "ValueNotConservedUTxO" $ do
+      (_, addr1) <- freshKeyAddr
+      let txAmount = Coin 1000000
+      txIn <- sendCoinTo addr1 txAmount
+      (_, addr2) <- freshKeyAddr
+      (_, rootTxOut) <- lookupImpRootTxOut
+      let extra = Coin 3
+          rootTxOutValue = rootTxOut ^. valueTxOutL
+          txBody =
+            mkBasicTxBody
+              & inputsTxBodyL .~ [txIn]
+              & outputsTxBodyL .~ [mkBasicTxOut addr2 (inject (Coin 200000))]
+          adjustTxOut = \case
+            Empty -> error "Unexpected empty sequence of outputs"
+            txOut :<| outs -> (txOut & coinTxOutL %~ (<> extra)) :<| outs
+          adjustFirstTxOut tx =
+            tx
+              & bodyTxL . outputsTxBodyL %~ adjustTxOut
+              & witsTxL .~ mkBasicTxWits
+      res <- withPostFixup (updateAddrTxWits . adjustFirstTxOut) $ trySubmitTx (mkBasicTx txBody)
+
+      predFailures <- expectLeftDeep res
+      predFailures
+        `shouldBe` [ injectFailure $
+                      ValueNotConservedUTxO
+                        (rootTxOutValue <> inject txAmount)
+                        (rootTxOutValue <> inject (txAmount <> extra))
+                   ]

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -835,8 +835,8 @@ fixupFees tx = impAnn "fixupFees" $ do
   pp <- getsNES $ nesEsL . curPParamsEpochStateL
   utxo <- getUTxO
   certState <- getsNES $ nesEsL . esLStateL . lsCertStateL
-  kpSpending <- lookupKeyPair =<< freshKeyHash
-  kpStaking <- lookupKeyPair =<< freshKeyHash
+  (_, kpSpending) <- freshKeyPair
+  (_, kpStaking) <- freshKeyPair
   nativeScriptKeyPairs <- impNativeScriptKeyPairs tx
   let
     nativeScriptKeyWits = Map.keysSet nativeScriptKeyPairs
@@ -1286,7 +1286,7 @@ registerRewardAccount ::
 registerRewardAccount = do
   khDelegator <- freshKeyHash
   kpDelegator <- lookupKeyPair khDelegator
-  kpSpending <- lookupKeyPair =<< freshKeyHash
+  (_, kpSpending) <- freshKeyPair
   let stakingCredential = KeyHashObj khDelegator
   submitTxAnn_ ("Register Reward Account: " <> T.unpack (credToText stakingCredential)) $
     mkBasicTx mkBasicTxBody

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -126,6 +126,7 @@ import Cardano.Ledger.BaseTypes (
   inject,
   mkTxIxPartial,
  )
+import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.CertState (certDStateL, dsUnifiedL)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
@@ -224,6 +225,7 @@ import Prettyprinter.Render.String (renderString)
 import System.Random
 import qualified System.Random as Random
 import Test.Cardano.Ledger.Core.Arbitrary ()
+import Test.Cardano.Ledger.Core.Binary.RoundTrip (roundTripEraExpectation)
 import Test.Cardano.Ledger.Core.KeyPair (
   ByronKeyPair (..),
   KeyPair (..),
@@ -315,63 +317,62 @@ impEventsL :: Lens' (ImpTestState era) [SomeSTSEvent era]
 impEventsL = lens impEvents (\x y -> x {impEvents = y})
 
 class
-  ( Show (NewEpochState era)
-  , ToExpr (NewEpochState era)
-  , ToExpr (Tx era)
-  , ToExpr (TxOut era)
-  , ToExpr (PParams era)
-  , ToExpr (StashedAVVMAddresses era)
-  , ToExpr (GovState era)
-  , ToExpr (PParamsHKD StrictMaybe era)
-  , ToExpr (PParamsHKD Identity era)
-  , ToExpr (Value era)
-  , Show (TxOut era)
-  , Show (PParams era)
-  , Show (StashedAVVMAddresses era)
-  , Show (GovState era)
-  , Eq (TxOut era)
-  , Eq (PParams era)
-  , Eq (StashedAVVMAddresses era)
-  , Eq (GovState era)
-  , Eq (Event (EraRule "LEDGER" era))
-  , Eq (Event (EraRule "TICK" era))
-  , Signal (EraRule "LEDGER" era) ~ Tx era
-  , BaseM (EraRule "LEDGER" era) ~ ShelleyBase
-  , STS (EraRule "LEDGER" era)
-  , Signable
-      (DSIGN (EraCrypto era))
-      (Hash (HASH (EraCrypto era)) EraIndependentTxBody)
-  , DSIGN (EraCrypto era) ~ Ed25519DSIGN
-  , ToExpr (PredicateFailure (EraRule "LEDGER" era))
-  , ToExpr (PredicateFailure (EraRule "UTXOW" era))
-  , ToExpr (Event (EraRule "LEDGER" era))
-  , ToExpr (Event (EraRule "TICK" era))
+  ( EraGov era
   , EraUTxO era
+  , EraTxOut era
+  , EraPParams era
   , ShelleyEraTxCert era
+  , ToExpr (Tx era)
+  , NFData (Tx era)
+  , ToExpr (TxOut era)
+  , ToExpr (Value era)
+  , ToExpr (PParams era)
+  , ToExpr (PParamsHKD Identity era)
+  , ToExpr (PParamsHKD StrictMaybe era)
+  , Show (NewEpochState era)
+  , ToExpr (NewEpochState era)
+  , ToExpr (GovState era)
+  , Eq (StashedAVVMAddresses era)
+  , Show (StashedAVVMAddresses era)
+  , ToExpr (StashedAVVMAddresses era)
+  , NFData (StashedAVVMAddresses era)
+  , -- For the LEDGER rule
+    STS (EraRule "LEDGER" era)
+  , BaseM (EraRule "LEDGER" era) ~ ShelleyBase
+  , Signal (EraRule "LEDGER" era) ~ Tx era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
-  , EraGov era
+  , Eq (PredicateFailure (EraRule "LEDGER" era))
+  , Show (PredicateFailure (EraRule "LEDGER" era))
+  , ToExpr (PredicateFailure (EraRule "LEDGER" era))
+  , NFData (PredicateFailure (EraRule "LEDGER" era))
+  , EncCBOR (PredicateFailure (EraRule "LEDGER" era))
+  , DecCBOR (PredicateFailure (EraRule "LEDGER" era))
+  , EraRuleEvent "LEDGER" era ~ Event (EraRule "LEDGER" era)
+  , Eq (EraRuleEvent "LEDGER" era)
+  , ToExpr (EraRuleEvent "LEDGER" era)
+  , NFData (EraRuleEvent "LEDGER" era)
+  , Typeable (EraRuleEvent "LEDGER" era)
+  , -- For the TICK rule
+    STS (EraRule "TICK" era)
   , BaseM (EraRule "TICK" era) ~ ShelleyBase
   , Signal (EraRule "TICK" era) ~ SlotNo
-  , Environment (EraRule "TICK" era) ~ ()
   , State (EraRule "TICK" era) ~ NewEpochState era
-  , STS (EraRule "TICK" era)
+  , Environment (EraRule "TICK" era) ~ ()
   , NFData (PredicateFailure (EraRule "TICK" era))
-  , NFData (StashedAVVMAddresses era)
-  , NFData (Tx era)
+  , EraRuleEvent "TICK" era ~ Event (EraRule "TICK" era)
+  , Eq (EraRuleEvent "TICK" era)
+  , ToExpr (EraRuleEvent "TICK" era)
+  , NFData (EraRuleEvent "TICK" era)
+  , Typeable (EraRuleEvent "TICK" era)
+  , ToExpr (PredicateFailure (EraRule "UTXOW" era))
+  , -- Necessary Crypto
+    DSIGN (EraCrypto era) ~ Ed25519DSIGN
   , NFData (VerKeyDSIGN (DSIGN (EraCrypto era)))
-  , NFData (PredicateFailure (EraRule "LEDGER" era))
-  , NFData (Event (EraRule "LEDGER" era))
-  , NFData (Event (EraRule "TICK" era))
   , VRF.VRFAlgorithm (VRF (EraCrypto era))
   , HashAlgorithm (HASH (EraCrypto era))
   , DSIGNAlgorithm (DSIGN (EraCrypto era))
-  , EraRuleEvent "LEDGER" era ~ Event (EraRule "LEDGER" era)
-  , EraRuleEvent "TICK" era ~ Event (EraRule "TICK" era)
-  , Typeable (EraRuleEvent "LEDGER" era)
-  , Typeable (EraRuleEvent "TICK" era)
-  , ToExpr (EraRuleEvent "LEDGER" era)
-  , ToExpr (EraRuleEvent "TICK" era)
+  , Signable (DSIGN (EraCrypto era)) (Hash (HASH (EraCrypto era)) EraIndependentTxBody)
   ) =>
   ShelleyEraImp era
   where
@@ -917,25 +918,30 @@ trySubmitTx tx = do
   lEnv <- impLedgerEnv st
   ImpTestState {impRootTxIn} <- get
   res <- tryRunImpRule @"LEDGER" lEnv (st ^. nesEsL . esLStateL) txFixed
-  let txId = TxId . hashAnnotated $ txFixed ^. bodyTxL
-      outsSize = SSeq.length $ txFixed ^. bodyTxL . outputsTxBodyL
-      rootIndex
-        | outsSize > 0 = outsSize - 1
-        | otherwise = error ("Expected at least 1 output after submitting tx: " <> show txId)
-  forM res $ \(st', events) -> do
-    tell $ fmap (SomeSTSEvent @era @"LEDGER") events
-    modify $ impNESL . nesEsL . esLStateL .~ st'
-    UTxO utxo <- getUTxO
-    -- This TxIn is in the utxo, and thus can be the new root, only if the transaction was phase2-valid.
-    -- Otherwise, no utxo with this id would have been created, and so we need to set the new root
-    -- to what it was before the submission.
-    let assumedNewRoot = TxIn txId (mkTxIxPartial (fromIntegral rootIndex))
-    let newRoot
-          | Map.member assumedNewRoot utxo = assumedNewRoot
-          | Map.member impRootTxIn utxo = impRootTxIn
-          | otherwise = error "Root not found in UTxO"
-    impRootTxInL .= newRoot
-    pure txFixed
+  case res of
+    Left predFailures -> do
+      -- Verify that produced predicate failures are ready for the node-to-client protocol
+      liftIO $ forM_ predFailures $ roundTripEraExpectation @era
+      pure $ Left predFailures
+    Right (st', events) -> do
+      let txId = TxId . hashAnnotated $ txFixed ^. bodyTxL
+          outsSize = SSeq.length $ txFixed ^. bodyTxL . outputsTxBodyL
+          rootIndex
+            | outsSize > 0 = outsSize - 1
+            | otherwise = error ("Expected at least 1 output after submitting tx: " <> show txId)
+      tell $ fmap (SomeSTSEvent @era @"LEDGER") events
+      modify $ impNESL . nesEsL . esLStateL .~ st'
+      UTxO utxo <- getUTxO
+      -- This TxIn is in the utxo, and thus can be the new root, only if the transaction
+      -- was phase2-valid.  Otherwise, no utxo with this id would have been created, and
+      -- so we need to set the new root to what it was before the submission.
+      let assumedNewRoot = TxIn txId (mkTxIxPartial (fromIntegral rootIndex))
+      let newRoot
+            | Map.member assumedNewRoot utxo = assumedNewRoot
+            | Map.member impRootTxIn utxo = impRootTxIn
+            | otherwise = error "Root not found in UTxO"
+      impRootTxInL .= newRoot
+      pure $ Right txFixed
 
 -- | Submit a transaction that is expected to be rejected. The inputs and
 -- outputs are automatically balanced.

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -60,7 +60,7 @@ library
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-conway >=1.13 && <1.15,
         cardano-ledger-core ^>=1.12,
-        cardano-ledger-mary ^>=1.5,
+        cardano-ledger-mary >=1.5 && <1.7,
         cardano-ledger-shelley ^>=1.10,
         cardano-slotting,
         containers,


### PR DESCRIPTION
# Description

## Problem description

When transaction does not balance out in presence of burning the user submitting the transaction will get `DeserialiseFailure 56 "expected word"` deserialization failure instead of `ValueNotConservedUTxO` predicate failure

## Fixes in this PR

* `ValueNotConservedUTxO` cannot handle negative values, therefore we need to fix how this failure is being reported. Instead of reporting negative values for burned tokens in consumed, we change it to report it as positive in the produced.

* Ensure every predicate failure produced in the Imp test is also tested for serialization issues.

* Reorganize a bit how Imp tests are being invoked. This PR changes it in such a way that current era is responsible for calling imp tests from the previous era. This ensures that  we are not gonna forget to run tests from some previous era in a new era.
 
# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
