### PR TITLE
Bump up version for `cardano-data`

### DIFF
--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -85,7 +85,7 @@ library
         aeson >=2.2,
         data-default-class,
         cardano-crypto-class,
-        cardano-data >=1.2.1,
+        cardano-data >=1.2.3,
         cardano-ledger-binary >=1.3.2,
         cardano-ledger-allegra ^>=1.5,
         cardano-ledger-alonzo ^>=1.10,

--- a/libs/cardano-data/CHANGELOG.md
+++ b/libs/cardano-data/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-data`
 
-## 1.2.2.1
+## 1.2.3.0
 
-*
+* Add `mapUnsafe`
 
 ## 1.2.2.0
 

--- a/libs/cardano-data/cardano-data.cabal
+++ b/libs/cardano-data/cardano-data.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-data
-version:            1.2.2.0
+version:            1.2.3.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK


### PR DESCRIPTION
# Description
This is a fixup PR that is needed for a release:

* In #4452 I forgot to bump up the version of `cardano-data` and increase the lower bound on it for `cardano-ledger-conway`

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
