### PR TITLE
Ts newstyle specs

### DIFF
--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
@@ -41,6 +41,7 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Core (
   runSpecTransM,
   toTestRep,
  )
+
 import Test.Cardano.Ledger.Imp.Common
 import Test.Cardano.Ledger.Shelley.ImpTest (
   ImpTestM,
@@ -341,7 +342,7 @@ generatesWithin ::
 generatesWithin gen timeout =
   prop (aName <> " generates in reasonable time")
     . forAllShow gen showExpr
-    $ \x -> within timeout $ ioProperty (evaluateDeep x $> ())
+    $ \x -> within timeout $ withMaxSuccess 2 $ ioProperty (evaluateDeep x $> ())
   where
     aName = show (typeRep $ Proxy @a)
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
@@ -17,6 +17,7 @@ spec = describe "Conway conformance tests" $ do
   xprop "UTXO" $ conformsToImpl @"UTXO" @ConwayFn @Conway
   prop "GOV" $ conformsToImpl @"GOV" @ConwayFn @Conway
   prop "CERT" $ conformsToImpl @"CERT" @ConwayFn @Conway
+
   xprop "RATIFY" $ conformsToImpl @"RATIFY" @ConwayFn @Conway
   prop "GOVCERT" $ conformsToImpl @"GOVCERT" @ConwayFn @Conway
   xprop "ENACT" $ conformsToImpl @"ENACT" @ConwayFn @Conway

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -63,6 +63,7 @@ library
         Test.Cardano.Ledger.Constrained.Conway.PParams
         Test.Cardano.Ledger.Constrained.Conway.Gov
         Test.Cardano.Ledger.Constrained.Conway.Utxo
+        Test.Cardano.Ledger.Constrained.Conway.State
         Test.Cardano.Ledger.Examples.BabbageFeatures
         Test.Cardano.Ledger.Examples.AlonzoValidTxUTXOW
         Test.Cardano.Ledger.Examples.AlonzoInvalidTxUTXOW

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Classes.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Classes.hs
@@ -744,8 +744,8 @@ data ProposedPPUpdatesF era where
 unProposedPPUpdates :: ProposedPPUpdatesF era -> PP.ProposedPPUpdates era
 unProposedPPUpdates (ProposedPPUpdatesF _ x) = x
 
-instance PrettyA (PParamsUpdate e) => PrettyA (ProposedPPUpdatesF e) where
-  prettyA (ProposedPPUpdatesF _p x) = ppProposedPPUpdates x
+instance PrettyA (ProposedPPUpdatesF e) where
+  prettyA (ProposedPPUpdatesF p x) = ppProposedPPUpdates p x
 
 proposedCoreL ::
   Lens' (PP.ProposedPPUpdates era) (Map (KeyHash 'Genesis (EraCrypto era)) (PParamsUpdate era))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
@@ -27,8 +27,8 @@ dStateSpec ::
   IsConwayUniv fn =>
   Specification fn (DState (ConwayEra StandardCrypto))
 dStateSpec = constrained $ \ds ->
-  match ds $ \rewardMap _futureGenDelegs _genDelegs _rewards ->
-    match rewardMap $ \rdMap ptrMap sPoolMap _dRepMap ->
+  match ds $ \umap _futureGenDelegs _genDelegs _rewards ->
+    match umap $ \rdMap ptrMap sPoolMap _dRepMap ->
       [ assertExplain ["dom sPoolMap is a subset of dom rdMap"] $ dom_ sPoolMap `subset_` dom_ rdMap
       , assertExplain ["dom ptrMap is empty"] $ dom_ ptrMap ==. mempty
       ]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/PParams.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/PParams.hs
@@ -1,64 +1,78 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Cardano.Ledger.Constrained.Conway.PParams where
 
 import Cardano.Ledger.BaseTypes
-import Cardano.Ledger.Conway.PParams
-
-import Constrained
-
-import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Crypto (StandardCrypto)
-import Test.Cardano.Ledger.Constrained.Conway.Instances (IsConwayUniv)
+import Constrained
+import Data.Word (Word16)
+import Test.Cardano.Ledger.Constrained.Conway.Instances (EraPP, IsConwayUniv, PParamSubset (..))
 
-pparamsSpec :: IsConwayUniv fn => Specification fn (PParams (ConwayEra StandardCrypto))
+-- | A Spec for PParamSubset, which we will lift to a Spec on PParams
+pparamSubsetSpec :: IsConwayUniv fn => Specification fn PParamSubset
+pparamSubsetSpec = constrained $ \pparamsubset ->
+  match pparamsubset $
+    \feeA
+     feeB
+     bbsize
+     txsize
+     bhsize
+     kdep
+     pdep
+     emax
+     _nopt
+     _a0
+     _rho
+     _tau
+     _decentral
+     _protocolVersion
+     _minval
+     poolCost
+     -- Alonzo
+     _coinsPerWord
+     costmod
+     _prices
+     _maxTxEx
+     _maBlockEx
+     valsize
+     col
+     _maxColSize
+     -- Babbage
+     coinsperbyte
+     -- Conway
+     _poolThresh
+     _drepThresh
+     _commMinSize
+     commMaxTerm
+     govactlife
+     actdep
+     drepdep
+     _drepAct
+     _minFeePerByte ->
+        [ assert $ bbsize <=. bhsize + txsize
+        , assert $ bhsize <=. (lit (fromIntegral (maxBound @Word16)))
+        , assert $ (lit 25000) <=. txsize
+        , assert $ (lit 1000) <=. bbsize
+        , assert $ valsize /=. lit 0
+        , assert $ col /=. lit 0
+        , assert $ costmod ==. lit mempty
+        , assert $ commMaxTerm /=. lit (EpochInterval 0)
+        , assert $ govactlife /=. lit (EpochInterval 0)
+        , assert $ pdep /=. lit (Coin 0)
+        , assert $ kdep /=. lit (Coin 0)
+        , assert $ actdep /=. lit (Coin 0)
+        , assert $ drepdep /=. lit (Coin 0)
+        , assert $ lit (EpochInterval 0) <. emax
+        , assert $ lit (Coin 0) <. coinsperbyte
+        , assert $ lit (Coin 0) <. feeA
+        , assert $ feeB <. feeA
+        , assert $ lit (Coin 10) <. poolCost
+        ]
+
+pparamsSpec :: (EraPP era, IsConwayUniv fn) => Specification fn (PParams era)
 pparamsSpec =
   constrained $ \pp ->
