### PR TITLE
Improved the translation of `PParamUpdate` in conformance

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -17,8 +17,8 @@ repository cardano-haskell-packages
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-executable-spec.git
-  tag: 75f5354ec2781673cc15f34f4909aff41f9d0cf1
-  --sha256: sha256-JjCMQZblcuh6kxYTonW3BKy7fhnfHTkBrWsZ09O9r2s=
+  tag: cb9359ade4dd20a13a0e5c384b04411de29b0329
+  --sha256: sha256-ADPVfitVyXn3AXJTYfLK8rHVIzCj4APMrCghgoi35cE=
 
 index-state:
   -- Bump this if you need newer packages from Hackage

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -69,6 +69,12 @@ deriving instance Ord VDeleg
 
 deriving instance Ord Vote
 
+deriving instance Ord PoolThresholds
+
+deriving instance Ord DrepThresholds
+
+deriving instance Ord PParamsUpdate
+
 deriving instance Ord GovAction
 
 deriving instance Ord GovActionState
@@ -92,6 +98,8 @@ deriving instance Eq DrepThresholds
 deriving instance Eq PParams
 
 deriving instance Eq UTxOState
+
+deriving instance Eq PParamsUpdate
 
 deriving instance Eq GovAction
 
@@ -126,6 +134,8 @@ deriving instance Eq RatifyState
 instance (NFData k, NFData v) => NFData (HSMap k v)
 
 instance NFData a => NFData (HSSet a)
+
+instance NFData PParamsUpdate
 
 instance NFData GovAction
 
@@ -200,6 +210,8 @@ instance ToExpr Credential where
   toExpr (ScriptObj h) = App "ScriptObj" [agdaHashToExpr 28 h]
 
 instance (ToExpr k, ToExpr v) => ToExpr (HSMap k v)
+
+instance ToExpr PParamsUpdate
 
 instance ToExpr GovAction
 
@@ -319,6 +331,8 @@ instance FixupSpecRep GState
 instance FixupSpecRep CertState
 
 instance FixupSpecRep Vote
+
+instance FixupSpecRep PParamsUpdate
 
 instance FixupSpecRep GovAction
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway.hs
@@ -853,8 +853,6 @@ instance
   where
   type SpecRep (GovAction era) = Agda.GovAction
 
-  -- TODO remove the failure cases once it's possible to update all of the
-  -- parameters in the spec
   toSpecRep (ParameterChange _ ppu _) = Agda.ChangePParams <$> toSpecRep ppu
   toSpecRep (HardForkInitiation _ pv) = Agda.TriggerHF <$> toSpecRep pv
   toSpecRep (TreasuryWithdrawals withdrawals _) =

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway.hs
@@ -803,21 +803,59 @@ instance SpecTranslate ctx (VotingProcedures era) where
               )
           <*> m
 
-instance EraPParams era => SpecTranslate ctx (GovAction era) where
+instance SpecTranslate ctx (ConwayPParams StrictMaybe era) where
+  type SpecRep (ConwayPParams StrictMaybe era) = Agda.PParamsUpdate
+
+  toSpecRep x =
+    Agda.MkPParamsUpdate
+      <$> toSpecRep (cppMinFeeA x)
+      <*> toSpecRep (cppMinFeeB x)
+      <*> pure (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxBBSize x)
+      <*> pure (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxTxSize x)
+      <*> pure (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxBHSize x)
+      <*> pure (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxValSize x)
+      <*> pure Nothing -- minUTxOValue has been deprecated and is not supported in Conway
+      <*> toSpecRep (cppPoolDeposit x)
+      <*> toSpecRep (cppKeyDeposit x)
+      <*> toSpecRep (cppEMax x)
+      <*> toSpecRep (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppNOpt x)
+      <*> pure Nothing
+      <*> toSpecRep (cppPoolVotingThresholds x)
+      <*> toSpecRep (cppDRepVotingThresholds x)
+      <*> toSpecRep (cppGovActionLifetime x)
+      <*> toSpecRep (cppGovActionDeposit x)
+      <*> toSpecRep (cppDRepDeposit x)
+      <*> toSpecRep (cppDRepActivity x)
+      <*> pure (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppCommitteeMinSize x)
+      <*> pure
+        (fmap (toInteger . unEpochInterval) . strictMaybeToMaybe . unTHKD $ cppCommitteeMaxTermLength x)
+      <*> toSpecRep (cppCostModels x)
+      <*> toSpecRep (cppPrices x)
+      <*> toSpecRep (cppMaxTxExUnits x)
+      <*> toSpecRep (cppMaxBlockExUnits x)
+      <*> toSpecRep (cppCoinsPerUTxOByte x)
+      <*> pure (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxCollateralInputs x)
+
+instance
+  SpecTranslate ctx (PParamsHKD StrictMaybe era) =>
+  SpecTranslate ctx (PParamsUpdate era)
+  where
+  type SpecRep (PParamsUpdate era) = SpecRep (PParamsHKD StrictMaybe era)
+
+  toSpecRep (PParamsUpdate ppu) = toSpecRep ppu
+
+instance
+  ( EraPParams era
+  , SpecTranslate ctx (PParamsHKD StrictMaybe era)
+  , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
+  ) =>
+  SpecTranslate ctx (GovAction era)
+  where
   type SpecRep (GovAction era) = Agda.GovAction
 
   -- TODO remove the failure cases once it's possible to update all of the
   -- parameters in the spec
