### PR TITLE
Specify numeric ranges explicitly in conway cddl files

### DIFF
--- a/eras/conway/impl/cddl-files/conway.cddl
+++ b/eras/conway/impl/cddl-files/conway.cddl
@@ -153,7 +153,7 @@ gov_action_id =
 required_signers = nonempty_set<addr_keyhash>
 
 transaction_input = [ transaction_id : $hash32
-                    , index : uint .size 8
+                    , index : uint .size 2
                     ]
 
 ; Both of the Alonzo and Babbage style TxOut formats are equally valid

--- a/eras/conway/impl/cddl-files/conway.cddl
+++ b/eras/conway/impl/cddl-files/conway.cddl
@@ -25,13 +25,13 @@ header =
   ]
 
 header_body =
-  [ block_number     : uint
-  , slot             : uint
+  [ block_number     : block_no
+  , slot             : slot_no
   , prev_hash        : $hash32 / null
   , issuer_vkey      : $vkey
   , vrf_vkey         : $vrf_vkey
   , vrf_result       : $vrf_cert ; replaces nonce_vrf and leader_vrf
-  , block_body_size  : uint
+  , block_body_size  : uint .size 4
   , block_body_hash  : $hash32 ; merkle triple root
   , operational_cert
   , protocol_version
@@ -39,7 +39,7 @@ header_body =
 
 operational_cert =
   [ hot_vkey        : $kes_vkey
-  , sequence_number : uint
+  , sequence_number : uint .size 8
   , kes_period      : uint
   , sigma           : $signature
   ]
@@ -54,11 +54,11 @@ transaction_body =
   { 0 : set<transaction_input>             ; inputs
   , 1 : [* transaction_output]
   , 2 : coin                               ; fee
-  , ? 3 : uint                             ; time to live
+  , ? 3 : slot_no                          ; time to live
   , ? 4 : certificates
   , ? 5 : withdrawals
   , ? 7 : auxiliary_data_hash
-  , ? 8 : uint                             ; validity interval start
+  , ? 8 : slot_no                          ; validity interval start
   , ? 9 : mint
   , ? 11 : script_data_hash
   , ? 13 : nonempty_set<transaction_input> ; collateral inputs
@@ -111,7 +111,7 @@ treasury_withdrawals_action = (2, { reward_account => coin }, policy_hash / null
 
 no_confidence = (3, gov_action_id / null)
 
-update_committee = (4, gov_action_id / null, set<committee_cold_credential>, { committee_cold_credential => epoch }, unit_interval)
+update_committee = (4, gov_action_id / null, set<committee_cold_credential>, { committee_cold_credential => epoch_no }, unit_interval)
 
 new_constitution = (5, gov_action_id / null, constitution)
 
@@ -147,13 +147,13 @@ vote = 0 .. 2
 
 gov_action_id =
   [ transaction_id   : $hash32
-  , gov_action_index : uint
+  , gov_action_index : uint .size 4
   ]
 
 required_signers = nonempty_set<addr_keyhash>
 
 transaction_input = [ transaction_id : $hash32
-                    , index : uint
+                    , index : uint .size 8
                     ]
 
 ; Both of the Alonzo and Babbage style TxOut formats are equally valid
@@ -298,7 +298,7 @@ stake_delegation = (2, stake_credential, pool_keyhash)
 
 ; POOL
 pool_registration = (3, pool_params)
-pool_retirement = (4, pool_keyhash, epoch)
+pool_retirement = (4, pool_keyhash, epoch_no)
 
 ; numbers 5 and 6 used to be the Genesis and MIR certificates respectively,
 ; which were deprecated in Conway
@@ -381,12 +381,12 @@ withdrawals = { + reward_account => coin }
 protocol_param_update =
   { ? 0:  coin                   ; minfee A
   , ? 1:  coin                   ; minfee B
-  , ? 2:  uint                   ; max block body size
-  , ? 3:  uint                   ; max transaction size
-  , ? 4:  uint                   ; max block header size
+  , ? 2:  uint .size 4           ; max block body size
+  , ? 3:  uint .size 4           ; max transaction size
+  , ? 4:  uint .size 2           ; max block header size
   , ? 5:  coin                   ; key deposit
   , ? 6:  coin                   ; pool deposit
-  , ? 7:  epoch                  ; maximum epoch
+  , ? 7:  epoch_interval         ; maximum epoch
   , ? 8:  uint                   ; n_opt: desired number of stake pools
   , ? 9:  nonnegative_interval   ; pool pledge influence
   , ? 10: unit_interval          ; expansion rate
@@ -403,11 +403,11 @@ protocol_param_update =
   , ? 25: pool_voting_thresholds ; pool voting thresholds
   , ? 26: drep_voting_thresholds ; DRep voting thresholds
   , ? 27: uint                   ; min committee size
-  , ? 28: epoch                  ; committee term limit
-  , ? 29: epoch                  ; governance action validity period
+  , ? 28: epoch_interval         ; committee term limit
+  , ? 29: epoch_interval         ; governance action validity period
   , ? 30: coin                   ; governance action deposit
   , ? 31: coin                   ; DRep deposit
-  , ? 32: epoch                  ; DRep inactivity period
+  , ? 32: epoch_interval         ; DRep inactivity period
   , ? 33: nonnegative_interval   ; MinFee RefScriptCostPerByte
   }
 
@@ -476,8 +476,8 @@ constr<a> =
 ; Flat Array support is included for backwards compatibility and will be removed in the next era.
 ; It is recommended for tools to adopt using a Map instead of Array going forward.
 redeemers =
-  [ + [ tag: redeemer_tag, index: uint, data: plutus_data, ex_units: ex_units ] ]
-  / { + [ tag: redeemer_tag, index: uint ] => [ data: plutus_data, ex_units: ex_units ] }
+  [ + [ tag: redeemer_tag, index: uint .size 4, data: plutus_data, ex_units: ex_units ] ]
+  / { + [ tag: redeemer_tag, index: uint .size 4 ] => [ data: plutus_data, ex_units: ex_units ] }
 
 redeemer_tag =
     0 ; Spending
@@ -515,7 +515,7 @@ transaction_metadatum =
   / bytes .size (0..64)
   / text .size (0..64)
 
-transaction_metadatum_label = uint
+transaction_metadatum_label = uint .size 8
 metadata = { * transaction_metadatum_label => transaction_metadatum }
 
 auxiliary_data =
@@ -556,8 +556,8 @@ script_pubkey = (0, addr_keyhash)
 script_all = (1, [ * native_script ])
 script_any = (2, [ * native_script ])
 script_n_of_k = (3, n: uint, [ * native_script ])
-invalid_before = (4, uint)
-invalid_hereafter = (5, uint)
+invalid_before = (4, slot_no)
+invalid_hereafter = (5, slot_no)
 
 coin = uint
 
@@ -565,21 +565,28 @@ multiasset<a> = { + policy_id => { + asset_name => a } }
 policy_id = scripthash
 asset_name = bytes .size (0..32)
 
-negInt64 = -9223372036854775808 .. -1
-posInt64 = 1 .. 9223372036854775807
+minInt64 = -9223372036854775808
+maxInt64 = 9223372036854775807
+maxWord64 = 18446744073709551615
+
+negInt64 = minInt64 .. -1
+posInt64 = 1 .. maxInt64
 nonZeroInt64 = negInt64 / posInt64 ; this is the same as the current int64 definition but without zero
 
-positive_coin = 1 .. 18446744073709551615
+positive_coin = 1 .. maxWord64
 
 value = coin / [coin, multiasset<positive_coin>]
 
 mint = multiasset<nonZeroInt64>
 
-int64 = -9223372036854775808 .. 9223372036854775807
+int64 = minInt64 .. maxInt64
 
 network_id = 0 / 1
 
-epoch = uint
+epoch_no = uint .size 8
+epoch_interval = uint .size 4
+slot_no = uint .size 8
+block_no = uint .size 8
 
 addr_keyhash           = $hash28
 pool_keyhash           = $hash28

--- a/eras/conway/impl/cddl-files/conway.cddl
+++ b/eras/conway/impl/cddl-files/conway.cddl
@@ -387,7 +387,7 @@ protocol_param_update =
   , ? 5:  coin                   ; key deposit
   , ? 6:  coin                   ; pool deposit
   , ? 7:  epoch_interval         ; maximum epoch
-  , ? 8:  uint                   ; n_opt: desired number of stake pools
+  , ? 8:  uint .size 2           ; n_opt: desired number of stake pools
   , ? 9:  nonnegative_interval   ; pool pledge influence
   , ? 10: unit_interval          ; expansion rate
   , ? 11: unit_interval          ; treasury growth rate
@@ -397,12 +397,12 @@ protocol_param_update =
   , ? 19: ex_unit_prices         ; execution costs
   , ? 20: ex_units               ; max tx ex units
   , ? 21: ex_units               ; max block ex units
-  , ? 22: uint                   ; max value size
-  , ? 23: uint                   ; collateral percentage
-  , ? 24: uint                   ; max collateral inputs
+  , ? 22: uint .size 4           ; max value size
+  , ? 23: uint .size 2           ; collateral percentage
+  , ? 24: uint .size 2           ; max collateral inputs
   , ? 25: pool_voting_thresholds ; pool voting thresholds
   , ? 26: drep_voting_thresholds ; DRep voting thresholds
-  , ? 27: uint                   ; min committee size
+  , ? 27: uint .size 2           ; min committee size
   , ? 28: epoch_interval         ; committee term limit
   , ? 29: epoch_interval         ; governance action validity period
   , ? 30: coin                   ; governance action deposit

--- a/eras/conway/impl/cddl-files/conway.cddl
+++ b/eras/conway/impl/cddl-files/conway.cddl
@@ -147,7 +147,7 @@ vote = 0 .. 2
 
 gov_action_id =
   [ transaction_id   : $hash32
-  , gov_action_index : uint .size 4
+  , gov_action_index : uint .size 2
   ]
 
 required_signers = nonempty_set<addr_keyhash>

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
@@ -145,12 +145,12 @@ import qualified Data.Sequence as Seq
 import Data.Set (Set)
 import qualified Data.Text as Text
 import Data.Unit.Strict (forceElemsToWHNF)
-import Data.Word (Word32)
+import Data.Word (Word16)
 import GHC.Generics (Generic)
 import Lens.Micro (Lens', lens, (^.))
 import NoThunks.Class (NoThunks)
 
-newtype GovActionIx = GovActionIx {unGovActionIx :: Word32}
+newtype GovActionIx = GovActionIx {unGovActionIx :: Word16}
   deriving
     ( Generic
     , Eq

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/GenesisSpec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/GenesisSpec.hs
@@ -45,7 +45,7 @@ propConwayPParamsUpgrade ppu pp = property $ do
   let pp' = upgradePParams ppu pp :: PParams Conway
   pp' ^. ppPoolVotingThresholdsL `shouldBe` ucppPoolVotingThresholds ppu
   pp' ^. ppDRepVotingThresholdsL `shouldBe` ucppDRepVotingThresholds ppu
-  pp' ^. ppCommitteeMinSizeL `shouldBe` ucppCommitteeMinSize ppu
+  fromIntegral (pp' ^. ppCommitteeMinSizeL) `shouldBe` ucppCommitteeMinSize ppu
   pp' ^. ppCommitteeMaxTermLengthL `shouldBe` ucppCommitteeMaxTermLength ppu
   pp' ^. ppGovActionLifetimeL `shouldBe` ucppGovActionLifetime ppu
   pp' ^. ppGovActionDepositL `shouldBe` ucppGovActionDeposit ppu

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -599,7 +599,7 @@ maxMultiSigDepth :: Int
 maxMultiSigDepth = 3
 
 maxMultiSigListLens :: Int
-maxMultiSigListLens = 5
+maxMultiSigListLens = 4
 
 sizedMultiSig :: ShelleyEraScript era => Int -> Gen (NativeScript era)
 sizedMultiSig 0 = RequireSignature <$> arbitrary

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Create a catch all `Inject a a` instance for the same type
 * Remove unnecessary instances: `Inject a ()` and `Inject Void a`
+* Add `integralToBounded` to `BaseTypes`
 
 ## 1.12.0.0
 

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -284,7 +284,8 @@ instance GenValid NonNegativeInterval where
   shrinkValid _ = []
 
 instance Arbitrary TxIx where
-  arbitrary = TxIx <$> arbitrary
+  -- starting with Conway, we only deserialize TxIx within Word16 range
+  arbitrary = TxIx . fromIntegral <$> arbitrary @Word16
 
 instance Arbitrary CertIx where
   arbitrary = CertIx <$> arbitrary

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -288,7 +288,8 @@ instance Arbitrary TxIx where
   arbitrary = TxIx . fromIntegral <$> arbitrary @Word16
 
 instance Arbitrary CertIx where
-  arbitrary = CertIx <$> arbitrary
+  -- starting with Conway, we only deserialize CertIx within Word16 range
+  arbitrary = CertIx . fromIntegral <$> arbitrary @Word16
 
 instance Arbitrary ProtVer where
   arbitrary = ProtVer <$> arbitrary <*> arbitrary

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
@@ -220,7 +220,7 @@ import Test.Cardano.Ledger.Generic.PrettyCore (
   ppString,
   ppVKey,
   ppValidityInterval,
-  ppWord32,
+  ppWord16,
   trim,
  )
 import Test.Cardano.Ledger.Generic.Proof
@@ -678,7 +678,7 @@ synopsis (PoolMetadataR _) x = show x
 synopsis DRepStateR x = show (pcDRepState x)
 synopsis DStateR x = show (pcDState x)
 synopsis GovActionIdR x = show (pcGovActionId x)
-synopsis GovActionIxR (GovActionIx a) = show (ppWord32 a)
+synopsis GovActionIxR (GovActionIx a) = show (ppWord16 a)
 synopsis GovActionStateR x = show (pcGovActionState x)
 synopsis (ProposalsR _p) x = show (pcProposals x)
 synopsis UnitIntervalR x = show x

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -2895,7 +2895,7 @@ instance Reflect era => PrettyA (EnactState era) where
   prettyA = pcEnactState reify
 
 pcGovActionId :: GovActionId c -> PDoc
-pcGovActionId (GovActionId txid (GovActionIx a)) = ppSexp "GovActId" [pcTxId txid, ppWord32 a]
+pcGovActionId (GovActionId txid (GovActionIx a)) = ppSexp "GovActId" [pcTxId txid, ppWord16 a]
 
 instance PrettyA (GovActionId c) where
   prettyA = pcGovActionId


### PR DESCRIPTION
and name some common types.

* Word16 -> uint .size 2
* Word32 -> uint .size 4
* Word64 -> uint .size 8

Define: epoch_interval, slot_no, block_no

Resolves https://github.com/IntersectMBO/cardano-ledger/issues/4296 https://github.com/IntersectMBO/cardano-ledger/issues/4360

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
