### PR TITLE
Added first Necessary And Sufficient EraRule tests

### DIFF
--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -63,6 +63,7 @@ library
         Test.Cardano.Ledger.Constrained.Conway.PParams
         Test.Cardano.Ledger.Constrained.Conway.Gov
         Test.Cardano.Ledger.Constrained.Conway.Utxo
+        Test.Cardano.Ledger.Constrained.Conway.NecessaryAndSufficient
         Test.Cardano.Ledger.Examples.BabbageFeatures
         Test.Cardano.Ledger.Examples.AlonzoValidTxUTXOW
         Test.Cardano.Ledger.Examples.AlonzoInvalidTxUTXOW

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -156,7 +156,8 @@ library
         vector,
         constrained-generators,
         random,
-        FailT
+        FailT,
+        template-haskell
 
 test-suite cardano-ledger-test
     type:             exitcode-stdio-1.0
@@ -172,7 +173,8 @@ test-suite cardano-ledger-test
         base,
         cardano-ledger-test,
         tasty,
-        data-default-class
+        data-default-class,
+        hspec
 
 benchmark bench
     type:             exitcode-stdio-1.0

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -154,6 +155,7 @@ import Test.Cardano.Ledger.Allegra.Arbitrary ()
 import Test.Cardano.Ledger.Alonzo.Arbitrary ()
 import Test.Cardano.Ledger.Core.Utils
 import Test.Cardano.Ledger.TreeDiff (ToExpr)
+import Test.Cardano.Slotting.Numeric ()
 import Test.QuickCheck hiding (Args, Fun, forAll)
 
 type ConwayUnivFns = StringFn : TreeFn : BaseFns
@@ -264,6 +266,8 @@ instance IsConwayUniv fn => HasSpec fn SlotNo
 instance HasSimpleRep EpochNo
 instance IsConwayUniv fn => OrdLike fn EpochNo
 instance IsConwayUniv fn => HasSpec fn EpochNo
