### PR TITLE
Re-enabled Full NewEpochstate test

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Classes.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Classes.hs
@@ -712,6 +712,16 @@ unPParams (PParamsF _ p) = p
 instance PrettyA (PParamsF era) where
   prettyA (PParamsF p x) = unReflect pcPParams p x
 
+instance Eq (PParamsF era) where
+  PParamsF p1 x == PParamsF _ y =
+    case p1 of
+      Shelley -> x == y
+      Allegra -> x == y
+      Mary -> x == y
+      Alonzo -> x == y
+      Babbage -> x == y
+      Conway -> x == y
+
 pparamsWrapperL :: Lens' (PParamsF era) (PParams era)
 pparamsWrapperL = lens unPParams (\(PParamsF p _) pp -> PParamsF p pp)
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Examples.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Examples.hs
@@ -613,6 +613,7 @@ utxostatePreds proof =
   , Random fees
   , Random (pparamProposals proof)
   , Random (futurePParamProposals proof)
+  , Random (futurePParams proof)
   ]
 
 epochstatePreds :: EraGov era => Proof era -> [Pred era]
@@ -835,9 +836,8 @@ allExampleTests =
     , testPropMax 30 "Test 13. Component tests" test13
     , testPropMax 30 "Test 15. Summation on Natural" test15
     , testPropMax 30 "Test 16. Test NonEmpty subset" test16
-    , -- FIXME: re-enable
-      -- , testPropMax 30 "Test 17. Full NewEpochState" (fmap (withMaxSuccess 30) test17)
-      testPropMax 30 "Test 18a. Projection test" test18a
+    , testPropMax 30 "Test 17. Full NewEpochState" (fmap (withMaxSuccess 30) test17)
+    , testPropMax 30 "Test 18a. Projection test" test18a
     , testPropMax 30 "Test 18b. Projection test" test18b
     , testPropMax 30 "Test 20. ptr & rewards are inverses" test20
     , testPropMax 30 "Constraint soundness" $ within 1000000 $ prop_soundness

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
@@ -141,7 +141,17 @@ ledgerStatePreds _usize p =
           GovStateConwayToConway ->
             [ Random randomProposals
             , currProposals p :<-: (Constr "reasonable" reasonable ^$ randomProposals)
-            , Lit (FuturePParamsR p) NoPParamsUpdate :=: futurePParams p
+            , Choose
+                (ExactSize 1)
+                futurepps
+                [
+                  ( 1
+                  , Constr "DefinitePParamsUpdate" (DefinitePParamsUpdate @era . unPParams) ^$ ppx
+                  , [ppx :=: currPParams p]
+                  )
+                , (1, Constr "NoPParamsUpdate" (const (NoPParamsUpdate @era)) ^$ unit, [Random unit])
+                ]
+            , futurePParams p :<-: (Constr "head" getOne ^$ futurepps)
             ]
               ++ prevPulsingPreds p -- Constraints to generate a valid Pulser
           GovStateShelleyToBabbage ->
@@ -152,6 +162,11 @@ ledgerStatePreds _usize p =
        )
   where
     randomProposals = Var (pV p "randomProposals" (ProposalsR p) No)
+    ppx = Var (pV p "ppx" (PParamsR p) No)
+    unit = Var (pV p "unit" UnitR No)
+    futurepps = Var (pV p "futurepps" (ListR (FuturePParamsR p)) No)
+    getOne (x : _) = x
+    getOne [] = NoPParamsUpdate
 
 ledgerStateStage ::
   Reflect era =>


### PR DESCRIPTION
Addresses issue #4341 

Probelems with FuturePParams, which had a change in representation. Added a (Random (futurePParams proof)) in the right place, and all works now.

Also made the LedgerStateStage more widely applicablae, as it now returns both a NoPParamsUpdate, and DefinitePParamsUpdate version randomly.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
