### PR TITLE
Add `NoThunks` instance for UTxO pred failures

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.14.0 0
 
+* Implement `NoThunks` instance for:
+  * `ConwayUtxoPredFailure`
+  * `ConwayUtxowPredFailure`
 * Add `ConwayUtxowPredFailure` era rule failure:
   * Implement its `InjectRuleFailure` instances for:
     * `BBODY`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -69,6 +70,7 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.Set (Set)
 import GHC.Generics (Generic)
 import GHC.Natural (Natural)
+import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
 
 -- ======================================================
 
@@ -214,6 +216,11 @@ deriving instance
   , Eq (TxIn (EraCrypto era))
   ) =>
   Eq (ConwayUtxoPredFailure era)
+
+deriving via
+  InspectHeapNamed "ConwayUtxoPred" (ConwayUtxoPredFailure era)
+  instance
+    NoThunks (ConwayUtxoPredFailure era)
 
 instance
   ( Era era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
@@ -78,6 +78,7 @@ import Control.State.Transition.Extended (Embed (..), STS (..))
 import Data.Maybe.Strict (StrictMaybe)
 import Data.Set (Set)
 import GHC.Generics (Generic)
+import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
 
 conwayWitsVKeyNeeded ::
   (EraTx era, ConwayEraTxBody era) =>
@@ -197,6 +198,11 @@ deriving instance
   , Eq (PredicateFailure (EraRule "UTXO" era))
   ) =>
   Eq (ConwayUtxowPredFailure era)
+
+deriving via
+  InspectHeapNamed "ConwayUtxowPred" (ConwayUtxowPredFailure era)
+  instance
+    NoThunks (ConwayUtxowPredFailure era)
 
 instance
   ( ConwayEraScript era


### PR DESCRIPTION
# Description
Resolves #4289 
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
