### PR TITLE
Threshold translation in conformance testing

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -17,8 +17,8 @@ repository cardano-haskell-packages
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-executable-spec.git
-  tag: c8651e5332b2d99e1f0ae0e1287c10bc187e91a8
-  --sha256: sha256-AOmMVq7GWixd9KnIRgo9p6oaSalSVHoITHRtlJUTJgg=
+  tag: 75f5354ec2781673cc15f34f4909aff41f9d0cf1
+  --sha256: sha256-JjCMQZblcuh6kxYTonW3BKy7fhnfHTkBrWsZ09O9r2s=
 
 index-state:
   -- Bump this if you need newer packages from Hackage

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Version history for `cardano-ledger-binary`
 
-## 1.3.2.1
+## 1.3.3.0
 
-*
+* Re-export:
+  * `Pretty`
+  * `ansiWlPretty`
+  * `ppEditExpr`
+  * `ediff`
 
 ## 1.3.2.0
 

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-binary
-version:       1.3.2.0
+version:       1.3.3.0
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/TreeDiff.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/TreeDiff.hs
@@ -19,6 +19,10 @@ module Test.Cardano.Ledger.Binary.TreeDiff (
   Expr (App, Rec, Lst),
   defaultExprViaShow,
   trimExprViaShow,
+  Pretty (..),
+  ansiWlPretty,
+  ppEditExpr,
+  ediff,
 )
 where
 

--- a/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
+++ b/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
@@ -62,9 +62,7 @@ library
         deepseq,
         small-steps >=1.1,
         text,
-        unliftio,
-        prettyprinter,
-        prettyprinter-ansi-terminal
+        unliftio
 
     if !impl(ghc >=9.2)
         ghc-options: -Wno-incomplete-patterns

--- a/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
+++ b/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
@@ -47,7 +47,7 @@ library
         data-default-class,
         microlens,
         mtl,
-        cardano-ledger-binary,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
         cardano-ledger-core,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
         cardano-ledger-alonzo,
@@ -62,7 +62,9 @@ library
         deepseq,
         small-steps >=1.1,
         text,
