### PR TITLE
`constrained-generators`: utility function for asserting over a reified value

### DIFF
--- a/libs/constrained-generators/src/Constrained.hs
+++ b/libs/constrained-generators/src/Constrained.hs
@@ -65,6 +65,8 @@ module Constrained (
   isJust,
   reify,
   reify',
+  reifies,
+  assertReified,
   genHint,
   dependsOn,
   forAll,

--- a/libs/constrained-generators/src/Constrained/Examples/Basic.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Basic.hs
@@ -150,3 +150,9 @@ basicSpec = constrained $ \x ->
   unsafeExists $ \y ->
     satisfies x $ constrained $ \x' ->
       x' <=. 1 + y
+
+assertReal :: Specification BaseFn Int
+assertReal = constrained $ \x ->
+  [ assert $ x <=. 10
+  , assertReified x (<= 10)
+  ]

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -44,6 +44,7 @@ testAll = hspec tests
 tests :: Spec
 tests =
   describe "constrained" $ do
+    testSpec "assertReal" assertReal
     testSpec "setSpec" setSpec
     testSpec "leqPair" leqPair
     testSpec "setPair" setPair


### PR DESCRIPTION
# Description

This is step 1 to helping @Soupstraw deal with an annoying shrinking issue where we cheated a bit.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
