### PR TITLE
`constrained-generators`: Improve error messages and make the tree generator reasonably sized

### DIFF
--- a/libs/constrained-generators/src/Constrained.hs
+++ b/libs/constrained-generators/src/Constrained.hs
@@ -45,6 +45,8 @@ module Constrained (
   conformsToSpec,
   conformsToSpecProp,
   monitorSpec,
+  forAllSpec,
+  forAllSpecShow,
   giveHint,
   typeSpec,
   con,
@@ -129,4 +131,5 @@ where
 import Constrained.GenT as X
 import Constrained.Internals
 import Constrained.List as X
+import Constrained.Properties
 import Constrained.Spec.Tree as X

--- a/libs/constrained-generators/src/Constrained/Base.hs
+++ b/libs/constrained-generators/src/Constrained/Base.hs
@@ -596,12 +596,10 @@ instance HasSpec fn a => Semigroup (Specification fn a) where
   ErrorSpec e <> ErrorSpec e' = ErrorSpec (e ++ "" : (replicate 20 '-') : "" : e')
   ErrorSpec e <> _ = ErrorSpec e
   _ <> ErrorSpec e = ErrorSpec e
-  -- TODO: these can interact poorly with unsafeExists!
-  -- MemberSpec [a] <> spec
-  --   | a `conformsToSpec` spec = MemberSpec [a]
-  --   | otherwise = ErrorSpec [show a, "does not conform to", show spec]
-  -- spec <> MemberSpec [a] = MemberSpec [a] <> spec
-  MemberSpec as <> MemberSpec as' = MemberSpec $ intersect as as'
+  MemberSpec as <> MemberSpec as' =
+    fromGESpec $
+      explain ["Intersecting: ", "  MemberSpec " ++ show as, "  MemberSpec " ++ show as'] $
+        pure (MemberSpec $ intersect as as')
   MemberSpec as <> TypeSpec s cant =
     MemberSpec $
       filter

--- a/libs/constrained-generators/src/Constrained/Base.hs
+++ b/libs/constrained-generators/src/Constrained/Base.hs
@@ -791,9 +791,9 @@ data WithHasSpec fn f a where
 -- The Forallable class ---------------------------------------------------
 
 class Forallable t e | t -> e where
-  forAllSpec ::
+  fromForAllSpec ::
     (HasSpec fn t, HasSpec fn e, BaseUniverse fn) => Specification fn e -> Specification fn t
-  default forAllSpec ::
+  default fromForAllSpec ::
     ( HasSpec fn t
     , HasSpec fn e
     , HasSimpleRep t
@@ -803,7 +803,7 @@ class Forallable t e | t -> e where
     ) =>
     Specification fn e ->
     Specification fn t
-  forAllSpec es = fromSimpleRepSpec $ forAllSpec @(SimpleRep t) @e es
+  fromForAllSpec es = fromSimpleRepSpec $ fromForAllSpec @(SimpleRep t) @e es
 
   forAllToList :: t -> [e]
   default forAllToList ::
@@ -1110,7 +1110,7 @@ computeSpecSimplified x p = fromGESpec $ case p of
   Assert es (Lit False) -> genError (es ++ ["Assert False"])
   Assert es t -> explain es $ propagateSpec (equalSpec True) <$> toCtx x t
   ForAll (Lit s) b -> pure $ foldMap (\val -> computeSpec x $ unBind val b) (forAllToList s)
-  ForAll t b -> propagateSpec (forAllSpec $ computeSpecBinderSimplified b) <$> toCtx x t
+  ForAll t b -> propagateSpec (fromForAllSpec $ computeSpecBinderSimplified b) <$> toCtx x t
   Case (Lit val) bs -> pure $ runCaseOn val bs $ \va vaVal psa -> computeSpec x (substPred (singletonEnv va vaVal) psa)
   Case t branches ->
     let branchSpecs = mapList computeSpecBinderSimplified branches
@@ -2820,7 +2820,7 @@ instance (Ord a, HasSpec fn a) => HasSpec fn (Set a) where
       <> satisfies (size_ s) size
 
 instance Ord a => Forallable (Set a) a where
-  forAllSpec (e :: Specification fn a)
+  fromForAllSpec (e :: Specification fn a)
     | Evidence <- prerequisites @fn @(Set a) = typeSpec $ SetSpec mempty e TrueSpec
   forAllToList = Set.toList
 
@@ -3008,7 +3008,7 @@ instance HasSpec fn a => HasGenHint fn [a] where
   giveHint szHint = typeSpec $ ListSpec (Just szHint) [] mempty mempty NoFold
 
 instance Forallable [a] a where
-  forAllSpec es = typeSpec (ListSpec Nothing [] mempty es NoFold)
+  fromForAllSpec es = typeSpec (ListSpec Nothing [] mempty es NoFold)
   forAllToList = id
 
 -- Numbers ----------------------------------------------------------------

--- a/libs/constrained-generators/src/Constrained/Properties.hs
+++ b/libs/constrained-generators/src/Constrained/Properties.hs
@@ -11,6 +11,16 @@ module Constrained.Properties where
 import Constrained.Internals
 import Test.QuickCheck qualified as QC
 
+forAllSpecShow ::
+  (HasSpec fn a, QC.Testable p) => Specification fn a -> (a -> String) -> (a -> p) -> QC.Property
+forAllSpecShow spec pp prop =
+  let sspec = simplifySpec spec
+   in QC.forAllShrinkShow (genFromSpec_ sspec) (shrinkWithSpec sspec) pp $ \a ->
+        monitorSpec spec a $ prop a
+
+forAllSpec :: (HasSpec fn a, QC.Testable p) => Specification fn a -> (a -> p) -> QC.Property
+forAllSpec spec prop = forAllSpecShow spec show prop
+
 prop_sound ::
   HasSpec fn a =>
   Specification fn a ->

--- a/libs/constrained-generators/src/Constrained/Spec/Map.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Map.hs
@@ -78,7 +78,7 @@ instance
 
   combineSpec
     (MapSpec mHint mustKeys mustVals size kvs foldSpec)
-    (MapSpec mHint' mustKeys' mustVals' size' kvs' foldSpec') = fromGE ErrorSpec $ do
+    (MapSpec mHint' mustKeys' mustVals' size' kvs' foldSpec') = fromGESpec $ do
       typeSpec
         . MapSpec
           -- This is min because that allows more compositionality - if a spec specifies a

--- a/libs/constrained-generators/src/Constrained/Spec/Map.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Map.hs
@@ -64,7 +64,7 @@ deriving instance
   ) =>
   Show (MapSpec fn k v)
 instance Ord k => Forallable (Map k v) (k, v) where
-  forAllSpec kvs = typeSpec $ defaultMapSpec {mapSpecElem = kvs}
+  fromForAllSpec kvs = typeSpec $ defaultMapSpec {mapSpecElem = kvs}
   forAllToList = Map.toList
 
 instance

--- a/libs/constrained-generators/src/Constrained/Spec/Tree.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Tree.hs
@@ -45,7 +45,7 @@ data BinTreeSpec fn a = BinTreeSpec (Maybe Integer) (Specification fn (BinTree a
   deriving (Show)
 
 instance Forallable (BinTree a) (BinTree a, a, BinTree a) where
-  forAllSpec = typeSpec . BinTreeSpec Nothing
+  fromForAllSpec = typeSpec . BinTreeSpec Nothing
   forAllToList BinTip = []
   forAllToList (BinNode left a right) = (left, a, right) : forAllToList left ++ forAllToList right
 
@@ -116,7 +116,7 @@ data TreeSpec fn a = TreeSpec
 deriving instance (HasSpec fn a, Member (TreeFn fn) fn) => Show (TreeSpec fn a)
 
 instance Forallable (Tree a) (a, [Tree a]) where
-  forAllSpec = guardRoseSpec . TreeSpec Nothing Nothing TrueSpec
+  fromForAllSpec = guardRoseSpec . TreeSpec Nothing Nothing TrueSpec
   forAllToList (Node a children) = (a, children) : concatMap forAllToList children
 
 -- TODO: get rid of this when we implement `cardinality`


### PR DESCRIPTION
# Description

The tree generator used to produce trees of size at most 8000, now it defaults to 20 unless otherwise specified.

This also makes it so that the `ErrorSpec` we get from a bunch of operations actually carries the `explain` calls with it to
improve error logging.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
