### PR TITLE
Add conformance testing for `ENACT`

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.8.1.0
 
 * Add `AllegraEraScript` and `ShelleyEraScript` instances for `AlonzoEra`
+* Add `Inject` instance for `AlonzoTx`
 
 ## testlib
 

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.14.1.0
 
+* Add `NFData` instances for:
+  * `RatifySignal`
+  * `EnactSignal`
 * Add instances for `ConwayGovCertEnv`. #4348
   * `NFData`
   * `ToExpr`
@@ -10,7 +13,9 @@
 
 ### `testlib`
 
-* Add `ToExpr` instance for `RatifySignal`
+* Add `ToExpr` instances for:
+  * `RatifySignal`
+  * `EnactSignal`
 
 ## 1.14.0.0
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Internal.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Internal.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Enact.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Enact.hs
@@ -36,6 +36,7 @@ import Cardano.Ledger.Conway.Governance (
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Keys (KeyRole (..))
 import Cardano.Ledger.Val (Val (..))
+import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended (
   STS (..),
   TRC (..),
@@ -56,6 +57,8 @@ data EnactSignal era = EnactSignal
   , esGovAction :: !(GovAction era)
   }
   deriving (Eq, Show, Generic)
+
+instance EraPParams era => NFData (EnactSignal era)
 
 instance EraGov era => STS (ConwayENACT era) where
   type Environment (ConwayENACT era) = ()

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
@@ -257,3 +257,5 @@ instance ToExpr (PParams era) => ToExpr (CertEnv era)
 instance ToExpr (PParams era) => ToExpr (ConwayDelegEnv era)
 
 instance ToExpr (PParamsHKD StrictMaybe era) => ToExpr (RatifySignal era)
+
+instance ToExpr (PParamsHKD StrictMaybe era) => ToExpr (EnactSignal era)

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -12,6 +12,9 @@
 * Change signatures of `evalMultiSig` and `validateMultiSig`:
   * replace `Era` constraint with `ShelleyEraScript`
   * replace `MultiSig` with `NativeScript`
+* Add `Inject` instances for:
+  * `UTxOState`
+  * `UtxoEnv`
 
 ### testlib
 * Add `withCborRoundTripFailures`

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -48,6 +50,8 @@ deriving instance Generic RatifyEnv
 deriving instance Generic RatifyState
 
 deriving instance Generic StakeDistrs
+
+deriving instance Generic EnactEnv
 
 deriving instance Ord Tag
 
@@ -171,6 +175,8 @@ instance NFData RatifyEnv
 
 instance NFData RatifyState
 
+instance NFData EnactEnv
+
 instance ToExpr a => ToExpr (HSSet a)
 
 instance ToExpr Credential where
@@ -235,6 +241,8 @@ instance ToExpr StakeDistrs
 instance ToExpr RatifyEnv
 
 instance ToExpr RatifyState
+
+instance ToExpr EnactEnv
 
 instance Default (HSMap k v)
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
@@ -19,6 +19,7 @@ spec = describe "Conway conformance tests" $ do
   prop "CERT" $ conformsToImpl @"CERT" @ConwayFn @Conway
   xprop "RATIFY" $ conformsToImpl @"RATIFY" @ConwayFn @Conway
   prop "GOVCERT" $ conformsToImpl @"GOVCERT" @ConwayFn @Conway
+  xprop "ENACT" $ conformsToImpl @"ENACT" @ConwayFn @Conway
   describe "Generators" $ do
     let
       genEnv = do

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}


### PR DESCRIPTION
# Description

Adds conformance testing for the `ENACT` rule. Because the environment of `ENACT` is the unit type, I had to add associated types to `ExecSpecRule` that enable overwriting the types that the constrained generator generates as long as there's a way to inject that type into the environment/state/signal that we need in order to run the rule. With this change we should be able to get rid of `ExecContext` at some point when we get to refactoring the conformance tests.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
