### PR TITLE
Tx refscript size check

### DIFF
--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Version history for `cardano-ledger-babbage`
 
-## 1.8.1.1
+## 1.8.2.0
 
-*
+### `testlib`
+
+* Add `produceRefScript` and `produceRefScripts`
 
 ## 1.8.1.0
 

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-babbage
-version:            1.8.1.0
+version:            1.8.2.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -116,7 +116,8 @@ library testlib
         cardano-crypto-class,
         cardano-ledger-babbage,
         cardano-ledger-binary,
-        cardano-ledger-core:{cardano-ledger-core, testlib},
+        cardano-ledger-core:{cardano-ledger-core, testlib} >=1.13.2,
+        cardano-strict-containers,
         generic-random,
         microlens,
         microlens-mtl,

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
@@ -9,14 +9,25 @@
 
 module Test.Cardano.Ledger.Babbage.ImpTest (
   module Test.Cardano.Ledger.Alonzo.ImpTest,
+  produceRefScript,
+  produceRefScripts,
 ) where
 
 import Cardano.Crypto.DSIGN (DSIGNAlgorithm (..), Ed25519DSIGN)
 import Cardano.Crypto.Hash (Hash)
 import Cardano.Ledger.Babbage (BabbageEra)
-import Cardano.Ledger.Core
+import Cardano.Ledger.Babbage.Core
+import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Crypto (Crypto (..))
 import Cardano.Ledger.Plutus.Language (SLanguage (..))
+import Cardano.Ledger.Shelley.LedgerState (curPParamsEpochStateL, nesEsL)
+import Cardano.Ledger.Tools (setMinCoinTxOut)
+import Cardano.Ledger.TxIn (TxIn, mkTxInPartial)
+import Control.Monad (forM)
+import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Sequence.Strict as SSeq
+import Lens.Micro ((&), (.~))
 import Lens.Micro.Mtl ((%=))
 import Test.Cardano.Ledger.Alonzo.ImpTest
 import Test.Cardano.Ledger.Babbage.TreeDiff ()
@@ -39,3 +50,26 @@ instance ShelleyEraImp (BabbageEra c) => MaryEraImp (BabbageEra c)
 
 instance ShelleyEraImp (BabbageEra c) => AlonzoEraImp (BabbageEra c) where
   scriptTestContexts = plutusTestScripts SPlutusV1 <> plutusTestScripts SPlutusV2
+
+produceRefScript ::
+  (ShelleyEraImp era, BabbageEraTxOut era) =>
+  Script era ->
+  ImpTestM era (TxIn (EraCrypto era))
+produceRefScript script = do
+  txIn :| [] <- produceRefScripts $ script :| []
+  pure txIn
+
+produceRefScripts ::
+  (ShelleyEraImp era, BabbageEraTxOut era) =>
+  NonEmpty (Script era) ->
+  ImpTestM era (NonEmpty (TxIn (EraCrypto era)))
+produceRefScripts scripts = do
+  pp <- getsNES $ nesEsL . curPParamsEpochStateL
+  txOuts <- forM scripts $ \script -> do
+    addr <- freshKeyAddr_
+    let txOutZero =
+          mkBasicTxOut addr mempty & referenceScriptTxOutL .~ SJust script
+    pure $ setMinCoinTxOut pp txOutZero
+  let txBody = mkBasicTxBody & outputsTxBodyL .~ SSeq.fromList (NE.toList txOuts)
+  txId <- txIdTx <$> submitTx (mkBasicTx txBody)
+  pure $ NE.zipWith (\_ -> mkTxInPartial txId) scripts (0 :| [1 ..])

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added `certsCurrentCommittee` and `certsCommitteeProposals` to `CertsEnv`
 * Added `cgceCurrentCommittee` and `cgceCommitteeProposals` to `ConwayGovCertEnv`
 * Added `proposalsWithPurpose`, `isGovActionWithPurpose` and `ToGovActionPurpose`
+* Added `ConwayTxRefScriptsSizeTooBig` predicate failure to `ConwayLedgerPredFailure`
 
 ## 1.15.1.0
 

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -121,9 +121,10 @@ library testlib
         Test.Cardano.Ledger.Conway.Imp.EnactSpec
         Test.Cardano.Ledger.Conway.Imp.GovSpec
         Test.Cardano.Ledger.Conway.Imp.GovCertSpec
+        Test.Cardano.Ledger.Conway.Imp.LedgerSpec
+        Test.Cardano.Ledger.Conway.Imp.RatifySpec
         Test.Cardano.Ledger.Conway.Imp.UtxoSpec
         Test.Cardano.Ledger.Conway.Imp.UtxosSpec
