### PR TITLE
`constrained-generators`: Fix bug in reifies

### DIFF
--- a/libs/constrained-generators/src/Constrained/Base.hs
+++ b/libs/constrained-generators/src/Constrained/Base.hs
@@ -1113,6 +1113,8 @@ simplifySpec spec = case spec of
   TrueSpec -> TrueSpec
 
 -- | Precondition: the `Pred fn` defines the `Var a`
+--
+-- Runs in `GE` in order for us to have detailed context on failure.
 computeSpecSimplified ::
   forall fn a. (HasSpec fn a, HasCallStack) => Var a -> Pred fn -> GE (Specification fn a)
 computeSpecSimplified x p = localGESpec $ case p of
@@ -1160,7 +1162,9 @@ computeSpecSimplified x p = localGESpec $ case p of
     localGESpec ge@FatalError {} = ge
     localGESpec ge = pure $ fromGESpec ge
 
--- | Precondition: the `Pred fn` defines the `Var a`
+-- | Precondition: the `Pred fn` defines the `Var a`.
+--
+-- Runs in `GE` in order for us to have detailed context on failure.
 computeSpec ::
   forall fn a. (HasSpec fn a, HasCallStack) => Var a -> Pred fn -> GE (Specification fn a)
 computeSpec x p = computeSpecSimplified x (simplifyPred p)

