### PR TITLE
`constrained-generators`: soundness tests and bugfixes

### DIFF
--- a/libs/constrained-generators/src/Constrained/Properties.hs
+++ b/libs/constrained-generators/src/Constrained/Properties.hs
@@ -1,14 +1,25 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Useful properties for debugging custom @HasSpec@ instances.
 module Constrained.Properties where
 
+import Constrained.Base
 import Constrained.Internals
+import Constrained.List
+import Data.Map (Map)
+import Data.Typeable
+import Prettyprinter
 import Test.QuickCheck qualified as QC
 
 forAllSpecShow ::
@@ -20,6 +31,17 @@ forAllSpecShow spec pp prop =
 
 forAllSpec :: (HasSpec fn a, QC.Testable p) => Specification fn a -> (a -> p) -> QC.Property
 forAllSpec spec prop = forAllSpecShow spec show prop
+
+forAllSpecDiscard :: (HasSpec fn a, QC.Testable p) => Specification fn a -> (a -> p) -> QC.Property
+forAllSpecDiscard spec prop =
+  let sspec = simplifySpec spec
+   in QC.forAllShrinkBlind
+        (strictGen $ genFromSpec @_ @_ @GE sspec)
+        (map pure . shrinkWithSpec sspec . errorGE)
+        $ \ge ->
+          fromGEDiscard $ do
+            a <- ge
+            pure $ QC.counterexample (show a) $ prop a
 
 prop_sound ::
   HasSpec fn a =>
@@ -69,20 +91,121 @@ prop_conformEmpty ::
   QC.Property
 prop_conformEmpty a = QC.property $ conformsTo @fn a (emptySpec @fn @a)
 
