### PR TITLE
Improve resilience of future PParams

### DIFF
--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -92,7 +92,7 @@ library
         cardano-ledger-babbage ^>=1.8,
         cardano-ledger-core ^>=1.13,
         cardano-ledger-mary ^>=1.6,
-        cardano-ledger-shelley ^>=1.12.1,
+        cardano-ledger-shelley ^>=1.12.2,
         cardano-slotting,
         cardano-strict-containers,
         containers,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -467,29 +467,30 @@ setFreshDRepPulsingState epochNo stakePoolDistr epochState = do
       umap = dsUnified dState
       umapSize = Map.size $ umElems umap
       pulseSize = max 1 (umapSize `div` (fromIntegral :: Word64 -> Int) (4 * k))
-      epochState' =
-        epochState
-          & epochStateGovStateL . cgsDRepPulsingStateL
-            .~ DRPulsing
-              ( DRepPulser
-                  { dpPulseSize = pulseSize
-                  , dpUMap = dsUnified dState
-                  , dpIndex = 0 -- used as the index of the remaining UMap
-                  , dpStakeDistr = stakeDistr -- used as part of the snapshot
-                  , dpStakePoolDistr = stakePoolDistr
-                  , dpDRepDistr = Map.empty -- The partial result starts as the empty map
-                  , dpDRepState = vsDReps vState
-                  , dpCurrentEpoch = epochNo
-                  , dpCommitteeState = vsCommitteeState vState
-                  , dpEnactState =
-                      mkEnactState govState
-                        & ensTreasuryL .~ epochState ^. epochStateTreasuryL
-                  , dpProposals = proposalsActions props
-                  , dpProposalDeposits = proposalsDeposits props
-                  , dpGlobals = globals
-                  }
-              )
-  pure epochState'
+      govState' =
+        predictFuturePParams $
+          govState
+            & cgsDRepPulsingStateL
+              .~ DRPulsing
+                ( DRepPulser
+                    { dpPulseSize = pulseSize
+                    , dpUMap = dsUnified dState
+                    , dpIndex = 0 -- used as the index of the remaining UMap
+                    , dpStakeDistr = stakeDistr -- used as part of the snapshot
+                    , dpStakePoolDistr = stakePoolDistr
+                    , dpDRepDistr = Map.empty -- The partial result starts as the empty map
+                    , dpDRepState = vsDReps vState
+                    , dpCurrentEpoch = epochNo
+                    , dpCommitteeState = vsCommitteeState vState
+                    , dpEnactState =
+                        mkEnactState govState
+                          & ensTreasuryL .~ epochState ^. epochStateTreasuryL
+                    , dpProposals = proposalsActions props
+                    , dpProposalDeposits = proposalsDeposits props
+                    , dpGlobals = globals
+                    }
+                )
+  pure $ epochState & epochStateGovStateL .~ govState'
 
 -- | Force computation of DRep stake distribution and figure out the next enact
 -- state. This operation is useful in cases when access to new EnactState or DRep stake

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
@@ -245,7 +245,7 @@ hardForkInitiationNoDRepsSpec =
 pparamPredictionSpec :: ConwayEraImp era => SpecWith (ImpTestState era)
 pparamPredictionSpec =
   it "futurePParams" $ do
-    (committeeMember :| _) <- registerInitialCommittee
+    committeeMembers' <- registerInitialCommittee
     modifyPParams $ ppPoolVotingThresholdsL . pvtHardForkInitiationL .~ 2 %! 3
     whenPostBootstrap (modifyPParams $ ppDRepVotingThresholdsL . dvtHardForkInitiationL .~ def)
     _ <- setupPoolWithStake $ Coin 22_000_000
@@ -255,7 +255,7 @@ pparamPredictionSpec =
     nextMajorVersion <- succVersion $ pvMajor curProtVer
     let nextProtVer = curProtVer {pvMajor = nextMajorVersion}
     govActionId <- submitGovAction $ HardForkInitiation SNothing nextProtVer
-    submitYesVote_ (CommitteeVoter committeeMember) govActionId
+    submitYesVoteCCs_ committeeMembers' govActionId
     submitYesVote_ (StakePoolVoter stakePoolId1) govActionId
     submitYesVote_ (StakePoolVoter stakePoolId2) govActionId
     passEpoch

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Version history for `cardano-ledger-shelley`
 
-## 1.12.1.1
+## 1.12.2.0
 
 *
+
+### `testlib`
+
+* Add `advanceToPointOfNoReturn`
 
 ## 1.12.1.0
 

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-shelley
-version:            1.12.1.0
+version:            1.12.2.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK


### PR DESCRIPTION
# Description

This PR adds a test for `futurePParams` prediction and fixes a problem where it would not work correctly when there was no `TICK`s before the point of no return (first 4k/f slots)

This isn't really a problem in practice, because of this property that Sam pointed out:

> if there isn't a single block in 3k/f slots, the ledger state goes out of view and no further blocks can be made

But it is nice to fix it regardless, because it simplifies the `futurePParams` state transition a bit

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
