### PR TITLE
Downgrade to Ubuntu-22.04 on CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         ghc: ["8.10.7", "9.2.8", "9.6.4", "9.8.2"]
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -150,7 +150,7 @@ jobs:
         - small-steps
         - vector-map
         ghc: ["8.10.7", "9.2.8", "9.6.4", "9.8.2"]
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -252,7 +252,7 @@ jobs:
 
   complete:
     name: Tests completed
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: test
     if: always()
     steps:
@@ -270,7 +270,7 @@ jobs:
         esac
 
   fourmolu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     defaults:
       run:
@@ -294,7 +294,7 @@ jobs:
       run: ./scripts/fourmolize.sh
 
   cabal-format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     defaults:
       run:
@@ -309,7 +309,7 @@ jobs:
       run: ./scripts/cabal-format.sh
 
   gen-hie:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     defaults:
       run:
@@ -341,7 +341,7 @@ jobs:
 
   branch-history:
     name: Check branch history
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.base_ref != '' && github.head_ref != '' }}
     steps:
     - uses: actions/checkout@v4
@@ -355,7 +355,7 @@ jobs:
 
   notify-nightly-failure:
     name: Send a slack notification on \#ledger-internal if the nightly build failed
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - test
     if: always() && github.event_name == 'schedule' && needs.test.result == 'failure'


### PR DESCRIPTION
Seems like there is an issue with runners, we can try temporarily downgrade to older Ubuntu image: https://github.com/actions/runner-images/issues/9959

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
