### PR TITLE
`constrained-generators`: identify and fix an issue with big bodies to ifElse

### DIFF
--- a/libs/constrained-generators/src/Constrained.hs
+++ b/libs/constrained-generators/src/Constrained.hs
@@ -65,6 +65,7 @@ module Constrained (
   branchW,
   chooseSpec,
   ifElse,
+  whenTrue,
   onJust,
   isJust,
   reify,

--- a/libs/constrained-generators/src/Constrained/Examples/Basic.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Basic.hs
@@ -256,3 +256,14 @@ posNegDistr =
     [ monitor $ \eval -> QC.cover 60 (0 < eval x) "x positive"
     , x `satisfies` chooseSpec (1, constrained (<. 0)) (2, constrained (0 <.))
     ]
+
+ifElseMany :: Specification BaseFn (Bool, Int, Int)
+ifElseMany = constrained' $ \b x y ->
+  ifElse
+    b
+    [ x <. 0
+    , y <. 10
+    ]
+    [ 0 <. x
+    , 10 <. y
+    ]

--- a/libs/constrained-generators/src/Constrained/Graph.hs
+++ b/libs/constrained-generators/src/Constrained/Graph.hs
@@ -6,6 +6,7 @@
 module Constrained.Graph where
 
 import Control.Monad
+import Data.Foldable
 import Data.List (sortOn)
 import Data.Map (Map)
 import Data.Map qualified as Map
@@ -30,7 +31,11 @@ instance Ord node => Monoid (Graph node) where
   mempty = Graph mempty mempty
 
 instance Pretty n => Pretty (Graph n) where
-  pretty gr = vsep [nest 2 $ pretty n <> " <- " <> pretty (Set.toList ns) | (n, ns) <- Map.toList (edges gr)]
+  pretty gr =
+    fold $
+      punctuate
+        hardline
+        [nest 2 $ pretty n <> " <- " <> pretty (Set.toList ns) | (n, ns) <- Map.toList (edges gr)]
 
 nodes :: Graph node -> Set node
 nodes (Graph e _) = Map.keysSet e

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -127,6 +127,7 @@ tests nightly =
     testSpecNoShrink "threeSpecific" threeSpecific
     testSpecNoShrink "threeSpecific'" threeSpecific'
     testSpecNoShrink "trueSpecUniform" trueSpecUniform
+    testSpec "ifElseMany" ifElseMany
     numberyTests
     sizeTests
     numNumSpecTree


### PR DESCRIPTION
# Description

This was identified when trying to add `explain :: [String] -> Pred fn -> Pred fn` but that's a bit more complicated to deal with so we start here.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
