### PR TITLE
Add a max-parallel constraint to GitHub CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -151,6 +151,7 @@ jobs:
         - vector-map
         ghc: ["8.10.7", "9.2.8", "9.6.4", "9.8.2"]
         os: [ubuntu-latest]
+      max-parallel: 25
       fail-fast: false
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Hoping this might fix the random job cancellations we've been seeing in the past few days