-        Test.Cardano.Ledger.Conway.Imp.RatifySpec
         Test.Cardano.Ledger.Conway.Proposals
         Test.Cardano.Ledger.Conway.TreeDiff
         Test.Cardano.Ledger.Conway.Genesis
@@ -149,7 +150,7 @@ library testlib
         cardano-ledger-allegra,
         cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
         cardano-ledger-binary,
-        cardano-ledger-babbage:{cardano-ledger-babbage, testlib},
+        cardano-ledger-babbage:{cardano-ledger-babbage, testlib} >=1.8.2,
         cardano-ledger-conway,
         cardano-ledger-core:{cardano-ledger-core, testlib},
         cardano-ledger-mary,

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -24,6 +24,7 @@ import Cardano.Ledger.Conway.Rules (
   ConwayEpochEvent,
   ConwayGovCertPredFailure,
   ConwayGovPredFailure,
+  ConwayLedgerPredFailure,
   ConwayNewEpochEvent,
  )
 import Cardano.Ledger.Conway.TxInfo (ConwayContextError)
@@ -36,6 +37,7 @@ import qualified Test.Cardano.Ledger.Conway.Imp.EnactSpec as Enact
 import qualified Test.Cardano.Ledger.Conway.Imp.EpochSpec as Epoch
 import qualified Test.Cardano.Ledger.Conway.Imp.GovCertSpec as GovCert
 import qualified Test.Cardano.Ledger.Conway.Imp.GovSpec as Gov
+import qualified Test.Cardano.Ledger.Conway.Imp.LedgerSpec as Ledger
 import qualified Test.Cardano.Ledger.Conway.Imp.RatifySpec as Ratify
 import qualified Test.Cardano.Ledger.Conway.Imp.UtxoSpec as Utxo
 import qualified Test.Cardano.Ledger.Conway.Imp.UtxosSpec as Utxos
@@ -58,6 +60,7 @@ spec ::
   , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
   , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
   , InjectRuleFailure "LEDGER" ConwayGovCertPredFailure era
+  , InjectRuleFailure "LEDGER" ConwayLedgerPredFailure era
   , NFData (Event (EraRule "ENACT" era))
   , ToExpr (Event (EraRule "ENACT" era))
   , Eq (Event (EraRule "ENACT" era))
@@ -78,6 +81,7 @@ spec = do
       describe "UTXO" $ Utxo.spec @era
       describe "UTXOS" $ Utxos.spec @era
       describe "RATIFY" $ Ratify.spec @era
+      describe "LEDGER" $ Ledger.spec @era
   describe "ConwayImpSpec - bootstrap phase (protocol version 9)" $
     withImpState @era $ do
       describe "ENACT" $ Enact.relevantDuringBootstrapSpec @era
@@ -87,3 +91,4 @@ spec = do
       describe "UTXO" $ Utxo.spec @era
       describe "UTXOS" $ Utxos.relevantDuringBootstrapSpec @era
       describe "RATIFY" $ Ratify.relevantDuringBootstrapSpec @era
+      describe "LEDGER" $ Ledger.spec @era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Conway.Imp.LedgerSpec (spec) where
+
+import Cardano.Ledger.Conway.Core
+import Cardano.Ledger.Conway.Rules (ConwayLedgerPredFailure (..), maxRefScriptSizePerTx)
+import Cardano.Ledger.Plutus (SLanguage (..))
+import Cardano.Ledger.SafeHash (originalBytesSize)
+import qualified Data.Set as Set
+import Lens.Micro ((&), (.~))
+import Test.Cardano.Ledger.Conway.ImpTest
+import Test.Cardano.Ledger.Imp.Common
+import Test.Cardano.Ledger.Plutus.Examples (alwaysFailsWithDatum)
+
+spec ::
+  forall era.
+  ( ConwayEraImp era
+  , InjectRuleFailure "LEDGER" ConwayLedgerPredFailure era
+  ) =>
+  SpecWith (ImpTestState era)
+spec =
+  it "TxRefScriptsSizeTooBig" $ do
+    -- we use here the largest script we currently have as many times as necessary to
+    -- trigger the predicate failure
+    Just plutusScript <- pure $ mkPlutusScript @era $ alwaysFailsWithDatum SPlutusV3
+    let script :: Script era
+        script = fromPlutusScript plutusScript
+        size = originalBytesSize script
+        (q, r) = maxRefScriptSizePerTx `quotRem` size
+        n = q + signum r
+    txIns <- replicateM n (produceRefScript script)
+    let tx :: Tx era
+        tx = mkBasicTx (mkBasicTxBody & referenceInputsTxBodyL .~ Set.fromList txIns)
+    submitFailingTx
+      tx
+      [ injectFailure $ ConwayTxRefScriptsSizeTooBig (size * n) maxRefScriptSizePerTx
+      ]

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -59,7 +59,7 @@ library
         cardano-ledger-babbage ^>=1.8.1,
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-conway >=1.13 && <1.17,
-        cardano-ledger-core ^>=1.13,
+        cardano-ledger-core ^>=1.13.2,
         cardano-ledger-mary >=1.5 && <1.7,
         cardano-ledger-shelley ^>=1.12,
         containers,

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Out.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Out.hs
@@ -86,27 +86,8 @@ import Cardano.Ledger.Core (
   eraProtVerLow,
   isAdaOnlyTxOutF,
  )
