### PR TITLE
GHA: Work around a bug in actions/download-artifact

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -107,12 +107,12 @@ jobs:
 
     # Pass working directory to test jobs
     - name: Archive working directory
-      run: tar --format pax -cf /var/tmp/state.tar . && mv /var/tmp/state.tar .
+      run: tar --format pax -czf /var/tmp/state.tgz . && mv /var/tmp/state.tgz .
     - name: Upload working directory archive
       uses: actions/upload-artifact@v4
       with:
         name: state-${{ matrix.ghc }}-${{ matrix.os }}
-        path: state.tar
+        path: state.tgz
         overwrite: true
         retention-days: 1
 
@@ -222,7 +222,7 @@ jobs:
       with:
         name: state-${{ matrix.ghc }}-${{ matrix.os }}
     - name: Unarchive working directory
-      run: tar -xf state.tar && rm state.tar
+      run: tar -xf state.tgz && rm state.tgz
 
     - uses: actions/cache@v4
       if: matrix.os != 'macos-latest'


### PR DESCRIPTION
We recently started getting "Unable to download and extract artifact" errors. Turning on debug logging reveals that the error is during extraction, and the message is "Invalid signature in zip file".

Downloading artifacts from the URL given in the upload step show that the 8.10.7 archive can't be extracted using the `unzip-stream` library that `actions/download-artifact` uses. Debug-logging that operation gives "Unexpected signature in zip file: 0x16d4b50 "PKm", skipped 1 bytes"

Compressing the tar file seems to make a difference, although it's not clear why, so this probably isn't a long-term solution.