### PR TITLE
Use the correct iohk action for installing Haskell in GitHub CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -58,17 +58,17 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install Haskell
-      uses: input-output-hk/setup-haskell@v1
-      id: setup-haskell
-      with:
-        ghc-version: ${{ matrix.ghc }}
-        cabal-version: latest
-
     - name: Install system dependencies
       uses: input-output-hk/actions/base@latest
       with:
         use-sodium-vrf: false # default is true
+
+    - name: Install Haskell
+      id: install-haskell
+      uses: input-output-hk/actions/haskell@latest
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: latest
 
     - name: Configure to use libsodium
       run: |
@@ -88,7 +88,7 @@ jobs:
       name: Cache cabal store
       with:
         path: |
-          ${{ steps.setup-haskell.outputs.cabal-store }}
+          ${{ steps.install-haskell.outputs.cabal-store }}
         # cache is invalidated upon a change to cabal.project (and/or cabal.project.local), a bump to
         # CABAL_CACHE_VERSION or after a week of inactivity
         key: cache-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-${{ hashFiles('cabal.project*') }}
@@ -171,17 +171,17 @@ jobs:
         shell: bash
 
     steps:
-    - name: Install Haskell
-      uses: input-output-hk/setup-haskell@v1
-      id: setup-haskell
-      with:
-        ghc-version: ${{ matrix.ghc }}
-        cabal-version: latest
-
     - name: Install system dependencies
       uses: input-output-hk/actions/base@latest
       with:
         use-sodium-vrf: false # default is true
+
+    - name: Install Haskell
+      id: install-haskell
+      uses: input-output-hk/actions/haskell@latest
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: latest
 
     - name: Set up Ruby 2.7
       uses: ruby/setup-ruby@v1
@@ -229,7 +229,7 @@ jobs:
       name: Cache cabal store
       with:
         path: |
-          ${{ steps.setup-haskell.outputs.cabal-store }}
+          ${{ steps.install-haskell.outputs.cabal-store }}
         # cache is invalidated upon a change to cabal.project (and/or cabal.project.local), a bump to
         # CABAL_CACHE_VERSION or after a week of inactivity
         key: cache-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-${{ hashFiles('cabal.project*') }}


### PR DESCRIPTION
# Description

This action has superseded the previous one but is currently identical to it, so this is just a housekeeping and future-proofing change.

I've also switched the order of `actions/base` and `actions/haskell` because in future the latter may depend on something installed by the former (eg `libtinfo`).

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff