### PR TITLE
Add identity instance for `Inject`

### DIFF
--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -67,7 +67,7 @@ library
         bytestring,
         cardano-crypto-class,
         cardano-ledger-binary ^>=1.3,
-        cardano-ledger-core ^>=1.12,
+        cardano-ledger-core ^>=1.13,
         cardano-ledger-shelley ^>=1.12,
         cardano-strict-containers,
         cardano-slotting,

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -79,7 +79,7 @@ library
         cardano-ledger-allegra ^>=1.5,
         cardano-crypto-class,
         cardano-ledger-binary ^>=1.3,
-        cardano-ledger-core ^>=1.12,
+        cardano-ledger-core ^>=1.13,
         cardano-ledger-mary ^>=1.6.0,
         cardano-ledger-shelley ^>=1.12,
         cardano-slotting,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
@@ -139,8 +139,6 @@ data AlonzoContextError era
 
 instance NoThunks (AlonzoContextError era)
 
-instance Inject (AlonzoContextError era) (AlonzoContextError era)
-
 instance Era era => NFData (AlonzoContextError era)
 
 instance Era era => EncCBOR (AlonzoContextError era) where

--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -46,7 +46,7 @@ library
         bytestring,
         cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib} >=1.7,
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
-        cardano-ledger-core:{cardano-ledger-core, testlib} >=1.11 && <1.13,
+        cardano-ledger-core:{cardano-ledger-core, testlib} >=1.11 && <1.14,
         cardano-ledger-allegra >=1.2,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.6 && <1.13,
         cardano-ledger-shelley-test >=1.2,

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -75,7 +75,7 @@ library
         cardano-ledger-allegra ^>=1.5,
         cardano-ledger-alonzo ^>=1.8,
         cardano-ledger-binary ^>=1.3,
-        cardano-ledger-core ^>=1.12,
+        cardano-ledger-core ^>=1.13,
         cardano-ledger-mary ^>=1.6,
         cardano-ledger-shelley ^>=1.12,
         cardano-strict-containers,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
@@ -232,8 +232,6 @@ instance NoThunks (PlutusPurpose AsIx era) => NoThunks (BabbageContextError era)
 
 instance (Era era, NFData (PlutusPurpose AsIx era)) => NFData (BabbageContextError era)
 
-instance Inject (BabbageContextError era) (BabbageContextError era)
-
 instance Inject (AlonzoContextError era) (BabbageContextError era) where
   inject = AlonzoContextError
 

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -90,7 +90,7 @@ library
         cardano-ledger-allegra ^>=1.5,
         cardano-ledger-alonzo ^>=1.8,
         cardano-ledger-babbage ^>=1.8,
-        cardano-ledger-core ^>=1.12,
+        cardano-ledger-core ^>=1.13,
         cardano-ledger-mary ^>=1.6,
         cardano-ledger-shelley ^>=1.12,
         cardano-slotting,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
@@ -158,8 +158,6 @@ deriving instance
   ) =>
   Show (ConwayContextError era)
 
-instance Inject (ConwayContextError era) (ConwayContextError era)
-
 instance Inject (BabbageContextError era) (ConwayContextError era) where
   inject = BabbageContextError
 

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -76,7 +76,7 @@ library
         cardano-data ^>=1.2,
         cardano-ledger-allegra ^>=1.5,
         cardano-ledger-binary ^>=1.3,
-        cardano-ledger-core ^>=1.12,
+        cardano-ledger-core ^>=1.13,
         cardano-ledger-shelley ^>=1.12,
         containers,
         deepseq,

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -108,7 +108,7 @@ library
         cardano-data ^>=1.2.2,
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-byron,
-        cardano-ledger-core ^>=1.12,
+        cardano-ledger-core ^>=1.13,
         cardano-slotting,
         vector-map ^>=1.1,
         containers,

--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -78,7 +78,7 @@ library
         cardano-data >=1.2,
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.3,
         cardano-ledger-byron,
-        cardano-ledger-core:{cardano-ledger-core, testlib} >=1.11 && <1.13,
+        cardano-ledger-core:{cardano-ledger-core, testlib} >=1.11 && <1.14,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib} ^>=1.12,
         cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib} >=1.0.1,
         cardano-slotting:{cardano-slotting, testlib},

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -59,7 +59,7 @@ library
         cardano-ledger-babbage ^>=1.8,
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-conway >=1.13 && <1.15,
-        cardano-ledger-core ^>=1.12,
+        cardano-ledger-core ^>=1.13,
         cardano-ledger-mary >=1.5 && <1.7,
         cardano-ledger-shelley ^>=1.12,
         cardano-slotting,

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-core`
 
-## 1.12.0.1
+## 1.13.0.0
 
-*
+* Create a catch all `Inject a a` instance for the same type
 
 ## 1.12.0.0
 

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.13.0.0
 
 * Create a catch all `Inject a a` instance for the same type
+* Remove unnecessary instances: `Inject a ()` and `Inject Void a`
 
 ## 1.12.0.0
 

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-core
-version:            1.12.0.0
+version:            1.13.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -846,14 +846,15 @@ instance Default Network where
 
 class Inject t s where
   inject :: t -> s
-  default inject :: t ~ s => t -> s
-  inject = id
 
 instance Inject t () where
   inject = const ()
 
 instance Inject Void s where
   inject = absurd
+
+instance Inject a a where
+  inject = id
 
 -- | Helper function for a common pattern of creating objects
 kindObject :: Text -> [Pair] -> Value

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -170,7 +170,6 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Text.Encoding (encodeUtf8)
 import Data.Typeable (Typeable)
-import Data.Void (Void, absurd)
 import Data.Word (Word16, Word64, Word8)
 import GHC.Exception.Type (Exception)
 import GHC.Generics (Generic)
@@ -846,12 +845,6 @@ instance Default Network where
 
 class Inject t s where
   inject :: t -> s
-
-instance Inject t () where
-  inject = const ()
-
-instance Inject Void s where
-  inject = absurd
 
 instance Inject a a where
   inject = id

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -714,7 +714,7 @@ instance DecCBOR Network where
       Just n -> pure n
   {-# INLINE decCBOR #-}
 
--- | Blocks made
+-- | Number of blocks which have been created by stake pools in the current epoch.
 newtype BlocksMade c = BlocksMade
   { unBlocksMade :: Map (KeyHash 'StakePool c) Natural
   }

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
@@ -71,8 +71,6 @@ newtype Coin = Coin {unCoin :: Integer}
   deriving (Semigroup, Monoid, Group, Abelian) via Sum Integer
   deriving newtype (PartialOrd, ToCBOR, EncCBOR, HeapWords)
 
-instance Inject Coin Coin
-
 instance FromCBOR Coin where
   fromCBOR = Coin . toInteger <$> Plain.decodeWord64
 


### PR DESCRIPTION
# Description

The only correct way to inject a type into itself is with `id`, therefore we can safely add a catch all instance for `Inject a a`

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