--- a/libs/constrained-generators/src/Constrained/Base.hs
+++ b/libs/constrained-generators/src/Constrained/Base.hs
@@ -998,8 +998,8 @@ genFromPreds (optimisePred . optimisePred -> preds) = explain [show $ "genFromPr
   -- and linearizing is memoized in properties that use `genFromPreds`.
   (linear, deps) <- runGE $ prepareLinearization preds
   explain [show $ "With graph:" /> pretty deps] $
-    explain [show $ "With linearization:" /> prettyLinear linear]
-          $ go mempty linear
+    explain [show $ "With linearization:" /> prettyLinear linear] $
+      go mempty linear
   where
     go :: (MonadGenError m, BaseUniverse fn) => Env -> [(Name fn, [Pred fn])] -> GenT m Env
     go env [] = pure env
@@ -1010,7 +1010,6 @@ genFromPreds (optimisePred . optimisePred -> preds) = explain [show $ "genFromPr
         pure $ fold specs
       val <- genFromSpec spec
       go (extendEnv v val env) nps
-
 
 -- TODO: here we can compute both the explicit hints (i.e. constraints that
 -- define the order of two variables) and any whole-program smarts.
@@ -1048,10 +1047,11 @@ linearize preds graph = do
     Left cycle ->
       fatalError $
         [ show $
-            "linearize: Dependency cycle in graph:" />
-              vcat ["cycle:" /> pretty cycle
-                   ,"graph:" /> pretty graph
-                   ]
+            "linearize: Dependency cycle in graph:"
+              /> vcat
+                [ "cycle:" /> pretty cycle
+                , "graph:" /> pretty graph
+                ]
         ]
     Right sorted -> pure sorted
   go sorted [(freeVarSet ps, ps) | ps <- filter isRelevantPred preds]
@@ -1072,8 +1072,10 @@ linearize preds graph = do
           fatalError $
             [ "Dependency error in `linearize`: "
             , show $ indent 2 $ "graph: " /> pretty graph
-            , show $ indent 2 $ "the following left-over constraints are not defining constraints for a unique variable:" />
-                            vcat (map (pretty . snd) ps)
+            , show $
+                indent 2 $
+                  "the following left-over constraints are not defining constraints for a unique variable:"
+                    /> vcat (map (pretty . snd) ps)
             ]
     go (n : ns) ps = do
       let (nps, ops) = partition (isLastVariable n . fst) ps
@@ -4138,8 +4140,7 @@ instance Pretty (Name fn) where
   pretty (Name v) = pretty v
 
 prettyLinear :: [(Name fn, [Pred fn])] -> Doc ann
-prettyLinear ln = vcat [ pretty n <+> "<-" /> vcat (map pretty ps) | (Name n, ps) <- ln ]
-
+prettyLinear ln = vcat [pretty n <+> "<-" /> vcat (map pretty ps) | (Name n, ps) <- ln]
 
 -- ======================================================================
 -- Size and its 'generic' operations over Sized types.

--- a/libs/constrained-generators/src/Constrained/Base.hs
+++ b/libs/constrained-generators/src/Constrained/Base.hs
@@ -1005,7 +1005,7 @@ genFromPreds (optimisePred . optimisePred -> preds) = explain [show $ "genFromPr
     go env [] = pure env
     go env ((Name v, ps) : nps) = do
       let ps' = substPred env <$> ps
-      spec <- runGE $ explain [show $ "Computing specs for:" /> vcat (map pretty ps')] $ do
+      spec <- runGE $ explain [show $ "Computing specs for:" /> vsep (map pretty ps')] $ do
         specs <- mapM (computeSpec v) ps'
         pure $ fold specs
       val <- genFromSpec spec
@@ -1048,7 +1048,7 @@ linearize preds graph = do
       fatalError $
         [ show $
             "linearize: Dependency cycle in graph:"
-              /> vcat
+              /> vsep
                 [ "cycle:" /> pretty cycle
                 , "graph:" /> pretty graph
                 ]
@@ -1075,7 +1075,7 @@ linearize preds graph = do
             , show $
                 indent 2 $
                   "the following left-over constraints are not defining constraints for a unique variable:"
-                    /> vcat (map (pretty . snd) ps)
+                    /> vsep (map (pretty . snd) ps)
             ]
     go (n : ns) ps = do
       let (nps, ops) = partition (isLastVariable n . fst) ps
@@ -4140,7 +4140,7 @@ instance Pretty (Name fn) where
   pretty (Name v) = pretty v
 
 prettyLinear :: [(Name fn, [Pred fn])] -> Doc ann
-prettyLinear ln = vcat [pretty n <+> "<-" /> vcat (map pretty ps) | (Name n, ps) <- ln]
+prettyLinear ln = vsep [pretty n <+> "<-" /> vsep (map pretty ps) | (Name n, ps) <- ln]
 
 -- ======================================================================
 -- Size and its 'generic' operations over Sized types.

--- a/libs/constrained-generators/src/Constrained/Base.hs
+++ b/libs/constrained-generators/src/Constrained/Base.hs
@@ -1129,7 +1129,8 @@ computeSpecSimplified x p = fromGESpec $ case p of
     | otherwise -> genError ["Value does not reify to literal: " ++ show val ++ " -/> " ++ show a]
   Reifies t' (Lit val) f ->
     propagateSpec (equalSpec (f val)) <$> toCtx x t'
-  Reifies Lit {} _ _ -> pure TrueSpec
+  Reifies Lit {} _ _ ->
+    fatalError ["Dependency error in computeSpec: Reifies", "  " ++ show p]
   -- Impossible cases that should be ruled out by the dependency analysis and linearizer
   DependsOn {} ->
     fatalError

--- a/libs/constrained-generators/src/Constrained/Examples/Basic.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Basic.hs
@@ -202,3 +202,9 @@ assertRealMultiple = constrained' $ \x y ->
   , assert $ 11 <=. y
   , assertReified (pair_ x y) $ uncurry (/=)
   ]
+
+reifiesMultiple :: Specification BaseFn (Int, Int, Int)
+reifiesMultiple = constrained' $ \x y z ->
+  [ reifies (x + y) z id
+  , x `dependsOn` y
+  ]

--- a/libs/constrained-generators/src/Constrained/Graph.hs
+++ b/libs/constrained-generators/src/Constrained/Graph.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module Constrained.Graph where
 
@@ -30,7 +30,7 @@ instance Ord node => Monoid (Graph node) where
   mempty = Graph mempty mempty
 
 instance Pretty n => Pretty (Graph n) where
-  pretty gr = vcat [nest 2 $ pretty n <> " <- " <> pretty (Set.toList ns) | (n, ns) <- Map.toList (edges gr) ]
+  pretty gr = vcat [nest 2 $ pretty n <> " <- " <> pretty (Set.toList ns) | (n, ns) <- Map.toList (edges gr)]
 
 nodes :: Graph node -> Set node
 nodes (Graph e _) = Map.keysSet e

--- a/libs/constrained-generators/src/Constrained/Graph.hs
+++ b/libs/constrained-generators/src/Constrained/Graph.hs
@@ -30,7 +30,7 @@ instance Ord node => Monoid (Graph node) where
   mempty = Graph mempty mempty
 
 instance Pretty n => Pretty (Graph n) where
-  pretty gr = vcat [nest 2 $ pretty n <> " <- " <> pretty (Set.toList ns) | (n, ns) <- Map.toList (edges gr)]
+  pretty gr = vsep [nest 2 $ pretty n <> " <- " <> pretty (Set.toList ns) | (n, ns) <- Map.toList (edges gr)]
 
 nodes :: Graph node -> Set node
 nodes (Graph e _) = Map.keysSet e

--- a/libs/constrained-generators/src/Constrained/Spec/Generics.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Generics.hs
@@ -372,7 +372,7 @@ forAll' xs f = forAll xs $ \x -> match @fn @p x f
 
 -- | Like `constrained` but pattern matches on the bound `Term fn a`
 constrained' ::
-  forall fn a p.
+  forall a fn p.
   ( Cases (SimpleRep a) ~ '[SimpleRep a]
   , TypeSpec fn a ~ TypeSpec fn (SimpleRep a)
   , HasSpec fn (SimpleRep a)

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -148,11 +148,6 @@ negativeTests =
         prop_complete @BaseFn @Int $
           constrained $ \x ->
             reify x id $ \y -> y ==. 10
-    prop "reify overconstrained" $
-      expectFailure $
-        prop_complete @BaseFn @Int $
-          constrained $ \x ->
-            reify x id $ \y -> y ==. 10
 
 numberyTests :: Spec
 numberyTests =

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -44,6 +44,7 @@ testAll = hspec tests
 tests :: Spec
 tests =
   describe "constrained" $ do
+    testSpec "reifiesMultiple" reifiesMultiple
     testSpec "assertReal" assertReal
     testSpec "assertRealMultiple" assertRealMultiple
     testSpec "setSpec" setSpec

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -133,6 +133,12 @@ tests =
       prop "Map Int Int" $ prop_conformEmpty @BaseFn @(Map Int Int)
       prop "[Int]" $ prop_conformEmpty @BaseFn @[Int]
       prop "[(Int, Int)]" $ prop_conformEmpty @BaseFn @[(Int, Int)]
+    negativeTests
+
+negativeTests :: Spec
+negativeTests =
+  describe "negative tests" $ do
+    prop "reifies 10 x id" $ expectFailure $ prop_complete @BaseFn @Int $ constrained $ \x -> reifies 10 x id
 
 numberyTests :: Spec
 numberyTests =

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -44,7 +44,8 @@ testAll = hspec tests
 tests :: Spec
 tests =
   describe "constrained" $ do
-    testSpec "reifiesMultiple" reifiesMultiple
+    -- TODO: double-shrinking
+    testSpecNoShrink "reifiesMultiple" reifiesMultiple
     testSpec "assertReal" assertReal
     testSpec "assertRealMultiple" assertRealMultiple
     testSpec "setSpec" setSpec

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -138,7 +138,21 @@ tests =
 negativeTests :: Spec
 negativeTests =
   describe "negative tests" $ do
-    prop "reifies 10 x id" $ expectFailure $ prop_complete @BaseFn @Int $ constrained $ \x -> reifies 10 x id
+    prop "reifies 10 x id" $
+      expectFailure $
+        prop_complete @BaseFn @Int $
+          constrained $
+            \x -> reifies 10 x id
+    prop "reify overconstrained" $
+      expectFailure $
+        prop_complete @BaseFn @Int $
+          constrained $ \x ->
+            reify x id $ \y -> y ==. 10
+    prop "reify overconstrained" $
+      expectFailure $
+        prop_complete @BaseFn @Int $
+          constrained $ \x ->
+            reify x id $ \y -> y ==. 10
 
 numberyTests :: Spec
 numberyTests =


### PR DESCRIPTION
# Description

When looking at improving some error messages I encountered a bug in reifies whereby `reifies 10 x id` would simplify away to `TrueSpec`. This was an oopsie introduced by yours truly but here is a fix!

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
