### PR TITLE
Fixed a bug in RATIFY

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Internal.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Internal.hs
@@ -376,6 +376,7 @@ votingStakePoolThresholdInternal pp isElectedCommittee action =
         , pvtCommitteeNormal
         , pvtHardForkInitiation
         , pvtPPSecurityGroup
+        , pvtMotionNoConfidence
         } = pp ^. ppPoolVotingThresholdsL
       isSecurityRelevant (PPGroups _ s) =
         case s of
@@ -386,7 +387,7 @@ votingStakePoolThresholdInternal pp isElectedCommittee action =
             VotingThreshold pvtPPSecurityGroup
         | otherwise = NoVotingAllowed
    in case action of
-        NoConfidence {} -> VotingThreshold pvtCommitteeNoConfidence
+        NoConfidence {} -> VotingThreshold pvtMotionNoConfidence
         UpdateCommittee {} ->
           VotingThreshold $
             if isElectedCommittee

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
@@ -17,7 +17,7 @@ spec = describe "Conway conformance tests" $ do
   xprop "UTXO" $ conformsToImpl @"UTXO" @ConwayFn @Conway
   prop "GOV" $ conformsToImpl @"GOV" @ConwayFn @Conway
   prop "CERT" $ conformsToImpl @"CERT" @ConwayFn @Conway
-  xprop "RATIFY" $ conformsToImpl @"RATIFY" @ConwayFn @Conway
+  prop "RATIFY" $ conformsToImpl @"RATIFY" @ConwayFn @Conway
   prop "GOVCERT" $ conformsToImpl @"GOVCERT" @ConwayFn @Conway
   xprop "ENACT" $ conformsToImpl @"ENACT" @ConwayFn @Conway
   prop "DELEG" $ conformsToImpl @"DELEG" @ConwayFn @Conway


### PR DESCRIPTION
# Description

This PR fixes a bug that was found by conformance testing. The implementation was using the wrong threshold for `NoConfidence` proposals.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
