### PR TITLE
`constrained-generators`: propagate information backwards in the solver

### DIFF
--- a/libs/constrained-generators/src/Constrained/Examples/Basic.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Basic.hs
@@ -282,3 +282,28 @@ propBack' = constrained' $ \x y ->
   , 8 >. y
   , y >. x - 20
   ]
+
+propBack'' :: Specification BaseFn (Int, Int)
+propBack'' = constrained' $ \x y ->
+  [ assert $ y + 10 ==. x
+  , x `dependsOn` y
+  , assert $ x <. 20
+  , assert $ 8 <. y
+  ]
+
+chooseBackwards :: Specification BaseFn (Int, [Int])
+chooseBackwards = constrained $ \xy ->
+  [ assert $ xy `elem_` lit [(1, [1001 .. 1005]), (2, [1006 .. 1010])]
+  , match xy $ \_ ys ->
+      forAll ys $ \y -> 0 <. y
+  ]
+
+chooseBackwards' :: Specification BaseFn ([(Int, [Int])], (Int, [Int]))
+chooseBackwards' = constrained' $ \xys xy ->
+  [ forAll' xys $ \_ ys ->
+      forAll ys $ \y -> 1000 <. y
+  , assert $ 0 <. length_ xys
+  , assert $ xy `elem_` xys
+  , match xy $ \_ ys ->
+      forAll ys $ \y -> 0 <. y
+  ]

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -48,6 +48,8 @@ tests nightly =
     -- TODO: double-shrinking
     testSpecNoShrink "reifiesMultiple" reifiesMultiple
     testSpec "assertReal" assertReal
+    testSpecNoShrink "chooseBackwards" chooseBackwards
+    testSpecNoShrink "chooseBackwards'" chooseBackwards'
     testSpec "assertRealMultiple" assertRealMultiple
     testSpec "setSpec" setSpec
     testSpec "leqPair" leqPair
@@ -132,6 +134,7 @@ tests nightly =
     testSpec "ifElseMany" ifElseMany
     testSpecNoShrink "propBack" propBack
     testSpecNoShrink "propBack'" propBack'
+    testSpecNoShrink "propBack''" propBack''
     testSpec "complexUnion" complexUnion
     testSpec "unionBounded" unionBounded
     numberyTests


### PR DESCRIPTION
# Description

This should hopefully solve @Soupstraw 's issue with controlling the distribution of votes.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
