### PR TITLE
Enable retrying flaky tests in nightly CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -243,7 +243,12 @@ jobs:
     - name: Run tests
       run: |
         export CARDANO_MAINNET_MIRROR="$(pwd)/epochs"
-        cabal test ${{ matrix.package }}
+        if [ -z "$NIGHTLY" ]; then
+          cabal test "${{ matrix.package }}"
+        else
+          TRIES=3
+          scripts/cabal-test-with-retries.sh "${{ matrix.package }}" "$TRIES"
+        fi
 
   complete:
     name: Tests completed

--- a/scripts/cabal-test-with-retries.sh
+++ b/scripts/cabal-test-with-retries.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PACKAGE=$1
+TRIES=$2
+CONDITION=${3-'Gave up! Passed only [0-9]* tests; [0-9]* discarded tests'}
+
+for TRY in $(seq "$TRIES"); do
+  echo ">>>>> Testing $PACKAGE ... attempt $TRY of $TRIES <<<<<"
+  if cabal test "$PACKAGE"; then
+    exit 0
+  elif ! find dist-newstyle -path '*/t/*' -name "$PACKAGE*.log" | xargs grep -h "$CONDITION"; then
+    echo "The test failure isn't retryable - aborting"
+    exit 1
+  fi
+done
+
+echo "Tests failed $TRY times - aborting"
+exit 2


### PR DESCRIPTION
Nightly tests continue to fail randomly due to an excessive number of discards. Fixing the discards problem will be difficult, but we can work around it for now by retrying test suites that have failed for this specific reason. However, we do this only for nightly CI and not for other workflow runs.