### PR TITLE
`constrained-generators`: introduce a hook for naming variables

### DIFF
--- a/libs/constrained-generators/constrained-generators.cabal
+++ b/libs/constrained-generators/constrained-generators.cabal
@@ -41,6 +41,7 @@ library
         Constrained.Examples.Tree
         Constrained.Examples.Either
         Constrained.Properties
+        Constrained.Syntax
 
     hs-source-dirs:   src
     default-language: Haskell2010
@@ -55,7 +56,8 @@ library
         mtl,
         prettyprinter,
         QuickCheck ^>=2.14,
-        random
+        random,
+        template-haskell
 
 test-suite constrained
     type:             exitcode-stdio-1.0

--- a/libs/constrained-generators/src/Constrained.hs
+++ b/libs/constrained-generators/src/Constrained.hs
@@ -55,6 +55,7 @@ module Constrained (
   caseBoolSpec,
   constrained,
   constrained',
+  name,
   satisfies,
   letBind,
   match,
@@ -138,3 +139,4 @@ import Constrained.Internals
 import Constrained.List as X
 import Constrained.Properties
 import Constrained.Spec.Tree as X
+import Constrained.Syntax as X

--- a/libs/constrained-generators/src/Constrained/Properties.hs
+++ b/libs/constrained-generators/src/Constrained/Properties.hs
@@ -143,7 +143,7 @@ showCtxWith fn (TestableCtx ctx) = show $ pretty tm
     tm :: Term fn b
     tm =
       uncurryList (app fn) $
-        fillListCtx (mapListCtxC @(HasSpec fn) (lit @_ @fn . unValue) ctx) (\HOLE -> V $ Var 0)
+        fillListCtx (mapListCtxC @(HasSpec fn) (lit @_ @fn . unValue) ctx) (\HOLE -> V $ Var 0 "v")
 
 data TestableFn fn where
   TestableFn ::

--- a/libs/constrained-generators/src/Constrained/Syntax.hs
+++ b/libs/constrained-generators/src/Constrained/Syntax.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+
+module Constrained.Syntax where
+
+import Language.Haskell.TH qualified as TH
+import Language.Haskell.TH.Quote qualified as TH
+
+mkNamed :: String -> TH.Q TH.Pat
+mkNamed x =
+  pure $
+    TH.ViewP (TH.AppE (TH.VarE $ TH.mkName "name") (TH.LitE $ TH.StringL x)) (TH.VarP $ TH.mkName x)
+
+mkNamedExpr :: String -> TH.Q TH.Exp
+mkNamedExpr x =
+  pure $
+    TH.AppE (TH.AppE (TH.VarE $ TH.mkName "name") (TH.LitE $ TH.StringL x)) (TH.VarE $ TH.mkName x)
+
+var :: TH.QuasiQuoter
+var =
+  TH.QuasiQuoter
+    { -- Parses variables e.g. `constrained $ \ [var| x |] [var| y |] -> ...` from the strings " x " and " y "
+      -- and replaces them with `name "x" -> x` and `name "y" -> y`
+      TH.quotePat = mkNamed . head . words
+    , -- Parses variables in expressions like `assert $ [var| x |] + 3 <. 10` and replaces them with `name "x" x`
+      TH.quoteExp = mkNamedExpr . head . words -- Parses
+    , TH.quoteDec = const $ fail "var should only be used at binding sites and in expressions"
+    , TH.quoteType = const $ fail "var should only be used at binding sites and in expressions"
+    }


### PR DESCRIPTION
# Description

You can use either the `name "x" -> x` view pattern or the `[var| x |]` quasi quoter. This greatly simplifies debugging specs.

For example, when you do this:
```haskell
leqPair :: Specification BaseFn (Int, Int)
leqPair = constrained $ \[var| p |] ->
  match p $ \[var| x |] [var| y |] ->
    x <=. y
```
Instead of getting a plan from `printPlan leqPair` that talks about variables `v0`, `v1`, and `v3` it instead looks like this:
```
Simplified spec:
  constrained $ \ p_3 ->
    let x_1 = Fst (ToGeneric p_3) in
    let y_0 = Snd (ToGeneric p_3) in assert $ LessOrEqual x_1 y_0
SolverPlan
  Dependencies:
    y_0 <- []
    x_1 <- [y_0]
    p_3 <- [y_0, x_1]
  Linearization:
    y_0 <- 
    x_1 <- assert $ LessOrEqual x_1 y_0
    p_3 <-
      assert $ Equal (Fst (ToGeneric p_3)) x_1
      assert $ Equal (Snd (ToGeneric p_3)) y_0
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
