### PR TITLE
CostModel json parsing

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Version history for `cardano-ledger-conway`
 
-## 1.15.0.1
+## 1.15.1.0
 
-*
+### `testlib`
+
+* Add `registerCommitteeHotKeys`
 
 ## 1.15.0.0
 

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-conway
-version:            1.15.0.0
+version:            1.15.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-core`
 
-## 1.13.0.1
+## 1.13.1.0
 
-*
+* Improve error reporting for `CostModel` json parsing
 
 ## 1.13.0.0
 

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-core
-version:            1.13.0.0
+version:            1.13.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Plutus/Examples.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Plutus/Examples.hs
@@ -2456,20 +2456,16 @@ datumIsWellformed =
       , "ae78004c010d5d10019aba10020051200112200212200130032253350011004221335005350022200130040011"
       , "22002122122330010040032323001001230022330020020011"
       ]
-    -- ScriptHash "64d905de3c32c400c1f9c1553e1c9a72bcb5a4148251bdc38b00b439"
+    -- ScriptHash "883bc139d6591f366cb12f95fba30920fc4597affbbd20eed74e142d"
     -- Preprocessed PlutusV3 Script:
     -- @@@
     -- datumIsWellformed_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
     --                        PlutusTx.Builtins.Internal.BuiltinUnit
     -- datumIsWellformed_0 arg_1 = PlutusTx.Prelude.check GHC.Base.$ (case PlutusTx.IsData.Class.unsafeFromBuiltinData arg_1 of
-    --                                                                {PlutusLedgerApi.V3.Contexts.ScriptContext _txInfo_2
+    --                                                                {PlutusLedgerApi.V3.Contexts.ScriptContext txInfo_2
     --                                                                                                           _redeemer_3
     --                                                                                                           (PlutusLedgerApi.V3.Contexts.SpendingScript _txOutRef_4
-    --                                                                                                                                                       (GHC.Maybe.Nothing)) -> GHC.Types.True;
-    --                                                                 PlutusLedgerApi.V3.Contexts.ScriptContext txInfo_5
-    --                                                                                                           _redeemer_6
-    --                                                                                                           (PlutusLedgerApi.V3.Contexts.SpendingScript _txOutRef_7
-    --                                                                                                                                                       (GHC.Maybe.Just datum_8)) -> Data.Foldable.null GHC.Base.$ (PlutusTx.List.filter (datum_8 PlutusTx.Eq.==) GHC.Base.$ (PlutusTx.AssocMap.elems GHC.Base.$ PlutusLedgerApi.V3.Contexts.txInfoData txInfo_5));
+    --                                                                                                                                                       (GHC.Maybe.Just datum_5)) -> Data.Foldable.null GHC.Base.$ (PlutusTx.List.filter (datum_5 PlutusTx.Eq.==) GHC.Base.$ (PlutusTx.AssocMap.elems GHC.Base.$ PlutusLedgerApi.V3.Contexts.txInfoData txInfo_2));
     --                                                                 _ -> GHC.Types.False})
     -- @@@
     SPlutusV3 ->
@@ -2525,7 +2521,7 @@ datumIsWellformed =
       , "19bad357426ae8800426026921035054310035573c0046aae74004dd50009aba20011300e49103505431003557"
       , "3c0046aae74004dd5000c88a400644260209210350543500909807a48103505435009109808249035054350090"
       , "9807a4810350543500914ac800c8c8564c004c052401e444444444444444400c8c002443002180a112c800c600"
-      , "1221325333573466ebc01800c600600700108009802000a300045268980824810350543500484c03d241035054"
+      , "1221325333573466ebc01800c600600700108009802000a300245268980824810350543500484c03d241035054"
       , "35000c0308894ccd5cd19b87480000044c031241035054330015333573466e2000520001330033370290000011"
       , "9b81480000044ca00266e1000c00666e10008004660080040026016444a666ae68cdc3a4000002200426600600"
       , "266e1800800480048c8c8c94ccd5cd19b874800000860042a666ae68cdc3a400400430001300a4910350543100"

--- a/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor/Source/V3.hs
+++ b/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor/Source/V3.hs
@@ -167,7 +167,6 @@ datumIsWellformedQ =
     datumIsWellformed arg =
       P.check $
         case unsafeFromBuiltinData arg of
-          PV3.ScriptContext _txInfo _redeemer (PV3.SpendingScript _txOutRef Nothing) -> True
           PV3.ScriptContext txInfo _redeemer (PV3.SpendingScript _txOutRef (Just datum)) ->
             null $ P.filter (datum P.==) $ PAM.elems $ PV3.txInfoData txInfo
           _ -> False


### PR DESCRIPTION
# Description

This PR replaces #4413 except error will be:
```
Error: Error decoding JSON cost model at "test/cardano-cli-golden/files/input/governance/costmodels.json": 
Error in $: Cost model language: PlutusV2
            ┃     │   Parameter name missing from cost model: "integerToByteString-cpu-arguments-c1"
            ┃     │   Parameter name missing from cost model: "integerToByteString-cpu-arguments-c0"
```

As always there are a few other minor improvements.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
