### PR TITLE
Ensure GitHub CI fails when tests are skipped due to a build failure

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -258,13 +258,15 @@ jobs:
     steps:
     - run: |
         case ${{ needs.test.result }} in
+          success)
+            echo 'All tests completed successfully'
+            true;;
           failure)
             echo 'Some tests failed'
             false;;
-          success)
-            echo 'All tests completed successfully';;
           *)
-            echo 'Tests were ${{ needs.test.result }}';;
+            echo 'Tests were ${{ needs.test.result }}'
+            false;;
         esac
 
   fourmolu:


### PR DESCRIPTION
# Description

When one of the matrix jobs for `build` fails, the `test` job is skipped and the logic in `complete` was not treating this as a failure. As a result, PRs were being merged that contained build failures and hadn't passed tests.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