-prop_propagateSpec ::
-  (HasSpec fn a, HasSpec fn b) =>
-  Var b ->
-  Term fn a ->
-  Specification fn a ->
-  QC.Property
-prop_propagateSpec var tm spec =
-  let spec' = errorGE $ do
-        ctx <- toCtx var tm
-        pure $ propagateSpec spec ctx
-   in QC.forAll (strictGen $ genFromSpec spec') $ \geval -> fromGE (\err -> QC.counterexample (unlines err) False) $ do
-        val <- geval
-        res <- runTerm (singletonEnv var val) tm
-        pure $ QC.property $ conformsToSpec res spec
+prop_univSound :: forall fn. TestableFn fn -> QC.Property
+prop_univSound (TestableFn fn) =
+  QC.label (show fn) $
+    QC.forAllShrinkBlind QC.arbitrary QC.shrink $ \(TestableCtx ctx :: TestableCtx fn as) ->
+      QC.forAllShrinkBlind QC.arbitrary QC.shrink $ \(spec :: Specification fn a) ->
+        QC.counterexample ("\nfn ctx = " ++ showCtxWith fn (TestableCtx ctx)) $
+          QC.counterexample (show $ "\nspec =" <+> pretty spec) $
+            let sspec = simplifySpec (propagateSpecFun fn ctx spec)
+             in QC.counterexample ("\n" ++ show ("propagateSpecFun fn ctx spec =" /> pretty sspec)) $
+                  QC.forAllBlind (strictGen $ genFromSpec @_ @_ @GE sspec) $ \ge ->
+                    fromGEDiscard $ do
+                      a <- ge
+                      let res = uncurryList_ unValue (sem fn) $ fillListCtx ctx $ \HOLE -> Value a
+                      pure $
+                        QC.counterexample ("\ngenerated value: a = " ++ show a) $
+                          QC.counterexample ("\nfn ctx[a] = " ++ show res) $
+                            conformsToSpecProp res spec
+
+prop_gen_sound :: forall fn a. HasSpec fn a => Specification fn a -> QC.Property
+prop_gen_sound spec =
+  let sspec = simplifySpec spec
+   in QC.counterexample ("\n" ++ show ("simplifySpec spec =" /> pretty sspec)) $
+        QC.forAllBlind (strictGen $ genFromSpec @_ @_ @GE sspec) $ \ge ->
+          fromGEDiscard $ do
+            a <- ge
+            pure $
+              QC.counterexample ("\ngenerated value: a = " ++ show a) $
+                conformsToSpecProp a spec
+
+showCtxWith ::
+  forall fn as b.
+  (Typeable as, TypeList as, All (HasSpec fn) as, HasSpec fn b) =>
+  fn as b ->
+  TestableCtx fn as ->
+  String
+showCtxWith fn (TestableCtx ctx) = show $ pretty tm
+  where
+    tm :: Term fn b
+    tm =
+      uncurryList (app fn) $
+        fillListCtx (mapListCtxC @(HasSpec fn) (lit @_ @fn . unValue) ctx) (\HOLE -> V $ Var 0)
+
+data TestableFn fn where
+  TestableFn ::
+    ( All (HasSpec fn) as
+    , TypeList as
+    , HasSpec fn b
+    , Typeable as
+    , QC.Arbitrary (Specification fn b)
+    , Typeable (FunTy as b)
+    ) =>
+    fn as b ->
+    TestableFn fn
+
+instance BaseUniverse fn => Show (TestableFn fn) where
+  show (TestableFn (fn :: fn as b)) =
+    show fn ++ " :: " ++ show (typeOf (undefined :: FunTy as b))
+
+data TestableCtx fn as where
+  TestableCtx ::
+    HasSpec fn a =>
+    ListCtx Value as (HOLE a) ->
+    TestableCtx fn as
+
+instance forall fn as. (All (HasSpec fn) as, TypeList as) => QC.Arbitrary (TestableCtx fn as) where
+  arbitrary = do
+    let shape = listShape @as
+    idx <- QC.choose (0, lengthList shape - 1)
+    go idx shape
+    where
+      go :: forall f as'. All (HasSpec fn) as' => Int -> List f as' -> QC.Gen (TestableCtx fn as')
+      go 0 (_ :> as) =
+        TestableCtx . (HOLE :?) <$> mapMListC @(HasSpec fn) (\_ -> Value <$> genFromSpec_ @fn TrueSpec) as
+      go n (_ :> as) = do
+        TestableCtx ctx <- go (n - 1) as
+        TestableCtx . (:! ctx) . Value <$> genFromSpec_ @fn TrueSpec
+      go _ _ = error "The impossible happened in Arbitrary for TestableCtx"
+
+  shrink (TestableCtx ctx) = TestableCtx <$> shrinkCtx ctx
+    where
+      shrinkCtx :: forall c as'. All (HasSpec fn) as' => ListCtx Value as' c -> [ListCtx Value as' c]
+      shrinkCtx (c :? as) = (c :?) <$> go as
+      shrinkCtx (Value a :! ctx') = map ((:! ctx') . Value) (shrinkWithSpec @fn TrueSpec a) ++ map (Value a :!) (shrinkCtx ctx')
+
+      go :: forall as'. All (HasSpec fn) as' => List Value as' -> [List Value as']
+      go Nil = []
+      go (Value a :> as) = map ((:> as) . Value) (shrinkWithSpec @fn TrueSpec a) ++ map (Value a :>) (go as)
+
+-- TODO: we should improve these
+instance fn ~ BaseFn => QC.Arbitrary (TestableFn fn) where
+  arbitrary =
+    QC.elements
+      [ TestableFn $ addFn @fn @Int
+      , TestableFn $ negateFn @fn @Int
+      , TestableFn $ sizeOfFn @fn @(Map Int Int)
+      , TestableFn $ memberFn @fn @Int
+      , TestableFn $ notFn @fn
+      , TestableFn $ disjointFn @fn @Int
+      , TestableFn $ subsetFn @fn @Int
+      , TestableFn $ subsetFn @fn @Int
+      , TestableFn $ elemFn @fn @Int
+      , TestableFn $ orFn @fn
+      , TestableFn $ lessFn @fn @Int
+      , TestableFn $ lessOrEqualFn @fn @Int
+      , TestableFn $ equalFn @fn @Int
+      , TestableFn $ fstFn @fn @Int @Int
+      , TestableFn $ sndFn @fn @Int @Int
+      , TestableFn $ pairFn @fn @Int @Int
+      , TestableFn $ injRightFn @fn @Int @Int
+      , TestableFn $ singletonFn @fn @Int
+      , TestableFn $ unionFn @fn @Int
+      , TestableFn $ foldMapFn @fn @Int idFn
+      , TestableFn $ rngFn @fn @Int @Int
+      , TestableFn $ domFn @fn @Int @Int
+      ]
 
 prop_mapSpec ::
   ( HasSpec fn a

--- a/libs/constrained-generators/src/Constrained/Properties.hs
+++ b/libs/constrained-generators/src/Constrained/Properties.hs
@@ -112,13 +112,22 @@ prop_univSound (TestableFn fn) =
 prop_gen_sound :: forall fn a. HasSpec fn a => Specification fn a -> QC.Property
 prop_gen_sound spec =
   let sspec = simplifySpec spec
-   in QC.counterexample ("\n" ++ show ("simplifySpec spec =" /> pretty sspec)) $
-        QC.forAllBlind (strictGen $ genFromSpec @_ @_ @GE sspec) $ \ge ->
-          fromGEDiscard $ do
-            a <- ge
-            pure $
-              QC.counterexample ("\ngenerated value: a = " ++ show a) $
-                conformsToSpecProp a spec
+   in QC.tabulate "specType spec" [specType spec] $
+        QC.tabulate "specType (simplifySpec spec)" [specType sspec] $
+          QC.counterexample ("\n" ++ show ("simplifySpec spec =" /> pretty sspec)) $
+            QC.forAllBlind (strictGen $ genFromSpec @_ @_ @GE sspec) $ \ge ->
+              fromGEDiscard $ do
+                a <- ge
+                pure $
+                  QC.counterexample ("\ngenerated value: a = " ++ show a) $
+                    conformsToSpecProp a spec
+
+specType :: Specification fn a -> String
+specType TrueSpec {} = "TrueSpec"
+specType SuspendedSpec {} = "SuspendedSpec"
+specType ErrorSpec {} = "ErrorSpec"
+specType MemberSpec {} = "MemberSpec"
+specType TypeSpec {} = "TypeSpec"
 
 showCtxWith ::
   forall fn as b.

--- a/libs/constrained-generators/src/Constrained/Spec/Generics.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Generics.hs
@@ -49,6 +49,7 @@ module Constrained.Spec.Generics (
 import Data.Typeable
 import GHC.TypeLits (Symbol)
 import GHC.TypeNats
+import Test.QuickCheck (Arbitrary (..), oneof)
 
 import Constrained.Base
 import Constrained.Core
@@ -564,3 +565,18 @@ isJust ::
   Term fn (Maybe a) ->
   Pred fn
 isJust = isCon @"Just"
+
+-- Arbitrary instances ----------------------------------------------------
+
+instance
+  (HasSpec fn a, HasSpec fn b, Arbitrary (FoldSpec fn a), Arbitrary (FoldSpec fn b)) =>
+  Arbitrary (FoldSpec fn (a, b))
+  where
+  arbitrary =
+    oneof
+      [ preMapFoldSpec (composeFn fstFn toGenericFn) <$> arbitrary
+      , preMapFoldSpec (composeFn sndFn toGenericFn) <$> arbitrary
+      , pure NoFold
+      ]
+  shrink NoFold = []
+  shrink FoldSpec {} = [NoFold]

--- a/libs/constrained-generators/src/Constrained/Spec/Map.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Map.hs
@@ -28,7 +28,7 @@ import Data.Map qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Prettyprinter
-import Test.QuickCheck (Arbitrary (..), shrinkList)
+import Test.QuickCheck (Arbitrary (..), frequency, shrinkList)
 
 ------------------------------------------------------------------------
 -- HasSpec
@@ -56,6 +56,8 @@ data MapSpec fn k v = MapSpec
 defaultMapSpec :: Ord k => MapSpec fn k v
 defaultMapSpec = MapSpec Nothing mempty mempty TrueSpec TrueSpec NoFold
 
+-- TODO: consider making this more interesting to get fewer discarded tests
+-- in `prop_gen_sound`
 instance
   ( Arbitrary k
   , Arbitrary v
@@ -63,11 +65,21 @@ instance
   , Arbitrary (TypeSpec fn v)
   , Ord k
   , HasSpec fn k
-  , HasSpec fn v
+  , Foldy fn v
   ) =>
   Arbitrary (MapSpec fn k v)
   where
-  arbitrary = MapSpec <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> pure NoFold
+  arbitrary =
+    MapSpec
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> frequency [(5, pure NoFold), (1, arbitrary)]
+
+instance Arbitrary (FoldSpec fn (Map k v)) where
+  arbitrary = pure NoFold
 
 instance
   ( HasSpec fn (k, v)

--- a/libs/constrained-generators/src/Constrained/Spec/Pairs.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Pairs.hs
@@ -24,6 +24,7 @@ import Constrained.Base
 import Constrained.Core
 import Constrained.List
 import Constrained.Univ
+import Test.QuickCheck
 
 -- HasSpec ----------------------------------------------------------------
 
@@ -39,6 +40,10 @@ cartesian _ (ErrorSpec es) = ErrorSpec es
 cartesian s s' = typeSpec $ Cartesian s s'
 
 data PairSpec fn a b = Cartesian (Specification fn a) (Specification fn b)
+
+instance (Arbitrary (Specification fn a), Arbitrary (Specification fn b)) => Arbitrary (PairSpec fn a b) where
+  arbitrary = Cartesian <$> arbitrary <*> arbitrary
+  shrink (Cartesian a b) = uncurry Cartesian <$> shrink (a, b)
 
 instance (HasSpec fn a, HasSpec fn b) => HasSpec fn (Prod a b) where
   type TypeSpec fn (Prod a b) = PairSpec fn a b
@@ -95,12 +100,18 @@ instance BaseUniverse fn => Functions (PairFn fn) fn where
       | HOLE :? Value b :> Nil <- ctx ->
           let sameSnd ps = [a | Prod a b' <- ps, b == b']
            in case spec of
-                TypeSpec (Cartesian sa _) cant -> sa <> foldMap notEqualSpec (sameSnd cant)
+                TypeSpec (Cartesian sa sb) cant
+                  | b `conformsToSpec` sb -> sa <> foldMap notEqualSpec (sameSnd cant)
+                  -- TODO: better error message
+                  | otherwise -> ErrorSpec ["propagateSpecFun Pair"]
                 MemberSpec es -> MemberSpec (sameSnd es)
       | Value a :! NilCtx HOLE <- ctx ->
           let sameFst ps = [b | Prod a' b <- ps, a == a']
            in case spec of
-                TypeSpec (Cartesian _ sb) cant -> sb <> foldMap notEqualSpec (sameFst cant)
+                TypeSpec (Cartesian sa sb) cant
+                  | a `conformsToSpec` sa -> sb <> foldMap notEqualSpec (sameFst cant)
+                  -- TODO: better error message
+                  | otherwise -> ErrorSpec ["propagateSpecFun Pair"]
                 MemberSpec es -> MemberSpec (sameFst es)
 
   rewriteRules Fst ((pairView -> Just (x, _)) :> Nil) = Just x

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -39,11 +39,11 @@ import Constrained.Properties
 ------------------------------------------------------------------------
 
 testAll :: IO ()
-testAll = hspec tests
+testAll = hspec $ tests False
 
-tests :: Spec
-tests =
-  describe "constrained" $ do
+tests :: Bool -> Spec
+tests nightly =
+  describe "constrained" . modifyMaxSuccess (\ms -> if nightly then ms * 10 else ms) $ do
     -- TODO: double-shrinking
     testSpecNoShrink "reifiesMultiple" reifiesMultiple
     testSpec "assertReal" assertReal
@@ -135,9 +135,11 @@ tests =
       prop "Map Int Int" $ prop_conformEmpty @BaseFn @(Map Int Int)
       prop "[Int]" $ prop_conformEmpty @BaseFn @[Int]
       prop "[(Int, Int)]" $ prop_conformEmpty @BaseFn @[(Int, Int)]
-    prop "prop_univSound @BaseFn" $ withMaxSuccess 10000 $ prop_univSound @BaseFn
+    prop "prop_univSound @BaseFn" $
+      withMaxSuccess (if nightly then 100_000 else 10_000) $
+        prop_univSound @BaseFn
     describe "prop_gen_sound @BaseFn" $ do
-      modifyMaxSuccess (const 1000) $ do
+      modifyMaxSuccess (const $ if nightly then 10_000 else 1000) $ do
         prop "Int" $ prop_gen_sound @BaseFn @Int
         prop "Bool" $ prop_gen_sound @BaseFn @Bool
         prop "(Int, Int)" $ prop_gen_sound @BaseFn @(Int, Int)

--- a/libs/constrained-generators/test/Tests.hs
+++ b/libs/constrained-generators/test/Tests.hs
@@ -1,8 +1,11 @@
 module Main where
 
 import Constrained.Test
-
+import Data.Maybe
+import System.Environment
 import Test.Hspec
 
 main :: IO ()
-main = hspec tests
+main = do
+  nightly <- isJust <$> lookupEnv "NIGHTLY"
+  hspec $ tests nightly


### PR DESCRIPTION
# Description

In this PR we introduce a basic soundness testing scheme for `propagateSpecFun`. The idea is that you take a random function symbol `fn`, a random context `ctx = v0 v1 ... x ... vn` such that `fn v0 v1 ... x ... vn` is well typed, you generate a random `spec` for the result type of `fn` and you propagate it through the `fn` and the `ctx` to give you a spec for `x`. You then generate a value `a` for `x` and evaluate `fn v0 v1 ... a ... vn` and check that the result conforms to `spec`.

This has found a bunch of tiny soundness bugs and a nasty little bug in the optimizer. It will greatly help us avoid regressions, esp. when we add new function symbols.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