-  toSpecRep (ParameterChange _ ppu _)
-    | SJust minFeeA <- ppu ^. ppuMinFeeAL =
-        if ppu == (def & ppuMinFeeAL .~ SJust minFeeA)
-          then Agda.ChangePParams <$> toSpecRep minFeeA
-          else
-            throwError
-              "Expecting PParamsUpdate to update only minFeeA, but it's also updating something else"
-    | otherwise =
-        throwError
-          "Expecting PParamsUpdate to update minFeeA, but it's not"
+  toSpecRep (ParameterChange _ ppu _) = Agda.ChangePParams <$> toSpecRep ppu
   toSpecRep (HardForkInitiation _ pv) = Agda.TriggerHF <$> toSpecRep pv
   toSpecRep (TreasuryWithdrawals withdrawals _) =
     Agda.TreasuryWdrl
@@ -850,7 +888,13 @@ instance
 
   toSpecRep = traverse (bimapM toSpecRep toSpecRep) . assocList
 
-instance EraPParams era => SpecTranslate ctx (ProposalProcedure era) where
+instance
+  ( EraPParams era
+  , SpecTranslate ctx (PParamsHKD StrictMaybe era)
+  , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
+  ) =>
+  SpecTranslate ctx (ProposalProcedure era)
+  where
   type SpecRep (ProposalProcedure era) = Agda.GovProposal
 
   toSpecRep ProposalProcedure {..} =
@@ -870,7 +914,10 @@ instance EraPParams era => SpecTranslate ctx (ProposalProcedure era) where
           _ -> SNothing
 
 instance
-  EraPParams era =>
+  ( EraPParams era
+  , SpecTranslate ctx (PParamsHKD StrictMaybe era)
+  , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
+  ) =>
   SpecTranslate ctx (GovProcedures era)
   where
   type SpecRep (GovProcedures era) = [Agda.GovSignal]
@@ -913,7 +960,13 @@ unionsHSMaps ((Agda.MkHSMap x) : xs) =
 mapHSMapKey :: (k -> l) -> Agda.HSMap k v -> Agda.HSMap l v
 mapHSMapKey f (Agda.MkHSMap l) = Agda.MkHSMap $ first f <$> l
 
-instance EraPParams era => SpecTranslate ctx (GovActionState era) where
+instance
+  ( EraPParams era
+  , SpecTranslate ctx (PParamsHKD StrictMaybe era)
+  , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
+  ) =>
+  SpecTranslate ctx (GovActionState era)
+  where
   type SpecRep (GovActionState era) = Agda.GovActionState
 
   toSpecRep gas@GovActionState {..} = do
@@ -947,7 +1000,13 @@ instance SpecTranslate ctx (GovActionId c) where
 
   toSpecRep (GovActionId txId gaIx) = toSpecRep (txId, gaIx)
 
-instance EraPParams era => SpecTranslate ctx (Proposals era) where
+instance
+  ( EraPParams era
+  , SpecTranslate ctx (PParamsHKD StrictMaybe era)
+  , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
+  ) =>
+  SpecTranslate ctx (Proposals era)
+  where
   type SpecRep (Proposals era) = Agda.GovState
 
   toSpecRep = toSpecRep . view pPropsL
@@ -1112,6 +1171,8 @@ instance
   , SpecTranslate ctx (PParamsHKD Identity era)
   , Inject ctx [GovActionState era]
   , ToExpr (PParamsHKD StrictMaybe era)
+  , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
+  , SpecTranslate ctx (PParamsHKD StrictMaybe era)
   ) =>
   SpecTranslate ctx (RatifyState era)
   where
@@ -1142,7 +1203,13 @@ instance
       <*> toSpecRep removed
       <*> toSpecRep rsDelayed
 
-instance EraPParams era => SpecTranslate ctx (RatifySignal era) where
+instance
+  ( EraPParams era
+  , SpecTranslate ctx (PParamsHKD StrictMaybe era)
+  , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
+  ) =>
+  SpecTranslate ctx (RatifySignal era)
+  where
   type
     SpecRep (RatifySignal era) =
       SpecRep [(GovActionId (EraCrypto era), GovActionState era)]
@@ -1151,7 +1218,13 @@ instance EraPParams era => SpecTranslate ctx (RatifySignal era) where
     toSpecRep $
       (\gas@GovActionState {gasId} -> (gasId, gas)) <$> x
 
-instance EraPParams era => SpecTranslate ctx (EnactSignal era) where
+instance
+  ( EraPParams era
+  , SpecTranslate ctx (PParamsHKD StrictMaybe era)
+  , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
+  ) =>
+  SpecTranslate ctx (EnactSignal era)
+  where
   type SpecRep (EnactSignal era) = SpecRep (GovAction era)
 
   toSpecRep (EnactSignal _ ga) = toSpecRep ga


### PR DESCRIPTION
# Description

This PR makes it possible for the `PParamUpdates` to change any field, not just `minFeeA`

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
