### PR TITLE
Fix cddl representing CostModels in Conway

### DIFF
--- a/eras/conway/impl/cddl-files/conway.cddl
+++ b/eras/conway/impl/cddl-files/conway.cddl
@@ -502,10 +502,10 @@ potential_languages = 0 .. 255
 ; versions in the future.
 ;
 costmdls =
-  { ? 0 : [ int64 ] ; Plutus v1
-  , ? 1 : [ int64 ] ; Plutus v2
-  , ? 2 : [ int64 ] ; Plutus v3
-  , ? 3 : [ int64 ] ; Any 8-bit unsigned number can be used as a key.
+  { ? 0 : [ * int64 ] ; Plutus v1
+  , ? 1 : [ * int64 ] ; Plutus v2
+  , ? 2 : [ * int64 ] ; Plutus v3
+  , * 3 .. maxWord8 => [ * int64 ] ; Any 8-bit unsigned number can be used as a key
   }
 
 transaction_metadatum =
@@ -568,6 +568,7 @@ asset_name = bytes .size (0..32)
 minInt64 = -9223372036854775808
 maxInt64 = 9223372036854775807
 maxWord64 = 18446744073709551615
+maxWord8 = 255
 
 negInt64 = minInt64 .. -1
 posInt64 = 1 .. maxInt64


### PR DESCRIPTION
# Description

Costmodel values are incorrectly represented in conway cddl as singleton lists.
This PR fixes it, and makes the specification for unknown languages more precise.  

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
