### PR TITLE
CERT conformance

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-executable-spec.git
-  tag: ac7af152d7d4c7b3ef1f3513e637c2c1e86ca30e
-  --sha256: sha256-hOdJTXA+vxm2Gh7t0hKXtSJ+3/iCoNyrzEiMzWGs6s4=
+  tag: ee25fa74979c39eb6adc2fa161ed4399506676e2
+  --sha256: sha256-6wXg52dFCqGNy9yjD9pCpt9WN/1PyegyfRgh8Cuxofc=
 
 index-state:
   -- Bump this if you need newer packages from Hackage

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## 1.14.0.0
 
+* Added `ConwayDelegEnv`
+* Changed the `Environment` of `ConwayDELEG` rule to `ConwayDelegEnv`
+* Moved `DelegateeNotRegisteredDELEG` to `ConwayDelegPredFailure`
 * Remove `gePrevGovActionIds` from `GovEnv`
 * Include proposal deposits in the DRep active voting stake. #4309
   * Add `proposalsDeposits` to `Governance.Proposals`.
@@ -69,6 +72,7 @@
 
 ### `testlib`
 
+* Add `ToExpr` instances for `CertEnv` and `ConwayDelegEnv`
 * Add `withPostBootstrap` to Conway ImpTest
 * Add `withImpStateWithProtVer` to Conway ImpTest
 * Add the following utilities. #4273

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
@@ -249,3 +249,7 @@ instance
   , ToExpr (TxCert era)
   ) =>
   ToExpr (ConwayUtxowPredFailure era)
+
+instance ToExpr (PParamsHKD Identity era) => ToExpr (CertEnv era)
+
+instance ToExpr (PParams era) => ToExpr (ConwayDelegEnv era)

--- a/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
+++ b/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
@@ -24,7 +24,7 @@ import Cardano.Ledger.Conway (Conway)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
 import Cardano.Ledger.Conway.Governance (VotingProcedures (..))
-import Cardano.Ledger.Conway.Rules (ConwayCERTS, ConwayCertsPredFailure (..), ConwayLEDGER)
+import Cardano.Ledger.Conway.Rules (ConwayDELEG, ConwayDelegPredFailure (..), ConwayLEDGER)
 import Cardano.Ledger.Conway.Scripts (ConwayPlutusPurpose (..))
 import Cardano.Ledger.Conway.Translation ()
 import Cardano.Ledger.Conway.Tx (AlonzoTx (..))
@@ -82,7 +82,7 @@ ledgerExamplesConway =
     , SLE.sleApplyTxError =
         ApplyTxError $
           pure $
-            wrapFailed @(ConwayCERTS Conway) @(ConwayLEDGER Conway) $
+            wrapFailed @(ConwayDELEG Conway) @(ConwayLEDGER Conway) $
               DelegateeNotRegisteredDELEG @Conway (SLE.mkKeyHash 1)
     , SLE.sleRewardsCredentials =
         Set.fromList

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ConformanceSpec.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ConformanceSpec.hs
@@ -7,7 +7,7 @@ import Cardano.Ledger.Crypto (StandardCrypto)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
 import Data.List (isInfixOf)
 import Test.Cardano.Ledger.Common
-import Test.Cardano.Ledger.Conformance (SpecTranslate (..), runSpecTransM)
+import Test.Cardano.Ledger.Conformance (runSpecTransM, toTestRep)
 import Test.Cardano.Ledger.Conformance.Spec.Conway ()
 import Test.Cardano.Ledger.Conformance.Utils (agdaHashToBytes)
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -4,9 +4,13 @@
 
 module Test.Cardano.Ledger.Conformance.Orphans where
 
+import Data.Bifunctor (Bifunctor (..))
+import Data.Default.Class (Default)
+import Data.List (sortOn)
 import GHC.Generics (Generic)
 import Lib
 import Test.Cardano.Ledger.Common (NFData, ToExpr)
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Core (FixupSpecRep (..), OpaqueErrorString)
 import Test.Cardano.Ledger.Conformance.Utils
 import Test.Cardano.Ledger.Conway.TreeDiff (Expr (..), ToExpr (..))
 
@@ -26,6 +30,16 @@ deriving instance Generic GovEnv
 
 deriving instance Generic EnactState
 
+deriving instance Generic CertEnv
+
+deriving instance Generic PState
+
+deriving instance Generic DState
+
+deriving instance Generic GState
+
+deriving instance Generic CertState
+
 deriving instance Eq AgdaEmpty
 
 deriving instance Eq TxBody
@@ -35,6 +49,8 @@ deriving instance Eq Tag
 deriving instance Ord Tag
 
 deriving instance Ord Credential
