### PR TITLE
`constrained-generators`: Fix various information propagation issues

### DIFF
--- a/libs/constrained-generators/src/Constrained/Examples/Basic.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Basic.hs
@@ -267,3 +267,10 @@ ifElseMany = constrained' $ \b x y ->
     [ 0 <. x
     , 10 <. y
     ]
+
+propBack :: Specification BaseFn (Int, Int)
+propBack = constrained' $ \x y ->
+  [ x ==. y + 10
+  , x <. 20
+  , 8 <. y
+  ]

--- a/libs/constrained-generators/src/Constrained/Examples/Map.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Map.hs
@@ -55,3 +55,14 @@ fixedRange = constrained $ \m ->
 rangeHint :: Specification BaseFn (Map Int Int)
 rangeHint = constrained $ \m ->
   genHint 10 (rng_ m)
+
+rangeSumSize :: Specification BaseFn (Map Int Int)
+rangeSumSize = constrained $ \m ->
+  [ assert $ sizeOf_ m <=. 0
+  , assert $ sum_ (rng_ m) <=. 0
+  , assert $ (-1) <=. sum_ (rng_ m)
+  , forAll' m $ \k v ->
+      [ k ==. (-1)
+      , v ==. 1
+      ]
+  ]

--- a/libs/constrained-generators/src/Constrained/Examples/Set.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Set.hs
@@ -162,3 +162,14 @@ foldSingleCase = constrained $ \x ->
       match p $ \_ p1 -> forAll p1 $ \p2 ->
         assert (0 <=. snd_ p2)
   ]
+
+complexUnion :: Specification BaseFn (Set Int, Set Int)
+complexUnion = constrained' $ \ys zs ->
+  [ sizeOf_ ys <=. 10
+  , 0 <. sizeOf_ (ys <> zs)
+  ]
+
+unionBounded :: Specification BaseFn (Set Int)
+unionBounded = constrained $ \xs ->
+  [ sizeOf_ (xs <> lit (Set.fromList [1, 2, 3])) <=. 3
+  ]

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -128,6 +128,9 @@ tests nightly =
     testSpecNoShrink "threeSpecific'" threeSpecific'
     testSpecNoShrink "trueSpecUniform" trueSpecUniform
     testSpec "ifElseMany" ifElseMany
+    testSpecNoShrink "propBack" propBack
+    testSpec "complexUnion" complexUnion
+    testSpec "unionBounded" unionBounded
     numberyTests
     sizeTests
     numNumSpecTree


### PR DESCRIPTION
# Description

This makes sure an example I wanted for the tutorial works as intended.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
