### PR TITLE
[Experiment, do not merge] Remove Eq and Ord from PlutusTx.AssocMap.Map

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -20,6 +20,12 @@ source-repository-package
   tag: cb9359ade4dd20a13a0e5c384b04411de29b0329
   --sha256: sha256-ADPVfitVyXn3AXJTYfLK8rHVIzCj4APMrCghgoi35cE=
 
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/plutus.git
+  tag: c4e88bd01e43603d1c8727aa294620c50775e3ac
+  --sha256: sha256-dBSH7q2ZMz4+a/6wxLdNq2j8fHzlToTyOhDOjhHPbeE=
+
 index-state:
   -- Bump this if you need newer packages from Hackage
   , hackage.haskell.org 2024-03-19T11:25:56Z


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
