### PR TITLE
Fix order of arguments to verifyVrf

### DIFF
--- a/eras/babbage/formal-spec/remove-overlay.tex
+++ b/eras/babbage/formal-spec/remove-overlay.tex
@@ -123,7 +123,7 @@ to re-use the single VRF value.
       \\
       & \fun{vrfChecks} \in \Seed \to \BHBody \to \Bool \\
       & \fun{vrfChecks}~\eta_0~\var{bhb} =
-          \verifyVrf{\Seed}{\var{vrfK}}{(\slotToSeed{slot}~\XOR~\eta_0)}{(\var{value},~\var{proof}}) \\
+          \verifyVrf{\Seed}{\var{vrfK}}{(\slotToSeed{slot}~\XOR~\eta_0)}{(\var{proof},~\var{value}}) \\
       & ~~~~\where \\
       & ~~~~~~~~~~\var{slot} \leteq \bslot{bhb} \\
       & ~~~~~~~~~~\var{vrfK} \leteq \fun{bvkvrf}~\var{bhb} \\


### PR DESCRIPTION
# Description

This was the final thing pointed out at https://github.com/IntersectMBO/cardano-ledger/pull/4287#issuecomment-2098975761.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
