### PR TITLE
`constrained-generators`: Introduce `fromList_ :: (HasSpec fn a, Ord a) => Term fn [a] -> Term fn (Set a)`

### DIFF
--- a/libs/constrained-generators/src/Constrained/Properties.hs
+++ b/libs/constrained-generators/src/Constrained/Properties.hs
@@ -214,6 +214,7 @@ instance fn ~ BaseFn => QC.Arbitrary (TestableFn fn) where
       , TestableFn $ foldMapFn @fn @Int idFn
       , TestableFn $ rngFn @fn @Int @Int
       , TestableFn $ domFn @fn @Int @Int
+      , TestableFn $ fromListFn @fn @Int
       ]
 
 prop_mapSpec ::

--- a/libs/constrained-generators/src/Constrained/Univ.hs
+++ b/libs/constrained-generators/src/Constrained/Univ.hs
@@ -346,6 +346,9 @@ elemFn = injectFn $ Elem @_ @fn
 disjointFn :: forall fn a. (Member (SetFn fn) fn, Ord a) => fn '[Set a, Set a] Bool
 disjointFn = injectFn $ Disjoint @_ @fn
 
+fromListFn :: forall fn a. (Member (SetFn fn) fn, Ord a) => fn '[[a]] (Set a)
+fromListFn = injectFn $ FromList @_ @fn
+
 data SetFn (fn :: [Type] -> Type -> Type) args res where
   Subset :: Ord a => SetFn fn '[Set a, Set a] Bool
   Disjoint :: Ord a => SetFn fn '[Set a, Set a] Bool
@@ -353,6 +356,7 @@ data SetFn (fn :: [Type] -> Type -> Type) args res where
   Singleton :: Ord a => SetFn fn '[a] (Set a)
   Union :: Ord a => SetFn fn '[Set a, Set a] (Set a)
   Elem :: Eq a => SetFn fn '[a, [a]] Bool
+  FromList :: Ord a => SetFn fn '[[a]] (Set a)
 
 deriving instance Show (SetFn fn args res)
 deriving instance Eq (SetFn fn args res)
@@ -365,6 +369,7 @@ instance FunctionLike (SetFn fn) where
     Singleton -> Set.singleton
     Union -> (<>)
     Elem -> elem
+    FromList -> Set.fromList
 
 ------------------------------------------------------------------------
 -- Maps


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
