### PR TITLE
Fixed `8.10` not building

### DIFF
--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
@@ -171,9 +171,6 @@ class
     , SpecTranslate (ExecContext fn rule era) (ExecState fn rule era)
     , FixupSpecRep (SpecRep (PredicateFailure (EraRule rule era)))
     , FixupSpecRep (SpecRep (ExecState fn rule era))
-    , Inject (SpecRep (ExecEnvironment fn rule era)) (SpecRep (ExecEnvironment fn rule era))
-    , Inject (SpecRep (ExecState fn rule era)) (SpecRep (ExecState fn rule era))
-    , Inject (SpecRep (ExecSignal fn rule era)) (SpecRep (ExecSignal fn rule era))
     ) =>
     ExecContext fn rule era ->
     ExecEnvironment fn rule era ->
@@ -246,9 +243,6 @@ defaultTestConformance ::
   , SpecTranslate (ExecContext fn rule era) (ExecState fn rule era)
   , FixupSpecRep (SpecRep (PredicateFailure (EraRule rule era)))
   , FixupSpecRep (SpecRep (ExecState fn rule era))
-  , Inject (SpecRep (ExecEnvironment fn rule era)) (SpecRep (ExecEnvironment fn rule era))
-  , Inject (SpecRep (ExecState fn rule era)) (SpecRep (ExecState fn rule era))
-  , Inject (SpecRep (ExecSignal fn rule era)) (SpecRep (ExecSignal fn rule era))
   ) =>
   ExecContext fn rule era ->
   ExecEnvironment fn rule era ->
@@ -269,9 +263,6 @@ runConformance ::
   , FixupSpecRep (SpecRep (ExecState fn rule era))
   , Inject (State (EraRule rule era)) (ExecState fn rule era)
   , SpecTranslate (ExecContext fn rule era) (ExecState fn rule era)
-  , Inject (SpecRep (ExecEnvironment fn rule era)) (SpecRep (ExecEnvironment fn rule era))
-  , Inject (SpecRep (ExecState fn rule era)) (SpecRep (ExecState fn rule era))
-  , Inject (SpecRep (ExecSignal fn rule era)) (SpecRep (ExecSignal fn rule era))
   ) =>
   ExecContext fn rule era ->
   ExecEnvironment fn rule era ->
@@ -297,7 +288,7 @@ runConformance execContext env st sig = do
     fmap (bimap (fixup <$>) fixup) $
       impAnn "Deep evaluating Agda output" $
         evaluateDeep $
-          runAgdaRule @fn @rule @era (inject specEnv) (inject specSt) (inject specSig)
+          runAgdaRule @fn @rule @era specEnv specSt specSig
   implRes <- tryRunImpRule @rule @era (inject env) (inject st) (inject sig)
   implResTest <-
     impAnn "Translating implementation values to SpecRep" $
@@ -317,9 +308,6 @@ conformsToImpl ::
   , ToExpr (ExecContext fn rule era)
   , SpecTranslate (ExecContext fn rule era) (State (EraRule rule era))
   , Eq (SpecRep (PredicateFailure (EraRule rule era)))
-  , Inject (SpecRep (ExecEnvironment fn rule era)) (SpecRep (ExecEnvironment fn rule era))
-  , Inject (SpecRep (ExecState fn rule era)) (SpecRep (ExecState fn rule era))
-  , Inject (SpecRep (ExecSignal fn rule era)) (SpecRep (ExecSignal fn rule era))
   , Inject (State (EraRule rule era)) (ExecState fn rule era)
   , Eq (SpecRep (ExecState fn rule era))
   , SpecTranslate (ExecContext fn rule era) (ExecState fn rule era)


### PR DESCRIPTION
# Description

There seems to be a problem with some `Inject` constraints in `ExecSpecRule`. It looks like 8.10 can derive some identity constraints from the `Inject a a` instance, but GHC 9 complains about overlapping instances. 

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