+
+deriving instance Ord GovRole
 
 deriving instance Eq TxWitnesses
 
@@ -61,6 +77,18 @@ deriving instance Eq GovEnv
 deriving instance Eq EnactState
 
 deriving instance Eq UTxOEnv
+
+deriving instance Eq CertEnv
+
+deriving instance Eq DState
+
+deriving instance Eq PState
+
+deriving instance Eq GState
+
+deriving instance Eq CertState
+
+instance (NFData k, NFData v) => NFData (HSMap k v)
 
 instance NFData GovAction
 
@@ -104,9 +132,21 @@ instance NFData Tx
 
 instance NFData UTxOEnv
 
+instance NFData CertEnv
+
+instance NFData PState
+
+instance NFData DState
+
+instance NFData GState
+
+instance NFData CertState
+
 instance ToExpr Credential where
   toExpr (KeyHashObj h) = App "KeyHashObj" [agdaHashToExpr h]
   toExpr (ScriptObj h) = App "ScriptObj" [agdaHashToExpr h]
+
+instance (ToExpr k, ToExpr v) => ToExpr (HSMap k v)
 
 instance ToExpr GovAction
 
@@ -148,3 +188,66 @@ instance ToExpr Tx
 instance ToExpr UTxOState
 
 instance ToExpr UTxOEnv
+
+instance ToExpr CertEnv
+
+instance ToExpr DState
+
+instance ToExpr PState
+
+instance ToExpr GState
+
+instance ToExpr CertState
+
+instance Default (HSMap k v)
+
+instance FixupSpecRep OpaqueErrorString
+
+instance FixupSpecRep a => FixupSpecRep [a]
+
+instance FixupSpecRep Char where
+  fixup = id
+
+instance
+  ( Ord k
+  , FixupSpecRep k
+  , FixupSpecRep v
+  ) =>
+  FixupSpecRep (HSMap k v)
+  where
+  fixup (MkHSMap l) = MkHSMap . sortOn fst $ bimap fixup fixup <$> l
+
+instance (FixupSpecRep a, FixupSpecRep b) => FixupSpecRep (a, b)
+
+instance FixupSpecRep a => FixupSpecRep (Maybe a)
+
+instance (FixupSpecRep a, FixupSpecRep b) => FixupSpecRep (Either a b)
+
+instance FixupSpecRep Integer where
+  fixup = id
+
+instance FixupSpecRep TxId
+
+instance FixupSpecRep ()
+
+instance FixupSpecRep UTxOState
+
+instance FixupSpecRep Credential
+
+instance FixupSpecRep GovRole
+
+instance FixupSpecRep VDeleg
+
+instance FixupSpecRep DState
+
+instance FixupSpecRep PState
+
+instance FixupSpecRep GState
+
+instance FixupSpecRep CertState
+
+instance FixupSpecRep Vote
+
+instance FixupSpecRep GovAction
+
+instance FixupSpecRep GovActionState

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
@@ -16,6 +16,7 @@ spec :: Spec
 spec = describe "Conway conformance tests" $ do
   xprop "UTXO" $ conformsToImpl @"UTXO" @ConwayFn @Conway
   prop "GOV" $ conformsToImpl @"GOV" @ConwayFn @Conway
+  prop "CERT" $ conformsToImpl @"CERT" @ConwayFn @Conway
   describe "Generators" $ do
     let
       genEnv = do

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -17,7 +17,6 @@
 * Add lenses to `RewardAccount`. #4309
   * `rewardAccountCredentialL`
   * `rewardAccountNetworkL`
-* Add `Inject` instances for tuples
 * Add `umElemDRepDelegatedReward` to `UMap`. #4273
 * Add `fromDeltaCoin`
 * Add trivial `Inject` instances for `()` and `Void`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -855,9 +855,6 @@ instance Inject t () where
 instance Inject Void s where
   inject = absurd
 
-instance (Inject c a, Inject c b) => Inject c (a, b) where
-  inject x = (inject x, inject x)
-
 -- | Helper function for a common pattern of creating objects
 kindObject :: Text -> [Pair] -> Value
 kindObject name obj = object $ ("kind" .= name) : obj

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
@@ -48,6 +48,8 @@ txCertSpec (CertEnv slot pp ce) CertState {..} =
   constrained $ \txCert ->
     caseOn
       txCert
-      (branch $ \delegCert -> satisfies delegCert $ delegCertSpec pp certDState)
+      (branch $ \delegCert -> satisfies delegCert $ delegCertSpec delegEnv certDState)
       (branch $ \poolCert -> satisfies poolCert $ poolCertSpec (PoolEnv slot pp) certPState)
       (branch $ \govCert -> satisfies govCert $ govCertSpec (ConwayGovCertEnv pp ce) certVState)
