### PR TITLE
Don't archive working directory in github action

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -107,10 +107,12 @@ jobs:
 
     # Pass working directory to test jobs
     - name: Archive working directory
+      run: tar -cvf /var/tmp/state.tar . && mv /var/tmp/state.tar .
+    - name: Upload working directory archive
       uses: actions/upload-artifact@v4
       with:
         name: state-${{ matrix.ghc }}-${{ matrix.os }}
-        path: .
+        path: state.tar
         overwrite: true
         retention-days: 1
 
@@ -219,7 +221,8 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: state-${{ matrix.ghc }}-${{ matrix.os }}
-        path: .
+    - name: Unarchive working directory
+      run: tar -xf state.tar && rm state.tar
 
     - uses: actions/cache@v4
       if: matrix.os != 'macos-latest'

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -107,12 +107,10 @@ jobs:
 
     # Pass working directory to test jobs
     - name: Archive working directory
-      run: tar --format pax -cf /var/tmp/state.tar . && mv /var/tmp/state.tar .
-    - name: Upload working directory archive
       uses: actions/upload-artifact@v4
       with:
         name: state-${{ matrix.ghc }}-${{ matrix.os }}
-        path: state.tar
+        path: .
         overwrite: true
         retention-days: 1
 
@@ -221,8 +219,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: state-${{ matrix.ghc }}-${{ matrix.os }}
-    - name: Unarchive working directory
-      run: tar -xf state.tar && rm state.tar
+        path: .
 
     - uses: actions/cache@v4
       if: matrix.os != 'macos-latest'


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

In our workflow, we are building the project with cabal and then compressing  and uploading the workspace as an artifact, after which we are downloading it in each job that runs tests. 
Something happened in the last PR that causes this download to fail. 
Debug logs show this error:`Failed to download artifact after 5 retries due to Invalid signature in zip file. Retrying in 5 seconds...`
In this PR I have changed upload and download artifact to skip the manual compressing, hoping that whatever caused the invalid signature was in the tar that we were building. And this seems to be true , since I don't see any download failures anymore.  Also, the size of the artifact doesnt' seem to have increased.
However, what I have seen started happening is a few  (non-8.10.7) jobs failing with this error:
`/home/runner/work/cardano-ledger/cardano-ledger/dist-newstyle/build/x86_64-linux/ghc-9.8.2/non-integral-1.0.0.0/t/non-integral-test/build/non-integral-test/non-integral-test: createProcess: posix_spawnp: permission denied (Permission denied)`

Not sure how these are related!  I guess this needs more investigation

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
