### PR TITLE
Add a lens to HasSubState

### DIFF
--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -642,14 +642,14 @@ instance (ShelleyEraImp era, Arbitrary a, Show a) => Example (a -> ImpTestM era 
 
 instance MonadGen (ImpTestM era) where
   liftGen (MkGen f) = do
-    qcSize <- iteQuickCheckSize <$> ask
+    qcSize <- asks iteQuickCheckSize
     StateGen qcGen <- subState split
     pure $ f qcGen qcSize
   variant n action = do
     subState (\(StateGen qcGen) -> ((), StateGen (integerVariant (toInteger n) qcGen)))
     action
   sized f = do
-    qcSize <- iteQuickCheckSize <$> ask
+    qcSize <- asks iteQuickCheckSize
     f qcSize
   resize n = local (\env -> env {iteQuickCheckSize = n})
   choose r = subState (Random.randomR r)

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.0.0
 
+* Add `subStateL` to `HasSubState`
 * Create a catch all `Inject a a` instance for the same type
 * Remove unnecessary instances: `Inject a ()` and `Inject Void a`
 * Add `integralToBounded` to `BaseTypes`

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Imp/Common.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Imp/Common.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -350,7 +349,7 @@ instance
   (HasGenEnv env g, R.StatefulGen g (ReaderT env m), Monad m) =>
   HasStatefulGen g (ReaderT env m)
   where
-  askStatefulGen = getGenEnv <$> ask
+  askStatefulGen = asks getGenEnv
 
 class HasSubState s where
   type SubState s :: Type
@@ -410,7 +409,7 @@ instance HasSubState (StateGen g) where
   type SubState (StateGen g) = g
   getSubState (StateGen g) = g
   {-# INLINE getSubState #-}
-  setSubState _ g = (StateGen g)
+  setSubState _ = StateGen
   {-# INLINE setSubState #-}
 
 subState :: (HasSubState s, MonadState s m) => (SubState s -> (a, SubState s)) -> m a


### PR DESCRIPTION
# Description

Add `subStateL` to `HasSubState`. The lens defaults to using the getter & setter, and those default to using the lens. Instances can define either the lens or the functions.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