+
+instance IsConwayUniv fn => NumLike fn EpochNo
 
 instance HasSimpleRep TxIx
 instance IsConwayUniv fn => HasSpec fn TxIx

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/NecessaryAndSufficient.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/NecessaryAndSufficient.hs
@@ -1,0 +1,410 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Test.Cardano.Ledger.Constrained.Conway.NecessaryAndSufficient where
+
+-- import Cardano.Crypto.Hash hiding (Blake2b_224)
+-- import Cardano.Crypto.Hashing (AbstractHash, abstractHashFromBytes)
+-- import Cardano.Ledger.Address
+-- import Cardano.Ledger.Allegra.Scripts
+-- import Cardano.Ledger.Alonzo.PParams
+-- import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..))
+-- import Cardano.Ledger.Alonzo.Tx
+-- import Cardano.Ledger.Alonzo.TxAuxData (AlonzoTxAuxData (..), AuxiliaryDataHash)
+-- import Cardano.Ledger.Alonzo.TxOut
+-- import Cardano.Ledger.Alonzo.TxWits
+-- import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
+import Cardano.Ledger.BaseTypes hiding (inject)
+
+-- import Cardano.Ledger.Binary (Sized (..))
+import Cardano.Ledger.CertState
+import Cardano.Ledger.Coin
+
+-- import Cardano.Ledger.Compactible
+import Cardano.Ledger.Conway (Conway, ConwayEra)
+import Cardano.Ledger.Conway.Core
+
+-- import Cardano.Ledger.Conway.Governance
+-- import Cardano.Ledger.Conway.PParams
+import Cardano.Ledger.Conway.Rules
+import Cardano.Ledger.Conway.Scripts ()
+
+-- import Cardano.Ledger.Conway.TxBody
+import Cardano.Ledger.Conway.TxCert
+import Cardano.Ledger.Credential
+import Cardano.Ledger.Crypto (Crypto, HASH, StandardCrypto)
+
+-- import Cardano.Ledger.EpochBoundary
+-- import Cardano.Ledger.HKD
+import Cardano.Ledger.Keys (
+  -- BootstrapWitness,
+  -- GenDelegPair (..),
+  -- GenDelegs (..),
+  KeyHash,
+  KeyRole (..),
+  -- WitVKey,
+ )
+
+-- import Cardano.Ledger.Mary.Value (AssetName (..), MaryValue (..), MultiAsset (..), PolicyID (..))
+-- import Cardano.Ledger.MemoBytes
+-- import Cardano.Ledger.Plutus.CostModels
+-- import Cardano.Ledger.Plutus.Data
+-- import Cardano.Ledger.Plutus.ExUnits
+-- import Cardano.Ledger.Plutus.Language
+-- import Cardano.Ledger.PoolDistr
+import Cardano.Ledger.PoolParams
+
+-- import Cardano.Ledger.SafeHash
+-- import Cardano.Ledger.Shelley.LedgerState hiding (ptrMap)
+-- import Cardano.Ledger.Shelley.PoolRank
+import Cardano.Ledger.Shelley.Rules
+
+-- import Cardano.Ledger.Shelley.TxAuxData (Metadatum)
+-- import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Cardano.Ledger.UMap
+
+-- import Cardano.Ledger.UTxO
+-- import Cardano.Ledger.Val (Val)
+import Constrained hiding (Value)
+
+-- import qualified Constrained as C
+import Constrained.Base
+
+-- import Constrained.Spec.Map
+-- import Constrained.Univ
+-- import Control.Monad.Trans.Fail.String
+-- import Crypto.Hash (Blake2b_224)
+-- import qualified Data.ByteString as BS
+-- import Data.ByteString.Short (ShortByteString)
+-- import qualified Data.ByteString.Short as SBS
+-- import Data.Coerce
+import Data.Default.Class (Default (def))
+
+-- import Data.Foldable
+-- import Data.Int
+-- import Data.Kind
+import Data.Map (Map)
+import qualified Data.Map.Strict as Map
+
+-- import Data.Maybe
+-- import qualified Data.OMap.Strict as OMap
+-- import qualified Data.OSet.Strict as SOS
+-- import Data.Sequence (Seq)
+-- import qualified Data.Sequence as Seq
+-- import Data.Sequence.Strict (StrictSeq)
+-- import qualified Data.Sequence.Strict as StrictSeq
+-- import Data.Set (Set)
+-- import qualified Data.Set as Set
+-- import Data.Text (Text)
+-- import Data.Tree
+-- import Data.Typeable
+-- import Data.VMap (VMap)
+-- import qualified Data.VMap as VMap
+-- import Data.Word
+-- import GHC.Generics (Generic)
+import Lens.Micro
+
+-- import Numeric.Natural (Natural)
+-- import qualified PlutusLedgerApi.V1 as PV1
+-- import System.Random
+import Test.Cardano.Ledger.Allegra.Arbitrary ()
+import Test.Cardano.Ledger.Alonzo.Arbitrary ()
+import Test.Cardano.Ledger.Constrained.Conway.Instances
+
+-- import Test.Cardano.Ledger.Core.Utils
+import Test.Cardano.Ledger.Generic.PrettyCore
+
+-- import Test.Cardano.Ledger.TreeDiff (ToExpr)
+import Test.QuickCheck hiding (Args, Fun, forAll)
+
+import qualified Cardano.Crypto.Hash.Class as Hash
+
+-- import Cardano.Ledger.Conway.Rules (ConwayDelegEnv)
+import Test.Cardano.Ledger.Constrained.Conway.PParams (pparamsSpec)
+import Test.Cardano.Ledger.Generic.Proof (Proof (..), WitRule (DELEG, GOVCERT, POOL), goSTS)
+import Test.Cardano.Ledger.Shelley.Utils (epochFromSlotNo)
+
+import Control.State.Transition.Extended (BaseM, STS (Environment, Signal))
+
+-- =====================================================
+
+initPParams :: PParams Conway
+initPParams =
+  def
+    & ppEMaxL .~ EpochInterval 20
+    & ppMinPoolCostL .~ Coin 10
+
+umapSpec :: (Crypto c, IsConwayUniv fn) => Specification fn (UMap c)
+umapSpec =
+  constrained $ \um ->
+    match um $ \regpairs ptrs staking voting ->
+      [ assert $ ptrs ==. lit (Map.empty)
+      , assert $ dom_ staking `subset_` dom_ regpairs
+      , assert $ dom_ voting `subset_` dom_ regpairs
+      ]
+
+pcUMap :: UMap c -> PDoc
+pcUMap um =
+  ppRecord
+    "Umap"
+    [
+      ( "regKeys"
+      , ppMap pcCredential (\x -> ppString $ show (rdRewardCoin x, rdDepositCoin x)) (rdPairMap um)
+      )
+    , ("stakeDelegated", ppMap pcCredential pcKeyHash (sPoolMap um))
+    -- , ("voteDelegated", ppMap pcCredential pcDRep (dRepMap um))
+    -- , ("ptrs", ppMap ppPtr pcCredential (ptrMap um))
+    ]
+
+-- =====================================================================================
+-- EraRule DELEG
+-- ======================================================================================
+
+delegCertSpec ::
+  forall fn.
+  IsConwayUniv fn =>
+  Status ->
+  PParams Conway ->
+  Specification fn (ConwayDelegEnv Conway, DState Conway, ConwayDelegCert StandardCrypto)
+delegCertSpec status pp =
+  constrained $ \triple ->
+    match triple $ \env dstate dcert ->
+      match env $ \pparams poolregs ->
+        match dstate $ \umap _futgenD _genD _iRewards ->
+          match umap $ \regpairs _ptrs delegstake _ ->
+            [ forAll' regpairs $ \_ rd -> match rd $ \rew _ -> satisfies rew (chooseSpec (1, equalSpec 0) (3, TrueSpec))
+            , assert $ pparams ==. (lit pp)
+            , --  , assert $ not_ (disjoint_ (dom_ regpairs) (dom_ delegstake))
+              (caseOn dcert)
+                -- ConwayRegCert !(StakeCredential c) !(StrictMaybe Coin)
+                ( branchW 1 $ \cred mcoin ->
+                    [ assert $ mcoin ==. lit (SJust (pp ^. ppKeyDepositL))
+                    , assertWith 1 status $ not_ (member_ cred (dom_ regpairs))
+                    ]
+                )
+                -- ConwayUnRegCert !(StakeCredential c) !(StrictMaybe Coin)
+                ( branchW 1 $ \cred mcoin ->
+                    [ -- You can only unregister things with 0 reward, so the pair (cred, RDPair 0 _) must be in the map
+                      assertWith 2 status $ member_ cred $ dom_ regpairs
+                    , dependsOn mcoin cred
+                    , forAll' regpairs $ \key rdpair ->
+                        [ whenTrue
+                            (key ==. cred)
+                            (satisfies (pair_ mcoin rdpair) pairSpec)
+                        ]
+                    ]
+                )
+                -- ConwayDelegCert !(StakeCredential c) !(Delegatee c)
+                ( branchW 1 $ \cred delegatee ->
+                    [ assert $ not_ (member_ cred (dom_ delegstake))
+                    , assertWith 3 status $ member_ cred (dom_ regpairs)
+                    , delegateeInPools poolregs delegatee
+                    ]
+                )
+                -- ConwayRegDelegCert !(StakeCredential c) !(Delegatee c) !Coin
+                ( branchW 1 $ \cred delegatee c ->
+                    [ assert $ c ==. lit (pp ^. ppKeyDepositL)
+                    , assertWith 4 status $ not_ (member_ cred (dom_ regpairs))
+                    , delegateeInPools poolregs delegatee
+                    ]
+                )
+            ]
+
+delegName :: ConwayDelegCert c -> String
+delegName (ConwayRegCert {}) = "RegCert"
+delegName (ConwayUnRegCert {}) = "UnRegCert"
+delegName (ConwayDelegCert {}) = "DelegCert"
+delegName (ConwayRegDelegCert {}) = "RegDelegCert"
+
+delegateeInPools ::
+  (Crypto c, IsConwayUniv fn) =>
+  Term fn (Map (KeyHash 'StakePool c) (PoolParams c)) ->
+  Term fn (Delegatee c) ->
+  Pred fn
+delegateeInPools regpools delegatee =
+  (caseOn delegatee)
+    -- DelegStake !(KeyHash 'StakePool c)
+    (branch $ \kh -> member_ kh (dom_ regpools))
+    -- DelegVote !(DRep c)
+    (branch $ \_ -> True)
+    --  DelegStakeVote !(KeyHash 'StakePool c) !(DRep c)
+    (branch $ \kh _ -> member_ kh (dom_ regpools))
+
+pairSpec :: IsConwayUniv fn => Specification fn (StrictMaybe Coin, RDPair)
+pairSpec = constrained $ \pair ->
+  match pair $ \mcoin rdpair ->
+    match rdpair $ \reward deposit ->
+      [ assert $ reward ==. lit (Coin 0)
+      , (caseOn mcoin)
+          -- SNothing
+          (branch $ \_ -> True)
+          -- SJust _
+          (branch $ \x -> x ==. deposit)
+      ]
+
+-- ==============================================
+-- EraRule "POOL"
+-- ==============================================
+
+poolRuleSpec ::
+  IsConwayUniv fn =>
+  Status ->
+  PParams Conway ->
+  Specification fn (PoolEnv Conway, PState Conway, PoolCert StandardCrypto)
+poolRuleSpec status pp = constrained $ \triple ->
+  match triple $ \poolenv pstate poolcert ->
+    match poolenv $ \slot pparams ->
+      [ assert $ pparams ==. lit (pp)
+      , (caseOn poolcert)
+          -- RegPool :: PoolParams c -> PoolCert c
+          ( branchW 1 $ \poolparam ->
+              [ match poolparam $ \_ident _vrf _pledge cost _margin rewAccnt _owners _relays mMetadata ->
+                  [ assertWith 1 status $ cost >=. lit (pp ^. ppMinPoolCostL)
+                  , match rewAccnt $ \net' _ -> [assertWith 2 status $ net' ==. lit Testnet]
+                  , onJust' mMetadata $ \metadata ->
+                      match metadata $ \_ hash -> [assertWith 3 status $ strLen_ hash <=. lit (maxMetaLen - 1)]
+                      -- Aside form these constraints
+                      -- registering a poolparam is very flexible. The ppol can already be registered.
+                      -- It can be schedled for retirement. It can aleady be in the future pool params.
+                      -- The only thing that can cause a failure (in Conway Era) is malformed poolparams
+                      -- properties. There are no properties relating the Poolparams to the Env or State.
+                  ]
+              ]
+          )
+          -- RetirePool :: (KeyHash 'StakePool c) -> EpochNo -> PoolCert c
+          ( branchW 1 $ \keyhash epochNo ->
+              match pstate $ \curPoolparams _futpoolparams _retiring _pooldeposits ->
+                [ curPoolparams `dependsOn` keyhash
+                , assertWith 4 status $ member_ keyhash (dom_ curPoolparams)
+                , reify
+                    slot
+                    (epochFromSlotNo)
+                    ( \curEpoch ->
+                        [ epochNo <=. lit (maxEpochFromPParams pp - 1)
+                        , curEpoch <. epochNo
+                        ]
+                    )
+                ]
+          )
+      ]
+
+maxEpochFromPParams :: EraPParams era => PParams era -> EpochNo
+maxEpochFromPParams pp = maxEpochNo
+  where
+    EpochInterval maxEp = pp ^. ppEMaxL
+    maxEpochNo = EpochNo (fromIntegral maxEp)
+
+maxMetaLen :: Int
+maxMetaLen = fromIntegral (Hash.sizeHash ([] @(HASH StandardCrypto)))
+
+poolName :: PoolCert c -> String
+poolName (RegPool {}) = "RegPool"
+poolName (RetirePool {}) = "RetirePool"
+
+-- =====================================================
+-- EraRule GOVCERT
+-- ==============================================
+
+govRuleSpec ::
+  IsConwayUniv fn =>
+  Status ->
+  Specification
+    fn
+    ( ConwayGovCertEnv (ConwayEra StandardCrypto)
+    , VState (ConwayEra StandardCrypto)
+    , ConwayGovCert StandardCrypto
+    )
+govRuleSpec status =
+  let getDeposits ::
+        Map (Credential 'DRepRole StandardCrypto) (DRepState StandardCrypto) ->
+        [(Credential 'DRepRole StandardCrypto, Coin)]
+      getDeposits vs = [(k, drepDeposit dep) | (k, dep) <- Map.toList vs]
+      getDRepDeposit :: ConwayEraPParams era => PParams era -> Coin
+      getDRepDeposit pp = pp ^. ppDRepDepositL
+   in constrained $ \triple ->
+        match triple $ \env vstate govcert ->
+          match env $ \pp _ ->
+            match vstate $ \voteDelegation _comState _dormantEpochs ->
+              [ satisfies pp pparamsSpec
+              , caseOn
+                  govcert
+                  -- ConwayRegDRep:: Credential 'DRepRole c -> Coin -> StrictMaybe (Anchor c) -> ConwayGovCert c
+                  ( branchW 3 $ \key coin _ ->
+                      [ assertWith 1 status $ not_ $ member_ key (dom_ voteDelegation)
+                      , reify pp getDRepDeposit (\deposit -> coin ==. deposit)
+                      ]
+                  )
+                  --  ConwayUnRegDRep:: Credential 'DRepRole c -> Coin -> ConayGovCert
+                  ( branchW 6 $ \cred coin ->
+                      [ dependsOn voteDelegation (pair_ cred coin)
+                      , reify voteDelegation getDeposits $ \deposits -> assertWith 1 status $ elem_ (pair_ cred coin) deposits
+                      ]
+                  )
+                  --  ConwayUpdateDRep :: Credential 'DRepRole c -> StrictMaybe (Anchor c) -> ConwayGovCert
+                  ( branchW 2 $ \key _ ->
+                      assertWith 1 status $ member_ key (dom_ voteDelegation)
+                  )
+                  -- ConwayAuthCommitteeHotKey:: Credential 'ColdCommitteeRole c -> Credential 'HotCommitteeRole c -> ConwayGovCert
+                  (branchW 1 $ \c _ -> assertWith 1 status (c ==. c))
+                  -- ConwayResignCommitteeColdKey :: Credential 'ColdCommitteeRole c -> StrictMaybe (Anchor c) -> ConwayGovCert
+                  (branchW 1 $ \c _ -> assertWith 1 status (c ==. c))
+              ]
+
+govName :: ConwayGovCert c -> String
+govName x = case x of
+  ConwayRegDRep {} -> "ConwayRegDRep"
+  ConwayUnRegDRep {} -> "ConwayUnRegDRep"
+  ConwayUpdateDRep {} -> "ConwayUpdateDRep"
+  ConwayAuthCommitteeHotKey {} -> "ConwayAuthCommitteeHotKey"
+  ConwayResignCommitteeColdKey {} -> "ConwayResignCommitteeColdKey"
+
+-- =================================================================
+-- A test for every Rule
+
+data Status = Apply | Invert | Remove deriving (Show)
+
+assertWith :: IsConwayUniv fn => Int -> Status -> Term fn Bool -> Pred fn
+assertWith n Apply x = assertExplain ["Status Apply " ++ show n ++ " (" ++ show x ++ ")"] x
+assertWith n Invert x = assertExplain ["Status Negate " ++ show n ++ " (" ++ show x ++ ")"] (not_ x)
+assertWith n Remove x = assertExplain ["Status Remove " ++ show n ++ " (" ++ show x ++ ")"] TruePred
+
+testRule ::
+  ( STS (EraRule s a)
+  , BaseM (EraRule s a) ~ ShelleyBase
+  , HasSpec ConwayFn (Environment (EraRule s a))
+  , HasSpec ConwayFn (State (EraRule s a))
+  , HasSpec ConwayFn (Signal (EraRule s a))
+  ) =>
+  WitRule s a ->
+  Status ->
+  Specification ConwayFn (Environment (EraRule s a), State (EraRule s a), Signal (EraRule s a)) ->
+  (Signal (EraRule s a) -> String) ->
+  Gen Property
+testRule witrule status thespec name = do
+  (env, state, signal) <- genFromSpec @ConwayFn thespec
+  goSTS
+    witrule
+    env
+    state
+    signal
+    ( \x ->
+        case (x, status) of
+          (Left fails, Apply) -> pure $ counterexample ("Apply " ++ show signal ++ "\n" ++ show fails) (property False)
+          (Left _fails, Invert) -> pure $ classify True (name signal ++ ", Does not pass, as expected.") $ property True
+          (Left _fails, Remove) -> pure $ classify True (name signal ++ " Fails") $ property True
+          (Right _newdstate, Apply) -> pure $ classify True (name signal) $ property True
+          (Right _newdstate, Invert) -> pure $ counterexample ("Invert " ++ show signal ++ "\nfails.") (property False)
+          (Right _newdstate, Remove) -> pure $ classify True (name signal ++ " We got lucky, it randomly succeeds.") $ property True
+    )
+
+go1, go2, go3 :: Status -> IO ()
+go1 status = quickCheck (testRule (DELEG Conway) status (delegCertSpec status initPParams) delegName)
+go2 status = quickCheck (testRule (POOL Conway) status (poolRuleSpec status initPParams) poolName)
+go3 status = quickCheck (testRule (GOVCERT Conway) status (govRuleSpec @ConwayFn status) govName)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Proof.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Proof.hs
@@ -215,6 +215,9 @@ data WitRule (s :: Symbol) (e :: Type) where
   ENACT :: Proof era -> WitRule "ENACT" era
   TALLY :: Proof era -> WitRule "TALLY" era
   EPOCH :: Proof era -> WitRule "EPOCH" era
+  DELEG :: Proof era -> WitRule "DELEG" era
+  POOL :: Proof era -> WitRule "POOL" era
+  GOVCERT :: Proof era -> WitRule "GOVCERT" era
 
 ruleProof :: WitRule s e -> Proof e
 ruleProof (UTXO p) = p
@@ -227,6 +230,9 @@ ruleProof (RATIFY p) = p
 ruleProof (ENACT p) = p
 ruleProof (TALLY p) = p
 ruleProof (EPOCH p) = p
+ruleProof (DELEG p) = p
+ruleProof (POOL p) = p
+ruleProof (GOVCERT p) = p
 
 runSTS ::
   forall s e ans.
@@ -246,6 +252,9 @@ runSTS (MOCKCHAIN _proof) x cont = cont (runShelleyBase (applySTSTest x))
 runSTS (RATIFY _proof) x cont = cont (runShelleyBase (applySTSTest x))
 runSTS (ENACT _proof) x cont = cont (runShelleyBase (applySTSTest x))
 runSTS (TALLY _proof) x cont = cont (runShelleyBase (applySTSTest x))
+runSTS (DELEG _proof) x cont = cont (runShelleyBase (applySTSTest x))
+runSTS (POOL _proof) x cont = cont (runShelleyBase (applySTSTest x))
+runSTS (GOVCERT _proof) x cont = cont (runShelleyBase (applySTSTest x))
 runSTS (_proof) x cont = cont (runShelleyBase (applySTSTest x))
 
 runSTS' ::
@@ -266,6 +275,9 @@ runSTS' (RATIFY _proof) x = runShelleyBase (applySTSTest x)
 runSTS' (ENACT _proof) x = runShelleyBase (applySTSTest x)
 runSTS' (TALLY _proof) x = runShelleyBase (applySTSTest x)
 runSTS' (EPOCH _proof) x = runShelleyBase (applySTSTest x)
+runSTS' (DELEG _proof) x = runShelleyBase (applySTSTest x)
+runSTS' (POOL _proof) x = runShelleyBase (applySTSTest x)
+runSTS' (GOVCERT _proof) x = runShelleyBase (applySTSTest x)
 
 -- | Like runSTS, but makes the components of the TRC triple explicit.
 --   in case you can't remember, in ghci type
@@ -315,6 +327,12 @@ goSTS (ENACT _proof) env state sig cont =
 goSTS (TALLY _proof) env state sig cont =
   cont (runShelleyBase (applySTSTest (TRC @(EraRule s e) (env, state, sig))))
 goSTS (EPOCH _proof) env state sig cont =
+  cont (runShelleyBase (applySTSTest (TRC @(EraRule s e) (env, state, sig))))
+goSTS (DELEG _proof) env state sig cont =
+  cont (runShelleyBase (applySTSTest (TRC @(EraRule s e) (env, state, sig))))
+goSTS (POOL _proof) env state sig cont =
+  cont (runShelleyBase (applySTSTest (TRC @(EraRule s e) (env, state, sig))))
+goSTS (GOVCERT _proof) env state sig cont =
   cont (runShelleyBase (applySTSTest (TRC @(EraRule s e) (env, state, sig))))
 
 -- ================================================================

--- a/libs/cardano-ledger-test/test/Tests.hs
+++ b/libs/cardano-ledger-test/test/Tests.hs
@@ -11,6 +11,7 @@ import Data.Default.Class (Default (def))
 import System.Environment (lookupEnv)
 import System.IO (hSetEncoding, stdout, utf8)
 import qualified Test.Cardano.Ledger.Alonzo.Tools as Tools
+import Test.Cardano.Ledger.Constrained.Conway.NecessaryAndSufficient (neccessaryAndSufficientTests)
 import Test.Cardano.Ledger.Constrained.Examples (allExampleTests)
 import Test.Cardano.Ledger.Constrained.Preds.Tx (predsTests)
 import Test.Cardano.Ledger.Constrained.Spec (allSpecTests)
@@ -27,11 +28,13 @@ import Test.Cardano.Ledger.Generic.Properties (genericProperties)
 import qualified Test.Cardano.Ledger.NoThunks as NoThunks
 import qualified Test.Cardano.Ledger.STS as ConstraintSTS
 import Test.Cardano.Ledger.Tickf (calcPoolDistOldEqualsNew)
+import Test.Hspec (hspec)
 import Test.Tasty (TestTree, defaultMain, testGroup)
 
 main :: IO ()
 main = do
   hSetEncoding stdout utf8
+  hspec neccessaryAndSufficientTests
   nightly <- lookupEnv "NIGHTLY"
   defaultMain $ case nightly of
     Nothing -> testGroup "cardano-core" defaultTests

--- a/libs/constrained-generators/src/Constrained/Examples/Tutorial.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Tutorial.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+module Constrained.Examples.Tutorial where
+
+import Constrained
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import GHC.Generics (Generic)
+import Test.QuickCheck.Gen
+
+-- Here are the defined function symbols
+-- You may also use the methods of Num, since there is a (Num (Term fn)) instance.
+import Constrained (
+  -- Function symbols and predicates
+  disjoint_,
+  dom_,
+  elem_,
+  length_,
+  member_,
+  not_,
+  rng_,
+  singleton_,
+  sizeOf_,
+  subset_,
+  sum_,
+  (/=.),
+  (<.),
+  (<=.),
+  (==.),
+  (>.),
+  (>=.),
+ )
+import Constrained.Base (fromList_, null_, union_)
+
+-- See the acompanying Google Doc
+-- https://docs.google.com/presentation/d/1AN6YFJKrjQ8yLUHX8a2uAksrIBHlQ9hOfIjjdyyPWA4/edit?usp=sharing
+
+-- =================================================
+
+data State = State
+  { utxo :: Map Integer Integer
+  , maxInputs :: Integer
+  , maxOutputs :: Integer
+  , minValue :: Integer
+  }
+  deriving (Generic, Eq)
+
+instance HasSimpleRep State
+instance BaseUniverse fn => HasSpec fn State
+
+instance Show State where
+  show (State u i o v) =
+    unlines
+      [ "  utxo = " ++ show u
+      , "  mapInputs = " ++ show i
+      , "  maxOutputs = " ++ show o
+      , "  minValue = " ++ show v
+      ]
+
+data Tx = Tx
+  { inputs :: Set Integer
+  , outputs :: [Integer]
+  , txBodyHash :: Integer
+  }
+  deriving (Generic, Eq)
+
+instance HasSimpleRep Tx
+instance BaseUniverse fn => HasSpec fn Tx
+
+instance Show Tx where
+  show (Tx i o h) = unlines ["  Inputs = " ++ show i, "  Outputs = " ++ show o, "  txBodyHash = " ++ show h]
+
+data System = System State Tx deriving (Generic, Eq)
+
+instance HasSimpleRep System
+instance BaseUniverse fn => HasSpec fn System
+
+instance Show System where
+  show (System s t) = unlines ["System", "State", show s, "Tx", show t]
+
+s :: Specification BaseFn System
+s = constrained $ \s ->
+  match s $ \state tx ->
+    match state $ \utxo maxO maxI minV ->
+      match tx $ \inputs outputs hash ->
+        [subset_ inputs (dom_ utxo)]
+
+main = generate (genFromSpec s)


### PR DESCRIPTION
Adds a new style of tests.

One writes a specification for a triple (Environment, State, Signal).
This specifucation specifies the minimal constraints to make the tests pass.
Tests can be run in 3 Modes 1) Apply, Invert, Remove
In Apply Mode, we test that the given tests are Sufficient to pass the STS rules.
in Invert Mode, we test that the given tests are Neccssary, as we invert them, and then Expect the test to Fail.
    if the test doesn't fail, the test is Not necessary.
in Remove Mode, we remove the constraint. It may or may not pass, as one can get lucky. We use classify
   to record which constraints can get lucky.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
