### PR TITLE
Fix strange CI failure.

### DIFF
--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/CommitteeRatifySpec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/CommitteeRatifySpec.hs
@@ -305,7 +305,7 @@ genNonExpiredEpoch :: Gen EpochNo
 genNonExpiredEpoch = EpochNo <$> choose (1000, maxBound)
 
 genExpiredEpoch :: Gen EpochNo
-genExpiredEpoch = EpochNo <$> choose (0, 100)
+genExpiredEpoch = EpochNo <$> choose (0, 99)
 
 genNonResignedCommitteeState ::
   forall era.


### PR DESCRIPTION
# Description

The range of generated expired epochs and unexpired epochs overlaped at point 100, which caused the `genExpiredOrResigned` to assume that all `Yes` voting committee members are to be expired, but according to the spec we consider members expired only after the current epoch is greater than their expiry epoch, whereas in this case both were 100.

The range of the generator has been adjusted according to these semantics.

Fixes #4274

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
