### PR TITLE
Fix `OMap.assocList`

### DIFF
--- a/libs/cardano-data/CHANGELOG.md
+++ b/libs/cardano-data/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.2.0
 
-* Add `assocList`
+* Add `assocList`, `elems`
 * Add module Data.MonoTuple
 
 ## 1.2.1.0

--- a/libs/cardano-data/src/Data/OMap/Strict.hs
+++ b/libs/cardano-data/src/Data/OMap/Strict.hs
@@ -27,6 +27,7 @@ module Data.OMap.Strict (
   fromFoldableDuplicates,
   toMap,
   assocList,
+  elems,
   toStrictSeq,
   toStrictSeqOKeys,
   toStrictSeqOfPairs,
@@ -63,7 +64,7 @@ import Data.Maybe (isJust)
 import Data.Sequence.Strict qualified as SSeq
 import Data.Set qualified as Set
 import Data.Typeable (Typeable)
-import GHC.Exts (IsList (..))
+import GHC.Exts qualified as Exts
 import GHC.Generics (Generic)
 import Lens.Micro
 import NoThunks.Class (NoThunks (..))
@@ -371,13 +372,16 @@ omapl ><| omapr = case omapl of
 
 infixr 5 ><|
 
-instance HasOKey k v => IsList (OMap k v) where
+instance HasOKey k v => Exts.IsList (OMap k v) where
   type Item (OMap k v) = v
   fromList = fromFoldable
   toList = F.toList
 
-assocList :: OMap k v -> [(k, v)]
-assocList = Map.toList . toMap
+assocList :: Ord k => OMap k v -> [(k, v)]
+assocList = F.toList . toStrictSeqOfPairs
+
+elems :: Ord k => OMap k v -> [v]
+elems = F.toList . toStrictSeq
 
 instance (HasOKey k v, ToJSON v) => ToJSON (OMap k v) where
   toJSON = toJSON . toStrictSeq

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway.hs
@@ -808,6 +808,7 @@ instance SpecTranslate ctx a => SpecTranslate ctx (OSet a) where
 instance
   ( SpecTranslate ctx k
   , SpecTranslate ctx v
+  , Ord k
   ) =>
   SpecTranslate ctx (OMap k v)
   where


### PR DESCRIPTION
# Description

This PR changes `assocList` so that the order of key-value pairs is preserved. Also added the `elems` function, which returns a list of elements of an `OMap`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
