### PR TITLE
Remove dependency on deprecated ansi-wl-print package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1714517469,
-        "narHash": "sha256-Mxf4EHvuT3OfTwNIU2wvL0QQu5s9JsJ/IQKmadFyPs8=",
+        "lastModified": 1716373120,
+        "narHash": "sha256-Yjss6ZO9UaQQQLWUlnaEg5VZYBa4z7pQuwALf8mvZpU=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "d42e1966e0d05b22c345fcaeb54ae5fc227665d4",
+        "rev": "5ea1c589969ab44a4dde64cf57023a65d461fd16",
         "type": "github"
       },
       "original": {
@@ -297,11 +297,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1712535859,
-        "narHash": "sha256-vlSP7kQMJE2w24qE/7uHY02ZW5JJ2gXQY12w7Xd1VEQ=",
+        "lastModified": 1716424417,
+        "narHash": "sha256-ua2dD0wqlquxWfx/288I2viXg7lFptTRwXTPvfxPfVY=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "bcd61e6c9a22fd661ce1e55e6b16a8b4dc8f4136",
+        "rev": "ede08f9fc0ab2acdef46b2095241a0ee3aaa1a3c",
         "type": "github"
       },
       "original": {

--- a/libs/set-algebra/set-algebra.cabal
+++ b/libs/set-algebra/set-algebra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               set-algebra
-version:            1.1.0.2
+version:            1.1.0.3
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -31,7 +31,7 @@ library
 
     build-depends:
         base >=4.14 && <5,
-        ansi-wl-pprint <1.0,
+        prettyprinter >=1.7,
         cardano-data >=1.1,
         containers
 

--- a/libs/set-algebra/src/Control/Iterate/Exp.hs
+++ b/libs/set-algebra/src/Control/Iterate/Exp.hs
@@ -28,7 +28,7 @@ import Data.List (sortBy)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-import Text.PrettyPrint.ANSI.Leijen (Doc, align, parens, text, vsep, (<+>))
+import Prettyprinter (Doc, align, parens, pretty, vsep, (<+>))
 import Prelude hiding (lookup)
 
 -- $Deep embedding
@@ -535,15 +535,15 @@ instance Ord k => HasQuery (Single k v) k v where
 -- =================================================
 -- Show Instance of Query
 
-ppQuery :: Query k v -> Doc
-ppQuery (BaseD rep _f) = parens $ text (show rep)
-ppQuery (ProjectD f p) = parens $ text "Proj" <+> align (vsep [ppQuery f, text (show p)])
-ppQuery (AndD f g) = parens $ text "And" <+> align (vsep [ppQuery f, ppQuery g])
-ppQuery (ChainD f g p) = parens $ text "Chain" <+> align (vsep [ppQuery f, ppQuery g, text (show p)])
-ppQuery (OrD f g p) = parens $ text "Or" <+> align (vsep [ppQuery f, ppQuery g, text (show p)])
-ppQuery (GuardD f p) = parens $ text "Guard" <+> align (vsep [ppQuery f, text (show p)])
-ppQuery (DiffD f g) = parens $ text "Diff" <+> align (vsep [ppQuery f, ppQuery g])
-ppQuery (AndPD f g p) = parens $ text "AndP" <+> align (vsep [ppQuery f, ppQuery g, text (show p)])
+ppQuery :: Query k v -> Doc a
+ppQuery (BaseD rep _f) = parens $ pretty (show rep)
+ppQuery (ProjectD f p) = parens $ pretty "Proj" <+> align (vsep [ppQuery f, pretty (show p)])
+ppQuery (AndD f g) = parens $ pretty "And" <+> align (vsep [ppQuery f, ppQuery g])
+ppQuery (ChainD f g p) = parens $ pretty "Chain" <+> align (vsep [ppQuery f, ppQuery g, pretty (show p)])
+ppQuery (OrD f g p) = parens $ pretty "Or" <+> align (vsep [ppQuery f, ppQuery g, pretty (show p)])
+ppQuery (GuardD f p) = parens $ pretty "Guard" <+> align (vsep [ppQuery f, pretty (show p)])
+ppQuery (DiffD f g) = parens $ pretty "Diff" <+> align (vsep [ppQuery f, ppQuery g])
+ppQuery (AndPD f g p) = parens $ pretty "AndP" <+> align (vsep [ppQuery f, ppQuery g, pretty (show p)])
 
 instance Show (Query k v) where
   show x = show (ppQuery x)


### PR DESCRIPTION
# Description
Replaced with Prettyprinter package.

https://hackage.haskell.org/package/ansi-wl-pprint (Depracated)
https://hackage.haskell.org/package/prettyprinter (Replacement)

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