-    match pp $ \cpp ->
-      match cpp $
-        \_cppMinFeeA
-         _cppMinFeeB
-         cppMaxBBSize
-         cppMaxTxSize
-         cppMaxBHSize
-         _cppKeyDeposit
-         cppPoolDeposit
-         cppEMax
-         _cppNOpt
-         _cppA0
-         _cppRho
-         _cppTau
-         _cppProtocolVersion
-         _cppMinPoolCost
-         _cppCoinsPerUTxOByte
-         _cppCostModels
-         _cppPrices
-         _cppMaxTxExUnits
-         _cppMaxBlockExUnits
-         cppMaxValSize
-         cppCollateralPercentage
-         _cppMaxCollateralInputs
-         _cppPoolVotingThresholds
-         _cppDRepVotingThresholds
-         _cppCommitteeMinSize
-         cppCommitteeMaxTermLength
-         cppGovActionLifetime
-         cppGovActionDeposit
-         cppDRepDeposit
-         _cppDRepActivity
-         _cppMinFeeRefScriptCoinsPerByte ->
-            [ assert $ cppMaxBBSize /=. lit (THKD 0)
-            , assert $ cppMaxTxSize /=. lit (THKD 0)
-            , assert $ cppMaxBHSize /=. lit (THKD 0)
-            , assert $ cppMaxValSize /=. lit (THKD 0)
-            , assert $ cppCollateralPercentage /=. lit (THKD 0)
-            , assert $ cppCommitteeMaxTermLength /=. lit (THKD $ EpochInterval 0)
-            , assert $ cppGovActionLifetime /=. lit (THKD $ EpochInterval 0)
-            , assert $ cppPoolDeposit /=. lit (THKD mempty)
-            , assert $ cppGovActionDeposit /=. lit (THKD mempty)
-            , assert $ cppDRepDeposit /=. lit (THKD mempty)
-            , match cppEMax $ \epochInterval ->
-                lit (EpochInterval 0) <. epochInterval
-            ]
+    match pp $ \ppsub -> [satisfies ppsub pparamSubsetSpec]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/State.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/State.hs
@@ -1,0 +1,914 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | Specs necessary to generate constrained (well formed) values in the Cardano Ledger.
+module Test.Cardano.Ledger.Constrained.Conway.State where
+
+import Cardano.Ledger.Alonzo.TxOut (AlonzoTxOut (..))
+import Cardano.Ledger.Api
+import Cardano.Ledger.Babbage.TxOut (BabbageTxOut (..))
+import Cardano.Ledger.BaseTypes hiding (inject)
+import Cardano.Ledger.CertState
+import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
+import Cardano.Ledger.Conway.Rules
+import Cardano.Ledger.Core (Value)
+import Cardano.Ledger.Credential (Credential, Ptr, StakeReference (..))
+import Cardano.Ledger.EpochBoundary (SnapShot (..), SnapShots (..), Stake (..), calculatePoolDistr)
+import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
+import Cardano.Ledger.Mary (MaryValue)
+import Cardano.Ledger.PoolDistr (PoolDistr (..))
+import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.SafeHash ()
+import Cardano.Ledger.Shelley.LedgerState (
+  AccountState (..),
+  EpochState (..),
+  IncrementalStake (..),
+  LedgerState (..),
+  NewEpochState (..),
+  StashedAVVMAddresses,
+  UTxOState (..),
+  updateStakeDistribution,
+ )
+import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
+import Cardano.Ledger.TxIn (TxId (..))
+import Cardano.Ledger.UMap (CompactForm (..), RDPair)
+import qualified Cardano.Ledger.UMap as UMap
+import Cardano.Ledger.UTxO (UTxO (..))
+import Constrained hiding (Value)
+import Constrained.Base (Pred (..), Sized (..), hasSize, rangeSize)
+
+-- import Constrained.Spec.Map (rngSet_)
+import Data.Default.Class (Default (def))
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Proxy (Proxy (..))
+import Data.VMap (VB, VMap, VP)
+import qualified Data.VMap as VMap
+import Data.Word (Word64)
+import System.IO.Unsafe (unsafePerformIO)
+import Test.Cardano.Ledger.Constrained.Conway ()
+import Test.Cardano.Ledger.Constrained.Conway.Gov (govProposalsSpec)
+import Test.Cardano.Ledger.Constrained.Conway.Instances
+import Test.Cardano.Ledger.Constrained.Conway.PParams (pparamsSpec)
+import Test.Cardano.Ledger.Generic.PrettyCore (
+  PrettyA (prettyA),
+  pcIRewards,
+  pcSnapShotL,
+  ppRecord,
+ )
+import Test.Hspec
+import Test.QuickCheck (Gen, Property, arbitrary, generate, property)
+
+-- ===========================================================
+
+-- | classes with operations to support Era parametric Specs.
+--   They contains methods that navigate the differences in types parameterized
+--   by 'era' that embed type families that change from one Era to another.
+--   For example (PParams era) in the 'EraPP' class, and
+--   TxOut, GovState, and StashedAVVMAddresses in the 'Constrain' class
+class
+  ( HasSpec fn (TxOut era)
+  , IsNormalType (TxOut era)
+  , HasSpec fn (GovState era)
+  , HasSpec fn (StashedAVVMAddresses era)
+  , EraTxOut era
+  , IsConwayUniv fn
+  , EraPP era
+  ) =>
+  Constrain era fn
+  where
+  irewardSpec :: Term fn AccountState -> Specification fn (InstantaneousRewards (EraCrypto era))
+  ptrPred ::
+    proxy era ->
+    Term fn (Map Ptr (Credential 'Staking (EraCrypto era))) ->
+    Term fn (Map (Credential 'Staking (EraCrypto era)) RDPair) ->
+    Pred fn
+  correctTxOut ::
+    Term fn (Map (Credential 'Staking (EraCrypto era)) (KeyHash 'StakePool (EraCrypto era))) ->
+    Term fn (TxOut era) ->
+    Pred fn
+  govStateSpec :: PParams era -> Specification fn (GovState era)
+  newEpochStateSpec :: PParams era -> Specification fn (NewEpochState era)
+
+instance IsConwayUniv fn => Constrain Shelley fn where
+  irewardSpec = instantaneousRewardsSpec
+  ptrPred _proxy = domEqualRng
+  correctTxOut = betterTxOutShelley
+  govStateSpec = shelleyGovStateSpec
+  newEpochStateSpec = newEpochStateSpecUTxO
+
+instance IsConwayUniv fn => Constrain Allegra fn where
+  irewardSpec = instantaneousRewardsSpec
+  ptrPred _proxy = domEqualRng
+  correctTxOut = betterTxOutShelley
+  govStateSpec = shelleyGovStateSpec
+  newEpochStateSpec = newEpochStateSpecUnit
+
+instance IsConwayUniv fn => Constrain Mary fn where
+  irewardSpec = instantaneousRewardsSpec
+  ptrPred _proxy = domEqualRng
+  correctTxOut = betterTxOutMary
+  govStateSpec = shelleyGovStateSpec
+  newEpochStateSpec = newEpochStateSpecUnit
+
+instance IsConwayUniv fn => Constrain Alonzo fn where
+  irewardSpec = instantaneousRewardsSpec
+  ptrPred _proxy = domEqualRng
+  correctTxOut = betterTxOutAlonzo
+  govStateSpec = shelleyGovStateSpec
+  newEpochStateSpec = newEpochStateSpecUnit
+
+instance IsConwayUniv fn => Constrain Babbage fn where
+  irewardSpec = instantaneousRewardsSpec
+  ptrPred _proxy = domEqualRng
+  correctTxOut = betterTxOutBabbage
+  govStateSpec = shelleyGovStateSpec
+  newEpochStateSpec = newEpochStateSpecUnit
+
+instance IsConwayUniv fn => Constrain Conway fn where
+  irewardSpec _ = constrained $ \irewards ->
+    match irewards $ \reserves treasury deltaRes deltaTreas ->
+      [ reserves ==. lit Map.empty
+      , treasury ==. lit Map.empty
+      , deltaRes ==. lit (DeltaCoin 0)
+      , deltaTreas ==. lit (DeltaCoin 0)
+      ]
+  ptrPred _proxy ptrmap _umap = assertExplain ["dom ptrMap is empty"] $ dom_ ptrmap ==. mempty
+  correctTxOut = betterTxOutBabbage
+  govStateSpec pp = conwayGovStateSpec pp (testGovEnv pp)
+  newEpochStateSpec = newEpochStateSpecUnit
+
+-- | Want (Rng v3) == (Dom v0), except the Rng is List and the Dom is a Set.
+domEqualRng ::
+  ( IsConwayUniv fn
+  , Ord ptr
+  , Ord cred
+  , IsNormalType cred
+  , HasSpec fn cred
+  , IsNormalType ptr
+  , HasSpec fn ptr
+  , IsNormalType ume
+  , HasSpec fn ume
+  ) =>
+  Term fn (Map ptr cred) ->
+  Term fn (Map cred ume) ->
+  Pred fn
+domEqualRng v3 v2 =
+  Block
+    [ assertExplain ["Domain v2 == Range v3"] $ rngSet_ v3 ==. dom_ v2
+    ]
+
+-- ======================================================================================
+-- TxOut and Value are two of the type families, whose instance changes from Era to Era.
+-- TxOuts, we need SimpleRep for each possible TxOut (Shelley,Mary,Alonzo,Babbage)
+-- We also need to define the method 'correctTxOut' for every 'Constrained' instance
+-- These instances are tricky, since there is a unique combination of Value and TxOut
+-- ======================================================================================
+
+betterTxOutShelley ::
+  (EraTxOut era, Value era ~ Coin, IsConwayUniv fn) =>
+  Term fn (Map (Credential 'Staking (EraCrypto era)) (KeyHash 'StakePool (EraCrypto era))) ->
+  Term fn (ShelleyTxOut era) ->
+  Pred fn
+betterTxOutShelley delegs txOut =
+  match txOut $ \addr v ->
+    [ match v $ \c -> [0 <. c, c <=. fromIntegral (maxBound :: Word64)]
+    , (caseOn addr)
+        ( branch $ \n _ r ->
+            [ assert $ n ==. lit Testnet
+            , satisfies r (delegatedStakeReference delegs)
+            ]
+        )
+        ( branch $ \bootstrapAddr ->
+            match bootstrapAddr $ \_ nm _ ->
+              (caseOn nm)
+                (branch $ \_ -> False)
+                (branch $ \_ -> True)
+        )
+    ]
+
+betterTxOutMary ::
+  (EraTxOut era, Value era ~ MaryValue (EraCrypto era), IsConwayUniv fn) =>
+  Term fn (Map (Credential 'Staking (EraCrypto era)) (KeyHash 'StakePool (EraCrypto era))) ->
+  Term fn (ShelleyTxOut era) ->
+  Pred fn
+betterTxOutMary delegs txOut =
+  match txOut $ \addr v ->
+    [ match v $ \c -> [0 <. c, c <=. fromIntegral (maxBound :: Word64)]
+    , (caseOn addr)
+        ( branch $ \n _ r ->
+            [ assert $ n ==. lit Testnet
+            , satisfies r (delegatedStakeReference delegs)
+            ]
+        )
+        ( branch $ \bootstrapAddr ->
+            match bootstrapAddr $ \_ nm _ ->
+              (caseOn nm)
+                (branch $ \_ -> False)
+                (branch $ \_ -> True)
+        )
+    ]
+
+betterTxOutAlonzo ::
+  (AlonzoEraTxOut era, Value era ~ MaryValue (EraCrypto era), IsConwayUniv fn) =>
+  Term fn (Map (Credential 'Staking (EraCrypto era)) (KeyHash 'StakePool (EraCrypto era))) ->
+  Term fn (AlonzoTxOut era) ->
+  Pred fn
+betterTxOutAlonzo delegs txOut =
+  match txOut $ \addr v _ ->
+    [ match v $ \c -> [0 <. c, c <=. fromIntegral (maxBound :: Word64)]
+    , (caseOn addr)
+        ( branch $ \n _ r ->
+            [ assert $ n ==. lit Testnet
+            , satisfies r (delegatedStakeReference delegs)
+            ]
+        )
+        ( branch $ \bootstrapAddr ->
+            match bootstrapAddr $ \_ _nm _ -> False
+            {-
+            (caseOn nm)
+              (branch $ \_ -> False)
+              (branch $ \_ -> True) -}
+        )
+    ]
+
+betterTxOutBabbage ::
+  ( EraTxOut era
+  , Value era ~ MaryValue (EraCrypto era)
+  , IsNormalType (Script era)
+  , HasSpec fn (Script era)
+  , IsConwayUniv fn
+  ) =>
+  Term fn (Map (Credential 'Staking (EraCrypto era)) (KeyHash 'StakePool (EraCrypto era))) ->
+  Term fn (BabbageTxOut era) ->
+  Pred fn
+betterTxOutBabbage delegs txOut =
+  match txOut $ \addr v _ _ ->
+    [ match v $ \c -> [0 <. c, c <=. fromIntegral (maxBound :: Word64)]
+    , (caseOn addr)
+        ( branch $ \n _ r ->
+            [ assert $ n ==. lit Testnet
+            , satisfies r (delegatedStakeReference delegs)
+            ]
+        )
+        ( branch $ \bootstrapAddr ->
+            match bootstrapAddr $ \_ nm _ ->
+              (caseOn nm)
+                (branch $ \_ -> False)
+                (branch $ \_ -> True)
+        )
+    ]
+
+delegatedStakeReference ::
+  (IsConwayUniv fn, Crypto c) =>
+  Term fn (Map (Credential 'Staking c) (KeyHash 'StakePool c)) ->
+  Specification fn (StakeReference c)
+delegatedStakeReference delegs =
+  constrained $ \ref ->
+    caseOn
+      ref
+      (branch $ \base -> member_ base (dom_ delegs))
+      (branch $ \_ptr -> False)
+      (branch $ \_null -> False)
+
+-- ====================================================================================
+-- Some Specifications are constrained by types (say 'x') that do not appear in the type being
+-- specified. We use the strategy of passing (Term fn x) as inputs to those specifcations.
+-- For example, the AcountState must have sufficient capacity to support the InstantaneousRewards
+-- So we pass a (Term fn AccountState) as input to 'instantaneousRewardsSpec'
+-- In order to create tests, not involving the outer specifications (i.e. instantaneousRewardsSpec
+-- in the example above), we make literal 'test' terms, we use by passing the test terms
+--  as inputs to the tests and examples of those 'inner' specifications.
+-- ====================================================================================
+
+testAcctState :: Term fn AccountState
+testAcctState = lit (AccountState (Coin 100) (Coin 100))
+
+testGovEnv :: Era era => PParams era -> GovEnv era
+testGovEnv pp =
+  GovEnv
+    (TxId def) -- SafeHash has a Default instance
+    (EpochNo 99)
+    pp
+    SNothing
+    (CommitteeState Map.empty)
+
+testEpochNo :: Term fn EpochNo
+testEpochNo = lit (EpochNo 99)
+
+testPools ::
+  forall era c.
+  (c ~ EraCrypto era, Constrain era ConwayFn) =>
+  Term ConwayFn (Map (KeyHash 'StakePool c) (PoolParams c))
+testPools = unsafePerformIO $ generate $ do
+  ps <- specToGen @(Map (KeyHash 'StakePool c) (PoolParams c)) (hasSize (rangeSize 8 8))
+  pure (lit ps)
+
+testDelegations ::
+  forall c. Crypto c => Term ConwayFn (Map (Credential 'Staking c) (KeyHash 'StakePool c))
+testDelegations = unsafePerformIO $ generate $ do
+  ds <- specToGen @(Map (Credential 'Staking c) (KeyHash 'StakePool c)) (hasSize (rangeSize 8 8))
+  pure (lit ds)
+
+testPP :: EraPParams era => PParams era
+testPP = def
+
+testCertState :: forall era. Constrain era ConwayFn => Term ConwayFn (CertState era)
+testCertState = unsafePerformIO $ generate $ do
+  cs <- specToGen @(CertState era) (certStateSpec testAcctState testEpochNo)
+  pure (lit cs)
+
+testLedgerState :: forall era. Constrain era ConwayFn => LedgerState era
+testLedgerState = unsafePerformIO $ generate $ do
+  ls <- specToGen @(LedgerState era) (ledgerStateSpec testPP testAcctState testEpochNo)
+  pure ls
+
+-- ================================================================================
+-- Specifications for types that appear in the Cardano Ledger
+-- the functions  goXX :: IO () (or IO Bool) visualize a test run they are crcuial
+-- to eyeballing that the spes are working as expected. Eventually we will get
+-- rid of them. But until the Specifications becoe stable, we will keep them.
+-- ================================================================================
+
+instantaneousRewardsSpec ::
+  forall c fn.
+  (IsConwayUniv fn, Crypto c) =>
+  Term fn AccountState ->
+  Specification fn (InstantaneousRewards c)
+instantaneousRewardsSpec acct = constrained $ \irewards ->
+  match irewards $ \reserves treasury deltaRes deltaTreas ->
+    match acct $ \acctRes acctTreas ->
+      [ assertExplain ["deltaTreausry and deltaReserves sum to 0"] $ negate deltaRes ==. deltaTreas
+      , sizeRng reserves 2 6
+      , sizeRng treasury 1 4
+      , forAll (rng_ reserves) (\x -> x /=. (lit (Coin 0)))
+      , forAll (rng_ treasury) (\x -> x /=. (lit (Coin 0)))
+      , assert $ (toDelta_ (foldMap_ id (rng_ reserves))) - deltaRes <=. toDelta_ acctRes
+      , assert $ (toDelta_ (foldMap_ id (rng_ treasury))) - deltaTreas <=. toDelta_ acctTreas
+      ]
+
+go1 :: IO ()
+go1 = do
+  acct <- generate (arbitrary :: Gen AccountState)
+  let xx :: Specification ConwayFn (InstantaneousRewards StandardCrypto)
+      xx = instantaneousRewardsSpec @(EraCrypto Shelley) @ConwayFn (lit acct)
+  ir <- generateSpec xx
+  putStrLn (show (pcIRewards ir))
+  putStrLn ("conforms " ++ show (conformsToSpec ir xx) ++ "  " ++ show acct)
+
+-- ========================================================================
+-- The CertState specs
+-- ========================================================================
+
+instance IsConwayUniv fn => NumLike fn EpochNo
+
+drepStateSpec :: (IsConwayUniv fn, Crypto c) => Term fn EpochNo -> Specification fn (DRepState c)
+drepStateSpec epoch = constrained $ \drepstate ->
+  match drepstate $ \expiry _anchor deposit ->
+    [ assertExplain ["epoch of expiration must follow the current epoch"] $ epoch <=. expiry
+    , assertExplain ["no deposit is 0"] $ lit (Coin 0) <=. deposit
+    ]
+
+go2 :: IO Bool
+go2 = ioTest @(DRepState StandardCrypto) (drepStateSpec testEpochNo)
+
+vstateSpec :: (IsConwayUniv fn, Era era) => Term fn EpochNo -> Specification fn (VState era)
+vstateSpec epoch = constrained $ \vstate ->
+  match vstate $ \dreps comstate numdormant ->
+    [ forAll (rng_ dreps) (\x -> x `satisfies` (drepStateSpec epoch))
+    , satisfies (dom_ dreps) (hasSize (rangeSize 5 12))
+    , assertExplain ["num dormant epochs should not be too large"] $
+        [epoch <=. numdormant, numdormant <=. epoch + (lit (EpochNo 10))]
+    , dependsOn numdormant epoch -- Solve epoch first.
+    , match comstate $ \commap -> sizeRng commap 1 4
+    ]
+
+go3 :: IO Bool
+go3 = ioTest @(VState Shelley) (vstateSpec testEpochNo)
+
+dstateSpec ::
+  forall era fn.
+  Constrain era fn =>
+  Term fn AccountState ->
+  Term fn (Map (KeyHash 'StakePool (EraCrypto era)) (PoolParams (EraCrypto era))) ->
+  Specification fn (DState era)
+dstateSpec acct poolreg = constrained $ \ds ->
+  match ds $ \umap futureGenDelegs genDelegs irewards ->
+    match umap $ {- \ umapRep -> match umapRep $ -} \rdMap ptrMap sPoolMap _dRepMap ->
+      [ assert $ (sizeOf_ rdMap) ==. 11
+      , assertExplain ["dom sPoolMap is a subset of dom rdMap"] $ dom_ sPoolMap `subset_` dom_ rdMap
+      , dependsOn rdMap sPoolMap
+      , -- reify here, forces us to solve for rdMap, before sovling for ptrMap
+        reify rdMap id (\rewdep -> ptrPred (Proxy @era) ptrMap rewdep)
+      , assertExplain ["The delegations delegate to actual pools"] $
+          forAll (rng_ sPoolMap) (\keyhash -> member_ keyhash (dom_ poolreg))
+      , assert $ (sizeOf_ sPoolMap) ==. 10
+      , satisfies irewards (irewardSpec @era acct)
+      , satisfies futureGenDelegs (hasSize (rangeSize 0 3))
+      , match genDelegs $ \x -> satisfies x (hasSize (rangeSize 1 4)) -- Strip off the newtype constructor
+      ]
+
+go4 :: IO Bool
+go4 = do
+  cs <-
+    generateSpec @(Map (KeyHash 'StakePool StandardCrypto) (PoolParams StandardCrypto))
+      (hasSize (rangeSize 10 10))
+  putStrLn ("STAKEPOOL MAP\n" ++ show (prettyA cs))
+  t <- generateSpec @(DState Shelley) (dstateSpec testAcctState (lit cs))
+  putStrLn ("DSTATE\n" ++ show (prettyA t))
+  pure (conformsToSpec @ConwayFn t (dstateSpec testAcctState (lit cs)))
+
+pstateSpec ::
+  (IsConwayUniv fn, Era era) =>
+  Term fn EpochNo ->
+  Specification fn (PState era)
+pstateSpec currepoch = constrained $ \ps ->
+  match ps $ \stakePoolParams futureStakePoolParams retiring deposits ->
+    [ assertExplain ["dom of retiring is a subset of dom of stakePoolParams"] $
+        dom_ retiring `subset_` dom_ stakePoolParams
+    , assertExplain ["retiring after current epoch"] $
+        forAll (rng_ retiring) (\epoch -> currepoch <=. epoch)
+    , assertExplain ["dom of deposits is dom of stakePoolParams"] $
+        dom_ deposits ==. dom_ stakePoolParams
+    , assertExplain ["no deposit is 0"] $
+        not_ $
+          lit (Coin 0) `elem_` rng_ deposits
+    , assertExplain ["dom of stakePoolParams is disjoint from futureStakePoolParams"] $
+        dom_ stakePoolParams `disjoint_` dom_ futureStakePoolParams
+    , assert $ sizeOf_ (dom_ futureStakePoolParams) <=. 4
+    , assert $ 3 <=. sizeOf_ (dom_ stakePoolParams)
+    , assert $ sizeOf_ (dom_ stakePoolParams) <=. 8
+    ]
+
+go5 :: IO Bool
+go5 = ioTest @(PState Shelley) (pstateSpec testEpochNo)
+
+accountStateSpec :: IsConwayUniv fn => Specification fn AccountState
+accountStateSpec =
+  constrained
+    ( \as ->
+        match as (\res treas -> [lit (Coin 100) <=. treas, lit (Coin 100) <=. res])
+    )
+
+certStateSpec ::
+  forall era fn.
+  Constrain era fn =>
+  Term fn AccountState ->
+  Term fn EpochNo ->
+  Specification fn (CertState era)
+certStateSpec acct epoch = constrained $ \cs ->
+  match cs $ \vState pState dState ->
+    [ satisfies vState (vstateSpec epoch)
+    , satisfies pState (pstateSpec epoch)
+    , reify pState psStakePoolParams (\poolreg -> satisfies dState (dstateSpec acct poolreg))
+    ]
+
+go6 :: IO Bool
+go6 = ioTest @(CertState Shelley) (certStateSpec testAcctState testEpochNo)
+
+-- ==============================================================
+-- Specs for UTxO and UTxOState
+-- ==============================================================
+
+utxoSpec ::
+  forall era fn.
+  Constrain era fn =>
+  Term fn (Map (Credential 'Staking (EraCrypto era)) (KeyHash 'StakePool (EraCrypto era))) ->
+  Specification fn (UTxO era)
+utxoSpec delegs = constrained $ \utxo ->
+  match utxo $ \m ->
+    [ forAll (rng_ m) (correctTxOut delegs)
+    , assert $ (sizeOf_ (rng_ m)) ==. 8 -- Arbitrary for testing purposes.
+    -- , GenHint 10 m
+    ]
+
+go7 :: IO Bool
+go7 = do
+  cs <-
+    generateSpec @(Map (Credential 'Staking StandardCrypto) (KeyHash 'StakePool StandardCrypto))
+      (hasSize (rangeSize 30 30))
+  putStrLn ("Stake Registration MAP\n" ++ show (prettyA cs))
+  t <- generateSpec @(UTxO Mary) (utxoSpec @Mary (lit cs))
+  putStrLn ("UTxO\n" ++ show (prettyA t))
+  pure (conformsToSpec @ConwayFn t (utxoSpec @Mary (lit cs)))
+
+utxoStateSpec ::
+  forall era fn.
+  Constrain era fn =>
+  PParams era ->
+  Term fn (CertState era) ->
+  Specification fn (UTxOState era)
+utxoStateSpec pp certstate =
+  constrained $ \u ->
+    match u $ \utxo deposits fees gov distr donation ->
+      [ assert $ donation ==. lit (Coin 0)
+      , reify
+          certstate
+          (sumObligation . obligationCertState)
+          (\depositsum -> assert $ deposits ==. depositsum)
+      , assert $ lit (Coin 0) <=. fees
+      , reify certstate getDelegs (\delegs -> satisfies utxo (utxoSpec delegs))
+      , satisfies gov (govStateSpec @era @fn pp)
+      , reify utxo (updateStakeDistribution pp mempty mempty) (\i -> distr ==. i)
+      ]
+
+getDelegs ::
+  forall era.
+  CertState era ->
+  Map (Credential 'Staking (EraCrypto era)) (KeyHash 'StakePool (EraCrypto era))
+getDelegs cs = UMap.sPoolMap (dsUnified (certDState cs))
+
+go8 :: IO Bool
+go8 = do
+  cs <- generateSpec @(CertState Shelley) (certStateSpec testAcctState testEpochNo)
+  t <- generateSpec @(UTxOState Shelley) (utxoStateSpec @Shelley @ConwayFn def (lit cs))
+  putStrLn ("UTXOSTATE\n" ++ show (prettyA t))
+  putStrLn ("CERTSTATE\n" ++ show (prettyA cs))
+  pure (conformsToSpec t (utxoStateSpec @Shelley @ConwayFn def (lit cs)))
+
+-- ====================================================================
+-- Specs for LedgerState
+-- ====================================================================
+
+shelleyGovStateSpec ::
+  forall era fn. Constrain era fn => PParams era -> Specification fn (ShelleyGovState era)
+shelleyGovStateSpec pp =
+  constrained $ \sgs ->
+    match sgs $ \curpro futpro curpp _prevpp _futpp ->
+      match curpro $ \cm ->
+        [ satisfies cm (hasSize (rangeSize 1 2))
+        , match futpro $ \fm -> satisfies fm (hasSize (rangeSize 1 2))
+        , assert $ curpp ==. lit pp
+        --  , match curpp (\ cpp ->   -- FIXME when canFollow is Fixed
+        --    match _futpp (\ fpp -> canFollow (protocolVersion_ fpp) (protocolVersion_ cpp)))
+        ]
+
+go9 :: IO Bool
+go9 = ioTest @(ShelleyGovState Mary) (shelleyGovStateSpec @Mary @ConwayFn def)
+
+govEnvSpec ::
+  IsConwayUniv fn =>
+  PParams Conway ->
+  Specification fn (GovEnv Conway)
+govEnvSpec pp = constrained $ \ge ->
+  match ge $ \_ _ cppx _ _ -> [assert $ lit pp ==. cppx]
+
+conwayGovStateSpec ::
+  forall fn.
+  Constrain Conway fn =>
+  PParams Conway ->
+  GovEnv Conway ->
+  Specification fn (ConwayGovState Conway)
+conwayGovStateSpec pp govenv =
+  constrained $ \conwaygs ->
+    match conwaygs $ \proposals _mcommittee _consti curpp _prevpp _futurepp _derepPulstate ->
+      [ assert $ curpp ==. lit pp
+      , satisfies proposals (govProposalsSpec govenv)
+      ]
+
+-- =========================================================================
+
+ledgerStateSpec ::
+  forall era fn.
+  Constrain era fn =>
+  PParams era ->
+  Term fn AccountState ->
+  Term fn EpochNo ->
+  Specification fn (LedgerState era)
+ledgerStateSpec pp acct epoch =
+  constrained $ \ls ->
+    match ls $ \utxoS csg ->
+      [ satisfies csg (certStateSpec @era @fn acct epoch)
+      , reify csg id (\certstate -> satisfies utxoS (utxoStateSpec @era @fn pp certstate))
+      ]
+
+go11 :: IO ()
+go11 = do
+  ls <- generateSpec (ledgerStateSpec @Shelley @ConwayFn def testAcctState testEpochNo)
+  let d = sumObligation $ obligationCertState $ lsCertState ls
+  putStrLn (show (prettyA ls))
+  putStrLn ("Total certstate deposits " ++ show d)
+
+-- ===========================================================
+
+-- TODO make this more realistic
+snapShotSpec :: (Crypto c, IsConwayUniv fn) => Specification fn (SnapShot c)
+snapShotSpec =
+  constrained $ \snap ->
+    match snap $ \stake delegs poolparams ->
+      match stake $ \stakemap ->
+        [ assert $ stakemap ==. lit VMap.empty
+        , assert $ delegs ==. lit VMap.empty
+        , assert $ poolparams ==. lit VMap.empty
+        ]
+
+go12 :: IO ()
+go12 = do
+  -- No PrettyA instance so we write it out
+  sn <- generateSpec (snapShotSpec @(EraCrypto Shelley) @ConwayFn)
+  putStrLn (show (ppRecord "SnapShot" (pcSnapShotL "" sn)))
+
+snapShotsSpec ::
+  (Crypto c, IsConwayUniv fn) => Term fn (SnapShot c) -> Specification fn (SnapShots c)
+snapShotsSpec marksnap =
+  constrained $ \snap ->
+    match snap $ \mark pooldistr set go _fee ->
+      Block
+        [ assert $ mark ==. marksnap
+        , satisfies set snapShotSpec
+        , satisfies go snapShotSpec
+        , reify marksnap calculatePoolDistr $ \pd -> pooldistr ==. pd
+        ]
+
+go13 :: IO Bool
+go13 =
+  ioTest @(SnapShots StandardCrypto)
+    (snapShotsSpec (lit (getMarkSnapShot (testLedgerState @Babbage))))
+
+-- | The Mark SnapShot (at the epochboundary) is a pure function of the LedgerState
+getMarkSnapShot :: forall era. LedgerState era -> SnapShot (EraCrypto era)
+getMarkSnapShot ls = SnapShot @(EraCrypto era) (Stake markStake) markDelegations markPoolParams
+  where
+    markStake :: VMap VB VP (Credential 'Staking (EraCrypto era)) (CompactForm Coin)
+    markStake = VMap.fromMap (credMap (utxosStakeDistr (lsUTxOState ls)))
+    markDelegations ::
+      VMap VB VB (Credential 'Staking (EraCrypto era)) (KeyHash 'StakePool (EraCrypto era))
+    markDelegations = VMap.fromMap (UMap.sPoolMap (dsUnified (certDState (lsCertState ls))))
+    markPoolParams :: VMap VB VB (KeyHash 'StakePool (EraCrypto era)) (PoolParams (EraCrypto era))
+    markPoolParams = VMap.fromMap (psStakePoolParams (certPState (lsCertState ls)))
+
+-- ====================================================================
+-- Specs for EpochState and NewEpochState
+-- ====================================================================
+
+epochStateSpec ::
+  forall era fn.
+  Constrain era fn =>
+  PParams era ->
+  Term fn EpochNo ->
+  Specification fn (EpochState era)
+epochStateSpec pp epoch =
+  constrained $ \es ->
+    match es $ \acctst ls snaps nonmyopic ->
+      Block
+        [ satisfies ls (ledgerStateSpec pp acctst epoch)
+        , reify ls getMarkSnapShot $ \marksnap -> satisfies snaps (snapShotsSpec marksnap)
+        , match acctst $ \treas res -> [lit (Coin 100) <=. treas, lit (Coin 100) <=. res]
+        , match nonmyopic $ \x c -> [assert $ (sizeOf_ x) ==. 0, assert $ c ==. lit (Coin 0)]
+        ]
+
+go14 :: IO Bool
+go14 = ioTest @(EpochState Babbage) (epochStateSpec def testEpochNo)
+
+getPoolDistr :: forall era. EpochState era -> PoolDistr (EraCrypto era)
+getPoolDistr es = ssStakeMarkPoolDistr (esSnapshots es)
+
+-- | Used for Eras where StashedAVVMAddresses era ~ () (Allegra,Mary,Alonzo,Babbage,Conway)
+-- The 'newEpochStateSpec' method (of (Constrain era fn) class) in the instances for (Allegra,Mary,Alonzo,Babbage,Conway)
+newEpochStateSpecUnit ::
+  forall era fn.
+  (Constrain era fn, StashedAVVMAddresses era ~ ()) =>
+  PParams era ->
+  Specification fn (NewEpochState era)
+newEpochStateSpecUnit pp =
+  constrained
+    ( \nes ->
+        match
+          (nes :: Term fn (NewEpochState era))
+          ( \eno bm1 bm2 es _mpulser pooldistr stashAvvm ->
+              Block
+                [ reify eno id (\epoch -> satisfies es (epochStateSpec @era @fn pp epoch))
+                , satisfies stashAvvm (constrained (\x -> lit () ==. x))
+                , reify es getPoolDistr $ \pd -> pooldistr ==. pd
+                , match bm1 (genHint 3)
+                , match bm2 (genHint 3)
+                ]
+          )
+    )
+
+-- | Used for Eras where StashedAVVMAddresses era ~ UTxO era (Shelley)
+-- The 'newEpochStateSpec' method (of (Constrain era fn) class) in the Shelley instance
+newEpochStateSpecUTxO ::
+  forall era fn.
+  (Constrain era fn, StashedAVVMAddresses era ~ UTxO era) =>
+  PParams era ->
+  Specification fn (NewEpochState era)
+newEpochStateSpecUTxO pp =
+  constrained
+    ( \nes ->
+        match
+          (nes :: Term fn (NewEpochState era))
+          ( \eno bm1 bm2 es _mpulser pooldistr stashAvvm ->
+              Block
+                [ reify eno id (\epoch -> satisfies es (epochStateSpec @era @fn pp epoch))
+                , satisfies stashAvvm (constrained (\u -> u ==. lit (UTxO @era Map.empty)))
+                , reify es getPoolDistr $ \pd -> pooldistr ==. pd
+                , match bm1 (genHint 3)
+                , match bm2 (genHint 3)
+                ]
+          )
+    )
+
+go15 :: IO Bool
+go15 = ioTest @(NewEpochState Shelley) (newEpochStateSpec def)
+
+go16 :: IO Bool
+go16 = ioTest @(NewEpochState Alonzo) (newEpochStateSpec def)
+
+-- ==============================================================
+-- The WellFormed class and instances
+-- ==============================================================
+
+class (HasSpec ConwayFn t, Constrain era ConwayFn) => WellFormed t era where
+  wffp :: PParams era -> Gen t
+  wff :: Gen t
+  wff = do
+    pp <- specToGen @(PParams era) pparamsSpec
+    wffp pp
+
+instance Constrain era ConwayFn => WellFormed (PParams era) era where
+  wff = specToGen @(PParams era) pparamsSpec
+  wffp p = pure p
+
+instance Constrain era ConwayFn => WellFormed AccountState era where
+  wff = specToGen @AccountState accountStateSpec
+  wffp _ = specToGen @AccountState accountStateSpec
+
+instance Constrain era ConwayFn => WellFormed (PState era) era where
+  wff = specToGen @(PState era) (pstateSpec testEpochNo)
+  wffp _ = specToGen @(PState era) (pstateSpec testEpochNo)
+
+instance Constrain era ConwayFn => WellFormed (DState era) era where
+  wff = specToGen @(DState era) (dstateSpec testAcctState (testPools @era @(EraCrypto era)))
+  wffp _ = specToGen @(DState era) (dstateSpec testAcctState (testPools @era @(EraCrypto era)))
+
+instance Constrain era ConwayFn => WellFormed (VState era) era where
+  wff = specToGen @(VState era) (vstateSpec testEpochNo)
+  wffp _ = specToGen @(VState era) (vstateSpec testEpochNo)
+
+instance Constrain era ConwayFn => WellFormed (CertState era) era where
+  wff = specToGen @(CertState era) (certStateSpec testAcctState testEpochNo)
+  wffp _ = specToGen @(CertState era) (certStateSpec testAcctState testEpochNo)
+
+instance Constrain era ConwayFn => WellFormed (UTxOState era) era where
+  wffp pp = specToGen @(UTxOState era) (utxoStateSpec pp testCertState)
+
+instance Constrain era ConwayFn => WellFormed (LedgerState era) era where
+  wffp pp = specToGen @(LedgerState era) (ledgerStateSpec pp testAcctState testEpochNo)
+
+-- TODO, this fails sometimes, has something to do with the sizes
+-- listOfUntilLenT fails finding lists with valid length where goalLen = 8
+-- We need to avoid suchThatT.
+
+instance Constrain era ConwayFn => WellFormed (EpochState era) era where
+  wffp pp = specToGen @(EpochState era) (epochStateSpec pp testEpochNo)
+
+instance Constrain era ConwayFn => WellFormed (NewEpochState era) era where
+  wffp pp = specToGen @(NewEpochState era) (newEpochStateSpec pp)
+
+instance WellFormed (GovEnv Conway) Conway where
+  wffp pp = specToGen @(GovEnv Conway) (govEnvSpec pp)
+
+instance WellFormed (ConwayGovState Conway) Conway where
+  wffp pp = do
+    env <- specToGen @(GovEnv Conway) (govEnvSpec pp)
+    specToGen @(ConwayGovState Conway) (conwayGovStateSpec pp env)
+
+instance Constrain era ConwayFn => WellFormed (ShelleyGovState era) era where
+  wffp pp = specToGen @(ShelleyGovState era) (shelleyGovStateSpec pp)
+
+instance (Constrain era ConwayFn, c ~ EraCrypto era) => WellFormed (SnapShot c) era where
+  wffp _ = specToGen @(SnapShot (EraCrypto era)) snapShotSpec
+  wff = specToGen @(SnapShot (EraCrypto era)) snapShotSpec
+
+instance (Constrain era ConwayFn, c ~ EraCrypto era) => WellFormed (SnapShots c) era where
+  wffp pp = do
+    ls <- specToGen @(LedgerState era) (ledgerStateSpec pp testAcctState testEpochNo)
+    specToGen @(SnapShots (EraCrypto era)) (snapShotsSpec (lit (getMarkSnapShot ls)))
+
+instance (Constrain era ConwayFn, c ~ EraCrypto era) => WellFormed (InstantaneousRewards c) era where
+  wffp _ = specToGen @(InstantaneousRewards (EraCrypto era)) (instantaneousRewardsSpec testAcctState)
+  wff = specToGen @(InstantaneousRewards (EraCrypto era)) (instantaneousRewardsSpec testAcctState)
+
+-- =============================================================
+-- helper functions for examples and tests
+
+testwff :: forall p era. (WellFormed (p era) era, PrettyA (p era)) => IO ()
+testwff = do
+  x <- generate (wff @(p era) @era)
+  putStrLn (show (prettyA x))
+
+generateSpec :: forall a. HasSpec ConwayFn a => Specification ConwayFn a -> IO a
+generateSpec specx = generate (genFromSpec @ConwayFn specx)
+
+specToGen :: forall t. HasSpec ConwayFn t => Specification ConwayFn t -> Gen t
+specToGen = genFromSpec
+
+genSpec :: HasSpec ConwayFn a => Specification ConwayFn a -> IO a
+genSpec = generateSpec
+
+ioTest :: forall t. (HasSpec ConwayFn t, PrettyA t) => Specification ConwayFn t -> IO Bool
+ioTest specx = do
+  t <- generateSpec @t specx
+  putStrLn (show (prettyA t))
+  pure (conformsToSpec t specx)
+
+sizeRng :: (HasSpec fn t, Sized t) => Term fn t -> Integer -> Integer -> Pred fn
+sizeRng t lo hi = satisfies t (hasSize (rangeSize lo hi))
+
+utxosDeposits_ ::
+  ( EraTxOut era
+  , IsNormalType (TxOut era)
+  , HasSpec fn (TxOut era)
+  , HasSpec fn (GovState era)
+  , IsConwayUniv fn
+  ) =>
+  Term fn (UTxOState era) ->
+  Term fn Coin
+utxosDeposits_ = sel @1
+
+-- ===================================================================
+-- HSpec tests
+-- ===================================================================
+
+soundSpec :: forall t. HasSpec ConwayFn t => Specification ConwayFn t -> Gen Property
+soundSpec specx = do
+  x <- specToGen @t specx
+  pure $ property $ (conformsToSpec x specx)
+
+spec :: Spec
+spec = do
+  describe "WellFormed types from the Cardano Ledger" $ do
+    it "InstantaneousRewards" $
+      property $
+        soundSpec @(InstantaneousRewards StandardCrypto) (instantaneousRewardsSpec testAcctState)
+    it "PState" $ property $ soundSpec @(PState Shelley) (pstateSpec testEpochNo)
+    it "DState" $ property $ soundSpec @(DState Shelley) (dstateSpec testAcctState (testPools @Shelley))
+    it "VState" $ property $ soundSpec @(VState Shelley) (vstateSpec testEpochNo)
+    it "CertState" $ property $ soundSpec @(CertState Shelley) (certStateSpec testAcctState testEpochNo)
+    it "UTxO" $ property $ soundSpec @(UTxO Mary) (utxoSpec testDelegations)
+    it "UTxOState" $ property $ soundSpec @(UTxOState Shelley) (utxoStateSpec testPP testCertState)
+    it "LedgerState" $
+      property $
+        soundSpec @(LedgerState Babbage) (ledgerStateSpec testPP testAcctState testEpochNo)
+    it "EpochState" $ property $ soundSpec @(EpochState Mary) (epochStateSpec testPP testEpochNo)
+    it "NewEpochState" $ property $ soundSpec @(NewEpochState Conway) (newEpochStateSpec testPP)
+    it "SnapShots" $
+      property $
+        soundSpec @(SnapShots StandardCrypto)
+          (snapShotsSpec (lit (getMarkSnapShot (testLedgerState @Babbage))))
+
+-- ========================================
+-- TODO FIXME The dependency on this needs to be debugged
+
+canFollow :: IsConwayUniv fn => Term fn ProtVer -> Term fn ProtVer -> Pred fn
+canFollow pv pv' =
+  match pv $ \majV minV ->
+    match pv' $ \majV' minV' ->
+      [ assert $ majV <=. majV'
+      , ifElse
+          (lit maxBound ==. majV)
+          (majV ==. majV')
+          (succV_ majV >=. majV')
+      , ifElse
+          (majV ==. majV')
+          (minV' ==. minV + 1)
+          (minV' ==. 0)
+          -- , majV `dependsOn` majV'
+      ]
+
+testfollow :: Specification ConwayFn (ProtVer, ProtVer)
+testfollow =
+  constrained
+    ( \x ->
+        match x (\p1 p2 -> canFollow p1 p2)
+    )
+
+go30 :: IO (ProtVer, ProtVer)
+go30 = generateSpec @(ProtVer, ProtVer) testfollow
+
+rngSpec :: Specification ConwayFn (Map Int Int)
+rngSpec = constrained $ \m -> 3 <=. sizeOf_ (rngSet_ m)
+
+testRngSet :: IO ()
+testRngSet = hspec $ do
+  describe "WellFormed types from the Cardano Ledger" $ do
+    it "Rng of Maps" $ property $ soundSpec @(Map Int Int) rngSpec

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
@@ -10,26 +10,25 @@ module Test.Cardano.Ledger.Constrained.Conway.Utxo where
 
 import Cardano.Ledger.Babbage.TxOut
 import Cardano.Ledger.BaseTypes
-import Cardano.Ledger.Conway.PParams
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway.Core (EraTx (..), ppMaxCollateralInputsL)
+import Cardano.Ledger.Crypto (StandardCrypto)
 import Cardano.Ledger.Mary.Value
 import Cardano.Ledger.Shelley.API.Types
 import Cardano.Ledger.UTxO
+import Constrained
 import Data.Foldable
 import Data.Map qualified as Map
 import Data.Maybe
 import Data.Set qualified as Set
 import Data.Word
 import Lens.Micro
-
-import Constrained
-
-import Cardano.Ledger.Conway (ConwayEra)
-import Cardano.Ledger.Conway.Core (EraTx (..), ppMaxCollateralInputsL)
-import Cardano.Ledger.Crypto (StandardCrypto)
 import Test.Cardano.Ledger.Constrained.Conway.Instances
-import Test.Cardano.Ledger.Constrained.Conway.PParams
+import Test.Cardano.Ledger.Constrained.Conway.PParams (pparamsSpec)
 
-utxoEnvSpec :: IsConwayUniv fn => Specification fn (UtxoEnv (ConwayEra StandardCrypto))
+utxoEnvSpec ::
+  IsConwayUniv fn =>
+  Specification fn (UtxoEnv (ConwayEra StandardCrypto))
 utxoEnvSpec =
   constrained $ \utxoEnv ->
     match utxoEnv $
@@ -37,43 +36,9 @@ utxoEnvSpec =
        uePParams
        _ueCertState ->
           [ satisfies uePParams pparamsSpec
-          , match uePParams $ \cpp ->
-              match cpp $
-                \_cppMinFeeA
-                 _cppMinFeeB
-                 _cppMaxBBSize
-                 cppMaxTxSize
-                 _cppMaxBHSize
-                 _cppKeyDeposit
-                 _cppPoolDeposit
-                 _cppEMax
-                 _cppNOpt
-                 _cppA0
-                 _cppRho
-                 _cppTau
-                 _cppProtocolVersion
-                 _cppMinPoolCost
-                 _cppCoinsPerUTxOByte
-                 _cppCostModels
-                 _cppPrices
-                 _cppMaxTxExUnits
-                 _cppMaxBlockExUnits
-                 _cppMaxValSize
-                 _cppCollateralPercentage
-                 _cppMaxCollateralInputs
-                 _cppPoolVotingThresholds
-                 _cppDRepVotingThresholds
-                 _cppCommitteeMinSize
-                 _cppCommitteeMaxTermLength
-                 _cppGovActionLifetime
-                 _cppGovActionDeposit
-                 _cppDRepDeposit
-                 _cppDRepActivity
-                 _cppMinFeeRefScriptCoinsPerByte ->
-                    -- NOTE: this is for testing only! We should figure out a nicer way
-                    -- of splitting generation and checking constraints here!
-                    [ assert $ lit (THKD 3000) ==. cppMaxTxSize
-                    ]
+          , -- NOTE: this is for testing only! We should figure out a nicer way
+            -- of splitting generation and checking constraints here!
+            match uePParams $ \cpp -> [assert $ (lit 3000) <=. maxTxSize_ cpp]
           ]
 
 utxoStateSpec ::

--- a/libs/constrained-generators/src/Constrained.hs
+++ b/libs/constrained-generators/src/Constrained.hs
@@ -101,6 +101,7 @@ module Constrained (
   sum_,
   size_,
   rng_,
+  rngSet_,
   dom_,
   lookup_,
   flip_,

--- a/libs/constrained-generators/src/Constrained/Examples/Either.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Either.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Constrained.Examples.Either where
 
@@ -7,17 +9,19 @@ import Data.Set qualified as Set
 import Constrained
 
 eitherSpec :: Specification BaseFn (Either Int Int)
-eitherSpec = constrained $ \e ->
+eitherSpec = constrained $ \ [var|e|] ->
   (caseOn e)
-    (branch $ \i -> i <=. 0)
-    (branch $ \i -> 0 <=. i)
+    (branch $ \ [var|left|] -> left <=. 0)
+    (branch $ \ [var|right|] -> 0 <=. right)
 
 foldTrueCases :: Specification BaseFn (Either Int Int)
-foldTrueCases = constrained $ \x ->
+foldTrueCases = constrained $ \ [var|x|] ->
   [ assert $ not_ $ member_ x (lit (Set.fromList [Left 10]))
-  , letBind (pair_ x (lit (0 :: Int))) $ \p ->
-      caseOn
-        (fst_ p)
-        (branch $ \_ -> True)
-        (branch $ \_ -> True)
+  , letBind (pair_ x (lit (0 :: Int))) $ \ [var|p|] ->
+      [ dependsOn p x
+      , caseOn
+          (fst_ p)
+          (branch $ \_ -> True)
+          (branch $ \_ -> True)
+      ]
   ]

--- a/libs/constrained-generators/src/Constrained/Examples/Map.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Map.hs
@@ -3,17 +3,22 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Constrained.Examples.Map where
 
-import Data.Map (Map)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Word
 
 import Constrained
 import Constrained.Examples.Basic
+import Test.QuickCheck.Gen
 
 mapElemSpec :: Specification BaseFn (Map Int (Bool, Int))
 mapElemSpec = constrained $ \m ->
@@ -80,3 +85,72 @@ lookupSpecific = constrained' $ \k v m ->
   [ m `dependsOn` k
   , assert $ lookup_ k m ==. cJust_ v
   ]
+
+rngSetSpec :: Specification BaseFn (Map Int Int)
+rngSetSpec = constrained $ \m -> 3 <=. sizeOf_ (rngSet_ m)
+
+richRngSetSpec :: Specification BaseFn (Map Int Int)
+richRngSetSpec =
+  constrained $ \m ->
+    [ assert $ lit (Set.fromList [20, 30]) `subset_` dom_ m
+    , assert $ elem_ (lit 3) (rng_ m)
+    , assert $ elem_ (lit 4) (rng_ m)
+    , assert $ sizeOf_ (dom_ m) >=. 10
+    , assert $ sizeOf_ (dom_ m) <=. 12
+    , assert $ sizeOf_ (rngSet_ m) >=. 4
+    , assert $ sizeOf_ (rngSet_ m) <=. 6
+    , forAll m (\p -> match p (\k v -> [assert $ k >=. v]))
+    ]
+
+rngSetWithHint :: Specification BaseFn (Map Int Int)
+rngSetWithHint = constrained $ \m ->
+  [ assert $ 3 <=. sizeOf_ (rngSet_ m)
+  , genHint 5 m
+  ]
+
+-- Different ways to constrain the size of a Map
+
+sizeOfMap :: Specification BaseFn (Map Int Int)
+sizeOfMap = constrained $ \m ->
+  [assert $ sizeOf_ m ==. 10]
+
+sizeOfDomMap :: Specification BaseFn (Map Int Int)
+sizeOfDomMap = constrained $ \m ->
+  [assert $ sizeOf_ (dom_ m) ==. 10] -- sizeOf_ works on things that are Sized
+
+sizeDomMap :: Specification BaseFn (Map Three Int)
+sizeDomMap = constrained $ \m -> size_ (dom_ m) <=. 3 -- size_ works on Sets,
+
+sizeOfRngMap :: Specification BaseFn (Map Int Int)
+sizeOfRngMap = constrained $ \m ->
+  [assert $ sizeOf_ (rng_ m) ==. 10]
+
+sizeOfRngSetMap :: Specification BaseFn (Map Int Int)
+sizeOfRngSetMap = constrained $ \m ->
+  [assert $ sizeOf_ (rngSet_ m) ==. 4]
+
+sizeNotEqualEmpty :: Specification BaseFn (Map Int Int)
+sizeNotEqualEmpty = constrained $ \m -> [assert $ m /=. lit mempty]
+
+sizeEqualEmpty :: Specification BaseFn (Map Int Int)
+sizeEqualEmpty = constrained $ \m -> [assert $ m ==. lit mempty]
+
+-- | When a test on a Map spec fails, this function traces the steps, to help
+--   discover what went wrong.
+manualMapTest ::
+  forall a b.
+  (Ord a, Ord b, HasSpec BaseFn a, IsNormalType a, HasSpec BaseFn b, IsNormalType b) =>
+  Specification BaseFn (Map a b) ->
+  IO Bool
+manualMapTest g1 = do
+  let g2 :: Specification BaseFn (Map a b)
+      g2 = simplifySpec g1
+  putStrLn (show g2)
+  let g3 :: IO (Map a b)
+      g3 = generate $ genFromGenT $ genFromSpecT @BaseFn @_ @GE g2
+  ans <- g3
+  let rangeset = Set.toList (Set.fromList (Map.elems ans))
+  putStrLn ("Answer =" ++ show (Map.toList ans) ++ ",   size=" ++ show (Map.size ans))
+  putStrLn ("Range =" ++ show (Map.elems ans))
+  putStrLn ("RangeSet =" ++ show rangeset ++ ",   size=" ++ show (length rangeset))
+  pure (conformsToSpec @BaseFn @(Map a b) ans g2)

--- a/libs/constrained-generators/src/Constrained/Examples/Set.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Set.hs
@@ -125,10 +125,17 @@ setSpec = constrained $ \ss ->
   forAll ss $ \s ->
     s <=. 10
 
+size100Spec :: Specification BaseFn (Set Int)
+size100Spec = constrained $ \s -> [assert $ size_ s <=. 100]
+
 compositionalSpec :: Specification BaseFn (Set Int)
 compositionalSpec = constrained $ \x ->
   [ satisfies x setSpec
   , assert $ 0 `member_` x
+  , satisfies x size100Spec -- Has a tendency to occaisionally fail when sizes over 100 are picked
+  -- Because it resorts to picking something not in a large set. We only get
+  -- 100 trys, so if the set is large the probability increases. Adding this
+  -- should not affect the property being tested.
   ]
 
 emptySetSpec :: Specification BaseFn (Set Int)

--- a/libs/constrained-generators/src/Constrained/Properties.hs
+++ b/libs/constrained-generators/src/Constrained/Properties.hs
@@ -216,6 +216,7 @@ instance fn ~ BaseFn => QC.Arbitrary (TestableFn fn) where
       , TestableFn $ unionFn @fn @Int
       , TestableFn $ foldMapFn @fn @Int idFn
       , TestableFn $ rngFn @fn @Int @Int
+      , TestableFn $ rngSetFn @fn @Int @Int
       , TestableFn $ domFn @fn @Int @Int
       , TestableFn $ fromListFn @fn @Int
       , TestableFn $ lookupFn @fn @Int @Int

--- a/libs/constrained-generators/src/Constrained/Spec/Generics.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Generics.hs
@@ -58,7 +58,7 @@ import Test.QuickCheck (Arbitrary (..), oneof)
 import Constrained.Base
 import Constrained.Core
 import Constrained.List
-import Constrained.Spec.Pairs ()
+import Constrained.Spec.Pairs (PairSpec (Cartesian))
 import Constrained.Univ
 
 ------------------------------------------------------------------------
@@ -109,14 +109,22 @@ instance HasSimpleRep (Either a b)
 instance
   ( HasSpec fn a
   , HasSpec fn b
+  , SimpleRep (a, b) ~ Prod a b
   ) =>
   HasSpec fn (a, b)
+  where
+  cardinalTypeSpec (Cartesian x y) = multSpecInt (cardinality x) (cardinality y)
+  cardinalTrueSpec = multSpecInt (cardinality (TrueSpec @fn @a)) (cardinality (TrueSpec @fn @b))
+
 instance
   ( HasSpec fn a
   , HasSpec fn b
   , HasSpec fn c
   ) =>
   HasSpec fn (a, b, c)
+  where
+  cardinalTypeSpec (Cartesian x y) = multSpecInt (cardinality x) (cardinality y) -- This works since 'y' is also a (PairSpec )
+  cardinalTrueSpec = multSpecInt (cardinality (TrueSpec @fn @a)) (cardinality (TrueSpec @fn @b))
 instance
   ( HasSpec fn a
   , HasSpec fn b
@@ -124,6 +132,9 @@ instance
   , HasSpec fn d
   ) =>
   HasSpec fn (a, b, c, d)
+  where
+  cardinalTypeSpec (Cartesian x y) = multSpecInt (cardinality x) (cardinality y)
+  cardinalTrueSpec = multSpecInt (cardinality (TrueSpec @fn @a)) (cardinality (TrueSpec @fn @b))
 instance
   ( HasSpec fn a
   , HasSpec fn b
@@ -132,6 +143,10 @@ instance
   , HasSpec fn e
   ) =>
   HasSpec fn (a, b, c, d, e)
+  where
+  cardinalTypeSpec (Cartesian x y) = multSpecInt (cardinality x) (cardinality y)
+  cardinalTrueSpec = multSpecInt (cardinality (TrueSpec @fn @a)) (cardinality (TrueSpec @fn @b))
+
 instance
   ( HasSpec fn a
   , HasSpec fn b
@@ -141,6 +156,9 @@ instance
   , HasSpec fn g
   ) =>
   HasSpec fn (a, b, c, d, e, g)
+  where
+  cardinalTypeSpec (Cartesian x y) = multSpecInt (cardinality x) (cardinality y)
+  cardinalTrueSpec = multSpecInt (cardinality (TrueSpec @fn @a)) (cardinality (TrueSpec @fn @b))
 instance
   ( HasSpec fn a
   , HasSpec fn b
@@ -151,6 +169,9 @@ instance
   , HasSpec fn h
   ) =>
   HasSpec fn (a, b, c, d, e, g, h)
+  where
+  cardinalTypeSpec (Cartesian x y) = multSpecInt (cardinality x) (cardinality y)
+  cardinalTrueSpec = multSpecInt (cardinality (TrueSpec @fn @a)) (cardinality (TrueSpec @fn @b))
 instance
   (IsNormalType a, HasSpec fn a) =>
   HasSpec fn (Maybe a)

--- a/libs/constrained-generators/src/Constrained/Spec/Map.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Map.hs
@@ -1,18 +1,25 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unused-binds #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
 
 -- The pattern completeness checker is much weaker before ghc-9.0. Rather than introducing redundant
 -- cases and turning off the overlap check in newer ghc versions we disable the check for old
@@ -21,24 +28,30 @@
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 #endif
 
-module Constrained.Spec.Map (MapSpec (..), defaultMapSpec, dom_, rng_, lookup_) where
+module Constrained.Spec.Map (MapSpec (..), defaultMapSpec, dom_, rng_, lookup_, rngSet_) where
 
-import Constrained.Base
+import Constrained.Base hiding (count)
 import Constrained.Core
 import Constrained.GenT
 import Constrained.Instances ()
 import Constrained.List
 import Constrained.Spec.Generics
 import Constrained.Univ
-import Control.Monad
-import Data.List (nub)
+import Control.Monad (forM)
+import Data.List (nub, sort)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
+
+import Data.Word
+import Debug.Trace
 import GHC.Generics
 import Prettyprinter
 import Test.QuickCheck (Arbitrary (..), frequency, genericShrink, shrinkList)
+import Test.QuickCheck hiding (Args (..), forAll)
+
+-- --------------------------------------------------------
 
 ------------------------------------------------------------------------
 -- HasSpec
@@ -46,12 +59,9 @@ import Test.QuickCheck (Arbitrary (..), frequency, genericShrink, shrinkList)
 
 instance Ord a => Sized (Map.Map a b) where
   sizeOf = toInteger . Map.size
+  liftSizeSpec sz [0] = typeSpec $ defaultMapSpec {mapSpecSize = TypeSpec (sz <> NumSpecInterval (Just 1) Nothing) []}
   liftSizeSpec sz cant = typeSpec $ defaultMapSpec {mapSpecSize = TypeSpec sz cant}
   liftMemberSpec xs = typeSpec $ defaultMapSpec {mapSpecSize = MemberSpec xs}
-  sizeOfTypeSpec (MapSpec _ mustk mustv size _ _) =
-    geqSpec (sizeOf mustk)
-      <> geqSpec (sizeOf mustv)
-      <> size
 
 data MapSpec fn k v = MapSpec
   { mapSpecHint :: Maybe Integer
@@ -60,38 +70,23 @@ data MapSpec fn k v = MapSpec
   , mapSpecSize :: Specification fn Integer
   , mapSpecElem :: Specification fn (k, v)
   , mapSpecFold :: FoldSpec fn v
+  , mapSpecMinValSize :: Maybe (MinValSize fn v)
+  -- Specifaction of the number of unique Values in the range of the Map that meet the Mapspec.
+  -- The Maybe is there because Nothing means (MinValSpec TrueSpec),
+  -- but does require the (Ord v) constraint
   }
   deriving (Generic)
 
+-- | Spec of the the number of unique values in the range of a map, needed to conform to the MapSpec
+--   Just a Spec, but carries the (Ord v) constraint
+data MinValSize fn v where
+  MinValSize :: Ord v => Specification fn Integer -> MinValSize fn v
+
+deriving instance BaseUniverse fn => Show (MinValSize fn v)
+
 -- | emptySpec without all the constraints
 defaultMapSpec :: Ord k => MapSpec fn k v
-defaultMapSpec = MapSpec Nothing mempty mempty TrueSpec TrueSpec NoFold
-
--- TODO: consider making this more interesting to get fewer discarded tests
--- in `prop_gen_sound`
-instance
-  ( Arbitrary k
-  , Arbitrary v
-  , Arbitrary (TypeSpec fn k)
-  , Arbitrary (TypeSpec fn v)
-  , Ord k
-  , HasSpec fn k
-  , Foldy fn v
-  ) =>
-  Arbitrary (MapSpec fn k v)
-  where
-  arbitrary =
-    MapSpec
-      <$> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-      <*> frequency [(1, pure NoFold), (1, arbitrary)]
-  shrink = genericShrink
-
-instance Arbitrary (FoldSpec fn (Map k v)) where
-  arbitrary = pure NoFold
+defaultMapSpec = MapSpec Nothing mempty mempty TrueSpec TrueSpec NoFold Nothing
 
 instance
   ( HasSpec fn (k, v)
@@ -106,11 +101,16 @@ instance
       "MapSpec"
         /> vsep
           [ "hint       =" <+> viaShow (mapSpecHint s)
-          , "mustKeys   =" <+> viaShow (mapSpecMustKeys s)
-          , "mustValues =" <+> viaShow (mapSpecMustValues s)
+          , "mustKeys   =" <+> viaShow (mapSpecMustKeys s) <+> (pretty (length (mapSpecMustKeys s)))
+          , "mustValues =" <+> viaShow (mapSpecMustValues s) <+> (pretty (length (mapSpecMustValues s)))
           , "size       =" <+> pretty (mapSpecSize s)
           , "elem       =" <+> pretty (mapSpecElem s)
           , "fold       =" <+> pretty (mapSpecFold s)
+          , "minValSize ="
+              <+> ( case (mapSpecMinValSize s) of
+                      Nothing -> viaShow (Nothing :: Maybe ())
+                      Just (MinValSize p) -> pretty p
+                  )
           ]
 
 instance
@@ -128,104 +128,80 @@ instance Ord k => Forallable (Map k v) (k, v) where
   forAllToList = Map.toList
 
 instance
-  (Ord k, HasSpec fn (Prod k v), HasSpec fn k, HasSpec fn v, HasSpec fn [v]) =>
+  ( Ord k
+  , HasSpec fn (Prod k v)
+  , HasSpec fn k
+  , HasSpec fn v
+  , HasSpec fn [v]
+  , IsNormalType v
+  , IsNormalType k
+  ) =>
   HasSpec fn (Map k v)
   where
   type TypeSpec fn (Map k v) = MapSpec fn k v
   type Prerequisites fn (Map k v) = (HasSpec fn k, HasSpec fn v)
 
+  typeSpecOpt ts [m] | Map.null m = TypeSpec ts {mapSpecSize = mapSpecSize ts <> geqSpec 1} []
+  typeSpecOpt ts cant = TypeSpec ts cant
+
   emptySpec = defaultMapSpec
 
   combineSpec
-    (MapSpec mHint mustKeys mustVals size kvs foldSpec)
-    (MapSpec mHint' mustKeys' mustVals' size' kvs' foldSpec') = fromGESpec $ do
+    (MapSpec mHint mustKeys mustVals size kvs foldSpec acceptable)
+    (MapSpec mHint' mustKeys' mustVals' size' kvs' foldSpec' acceptable') = fromGESpec $ do
       typeSpec
-        . MapSpec
-          -- This is min because that allows more compositionality - if a spec specifies a
-          -- low upper bound because some part of the spec will be slow it doesn't make sense
-          -- to increase it somewhere else because that part isn't slow.
-          (unionWithMaybe min mHint mHint')
-          (mustKeys <> mustKeys')
-          (nub $ mustVals <> mustVals')
-          (size <> size')
-          (kvs <> kvs')
-        <$> combineFoldSpec foldSpec foldSpec'
+        <$> ( MapSpec
+                -- This is min because that allows more compositionality - if a spec specifies a
+                -- low upper bound because some part of the spec will be slow it doesn't make sense
+                -- to increase it somewhere else because that part isn't slow.
+                (unionWithMaybe min mHint mHint')
+                (mustKeys <> mustKeys')
+                (nub $ mustVals <> mustVals')
+                (size <> size')
+                (kvs <> kvs')
+                <$> (combineFoldSpec foldSpec foldSpec')
+                <*> (pure (smallestAcceptableSize acceptable acceptable'))
+            )
 
-  conformsTo m (MapSpec _ mustKeys mustVals size kvs foldSpec) =
+  conformsTo m (MapSpec _ mustKeys mustVals size kvs foldSpec minval) =
     and
       [ mustKeys `Set.isSubsetOf` Map.keysSet m
       , all (`elem` Map.elems m) mustVals
       , sizeOf m `conformsToSpec` size
       , all (`conformsToSpec` kvs) (Map.toList m)
       , Map.elems m `conformsToFoldSpec` foldSpec
+      , conformsToSpec @fn (sizeOf (nub (Map.elems m))) (extractFromMinValSize minval)
       ]
 
-  genFromTypeSpec (MapSpec mHint mustKeys mustVals size (simplifySpec -> kvs) foldSpec) = do
-    mustMap <- explain ["Make the mustMap"] $ forM (Set.toList mustKeys) $ \k -> do
-      let vSpec = constrained $ \v -> satisfies (pair_ (lit k) v) kvs
-      v <- explain [show $ "vSpec =" <+> pretty vSpec] $ genFromSpecT vSpec
-      pure (k, v)
-    let haveVals = map snd mustMap
-        mustVals' = filter (`notElem` haveVals) mustVals
-        size' = simplifySpec $ constrained $ \sz ->
-          -- TODO, we should make sure size' is greater than or equal to 0
-          satisfies
-            (sz + Lit (sizeOf mustMap))
-            ( maybe TrueSpec (leqSpec . max 0) mHint
-                <> size
-                <> maxSpec (cardinality (mapSpec fstFn $ mapSpec toGenericFn kvs))
-                <> maxSpec (cardinalTrueSpec @fn @k)
-            )
-        foldSpec' = case foldSpec of
-          NoFold -> NoFold
-          FoldSpec fn sumSpec -> FoldSpec fn $ propagateSpecFun (theAddFn @fn) (HOLE :? Value mustSum :> Nil) sumSpec
-            where
-              mustSum = adds @fn (map (sem fn) haveVals)
-    let valsSpec =
-          ListSpec
-            Nothing
-            mustVals'
-            size'
-            (simplifySpec $ constrained $ \v -> unsafeExists $ \k -> pair_ k v `satisfies` kvs)
-            foldSpec'
-
-    restVals <-
-      explain
-        [ "Make the restVals"
-        , show $ "  valsSpec =" <+> pretty valsSpec
-        , show $ "  mustMap =" <+> viaShow mustMap
-        ]
-        $ genFromTypeSpec
-        $ valsSpec
-    let go m [] = pure m
-        go m (v : restVals') = do
-          let keySpec = notMemberSpec (Map.keysSet m) <> constrained (\k -> pair_ k (lit v) `satisfies` kvs)
-          k <-
-            explain
-              [ "Make a key"
-              , show $ indent 4 $ "keySpec =" <+> pretty keySpec
-              ]
-              $ genFromSpecT keySpec
-          go (Map.insert k v m) restVals'
-    go (Map.fromList mustMap) restVals
+  genFromTypeSpec = genFromMapSpec
 
   cardinalTypeSpec _ = TrueSpec
 
-  shrinkWithTypeSpec (MapSpec _ _ _ _ kvs _) m = map Map.fromList $ shrinkList (shrinkWithSpec kvs) (Map.toList m)
+  shrinkWithTypeSpec (MapSpec _ _ _ _ kvs _ _) m = map Map.fromList $ shrinkList (shrinkWithSpec kvs) (Map.toList m)
 
-  toPreds m (MapSpec mHint mustKeys mustVals size kvs foldSpec) =
-    toPred $
+  toPreds m (MapSpec mHint mustKeys mustVals size kvs foldSpec minvalsize) =
+    toPred
       [ assert $ lit mustKeys `subset_` dom_ m
       , forAll (Lit mustVals) $ \val ->
           val `elem_` rng_ m
       , sizeOf_ (rng_ m) `satisfies` size
+      , case minvalsize of
+          Nothing -> TruePred
+          Just (MinValSize n) -> sizeOf_ (rngSet_ m) `satisfies` n
       , forAll m $ \kv -> satisfies kv kvs
       , toPredsFoldSpec (rng_ m) foldSpec
       , maybe TruePred (`genHint` m) mHint
       ]
 
 instance
-  (Ord k, HasSpec fn (Prod k v), HasSpec fn k, HasSpec fn v, HasSpec fn [v]) =>
+  ( Ord k
+  , HasSpec fn (Prod k v)
+  , HasSpec fn k
+  , HasSpec fn v
+  , HasSpec fn [v]
+  , IsNormalType v
+  , IsNormalType k
+  ) =>
   HasGenHint fn (Map k v)
   where
   type Hint (Map k v) = Integer
@@ -253,8 +229,7 @@ instance BaseUniverse fn => Functions (MapFn fn) fn where
           , Evidence <- prerequisites @fn @(Map k v) ->
               case spec of
                 MemberSpec [s] ->
-                  typeSpec $
-                    MapSpec Nothing s [] (equalSpec $ sizeOf s) TrueSpec NoFold
+                  typeSpec $ MapSpec Nothing s [] (equalSpec $ sizeOf s) TrueSpec NoFold Nothing
                 TypeSpec (SetSpec must elemspec size) [] ->
                   typeSpec $
                     MapSpec
@@ -264,6 +239,7 @@ instance BaseUniverse fn => Functions (MapFn fn) fn where
                       size
                       (constrained $ \kv -> satisfies (app (fstFn @fn) (app (toGenericFn @fn) kv)) elemspec)
                       NoFold
+                      Nothing
                 _ -> ErrorSpec ["Dom on bad map spec", show spec]
     Rng ->
       -- No TypeAbstractions in ghc-8.10
@@ -279,8 +255,9 @@ instance BaseUniverse fn => Functions (MapFn fn) fn where
                       Set.empty
                       must
                       size
-                      (constrained $ \kv -> satisfies (app (sndFn @fn) (app (toGenericFn @fn) kv)) elemspec)
+                      (constrained $ \kv -> satisfies (snd_ kv) elemspec)
                       foldspec
+                      Nothing
                 -- NOTE: you'd think `MemberSpec [r]` was a safe and easy case. However, that requires not only that the elements
                 -- of the map are fixed to what is in `r`, but they appear in the order that they are in `r`. That's
                 -- very difficult to achieve!
@@ -309,6 +286,33 @@ instance BaseUniverse fn => Functions (MapFn fn) fn where
                                 TypeSpec (SumSpec _ _ vspec) cant ->
                                   v `satisfies` (vspec <> notMemberSpec [a | Just a <- cant])
                      ]
+    RngSet ->
+      case fn of
+        (_ :: MapFn fn '[Map k v] (Set v))
+          | NilCtx HOLE <- ctx
+          , Evidence <- prerequisites @fn @(Map k v) ->
+              case spec of
+                MemberSpec [r] ->
+                  typeSpec $
+                    MapSpec
+                      Nothing
+                      Set.empty
+                      (Set.toList r)
+                      (atLeastSpec (equalSpec $ sizeOf r))
+                      TrueSpec
+                      NoFold
+                      (Just (MinValSize (equalSpec (sizeOf r))))
+                TypeSpec (SetSpec must elemspec setsize) [] ->
+                  typeSpec $
+                    MapSpec
+                      Nothing
+                      Set.empty
+                      (Set.toList must)
+                      (atLeastSpec (geqSpec (sizeOf must) <> setsize)) -- This might be overconstrained.
+                      (constrained $ \kv -> satisfies (app (sndFn @fn) (app (toGenericFn @fn) kv)) elemspec)
+                      NoFold
+                      (injectMinValSize setsize)
+                _ -> ErrorSpec ["RngSet on bad map spec", show spec]
 
   -- NOTE: this function over-approximates and returns a liberal spec.
   mapTypeSpec f ts = case f of
@@ -318,16 +322,23 @@ instance BaseUniverse fn => Functions (MapFn fn) fn where
       -- No TypeAbstractions in ghc-8.10
       case f of
         (_ :: MapFn fn '[Map k v] (Set k))
-          | MapSpec _ mustSet _ sz kvSpec _ <- ts
+          | MapSpec _ mustSet _ sz kvSpec _ _ <- ts
           , Evidence <- prerequisites @fn @(Map k v) ->
               typeSpec $ SetSpec mustSet (mapSpec (fstFn @fn) $ toSimpleRepSpec kvSpec) sz
     Rng ->
       -- No TypeAbstractions in ghc-8.10
       case f of
         (_ :: MapFn fn '[Map k v] [v])
-          | MapSpec _ _ mustList sz kvSpec foldSpec <- ts
+          | MapSpec _ _ mustList sz kvSpec foldSpec _ <- ts
           , Evidence <- prerequisites @fn @(Map k v) ->
               typeSpec $ ListSpec Nothing mustList sz (mapSpec (sndFn @fn) $ toSimpleRepSpec kvSpec) foldSpec
+    RngSet ->
+      case f of
+        (_ :: MapFn fn '[Map k v] (Set v))
+          | MapSpec _ _ mustList sz kvSpec _foldSpec _ <- ts
+          , Evidence <- prerequisites @fn @(Map k v) ->
+              typeSpec $
+                SetSpec (Set.fromList mustList) (mapSpec (sndFn @fn) $ toSimpleRepSpec kvSpec) (atMostSpec sz)
 
 ------------------------------------------------------------------------
 -- Syntax
@@ -340,14 +351,585 @@ dom_ ::
 dom_ = app domFn
 
 rng_ ::
-  (HasSpec fn k, HasSpec fn v, Ord k) =>
+  (HasSpec fn k, HasSpec fn v, Ord k, IsNormalType v, IsNormalType k) =>
   Term fn (Map k v) ->
   Term fn [v]
 rng_ = app rngFn
 
 lookup_ ::
-  (HasSpec fn k, HasSpec fn v, Ord k, IsNormalType v) =>
+  (HasSpec fn k, HasSpec fn v, Ord k, IsNormalType k, IsNormalType v) =>
   Term fn k ->
   Term fn (Map k v) ->
   Term fn (Maybe v)
 lookup_ = app lookupFn
+
+rngSet_ ::
+  (HasSpec fn k, HasSpec fn v, Ord k, Ord v, IsNormalType v, IsNormalType k) =>
+  Term fn (Map k v) ->
+  Term fn (Set v)
+rngSet_ = app rngSetFn
+
+-- ======================================================================
+-- How to deal with size constraints on the RngSet of a Map
+-- There are two parts to this.
+--  1) changes to genFromTypeSpec to generate the right thing
+--  2) changes to (TypeSpec @Map) to encode the additional constraints needed. See (MinValSize fn v)
+
+-- | Merge two MinValSizes, each from a separate MapSpec, which are being merged.
+smallestAcceptableSize ::
+  BaseUniverse fn => Maybe (MinValSize fn v) -> Maybe (MinValSize fn v) -> Maybe (MinValSize fn v)
+smallestAcceptableSize (Just (MinValSize x)) (Just (MinValSize y)) = Just (MinValSize (x <> y))
+smallestAcceptableSize Nothing x = x
+smallestAcceptableSize x Nothing = x
+
+-- | Extract a Specification from (Maybe (MinValSize fn v)), Nothing extracts TrueSpec
+extractFromMinValSize :: Maybe (MinValSize fn v) -> Specification fn Integer
+extractFromMinValSize (Just (MinValSize s)) = s
+extractFromMinValSize Nothing = TrueSpec
+
+-- | Inject a Specification into a (Maybe (MinValSize fn v))
+injectMinValSize :: Ord v => Specification fn Integer -> Maybe (MinValSize fn v)
+injectMinValSize TrueSpec = Nothing
+injectMinValSize (MemberSpec []) = Nothing
+injectMinValSize spec = Just (MinValSize spec)
+
+-- ========================================================================================================
+-- How sequence (GenT m a) until one of them succeeds
+
+-- | Lift any errors in (GenT GE a), into (monadGenError m) so we get back to (GenT m a)
+--   This allows us to use 'tryGen' to try different things until one works. See 'tryGenFromList'
+liftGE :: forall m a. MonadGenError m => GenT GE a -> GenT m a
+liftGE action = do mm <- pureGen action2; mm
+  where
+    action2 :: Gen (GenT m a)
+    action2 = do
+      x <- runGenT action Loose
+      pure (runGE x)
+
+trySpecs :: (MonadGenError m, HasSpec fn a) => [Specification fn a] -> GenT m a
+trySpecs specs = go specs
+  where
+    go [] = genError ("No spec in trySpecs succeeds" : (map show specs))
+    go (x : xs) = do
+      m <- (tryGen . genFromSpecT) x
+      case m of
+        Just ans -> pure ans
+        Nothing -> go xs
+
+-- | Try to satisfy some generator on a input list, where the order of the elements
+--   in the list may affect the success of the operation. Repeat the operation
+--   upto 'n' times, each time with a different order.
+tryGenFromList :: (Show b, Show a, MonadGenError m) => Int -> ([a] -> GenT GE b) -> [a] -> GenT m b
+tryGenFromList 0 _ _ = genError ["tryGenFromList ran out of tries"]
+tryGenFromList _ action [] = liftGE $ action []
+tryGenFromList _ action [x] = liftGE $ action [x]
+tryGenFromList n action input = do
+  m <- liftGE $ tryGen (action input)
+  case m of
+    Just ans -> pure ans
+    Nothing -> do
+      input2 <- pureGen (shuffle input)
+      tryGenFromList (n - 1) action input2
+
+-- ================================================
+-- How to handle a FoldSpec, this is the old style
+-- ================================================
+
+genFromMapSpecWithFold ::
+  forall fn k v m.
+  (HasSpec fn k, HasSpec fn v, Ord k, MonadGenError m) =>
+  MapSpec fn k v ->
+  GenT m (Map k v)
+genFromMapSpecWithFold m@(MapSpec mHint mustKeys mustVals size (simplifySpec -> kvs) foldspec _) = do
+  mustMap <-
+    explain
+      ["Make the mustMap for MapSpec", show m]
+      ( forM (Set.toList mustKeys) $ \k -> do
+          let vSpec = constrained $ \v -> satisfies (pair_ (lit k) v) kvs
+          v <- explain [show $ "vSpec =" <+> pretty vSpec] $ genFromSpecT vSpec
+          pure (k, v)
+      )
+  let haveVals = map snd mustMap
+      residualMustVals = filter (`notElem` haveVals) mustVals
+      size' = simplifySpec $ constrained $ \sz ->
+        satisfies
+          (sz + Lit (sizeOf mustMap))
+          ( maybe TrueSpec (leqSpec . max 0) mHint
+              <> size
+              <> maxSpecSize (cardinality (mapSpec fstFn $ mapSpec toGenericFn kvs))
+              <> maxSpecSize (cardinalTrueSpec @fn @k)
+          )
+
+      foldSpec' = case foldspec of
+        NoFold -> NoFold
+        FoldSpec fn sumSpec -> FoldSpec fn $ propagateSpecFun (theAddFn @fn) (HOLE :? Value mustSum :> Nil) sumSpec
+          where
+            mustSum = adds @fn (map (sem fn) haveVals)
+
+      valsSpec =
+        ListSpec
+          Nothing
+          residualMustVals
+          size'
+          (simplifySpec $ constrained $ \v -> unsafeExists $ \k -> pair_ k v `satisfies` kvs)
+          foldSpec'
+  restVals <-
+    explain
+      [ "Generating values for additional pairs for MapSpec"
+      , show m
+      , "We have already computed " ++ show mustMap
+      , "We need additional values (of size " ++ show size' ++ ") that meet the spec"
+      , show valsSpec
+      ]
+      (genFromTypeSpec valsSpec)
+  let go mp [] = pure mp
+      go mp (v : restVals') = do
+        let keySpec = notMemberSpec (Map.keysSet mp) <> constrained (\k -> pair_ k (lit v) `satisfies` kvs)
+        k <-
+          explain
+            [ "Make a key for the value " ++ show v
+            , "keySpec =\n  " ++ show (simplifySpec keySpec)
+            ]
+            $ genFromSpecT keySpec
+        go (Map.insert k v mp) restVals'
+  go (Map.fromList mustMap) restVals
+
+-- ====================================================================================
+-- Compute a combined SizeSpec for a MapSpec. Combines all the size info into one Spec
+-- Attempts to explain where things go wrong if the sizes are inconsistent.
+-- ===================================================================================
+
+--  | Generate specification that satisfies some things greater than or equal to 'm'
+--    Note that sizeSpec can never have zero or negative numbers
+genSizeSpec :: BaseUniverse fn => Integer -> Integer -> Gen (Specification fn Integer)
+genSizeSpec m maxMember = do
+  delta <- choose (1, maxMember) --
+  xs <- vectorOf 5 (choose (1, maxMember))
+  frequency
+    [ (1, pure $ (TypeSpec (rangeSize m (m + delta)) []))
+    , (1, pure $ MemberSpec (sort (nub (m : (filter (m <=) xs)))))
+    ]
+
+-- | Given a MapSpec, check that all the size specs are consistent, and then returns sizes
+--   for the set of keys, the list of values, and the size of value list as a set.
+--   That might be smaller than the list of values, because it may contain duplicates.
+mapSizes ::
+  forall a b fn m.
+  (MonadGenError m, Ord a, HasSpec fn a, HasSpec fn b) =>
+  MapSpec fn a b ->
+  GenT m (Integer, Integer, Integer)
+mapSizes m@(MapSpec mHint mustKeys mustVals msize pairspec _foldSpec vSetSize) = do
+  let specForRng :: Specification fn b
+      specForRng = mapSpec sndFn $ mapSpec toGenericFn (simplifySpec pairspec)
+      specForDom :: Specification fn a
+      specForDom = mapSpec fstFn $ mapSpec toGenericFn (simplifySpec pairspec)
+      cardRng = cardinality specForRng
+      cardDom = cardinality specForDom
+      rawValSpec = extractFromMinValSize vSetSize
+      table =
+        [ ("Sizes are nonneagtive ", geqSpec 0)
+        , maybe
+            ("No hint               ", TrueSpec)
+            (\n -> ("The hint             " ++ show n, leqSpec (max 0 n)))
+            mHint
+        , ("Map size              ", msize)
+        , ("Cardinality range     ", atMostSpec cardRng) -- Can't have more than the cardinality of the range 'b'
+        , ("Cardinality dom       ", atMostSpec cardDom) -- Can't have more than the cardinality of the range 'b'
+        , ("MustKeys              ", geqSpec (sizeOf mustKeys))
+        , ("Mustvals              ", geqSpec (sizeOf mustVals))
+        , ("ValSet (atLeast " ++ show rawValSpec ++ ")", atLeastSpec rawValSpec)
+        ]
+      describe (msg, spec) = "  " ++ msg ++ " = " ++ show spec
+      size =
+        explainSpec
+          (["Map spec sizes are inconsistent. Relevant Size Specs"] ++ map describe table)
+          (foldMap snd table)
+  keysize <- genFromSpecT size
+  (valsize, valSetSize) <-
+    explain
+      ["Picking the size of the set of values, given the size of the set of keys: " ++ show keysize]
+      $ case vSetSize of
+        Nothing -> pure (keysize, keysize)
+        Just (MinValSize minvalspec) -> do
+          sizeAsSet <- genFromSpecT (geqSpec 1 <> minvalspec <> geqSpec (sizeOf mustVals))
+          pure (keysize, sizeAsSet)
+  pure (keysize, valsize, valSetSize)
+
+-- ==============================================================
+-- How to hande the size constraints on the RngSet of a Map
+-- This is the new style. It calls the old style if a FoldSpec is used.
+-- ==============================================================
+
+genFromMapSpec ::
+  forall fn k v m.
+  ( Ord k
+  , HasSpec fn k
+  , IsNormalType k
+  , HasSpec fn v
+  , IsNormalType v
+  , MonadGenError m
+  ) =>
+  MapSpec fn k v ->
+  GenT m (Map k v)
+genFromMapSpec m@(MapSpec _mHint mustKeys mustVals msize pairspec (FoldSpec _ _) (Just _)) =
+  fatalError ["MapSpec with both Fold and MinValSize", show m]
+genFromMapSpec m@(MapSpec _mHint mustKeys mustVals msize pairspec (FoldSpec _ _) Nothing) = genFromMapSpecWithFold m
+genFromMapSpec m@(MapSpec _mHint mustKeys mustVals msize pairspec NoFold Nothing) = genFromMapSpecWithFold m
+genFromMapSpec m@(MapSpec _mHint mustKeys mustVals msize pairspec NoFold (Just (MinValSize (MemberSpec [])))) =
+  fatalError ["MemberSpec [] in MinValSpec", show m]
+genFromMapSpec m@(MapSpec _mHint mustKeys mustVals msize pairspec NoFold vsize) = do
+  zs@(keysize, valsize, valAsSetSize) <- mapSizes m
+  -- let !_ = trace ("(keysize, valsize,valAsSetSize) " ++ show zs) True
+  (kvPairsForMustVals, residualKeys, badvs, badks) <-
+    explain
+      [ "\nTrying to pair up the mustVals "
+      , "   " ++ show (nub mustVals)
+      , "with the must keys"
+      , "   " ++ show mustKeys
+      , "In a way that meets the key-val-spec"
+      , show (simplifySpec pairspec)
+      , "This may not be possible."
+      , "msize = " ++ show msize
+      , "(keysize, valsize, valAsSetSize) = "
+          ++ show (keysize, valsize, valAsSetSize)
+      , ""
+      ]
+      (tryGenFromList 10 (loopV (sizeOf (nub mustVals)) mustKeys [] Set.empty pairspec) (nub mustVals)) -- DO WE NEED nub here?
+      -- let !_ = trace ("mustval pairs = "++show kvPairsForMustVals++", residual keys = "++ show residualKeys) True
+  let
+    -- \| The number of additional pairs we must generate
+    morePairs = keysize - (sizeOf kvPairsForMustVals)
+  -- \| The set of vals we have already generated, this should be equal (as a set) to the mustVal
+
+  kvPairsForResidualKeys <-
+    explain
+      [ "\nWe are trying to expand the unmatched keys " ++ show (Set.toList residualKeys)
+      , "to a list of pairs with length " ++ show keysize
+      , "And the (pair key value) must meet the spec " ++ show pairspec
+      , "This is not always possible."
+      , "MapSpec is "
+      , show m
+      , ""
+      ]
+      ( loopK
+          kvPairsForMustVals
+          (Set.toList residualKeys)
+          morePairs
+          valAsSetSize
+          badvs
+          (Set.toList badks)
+          pairspec
+      )
+  pure (Map.fromList kvPairsForResidualKeys)
+
+-- | Match mustVals with satisfying mustKeys
+--   Given a val 'v', try to find a satisfying k in 'mustks' (satisfy (k,v) ok)
+--   if you can't find a satisfying k, then generate one.
+--   Remember each 'k' you found or generated in 'usedKs',  so you won't pick it again.
+--   Remember each 'v' you process in 'usedVs', so you won't pick it again
+--   When you run out of mustVals, add 'count' additional fresh pairs that satisfy 'ok'
+loopV ::
+  forall fn m k v.
+  (Ord k, HasSpec fn k, IsNormalType k, IsNormalType v, HasSpec fn v, MonadGenError m) =>
+  Integer ->
+  Set k ->
+  [v] ->
+  Set k ->
+  Specification fn (k, v) ->
+  [v] ->
+  GenT m ([(k, v)], Set k, [v], Set k)
+loopV count mustKeys usedVs usedKs ok mustVals =
+  -- trace ("LOOPV "++show(count,mustVals,mustKeys,usedVs,usedKs)) $
+  explain
+    [ "Matching mustVals " ++ show mustVals
+    , "with satisfying mustKeys " ++ show mustKeys
+    ]
+    $ case (count, mustVals, mustKeys) of
+      (0, [], residualks) -> pure ([], residualks, usedVs, usedKs) -- We are Done
+      (n, [], mustks) -> step3 n (Set.toList mustks) usedVs usedKs -- Add 'n' additional pairs choosing 'k' from 'mustks'
+      (n, v : vs, mustks) | Set.null mustks -> step1 n usedVs usedKs v vs -- Generate a match for 'v' (since 'mustks' is null)
+      (n, v : vs, mustks) -> step2 n mustks usedVs usedKs v vs -- Find (in 'mustks') or genrate an unused key, such that ok(key,'v')
+  where
+    -- mustks exhausted, generate a fresh k
+    step1 n usedvs usedks v vs = do
+      k <-
+        genFromSpecT @fn
+          ( constrained $ \k ->
+              [ assert $ not_ (member_ k (lit usedks))
+              , satisfies (pair_ k (lit v)) ok
+              ]
+          )
+      (pairs, _, usedvals, usedkeys) <- loopV (n - 1) Set.empty (v : usedvs) (Set.insert k usedks) ok vs
+      pure ((k, v) : pairs, Set.empty, usedvals, usedkeys)
+
+    -- Still some mustkeys. Pick one (if possible), or generate a fresh one if not.
+    step2 n mustks usedvs usedks v vs = do
+      k <- genOrFindMatchFor v mustks usedks ok
+      (pairs, mustkeys, usedvals, usedkeys) <-
+        loopV (n - 1) (Set.delete k mustks) (v : usedvs) (Set.insert k usedks) ok vs
+      pure ((k, v) : pairs, mustkeys, usedvals, usedkeys)
+
+    -- Add 'n' additional pairs
+    step3 0 mustks usedvs usedks =
+      -- We are done
+      pure ([], Set.fromList mustks, usedvs, usedks)
+    step3 n [] usedvs usedks = do
+      -- Still have 'n' pairs to choose, but both 'k' and 'v' are unused random
+      (k, v) <-
+        genFromSpecT @fn
+          ( constrained $ \p -> match p $ \k v ->
+              [ assert $ not_ (member_ k (lit usedks))
+              , assert $ not_ (elem_ v (lit usedvs))
+              , satisfies (pair_ k v) ok
+              ]
+          )
+      (pairs, mustks, usedvals, usedkeys) <- step3 (n - 1) [] (v : usedvs) (Set.insert k usedks)
+      pure ((k, v) : pairs, mustks, usedvals, usedkeys)
+    step3 n (k : ks) usedvs usedks = do
+      -- Still have 'n' pairs to choose, but 'k' is fixed, 'v' is unused random
+      v <-
+        genFromSpecT @fn
+          ( constrained $ \v ->
+              [ assert $ not_ (elem_ v (lit usedvs))
+              , satisfies (pair_ (lit k) v) ok
+              ]
+          )
+      (pairs, mustks, usedvals, usedkeys) <- step3 (n - 1) ks (v : usedvs) (Set.insert k usedks)
+      pure ((k, v) : pairs, mustks, usedvals, usedkeys)
+
+-- | Generate a random [(k,v)] from the residual 'mustKeys' (those not yet paired with some mustVal)
+--   'newVcount' is how many random vs must be generated
+--   'dups' how may duplicate vs must be generated.
+--   This is because the size of the Range as a set, might be smaller smaller than the size of the Range as a list.
+--   'usedVs' have already been chosen to be in the range of result.
+--   'usedKs' have already been chosen to be in the domain of the result.
+loopK ::
+  forall fn m k v.
+  (HasSpec fn k, IsNormalType k, IsNormalType v, HasSpec fn v, MonadGenError m) =>
+  [(k, v)] ->
+  [k] ->
+  Integer ->
+  Integer ->
+  [v] ->
+  [k] ->
+  Specification fn (k, v) ->
+  GenT m [(k, v)]
+loopK ans mustKeys newVcount dups usedVs usedKs ok =
+  -- trace ("LOOPK "++show(mustKeys,newVcount,dups,usedVs,usedKs)++"  "++show ans) $
+  case (mustKeys, newVcount) of
+    ([], 0) -> pure ans
+    ([], n) ->
+      if sizeOf usedVs >= dups && dups /= 0
+        then randomKusedV (n - 1) usedVs usedKs
+        else randomKrandomV (n - 1) usedVs usedKs
+    (k : ks, n) ->
+      if sizeOf usedVs >= dups && dups /= 0
+        then fixedKusedV ks (n - 1) usedVs usedKs k
+        else fixedKrandomV ks (n - 1) usedVs usedKs k
+  where
+    -- Random unused k, duplicate v
+    randomKusedV n usedvs usedks = do
+      (k, v) <-
+        genFromSpecT @fn @_ @m
+          ( constrained $ \p -> match p $ \k v ->
+              [ assert $ not_ (elem_ k (lit usedks))
+              , assert $ elem_ v (lit usedvs)
+              , satisfies (pair_ k v) ok
+              ]
+          )
+      loopK ((k, v) : ans) [] n dups usedvs (k : usedks) ok
+
+    -- Random unused k, Random unused v
+    randomKrandomV n usedvs usedks = do
+      (k, v) <-
+        genFromSpecT @fn @_ @m
+          ( constrained $ \p -> match p $ \k v ->
+              [ assert $ not_ (elem_ k (lit usedks))
+              , assert $ not_ (elem_ v (lit usedvs))
+              , satisfies (pair_ k v) ok
+              ]
+          )
+      loopK ((k, v) : ans) [] n dups (v : usedvs) (k : usedks) ok
+
+    -- Given k, duplicate v
+    fixedKusedV ks n usedvs usedks k = do
+      v <-
+        genFromSpecT @fn @_ @m
+          ( constrained $ \v ->
+              [ assert $ elem_ v (lit usedvs)
+              , satisfies (pair_ (lit k) v) ok
+              ]
+          )
+      loopK ((k, v) : ans) ks n dups usedvs (k : usedks) ok
+
+    -- Given k, Random unused v
+    fixedKrandomV ks n usedvs usedks k = do
+      v <-
+        genFromSpecT @fn @_ @m
+          ( constrained $ \v ->
+              [ assert $ not_ (elem_ v (lit usedvs))
+              , satisfies (pair_ (lit k) v) ok
+              ]
+          )
+      loopK ((k, v) : ans) ks n dups (v : usedvs) (k : usedks) ok
+
+-- | Generate, or find a match , k, (in 'mustks') for v, that satisfies ok (k,v)
+genOrFindMatchFor ::
+  (MonadGenError m, HasSpec fn v, HasSpec fn k, Ord k) =>
+  v ->
+  Set k ->
+  Set k ->
+  Specification fn (k, v) ->
+  GenT m k
+genOrFindMatchFor v mustks usedks ok =
+  explain
+    [ "Find a k-match for v=" ++ show v ++ " where k in " ++ show (Set.toList mustks)
+    , "  or"
+    , "Gen a k-match for v="
+        ++ show v
+        ++ " where k not in "
+        ++ show (Set.toList (Set.union mustks usedks))
+    ]
+    (trySpecs [findMatch, genMatch])
+  where
+    genMatch =
+      constrained $ \key ->
+        [ satisfies (pair_ key (lit v)) ok
+        , assert $ not_ (member_ key (lit (Set.union mustks usedks)))
+        ]
+    findMatch =
+      constrained $ \key ->
+        [ satisfies (pair_ key (lit v)) ok
+        , assert $ member_ key (lit mustks)
+        ]
+
+-- =================================================================================
+-- More accurate than the Arbitrary instance
+-- =================================================================================
+
+-- | Usefull for generating (MapSpec fn Integer Integer) for use in tests
+--   Most of the MapSpec's generated should be valid, with a good distribution
+--   of different sizes for mustVals and mustKeys, and a high probability of
+--   satisfying kvSpec (key >= val)
+genMapSpec :: forall fn. BaseUniverse fn => Gen (MapSpec fn Integer Integer)
+genMapSpec = do
+  (mustKeyLen, mustValLen, _slack) <- genSizes
+  mapsize <- genSizeSpec @fn (mustKeyLen + mustValLen) 6
+  let biggest = maxSize mapsize
+  let ok x = x <= biggest && x > mustValLen
+  let genOk = if mustValLen == biggest then pure biggest else arbitrary `suchThat` ok -- ((getSmall <$> arbitrary) `suchThat` ok)
+  valsize <-
+    frequency
+      [ (1, pure $ Just (MinValSize (typeSpec (NumSpecInterval (Just mustValLen) (Just biggest)))))
+      , (1, pure $ Just (MinValSize (typeSpec (NumSpecInterval Nothing (Just biggest)))))
+      , (1, pure Nothing)
+      , (1, Just . MinValSize . MemberSpec . (mustValLen :) <$> vectorOf 5 genOk)
+      ]
+  mustval <- vectorOf (fromInteger mustValLen) arbitrary
+  let avg =
+        if null mustval
+          then 0 :: Integer
+          else sum mustval `div` toInteger (length mustval)
+      goodMust = constrained (\n -> n >=. (lit avg))
+  mustkey <- genFromGenT $ (Set.fromList <$> genDistinctList @_ @fn goodMust mustKeyLen [])
+  let kvSpec =
+        constrained
+          ( \p ->
+              match p (\key val -> [assert $ key >=. val])
+          )
+  pure (MapSpec Nothing mustkey mustval mapsize kvSpec NoFold valsize)
+
+maxSize :: Specification fn Integer -> Integer
+maxSize (TypeSpec (NumSpecInterval _ (Just n)) _) = n
+maxSize (TypeSpec (NumSpecInterval _ Nothing) _) = 8
+maxSize (MemberSpec xs) = maximum xs
+maxSize _ = 9
+
+-- | Gen 3 Integers They correspond to the
+--   1) size of the mustKeys,
+--   2) size of the mustVals
+--   3) The minimum size, one might get from the SizeSpec for the Map
+--   All of them could be 0
+genSizes :: Gen (Integer, Integer, Integer)
+genSizes =
+  genFromGenT
+    ( genFromSpecT @BaseFn
+        ( constrained
+            ( \triple ->
+                match
+                  triple
+                  ( \k v slack ->
+                      [ assert $ 0 <=. v
+                      , assert $ v <=. 6
+                      , assert $ 0 <=. k
+                      , assert $ k <=. 7
+                      , assert $ 0 <=. slack
+                      , assert $ slack <=. 5
+                      ]
+                  )
+            )
+        )
+    )
+
+-- TODO: consider making this more interesting to get fewer discarded tests in `prop_gen_sound`.
+-- See genMapSpec as a first attempt, but we would have to generalize Integer to k and v
+instance
+  ( Arbitrary k
+  , Arbitrary v
+  , Arbitrary (TypeSpec fn k)
+  , Arbitrary (TypeSpec fn v)
+  , Ord k
+  , Ord v
+  , HasSpec fn k
+  , Foldy fn v
+  ) =>
+  Arbitrary (MapSpec fn k v)
+  where
+  arbitrary =
+    MapSpec
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> frequency [(1, pure NoFold), (1, arbitrary)]
+      <*> frequency [(2, pure Nothing), (1, Just <$> arbitrary)]
+  shrink = genericShrink
+
+instance (BaseUniverse fn, Ord v) => Arbitrary (MinValSize fn v) where
+  arbitrary = MinValSize <$> arbitrary
+
+instance Arbitrary (FoldSpec fn (Map k v)) where
+  arbitrary = pure NoFold
+
+-- ==============================================================================
+
+-- Like conformsTo, but tells which of the sub conformance components fail
+-- Nothing means success, (Just s), means 's' tells what went wrong.
+conformsToMapMaybe ::
+  forall fn k v.
+  (HasSpec fn (Map k v), HasSpec fn k, HasSpec fn v, Ord k) =>
+  Map k v ->
+  MapSpec fn k v ->
+  Maybe String
+conformsToMapMaybe m (MapSpec _ mustKeys mustVals size kvs foldSpec minval) =
+  allOf
+    [ tell "mustKeys" $ mustKeys `Set.isSubsetOf` Map.keysSet m
+    , tell "mustVals" $ all (`elem` Map.elems m) mustVals
+    , tell ("size (" ++ show size ++ ") on map with size" ++ show (Map.size m)) $
+        sizeOf m `conformsToSpec` size
+    , tell "kvs" $ all (`conformsToSpec` kvs) (Map.toList m)
+    , tell "foldSpec" $ Map.elems m `conformsToFoldSpec` foldSpec
+    , tell "minValSize" $ conformsToSpec @fn (sizeOf (nub (Map.elems m))) (extractFromMinValSize minval)
+    ]
+  where
+    tell :: String -> Bool -> Maybe String
+    tell _ True = Nothing
+    tell msg False = Just msg
+
+    allOf :: [Maybe String] -> Maybe String
+    allOf xs = foldr accum Nothing xs
+      where
+        accum Nothing ans = ans
+        accum (Just s) Nothing = Just s
+        accum (Just s) (Just more) = Just (s ++ "\n" ++ more)

--- a/libs/constrained-generators/src/Constrained/Spec/Pairs.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Pairs.hs
@@ -67,6 +67,7 @@ instance (HasSpec fn a, HasSpec fn b) => HasSpec fn (Prod a b) where
       <> satisfies (app sndFn x) ss
 
   cardinalTypeSpec (Cartesian x y) = multSpecInt (cardinality x) (cardinality y)
+  cardinalTrueSpec = multSpecInt (cardinality (TrueSpec @fn @a)) (cardinality (TrueSpec @fn @b))
 
 deriving instance (HasSpec fn a, HasSpec fn b) => Show (PairSpec fn a b)
 

--- a/libs/constrained-generators/src/Constrained/Univ.hs
+++ b/libs/constrained-generators/src/Constrained/Univ.hs
@@ -379,6 +379,7 @@ data MapFn (fn :: [Type] -> Type -> Type) args res where
   Dom :: Ord k => MapFn fn '[Map k v] (Set k)
   Rng :: MapFn fn '[Map k v] [v]
   Lookup :: Ord k => MapFn fn '[k, Map k v] (Maybe v)
+  RngSet :: Ord v => MapFn fn '[Map k v] (Set v)
 
 deriving instance Show (MapFn fn args res)
 deriving instance Eq (MapFn fn args res)
@@ -388,6 +389,7 @@ instance FunctionLike (MapFn fn) where
     Dom -> Map.keysSet
     Rng -> Map.elems
     Lookup -> Map.lookup
+    RngSet -> Set.fromList . Map.elems
 
 domFn :: forall fn k v. (Member (MapFn fn) fn, Ord k) => fn '[Map k v] (Set k)
 domFn = injectFn $ Dom @_ @fn
@@ -397,3 +399,6 @@ rngFn = injectFn $ Rng @fn
 
 lookupFn :: forall fn k v. (Member (MapFn fn) fn, Ord k) => fn '[k, Map k v] (Maybe v)
 lookupFn = injectFn $ Lookup @_ @fn
+
+rngSetFn :: forall fn k v. (Member (MapFn fn) fn, Ord v) => fn '[Map k v] (Set v)
+rngSetFn = injectFn $ RngSet @_ @fn

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -126,6 +126,19 @@ tests nightly =
     testSpecNoShrink "reifyYucky" reifyYucky
     testSpec "fixedRange" fixedRange
     testSpec "rangeHint" rangeHint
+    testSpec "rngSetSpec" rngSetSpec
+    testSpec "richRngSetSpec" richRngSetSpec
+    testSpec "rngSetWithHint" rngSetWithHint
+    testSpec "richRngSetSpec" richRngSetSpec
+
+    testSpec "sizeOfMap" sizeOfMap
+    testSpec "sizeOfDomMap" sizeOfDomMap
+    testSpec "sizeDomMap" sizeDomMap
+    testSpec "sizeOfRngMap" sizeOfRngMap
+    testSpec "sizeOfRngSetMap" sizeOfRngSetMap
+    testSpec "sizeNotEqualEmpty" sizeNotEqualEmpty
+    testSpecNoShrink "sizeEqualEmpty" sizeEqualEmpty
+
     testSpec "basicSpec" basicSpec
     testSpec "canFollowLike" canFollowLike
     testSpec "ifElseBackwards" ifElseBackwards
@@ -193,6 +206,15 @@ negativeTests =
             explanation ["You can't constrain the variable introduced by reify as its already decided"] $
               reify x id $
                 \y -> y ==. 10
+    prop "rngSetWithHintInconsistent" $
+      expectFailure $
+        prop_complete @BaseFn @(Map Int Int) $
+          constrained $ \m ->
+            explanation ["Hint (5) is inconsistent with minimum rngSet size. (6)"] $
+              Block
+                [ assert $ 6 <=. sizeOf_ (rngSet_ m)
+                , genHint 5 m
+                ]
 
 numberyTests :: Spec
 numberyTests =


### PR DESCRIPTION
Use the new style constrained generators to build Specifications of well formed type used in the Cardano Ledger.
Well formed means that constraints that should hold in the NewEpochState on the chain will hold on the randomly generated
values. The (WellFormed t) class has a has a member function with type (  wff :: Gen t )

These Specifications will probably have to be refined over time. But they are complete in that the machinery exists for every
type in the Ledger. Currently they mimic the constraints in the oldstyle constrained generators. They are significantly simpler and much more composeable.

The PR also has a few fixes that were necessary to handle the constraints we wrote. This PR exercised the constrained generators library quite a bit, and it needed some additions. These include

- Filled in missing cases in computation of cardinality, methods cardinalTypeSpec and cardinalTrueSpec
- Better use of constraints like  (x ==. mempty) to get accurate size information
- Added typeSpecOpt to a few HasSpec instances
- Added the function rngSet_ :: Term fn (Map a b) -> Term (Set b)

 

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
