### PR TITLE
Remove unnecessary allocation in non-integral reference code

### DIFF
--- a/libs/non-integral/reference/non_integral.c
+++ b/libs/non-integral/reference/non_integral.c
@@ -197,8 +197,6 @@ void mp_lnN(mpz_t rop, const int maxN, const mpz_t x, const mpz_t epsilon)
    and then calls the continued fraction approximation function. */
 int ref_exp_(mpz_t rop, const mpz_t x)
 {
-  mpz_t temp_q, temp_r;
-  mpz_init(temp_q); mpz_init(temp_r);
   int iterations = 0;
 
   if(mpz_cmp(x, zero) == 0)
@@ -232,7 +230,6 @@ int ref_exp_(mpz_t rop, const mpz_t x)
       mpz_clear(n_exponent); mpz_clear(x_); mpz_clear(temp_r); mpz_clear(temp_q);
     }
 
-  mpz_clear(temp_r); mpz_clear(temp_q);
   return iterations;
 }
 


### PR DESCRIPTION
# Description

Temp variables in `ref_exp_` function are never used. They are just allocated and cleared. Since this is a recursive function and the reference code serves as a baseline for performance, it should be fixed.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Self-reviewed the diff