-        unliftio
+        unliftio,
+        prettyprinter,
+        prettyprinter-ansi-terminal
 
     if !impl(ghc >=9.2)
         ghc-options: -Wno-incomplete-patterns

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway.hs
@@ -25,9 +25,9 @@ import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway (Conway)
 import Cardano.Ledger.Conway.Core (Era (..), EraPParams (..), PParamsUpdate)
 import Cardano.Ledger.Conway.Governance (
-  GovAction,
   Committee (..),
   EnactState (..),
+  GovAction,
   GovActionState (..),
   GovProcedures (..),
   ProposalProcedure,

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
@@ -34,8 +34,6 @@ import Data.Typeable (Proxy (..), Typeable, typeRep)
 import GHC.Base (Constraint, NonEmpty, Symbol, Type)
 import GHC.TypeLits (KnownSymbol)
 import qualified Lib as Agda
-import qualified Prettyprinter as Doc
-import Prettyprinter.Render.Terminal
 import Test.Cardano.Ledger.Binary.TreeDiff (Pretty (..), ansiWlPretty, ediff, ppEditExpr)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Core (
   FixupSpecRep (..),
@@ -210,19 +208,17 @@ checkConformance implResTest agdaResTest = do
     conformancePretty =
       ansiWlPretty
         { ppDel = \d ->
-            Doc.annotate (color Red) $
-              mconcat
-                [ Doc.text "(Impl: "
-                , d
-                , Doc.text ")"
-                ]
+            mconcat
+              [ Doc.text "\ESC[91m(Impl: "
+              , d
+              , Doc.text ")\ESC[39m"
+              ]
         , ppIns = \d ->
-            Doc.annotate (color Green) $
-              mconcat
-                [ Doc.text "(Agda: "
-                , d
-                , Doc.text ")"
-                ]
+            mconcat
+              [ Doc.text "\ESC[92m(Agda: "
+              , d
+              , Doc.text ")\ESC[39m"
+              ]
         }
     failMsg =
       unlines
@@ -339,7 +335,7 @@ conformsToImpl =
               let stSpec = simplifySpec $ stateSpec @fn @rule @era ctx env
                in forAllShrinkShow (CV2.genFromSpec stSpec) (shrinkWithSpec stSpec) showExpr $ \st ->
                     let sigSpec = simplifySpec $ signalSpec @fn @rule @era ctx env st
-                     in forAllShrinkShow (CV2.genFromSpec sigSpec) (shrinkWithSpec sigSpec) showExpr $ \sig -> do
+                     in forAllShrinkShow (CV2.genFromSpec sigSpec) (shrinkWithSpec sigSpec) showExpr $ \sig ->
                           counterexample (extraInfo @fn @rule @era ctx (inject env) (inject st) (inject sig)) $ do
                             _ <- impAnn @_ @era "Deep evaluating env" $ evaluateDeep env
                             _ <- impAnn "Deep evaluating st" $ evaluateDeep st

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -55,6 +55,10 @@ deriving instance Generic EnactEnv
 
 deriving instance Generic DelegEnv
 
+deriving instance Generic PoolThresholds
+
+deriving instance Generic DrepThresholds
+
 deriving instance Ord Tag
 
 deriving instance Ord Credential
@@ -80,6 +84,10 @@ deriving instance Eq Tag
 deriving instance Eq TxWitnesses
 
 deriving instance Eq Tx
+
+deriving instance Eq PoolThresholds
+
+deriving instance Eq DrepThresholds
 
 deriving instance Eq PParams
 
@@ -140,6 +148,10 @@ instance NFData GovVote
 instance NFData GovProposal
 
 instance NFData GovSignal
+
+instance NFData DrepThresholds
+
+instance NFData PoolThresholds
 
 instance NFData PParams
 
@@ -205,6 +217,10 @@ instance ToExpr GovProposal
 instance ToExpr GovVote
 
 instance ToExpr GovSignal
+
+instance ToExpr PoolThresholds
+
+instance ToExpr DrepThresholds
 
 instance ToExpr PParams
 
@@ -311,6 +327,10 @@ instance FixupSpecRep GovActionState
 instance FixupSpecRep AgdaEmpty
 
 instance FixupSpecRep StakeDistrs
+
+instance FixupSpecRep PoolThresholds
+
+instance FixupSpecRep DrepThresholds
 
 instance FixupSpecRep PParams
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
@@ -17,7 +17,7 @@ spec = describe "Conway conformance tests" $ do
   xprop "UTXO" $ conformsToImpl @"UTXO" @ConwayFn @Conway
   prop "GOV" $ conformsToImpl @"GOV" @ConwayFn @Conway
   prop "CERT" $ conformsToImpl @"CERT" @ConwayFn @Conway
-  prop "RATIFY" $ conformsToImpl @"RATIFY" @ConwayFn @Conway
+  xprop "RATIFY" $ conformsToImpl @"RATIFY" @ConwayFn @Conway
   prop "GOVCERT" $ conformsToImpl @"GOVCERT" @ConwayFn @Conway
   xprop "ENACT" $ conformsToImpl @"ENACT" @ConwayFn @Conway
   prop "DELEG" $ conformsToImpl @"DELEG" @ConwayFn @Conway

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway.hs
@@ -284,16 +284,6 @@ instance SpecTranslate ctx ProtVer where
 
   toSpecRep (ProtVer ver minor) = pure (getVersion ver, toInteger minor)
 
-data VotingThresholds
-  = VotingThresholds
-      DRepVotingThresholds
-      PoolVotingThresholds
-
-instance SpecTranslate ctx VotingThresholds where
-  type SpecRep VotingThresholds = ()
-
-  toSpecRep _ = pure ()
-
 instance SpecTranslate ctx CostModels where
   type SpecRep CostModels = ()
 
@@ -321,6 +311,33 @@ instance
 
   toSpecRep = toSpecRep . unTHKD
 
+instance SpecTranslate ctx DRepVotingThresholds where
+  type SpecRep DRepVotingThresholds = Agda.DrepThresholds
+
+  toSpecRep DRepVotingThresholds {..} =
+    Agda.MkDrepThresholds
+      <$> toSpecRep dvtMotionNoConfidence
+      <*> toSpecRep dvtCommitteeNormal
+      <*> toSpecRep dvtCommitteeNoConfidence
+      <*> toSpecRep dvtUpdateToConstitution
+      <*> toSpecRep dvtHardForkInitiation
+      <*> toSpecRep dvtPPNetworkGroup
+      <*> toSpecRep dvtPPEconomicGroup
+      <*> toSpecRep dvtPPTechnicalGroup
+      <*> toSpecRep dvtPPGovGroup
+      <*> toSpecRep dvtTreasuryWithdrawal
+
+instance SpecTranslate ctx PoolVotingThresholds where
+  type SpecRep PoolVotingThresholds = Agda.PoolThresholds
+
+  toSpecRep PoolVotingThresholds {..} =
+    Agda.MkPoolThresholds
+      <$> toSpecRep pvtMotionNoConfidence
+      <*> toSpecRep pvtCommitteeNormal
+      <*> toSpecRep pvtCommitteeNoConfidence
+      <*> toSpecRep pvtHardForkInitiation
+      <*> toSpecRep pvtPPSecurityGroup
+
 instance SpecTranslate ctx (ConwayPParams Identity era) where
   type SpecRep (ConwayPParams Identity era) = Agda.PParams
 
@@ -338,11 +355,8 @@ instance SpecTranslate ctx (ConwayPParams Identity era) where
       <*> toSpecRep (cppEMax x)
       <*> toSpecRep (toInteger . unTHKD $ cppNOpt x)
       <*> toSpecRep (cppProtocolVersion x)
-      <*> toSpecRep
-        ( VotingThresholds
-            (unTHKD $ cppDRepVotingThresholds x)
-            (unTHKD $ cppPoolVotingThresholds x)
-        )
+      <*> toSpecRep (cppPoolVotingThresholds x)
+      <*> toSpecRep (cppDRepVotingThresholds x)
       <*> toSpecRep (cppGovActionLifetime x)
       <*> toSpecRep (cppGovActionDeposit x)
       <*> toSpecRep (cppDRepDeposit x)


### PR DESCRIPTION
# Description

This PR adds translations for `DRepVotingThresholds` and `PoolVotingThresholds`.

I also modified the pretty printer that's used for printing out diffs in conformance testing to make it easier to distinguish where the difference is.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
