### PR TITLE
Make reference scripts fee grow exponentially with size

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.15.1.0
 
+* Add `tierRefScriptFee` and `txNonDistinctRefScriptsSize`
+* Make reference scripts fee grow exponentially with size
+
 ### `testlib`
 
 * Add `registerCommitteeHotKeys`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -167,6 +167,7 @@ test-suite tests
     main-is:          Main.hs
     hs-source-dirs:   test
     other-modules:
+        Test.Cardano.Ledger.Conway.Spec
         Test.Cardano.Ledger.Conway.BinarySpec
         Test.Cardano.Ledger.Conway.Binary.CddlSpec
         Test.Cardano.Ledger.Conway.DRepRatifySpec

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -6,6 +8,7 @@
 
 module Cardano.Ledger.Conway.Tx (
   module BabbageTxReExport,
+  tierRefScriptFee,
 )
 where
 
@@ -38,6 +41,7 @@ import Cardano.Ledger.Conway.TxWits ()
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Val (Val (..))
+import Data.Ratio ((%))
 import Lens.Micro ((^.))
 
 instance Crypto c => EraTx (ConwayEra c) where
@@ -85,7 +89,30 @@ getConwayMinFeeTx pp tx refScriptsSize =
   alonzoMinFeeTx pp tx <+> refScriptsFee
   where
     refScriptCostPerByte = unboundRational (pp ^. ppMinFeeRefScriptCostPerByteL)
-    refScriptsFee = Coin (floor (fromIntegral @Int @Rational refScriptsSize * refScriptCostPerByte))
+    refScriptsFee = tierRefScriptFee multiplier sizeIncrement refScriptCostPerByte refScriptsSize
+    multiplier = 1.2
+    sizeIncrement = 25_600 -- 25KiB
+
+-- | Calculate the fee for reference scripts using an expoential growth of the price per
+-- byte with linear increments
+tierRefScriptFee ::
+  -- | Growth factor or step multiplier
+  Rational ->
+  -- | Increment size in which price grows linearly according to the price
+  Int ->
+  -- | Base fee. Currently this is customizable by `ppMinFeeRefScriptCostPerByteL`
+  Rational ->
+  -- | Total RefScript size in bytes
+  Int ->
+  Coin
+tierRefScriptFee multiplier sizeIncrement = go 0
+  where
+    go !acc !curTierPrice !n
+      | n < sizeIncrement =
+          Coin $ floor (acc + (toInteger n % 1) * curTierPrice)
+      | otherwise =
+          go (acc + sizeIncrementRational * curTierPrice) (multiplier * curTierPrice) (n - sizeIncrement)
+    sizeIncrementRational = toInteger sizeIncrement % 1
 
 instance Crypto c => AlonzoEraTx (ConwayEra c) where
   {-# SPECIALIZE instance AlonzoEraTx (ConwayEra StandardCrypto) #-}

--- a/eras/conway/impl/test/Main.hs
+++ b/eras/conway/impl/test/Main.hs
@@ -7,6 +7,7 @@ import qualified Test.Cardano.Ledger.Alonzo.Binary.CostModelsSpec as CostModelsS
 import qualified Test.Cardano.Ledger.Alonzo.Binary.TxWitsSpec as TxWitsSpec
 import qualified Test.Cardano.Ledger.Alonzo.Imp as AlonzoImp
 import Test.Cardano.Ledger.Common
+import qualified Test.Cardano.Ledger.Conway.Spec as Spec
 import qualified Test.Cardano.Ledger.Conway.Binary.CddlSpec as Cddl
 import qualified Test.Cardano.Ledger.Conway.Binary.Regression as Regression
 import qualified Test.Cardano.Ledger.Conway.BinarySpec as Binary
@@ -24,6 +25,7 @@ main :: IO ()
 main =
   ledgerTestMain $
     describe "Conway" $ do
+      Spec.spec
       Proposals.spec
       Binary.spec
       Cddl.spec

--- a/eras/conway/impl/test/Main.hs
+++ b/eras/conway/impl/test/Main.hs
@@ -7,7 +7,6 @@ import qualified Test.Cardano.Ledger.Alonzo.Binary.CostModelsSpec as CostModelsS
 import qualified Test.Cardano.Ledger.Alonzo.Binary.TxWitsSpec as TxWitsSpec
 import qualified Test.Cardano.Ledger.Alonzo.Imp as AlonzoImp
 import Test.Cardano.Ledger.Common
-import qualified Test.Cardano.Ledger.Conway.Spec as Spec
 import qualified Test.Cardano.Ledger.Conway.Binary.CddlSpec as Cddl
 import qualified Test.Cardano.Ledger.Conway.Binary.Regression as Regression
 import qualified Test.Cardano.Ledger.Conway.BinarySpec as Binary
@@ -18,6 +17,7 @@ import qualified Test.Cardano.Ledger.Conway.GovActionReorderSpec as GovActionReo
 import qualified Test.Cardano.Ledger.Conway.Imp as ConwayImp
 import Test.Cardano.Ledger.Conway.Plutus.PlutusSpec as PlutusSpec
 import qualified Test.Cardano.Ledger.Conway.Proposals as Proposals
+import qualified Test.Cardano.Ledger.Conway.Spec as Spec
 import Test.Cardano.Ledger.Core.JSON (roundTripJsonEraSpec)
 import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/Spec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/Spec.hs
@@ -1,0 +1,13 @@
+module Test.Cardano.Ledger.Conway.Spec (spec) where
+
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway.Tx (tierRefScriptFee)
+import Test.Cardano.Ledger.Common
+
+spec :: Spec
+spec = do
+  describe "Various tests for functions defined in Conway" $ do
+    it "tierRefScriptFee" $ do
+      let step = 25600
+      map (tierRefScriptFee 1.5 step 15) [0, step .. 204800]
+        `shouldBe` map Coin [0, 384000, 960000, 1824000, 3120000, 5064000, 7980000, 12354000, 18915000]

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/Spec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/Spec.hs
@@ -7,6 +7,9 @@ import Test.Cardano.Ledger.Common
 spec :: Spec
 spec = do
   describe "Various tests for functions defined in Conway" $ do
+    prop "tierRefScriptFee is a linear function when growth is 1" $ \(Positive sizeIncrement) baseFee (NonNegative size) ->
+      tierRefScriptFee 1 sizeIncrement baseFee size
+        === Coin (floor (fromIntegral size * baseFee))
     it "tierRefScriptFee" $ do
       let step = 25600
       map (tierRefScriptFee 1.5 step 15) [0, step .. 204800]


### PR DESCRIPTION
# Description

This PR changes linear fee calculation for reference scripts to exponential.

Here are two plots of how much fee a user will have to pay for a total size of the reference scripts included in a transaction. Exponent that we settled on is: `1.2`

* Up to 1MiB:
![ref-1 2](https://github.com/IntersectMBO/cardano-ledger/assets/2333894/1ea3c198-0cbc-4e29-9cc8-9a10cf16d064)

* Zoomed in version to up to 160KiB
![ref-1 2-160KiB](https://github.com/IntersectMBO/cardano-ledger/assets/2333894/4d2aea09-180f-4ddc-bf41-a748c45c8015)


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