+  where
+    delegEnv = ConwayDelegEnv pp (psStakePoolParams certPState)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances.hs
@@ -1426,3 +1426,6 @@ onSized ::
   (Term fn a -> p) ->
   Pred fn
 onSized sz p = match sz $ \a _ -> p a
+
+instance HasSimpleRep (ConwayDelegEnv era)
+instance (IsConwayUniv fn, HasSpec fn (PParams era), Era era) => HasSpec fn (ConwayDelegEnv era)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -116,6 +116,7 @@ import Cardano.Ledger.Conway.Governance (
 import Cardano.Ledger.Conway.Rules (
   CertEnv (..),
   ConwayCertsPredFailure (..),
+  ConwayDelegEnv (..),
   ConwayDelegPredFailure (..),
   ConwayGovCertEnv (..),
   ConwayGovCertPredFailure (..),
@@ -1475,7 +1476,6 @@ instance PrettyA (ConwayGovCertPredFailure era) where
 
 ppConwayCertsPredFailure :: Proof era -> ConwayCertsPredFailure era -> PDoc
 ppConwayCertsPredFailure proof x = case x of
-  ConwayRules.DelegateeNotRegisteredDELEG kh -> ppSexp "DelegateeNotRegisteredDELEG" [pcKeyHash kh]
   WithdrawalsNotInRewardsCERTS m -> ppSexp "WithdrawalsNotInRewardsCERTS" [ppMap pcRewardAccount pcCoin m]
   CertFailure pf -> case proof of
     Conway -> ppSexp " CertFailure" [ppConwayCertPredFailure proof pf] -- !(PredicateFailure (EraRule "CERT" era))
@@ -1912,6 +1912,7 @@ ppConwayDelegPredFailure x = case x of
     ppSexp "StakeKeyHasNonZeroRewardAccountBalanceDELEG" [pcCoin c]
   DRepAlreadyRegisteredForStakeKeyDELEG cred ->
     ppSexp "DRepAlreadyRegisteredForStakeKeyDELEG" [pcCredential cred]
+  ConwayRules.DelegateeNotRegisteredDELEG kh -> ppSexp "DelegateeNotRegisteredDELEG" [pcKeyHash kh]
 
 instance PrettyA (ConwayDelegPredFailure era) where
   prettyA = ppConwayDelegPredFailure
@@ -2691,6 +2692,14 @@ pcConwayDelegCert (ConwayRegDelegCert cred d c) =
 
 instance PrettyA (ConwayDelegCert c) where
   prettyA = pcConwayDelegCert
+
+instance Reflect era => PrettyA (ConwayDelegEnv era) where
+  prettyA ConwayDelegEnv {..} =
+    ppRecord
+      "ConwayDelegEnv"
+      [ ("cdePParams", prettyA cdePParams)
+      , ("cdePools", prettyA cdePools)
+      ]
 
 pcDelegatee :: Delegatee c -> PDoc
 pcDelegatee (DelegStake kh) = ppSexp "DelegStake" [pcKeyHash kh]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -27,7 +27,6 @@ import Test.Cardano.Ledger.Constrained.Conway.Gov
 import Test.Cardano.Ledger.Constrained.Conway.GovCert
 import Test.Cardano.Ledger.Constrained.Conway.Instances
 import Test.Cardano.Ledger.Constrained.Conway.Ledger
-import Test.Cardano.Ledger.Constrained.Conway.PParams
 import Test.Cardano.Ledger.Constrained.Conway.Pool
 import Test.Cardano.Ledger.Constrained.Conway.Utxo
 
@@ -179,7 +178,7 @@ prop_CERT =
 prop_DELEG :: Property
 prop_DELEG =
   stsPropertyV2 @"DELEG" @ConwayFn
-    pparamsSpec
+    delegEnvSpec
     (\_env -> dStateSpec)
     delegCertSpec
     $ \_env _st _sig _st' -> True


### PR DESCRIPTION
# Description

Adds conformance testing for `CERT` rule. 

There is an issue with DRep registration certificates that I couldn't figure out so I just modified the constraints so that these certificates aren't generated until we figure out what's causing the problem. 

I have also gotten rid of the `TestRep` associated type, since it was annoying to work with. I've replaced `TestRep` with the `FixupSpecRep` typeclass, which also has a generic instance which fixes up these values recursively. 

This PR also moves the check that checks if a stake pool delegatee is registered from `CERTS` rule to `DELEG` rule since it makes a lot more sense there and has already caused much confusion.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
