### PR TITLE
Expect minimum deposit for proposals to be higher than the minimum

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -355,7 +355,7 @@ govTransition = do
         -- Deposit check
         let expectedDep = pp ^. ppGovActionDepositL
          in pProcDeposit
-              == expectedDep
+              >= expectedDep
                 ?! ProposalDepositIncorrect pProcDeposit expectedDep
 
         -- Return address network id check


### PR DESCRIPTION
Expect minimum deposit for proposals to be higher than the minimum instead of equal. This allows a proposal to leave more funds than necessary. This could be used to draw greater attention to important proposals in the event of a DOS attack - frontends could use a rank by deposit size mechanism.