### PR TITLE
Fixed issue #4340. Problem with futurePParams not adequate in Conway.

### DIFF
--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
@@ -41,7 +41,6 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Core (
   runSpecTransM,
   toTestRep,
  )
-import qualified Test.Cardano.Ledger.Generic.PrettyCore as Doc
 import Test.Cardano.Ledger.Imp.Common
 import Test.Cardano.Ledger.Shelley.ImpTest (
   ImpTestM,
@@ -206,15 +205,15 @@ checkConformance implResTest agdaResTest = do
       ansiWlPretty
         { ppDel = \d ->
             mconcat
-              [ Doc.text "\ESC[91m(Impl: "
+              [ "\ESC[91m(Impl: "
               , d
-              , Doc.text ")\ESC[39m"
+              , ")\ESC[39m"
               ]
         , ppIns = \d ->
             mconcat
-              [ Doc.text "\ESC[92m(Agda: "
+              [ "\ESC[92m(Agda: "
               , d
-              , Doc.text ")\ESC[39m"
+              , ")\ESC[39m"
               ]
         }
     failMsg =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Classes.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Classes.hs
@@ -69,7 +69,8 @@ import Test.Cardano.Ledger.Generic.Functions (protocolVersion)
 import Test.Cardano.Ledger.Generic.GenState (plutusPurposeTags)
 import Test.Cardano.Ledger.Generic.PrettyCore (
   PDoc,
-  PrettyA,
+  PrettyA (..),
+  pcPParams,
   pcScript,
   pcScriptsNeeded,
   pcTx,
@@ -80,6 +81,7 @@ import Test.Cardano.Ledger.Generic.PrettyCore (
   pcWitnesses,
   ppPlutusPurposeAsIx,
   ppPlutusPurposeAsIxItem,
+  ppProposedPPUpdates,
   ppString,
  )
 import Test.Cardano.Ledger.Generic.Proof (
@@ -533,6 +535,9 @@ data TxF era where
 unTxF :: TxF era -> Tx era
 unTxF (TxF _ x) = x
 
+instance PrettyA (TxF era) where
+  prettyA (TxF p tx) = pcTx p tx
+
 instance PrettyA (PParamsUpdate era) => Show (TxF era) where
   show (TxF p x) = show ((unReflect pcTx p x) :: PDoc)
 
@@ -574,6 +579,9 @@ unTxBodyF (TxBodyF _ x) = x
 instance PrettyA (PParamsUpdate era) => Show (TxBodyF era) where
   show (TxBodyF p x) = show ((unReflect pcTxBody p x) :: PDoc)
 
+instance PrettyA (TxBodyF era) where
+  prettyA (TxBodyF p x) = unReflect pcTxBody p x
+
 instance Eq (TxBodyF era) where
   (TxBodyF Shelley x) == (TxBodyF Shelley y) = x == y
   (TxBodyF Allegra x) == (TxBodyF Allegra y) = x == y
@@ -588,6 +596,9 @@ data TxCertF era where
 
 unTxCertF :: TxCertF era -> TxCert era
 unTxCertF (TxCertF _ x) = x
+
+instance PrettyA (TxCertF era) where
+  prettyA (TxCertF p x) = pcTxCert p x
 
 instance Show (TxCertF era) where
   show (TxCertF p x) = show (pcTxCert p x)
@@ -644,6 +655,9 @@ data TxOutF era where
 unTxOut :: TxOutF era -> TxOut era
 unTxOut (TxOutF _ x) = x
 
+instance PrettyA (TxOutF era) where
+  prettyA (TxOutF p x) = unReflect pcTxOut p x
+
 instance Eq (TxOutF era) where
   x1 == x2 = compare x1 x2 == EQ
 
@@ -664,6 +678,9 @@ instance Ord (TxOutF era) where
 -- ======
 data ValueF era where
   ValueF :: Proof era -> Value era -> ValueF era
+
+instance PrettyA (ValueF era) where
+  prettyA (ValueF p v) = pcVal p v
 
 unValue :: ValueF era -> Value era
 unValue (ValueF _ v) = v
@@ -692,6 +709,9 @@ data PParamsF era where
 unPParams :: PParamsF era -> PParams era
 unPParams (PParamsF _ p) = p
 
+instance PrettyA (PParamsF era) where
+  prettyA (PParamsF p x) = unReflect pcPParams p x
+
 pparamsWrapperL :: Lens' (PParamsF era) (PParams era)
 pparamsWrapperL = lens unPParams (\(PParamsF p _) pp -> PParamsF p pp)
 
@@ -713,6 +733,9 @@ data ProposedPPUpdatesF era where
 
 unProposedPPUpdates :: ProposedPPUpdatesF era -> PP.ProposedPPUpdates era
 unProposedPPUpdates (ProposedPPUpdatesF _ x) = x
+
+instance PrettyA (PParamsUpdate e) => PrettyA (ProposedPPUpdatesF e) where
+  prettyA (ProposedPPUpdatesF _p x) = ppProposedPPUpdates x
 
 proposedCoreL ::
   Lens' (PP.ProposedPPUpdates era) (Map (KeyHash 'Genesis (EraCrypto era)) (PParamsUpdate era))
@@ -869,6 +892,9 @@ data ScriptF era where
 
 unScriptF :: ScriptF era -> Script era
 unScriptF (ScriptF _ v) = v
+
+instance PrettyA (ScriptF era) where
+  prettyA (ScriptF p x) = unReflect pcScript p x
 
 instance Show (ScriptF era) where
   show (ScriptF p t) = show ((unReflect pcScript p t) :: PDoc)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
@@ -38,6 +38,7 @@ import Cardano.Ledger.Core (
   ppuMinFeeBL,
  )
 import Cardano.Ledger.DRep (drepDepositL)
+import Cardano.Ledger.Shelley.Governance (FuturePParams (..))
 import Control.Monad (when)
 import Data.Default.Class (Default (def))
 import qualified Data.List as List
@@ -140,13 +141,13 @@ ledgerStatePreds _usize p =
           GovStateConwayToConway ->
             [ Random randomProposals
             , currProposals p :<-: (Constr "reasonable" reasonable ^$ randomProposals)
-            , Random (futurePParams p)
+            , Lit (FuturePParamsR p) NoPParamsUpdate :=: futurePParams p
             ]
               ++ prevPulsingPreds p -- Constraints to generate a valid Pulser
           GovStateShelleyToBabbage ->
             [ Sized (Range 0 1) (pparamProposals p)
             , Sized (Range 0 1) (futurePParamProposals p)
-            , Random (futurePParams p)
+            , Lit (FuturePParamsR p) NoPParamsUpdate :=: futurePParams p
             ]
        )
   where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/TraceMonad.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/TraceMonad.hs
@@ -88,6 +88,7 @@ import Test.Cardano.Ledger.Generic.PrettyCore (
   ppList,
   ppPair,
   ppStrictSeq,
+  psNewEpochState,
   summaryMapCompact,
  )
 import Test.Cardano.Ledger.Generic.Proof hiding (lift)
@@ -397,7 +398,13 @@ instance
     case runShelleyBase (applySTSTest (TRC @(MOCKCHAIN era) ((), mcs, mockblock))) of
       Left pdfs ->
         let _txsl = Fold.toList txs
-         in error . unlines $ "FAILS" : map show (toList pdfs)
+         in error . unlines $
+              ( "FAILS"
+                  : ["epochNum " ++ show epochnum, "slot " ++ show lastSlot]
+                  ++ map (show . pcTx reify) (toList txs)
+                  ++ map show (toList pdfs)
+                  ++ [show (psNewEpochState reify newepoch)]
+              )
       Right mcs2 -> seq mcs2 (pure mockblock)
 
   shrinkSignal _ = []

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -331,6 +331,9 @@ import Test.Cardano.Ledger.Generic.Fields (
 import qualified Test.Cardano.Ledger.Generic.Fields as Fields
 import Test.Cardano.Ledger.Generic.Proof (
   AllegraEra,
+  AlonzoEra,
+  BabbageEra,
+  ConwayEra,
   GovStateWit (..),
   MaryEra,
   Proof (..),
@@ -797,6 +800,15 @@ instance Crypto c => PrettyA (PParamsUpdate (AllegraEra c)) where
 instance Crypto c => PrettyA (PParamsUpdate (MaryEra c)) where
   prettyA = ppPParamsUpdate
 
+instance Crypto c => PrettyA (PParamsUpdate (AlonzoEra c)) where
+  prettyA _ = ppString ("PParamsUpdate (AlonzoEra c)")
+
+instance Crypto c => PrettyA (PParamsUpdate (BabbageEra c)) where
+  prettyA _ = ppString ("PParamsUpdate (BabbageEra c)")
+
+instance Crypto c => PrettyA (PParamsUpdate (ConwayEra c)) where
+  prettyA _ = ppString ("PParamsUpdate (ConwayEra c)")
+
 ppUpdate :: PrettyA (PParamsUpdate era) => PParams.Update era -> PDoc
 ppUpdate (PParams.Update prop epn) = ppSexp "Update" [ppProposedPPUpdates prop, ppEpochNo epn]
 
@@ -1046,6 +1058,9 @@ pcWitnesses proof txwits = ppRecord "Witnesses" pairs
     fields = abstractWitnesses proof txwits
     pairs = concat (map (pcWitnessesField proof) fields)
 
+-- | Pretty print a Tx.
+--   Also see Test.Cardano.Ledger.Constrained.Preds.Tx(pcTxWithUTxO)
+--   which expands the inputs (given the UTxO)
 pcTx :: Proof era -> Tx era -> PDoc
 pcTx proof tx = ppRecord "Tx" pairs
   where


### PR DESCRIPTION
Addresses issue #4340.
The problem was the value of FuturePParams in the Conway era.
Also added some additional information when one of the TraceM tests failed. To make it easier to figure out what went wrong.
Requres a few additional PrettyA instances.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
