### PR TITLE
GHA: Downgrade the version of actions/upload-artifact

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -109,7 +109,7 @@ jobs:
     - name: Archive working directory
       run: tar --format pax -cf /var/tmp/state.tar . && mv /var/tmp/state.tar .
     - name: Upload working directory archive
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.2.0
       with:
         name: state-${{ matrix.ghc }}-${{ matrix.os }}
         path: state.tar


### PR DESCRIPTION
We recently started getting "Unable to download and extract artifact" errors. Turning on debug logging reveals that the error is during extraction, and the message is "Invalid signature in zip file". This is coming from the `unzip-stream` npm library.

Downgrading the version of `actions/upload-artifact` results in using an older version of `actions/artifact` which in turn uses an older version of `archiver` which is what's producing the files that `unzip-stream` can't handle.