### PR TITLE
Fix RATIFY conformance

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,7 @@ repository cardano-haskell-packages
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-executable-spec.git
-  tag: 81b976c40c2726998a4828220231acf75b3a685e
-  --sha256: sha256-1CiTiLzROoHz8GxVPCouofUFzwzWUclQUq5AthtwPz4=
+  tag: d6effa703ed06ffc6239a963fdbccccd25dfa663
 
 index-state:
   -- Bump this if you need newer packages from Hackage

--- a/cabal.project
+++ b/cabal.project
@@ -10,10 +10,15 @@ repository cardano-haskell-packages
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
+-- While using SRPs one can obtain the `--sha256` value for a package
+-- by first setting it to some random value and letting the tooling
+-- tell you what it should be, for example, using `nix develop` will
+-- throw an error with the correct value to use
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-executable-spec.git
   tag: d6effa703ed06ffc6239a963fdbccccd25dfa663
+  --sha256: sha256-b+HRjMrriceFM/fUn9Qn+LJjMh3I3/F9PtYxrmGOiug=
 
 index-state:
   -- Bump this if you need newer packages from Hackage

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -6,7 +6,8 @@ module Test.Cardano.Ledger.Conformance.Orphans where
 
 import Data.Bifunctor (Bifunctor (..))
 import Data.Default.Class (Default)
-import Data.List (sort, sortOn)
+import Data.List (sortOn)
+import qualified Data.Set as Set
 import GHC.Generics (Generic)
 import Lib
 import Test.Cardano.Ledger.Common (NFData, ToExpr)
@@ -254,7 +255,7 @@ instance
   fixup (MkHSMap l) = MkHSMap . sortOn fst $ bimap fixup fixup <$> l
 
 instance (Ord a, FixupSpecRep a) => FixupSpecRep (HSSet a) where
-  fixup (MkHSSet l) = MkHSSet . sort $ fixup <$> l
+  fixup (MkHSSet l) = MkHSSet . Set.toList . Set.fromList $ fixup <$> l
 
 instance (FixupSpecRep a, FixupSpecRep b) => FixupSpecRep (a, b)
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
@@ -17,7 +17,7 @@ spec = describe "Conway conformance tests" $ do
   xprop "UTXO" $ conformsToImpl @"UTXO" @ConwayFn @Conway
   prop "GOV" $ conformsToImpl @"GOV" @ConwayFn @Conway
   prop "CERT" $ conformsToImpl @"CERT" @ConwayFn @Conway
-  xprop "RATIFY" $ conformsToImpl @"RATIFY" @ConwayFn @Conway
+  prop "RATIFY" $ conformsToImpl @"RATIFY" @ConwayFn @Conway
   describe "Generators" $ do
     let
       genEnv = do


### PR DESCRIPTION
# Description

This still requires the corresponding `HSSet` de-duplication to work.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
