### PR TITLE
Take care of all compiler warnings for GHC-9.8

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -69,10 +69,8 @@ packages:
   libs/ledger-state
   libs/constrained-generators
 
--- GHC 9.8 introduces new warnings on partial functions.
-if impl(ghc < 9.8)
-  program-options
-    ghc-options: -Werror
+program-options
+  ghc-options: -Werror
 
 package plutus-preprocessor
   haddock-options: "--optghc=-fplugin-opt PlutusTx.Plugin:defer-errors"

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Allegra.Rules (
   module Cardano.Ledger.Allegra.Rules.Utxo,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Alonzo.Rules (
   module Cardano.Ledger.Alonzo.Rules.Bbody,

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/EraMapping.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/EraMapping.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Alonzo.EraMapping where
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Babbage.Rules (
   module Cardano.Ledger.Babbage.Rules.Ledger,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Pool.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Pool.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Conway.Rules.Pool () where
 

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Rules.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Rules.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Mary.Rules () where
 

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/AllegraEraGen.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/AllegraEraGen.hs
@@ -219,7 +219,7 @@ intervals ::
   AllegraEraScript era =>
   [Int] ->
   [NativeScript era]
-intervals xs = zipWith mkInterval padded (tail padded)
+intervals xs = zipWith mkInterval padded (drop 1 padded)
   where
     padded = Nothing : (Just . SlotNo . fromIntegral <$> xs) ++ [Nothing]
     start Nothing = []

--- a/eras/shelley-ma/test-suite/test/Tests.hs
+++ b/eras/shelley-ma/test-suite/test/Tests.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Main where
 

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -174,9 +174,7 @@ instance
   shrink LedgerState {..} =
     -- We drop the first element in the list so the list does not contain the
     -- original LedgerState which would cause `shrink` to loop indefinitely.
-    -- This call of `tail` is safe since the list guaranteed to have at least
-    -- one element.
-    tail $
+    drop 1 $
       LedgerState
         <$> (lsUTxOState : shrink lsUTxOState)
         <*> (lsCertState : shrink lsCertState)

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
@@ -64,6 +64,8 @@ import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Either as Either (partitionEithers)
 import qualified Data.IntSet as IntSet
 import Data.List (foldl')
+import Data.List.NonEmpty (nonEmpty)
+import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Proxy (Proxy (..))
@@ -492,11 +494,12 @@ genNextDeltaTilFixPoint ::
   Tx era ->
   Gen (Delta era)
 genNextDeltaTilFixPoint scriptinfo initialfee keys scripts utxo pparams keySpace tx = do
-  addr <- genRecipients @era 1 keys scripts
+  addrs <- genRecipients @era 1 keys scripts
+  let addr = maybe (error "genNextDeltaTilFixPoint: empty addrs") NE.head $ nonEmpty addrs
   fix
     0
     (genNextDelta scriptinfo utxo pparams keySpace tx)
-    (deltaZero initialfee pparams (head addr))
+    (deltaZero initialfee pparams addr)
 
 applyDelta ::
   forall era.

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/TraceMonad.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/TraceMonad.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Constrained.Trace.TraceMonad where
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Generic.MockChain where
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Generic.Trace where
 

--- a/libs/constrained-generators/src/Constrained/Syntax.hs
+++ b/libs/constrained-generators/src/Constrained/Syntax.hs
@@ -20,9 +20,13 @@ var =
   TH.QuasiQuoter
     { -- Parses variables e.g. `constrained $ \ [var| x |] [var| y |] -> ...` from the strings " x " and " y "
       -- and replaces them with `name "x" -> x` and `name "y" -> y`
-      TH.quotePat = mkNamed . head . words
+      TH.quotePat = mkNamed . varName
     , -- Parses variables in expressions like `assert $ [var| x |] + 3 <. 10` and replaces them with `name "x" x`
-      TH.quoteExp = mkNamedExpr . head . words -- Parses
+      TH.quoteExp = mkNamedExpr . varName
     , TH.quoteDec = const $ fail "var should only be used at binding sites and in expressions"
     , TH.quoteType = const $ fail "var should only be used at binding sites and in expressions"
     }
+  where
+    varName s = case words s of
+      [w] -> w
+      _ -> fail "expected a single var name"

--- a/libs/plutus-preprocessor/src/Debug.hs
+++ b/libs/plutus-preprocessor/src/Debug.hs
@@ -7,4 +7,4 @@ import Cardano.Ledger.Plutus.Evaluate (debugPlutus)
 import System.Environment (getArgs)
 
 main :: IO ()
-main = print . debugPlutus @StandardCrypto . head =<< getArgs
+main = mapM_ (print . debugPlutus @StandardCrypto) =<< getArgs


### PR DESCRIPTION
# Description

There are new warnings in ghc 9.8 for partial functions and orphan type family instances. This fixes the warnings and re-enables `-Werror` for all ghc versions.

Closes #3990

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