+import Cardano.Ledger.Tools (setMinCoinTxOut, setMinCoinTxOutWith)
 import Lens.Micro
-
-setMinCoinTxOutInternal ::
-  EraTxOut era =>
-  (Coin -> Coin -> Bool) ->
-  PParams era ->
-  TxOut era ->
-  TxOut era
-setMinCoinTxOutInternal f pp = go
-  where
-    go !txOut =
-      let curMinCoin = getMinCoinTxOut pp txOut
-          curCoin = txOut ^. coinTxOutL
-       in if curCoin `f` curMinCoin
-            then txOut
-            else go (txOut & coinTxOutL .~ curMinCoin)
-
--- | Same as `setMinCoinSizedTxOut`, except it doesn't require the size of the
--- TxOut and will recompute it if needed. Initial amount is not important.
-setMinCoinTxOut :: EraTxOut era => PParams era -> TxOut era -> TxOut era
-setMinCoinTxOut = setMinCoinTxOutInternal (==)
 
 -- | Similar to `setMinCoinTxOut` it will guarantee that the minimum requirement for the
 -- output amount is satisified, however it makes it possible to set a higher amount than
@@ -117,7 +98,7 @@ setMinCoinTxOut = setMinCoinTxOutInternal (==)
 -- > (ensureMinCoinTxOut pp txOut ^. coinTxOutL) >= (setMinCoinTxOut pp txOut ^. coinTxOutL)
 -- @
 ensureMinCoinTxOut :: EraTxOut era => PParams era -> TxOut era -> TxOut era
-ensureMinCoinTxOut = setMinCoinTxOutInternal (>=)
+ensureMinCoinTxOut = setMinCoinTxOutWith (>=)
 
 setMinCoinSizedTxOutInternal ::
   forall era.

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-core`
 
-## 1.13.1.1
+## 1.13.2.0
 
-*
+* Add `setMinCoinTxOut` and `setMinCoinTxOutWith`
 
 ## 1.13.1.0
 

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-core
-version:            1.13.1.0
+version:            1.13.2.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Utils.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Utils.hs
@@ -49,5 +49,5 @@ mkDummySafeHash _ = unsafeMakeSafeHash . mkDummyHash @(HASH c)
 
 txInAt :: (HasCallStack, Integral i, EraTx era) => i -> Tx era -> TxIn (EraCrypto era)
 txInAt index tx =
-  let txid = txIdTx tx
-   in mkTxInPartial txid (toInteger index)
+  let txId = txIdTx tx
+   in mkTxInPartial txId (toInteger index)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1478,6 +1478,12 @@ ppConwayLedgerPredFailure proof x = case x of
     _ ->
       error
         ("Only the ConwayEra has a (PredicateFailure (EraRule \"CERTS\" era)). This Era is " ++ show proof)
+  ConwayTxRefScriptsSizeTooBig s1 s2 ->
+    ppRecord
+      "ConwayTxRefScriptsSizeTooBig"
+      [ ("Computed sum of reference script size", ppInt s1)
+      , ("Maximum allowed total reference script size", ppInt s2)
+      ]
 
 instance Reflect era => PrettyA (ConwayLedgerPredFailure era) where
   prettyA = ppConwayLedgerPredFailure reify


### PR DESCRIPTION
# Description

This PR does two things:

* Adds a new predicate failure for the total max size of reference scripts that can be used in any transaction
* Moves the `ConwayTreasuryValueMismatch` predicate check into the section that validates `isValid == True` transactions. There is no need to validate this value for phase2 failed transactions.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
