### PR TITLE
Conformance DELEG: Extract `Deleg` ExecSpecRule and `SpecTranslate` instances

### DIFF
--- a/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
+++ b/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
@@ -31,11 +31,13 @@ library
         Test.Cardano.Ledger.Conformance.SpecTranslate.Core
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
+        Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Core
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base
+        Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Pool
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway.hs
@@ -2,4 +2,5 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway () where
 
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base ()
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert ()
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg ()
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Pool ()

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
@@ -49,9 +49,9 @@ import Cardano.Ledger.Conway.Rules (
   spoAcceptedRatio,
  )
 import Cardano.Ledger.Conway.Tx (AlonzoTx)
-import Cardano.Ledger.Conway.TxCert (ConwayDelegCert, ConwayGovCert)
+import Cardano.Ledger.Conway.TxCert (ConwayGovCert)
 import Cardano.Ledger.Credential (Credential)
-import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
+import Cardano.Ledger.Crypto (StandardCrypto)
 import Cardano.Ledger.Keys (KeyRole (..))
 import Cardano.Ledger.TxIn (TxId)
 import Constrained
@@ -82,9 +82,6 @@ import Test.Cardano.Ledger.Constrained.Conway (
   EpochExecEnv,
   IsConwayUniv,
   ProposalsSplit,
-  dStateSpec,
-  delegCertSpec,
-  delegEnvSpec,
   epochEnvSpec,
   epochSignalSpec,
   epochStateSpec,
@@ -258,19 +255,6 @@ instance Inject (ConwayCertExecContext era) (VotingProcedures era) where
 
 instance Era era => ToExpr (ConwayCertExecContext era)
 
-disableRegCertsDelegCert ::
-  ( IsConwayUniv fn
-  , Crypto c
-  ) =>
-  Term fn (ConwayDelegCert c) ->
-  Pred fn
-disableRegCertsDelegCert delegCert =
-  (caseOn delegCert)
-    (branch $ \_ _ -> False)
-    (branch $ \_ _ -> True)
-    (branch $ \_ _ -> True)
-    (branch $ \_ _ _ -> True)
-
 data ConwayRatifyExecContext era = ConwayRatifyExecContext
   { crecTreasury :: Coin
   , crecGovActionMap :: [GovActionState era]
@@ -404,20 +388,6 @@ instance IsConwayUniv fn => ExecSpecRule fn "ENACT" Conway where
     first (error "ENACT failed")
       . computationResultToEither
       $ Agda.enactStep env st sig
-
-instance IsConwayUniv fn => ExecSpecRule fn "DELEG" Conway where
-  environmentSpec _ = delegEnvSpec
-
-  stateSpec _ _ = dStateSpec
-
-  signalSpec _ env st =
-    delegCertSpec env st
-      <> constrained disableRegCertsDelegCert
-
-  runAgdaRule env st sig =
-    first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
-      . computationResultToEither
-      $ Agda.delegStep env st sig
 
 instance Inject (EpochExecEnv era) () where
   inject _ = ()

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
@@ -36,13 +36,7 @@ instance
       disableCerts :: Term fn (ConwayTxCert Conway) -> Pred fn
       disableCerts cert =
         (caseOn cert)
-          ( branch $ \delegCert ->
-              (caseOn delegCert)
-                (branch $ \_ _ -> False) -- TODO DelegRegCert is disabled! Investigate why!
-                (branch $ \_ _ -> True)
-                (branch $ \_ _ -> True)
-                (branch $ \_ _ _ -> True)
-          )
+          (branch $ \_ -> True)
           (branch $ \_ -> True)
           (branch disableDRepRegCerts)
   runAgdaRule env st sig =

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg () where
+
+import Cardano.Ledger.Conway
+import Cardano.Ledger.Conway.TxCert (ConwayDelegCert)
+import Cardano.Ledger.Crypto
+import Constrained
+import Data.Bifunctor (first)
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Text as T
+import qualified Lib as Agda
+import Test.Cardano.Ledger.Conformance
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core ()
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
+import Test.Cardano.Ledger.Constrained.Conway
+
+instance IsConwayUniv fn => ExecSpecRule fn "DELEG" Conway where
+  environmentSpec _ = delegEnvSpec
+
+  stateSpec _ _ = dStateSpec
+
+  signalSpec _ env st =
+    delegCertSpec env st
+      <> constrained disableRegCertsDelegCert
+
+  runAgdaRule env st sig =
+    first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
+      . computationResultToEither
+      $ Agda.delegStep env st sig
+
+disableRegCertsDelegCert ::
+  ( IsConwayUniv fn
+  , Crypto c
+  ) =>
+  Term fn (ConwayDelegCert c) ->
+  Pred fn
+disableRegCertsDelegCert delegCert =
+  (caseOn delegCert)
+    (branch $ \_ _ -> False)
+    (branch $ \_ _ -> True)
+    (branch $ \_ _ -> True)
+    (branch $ \_ _ _ -> True)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
@@ -8,9 +8,6 @@
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg () where
 
 import Cardano.Ledger.Conway
-import Cardano.Ledger.Conway.TxCert (ConwayDelegCert)
-import Cardano.Ledger.Crypto
-import Constrained
 import Data.Bifunctor (first)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
@@ -26,24 +23,9 @@ instance IsConwayUniv fn => ExecSpecRule fn "DELEG" Conway where
 
   stateSpec _ _ = dStateSpec
 
-  signalSpec _ env st =
-    delegCertSpec env st
-      <> constrained disableRegCertsDelegCert
+  signalSpec _ = delegCertSpec
 
   runAgdaRule env st sig =
     first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
       . computationResultToEither
       $ Agda.delegStep env st sig
-
-disableRegCertsDelegCert ::
-  ( IsConwayUniv fn
-  , Crypto c
-  ) =>
-  Term fn (ConwayDelegCert c) ->
-  Pred fn
-disableRegCertsDelegCert delegCert =
-  (caseOn delegCert)
-    (branch $ \_ _ -> False)
-    (branch $ \_ _ -> True)
-    (branch $ \_ _ -> True)
-    (branch $ \_ _ _ -> True)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway.hs
@@ -2,4 +2,5 @@ module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway () where
 
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert ()
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool ()

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
@@ -24,13 +24,13 @@ import Cardano.Ledger.Credential
 import Cardano.Ledger.EpochBoundary
 import Cardano.Ledger.Keys
 import Cardano.Ledger.Shelley.LedgerState
-import Cardano.Ledger.UMap
 import Data.Functor.Identity (Identity)
 import Data.Map.Strict (Map)
 import qualified Data.VMap as VMap
 import Lens.Micro
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool ()
 import Test.Cardano.Ledger.Conway.TreeDiff
 
@@ -51,15 +51,6 @@ instance
       <*> toSpecRep cePParams
       <*> toSpecRep votes
       <*> toSpecRep withdrawals
-
-instance SpecTranslate ctx (DState era) where
-  type SpecRep (DState era) = Agda.DState
-
-  toSpecRep DState {..} =
-    Agda.MkDState
-      <$> toSpecRep (dRepMap dsUnified)
-      <*> toSpecRep (sPoolMap dsUnified)
-      <*> toSpecRep (rewardMap dsUnified)
 
 instance SpecTranslate ctx (CertState era) where
   type SpecRep (CertState era) = Agda.CertState

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
@@ -49,7 +49,12 @@ instance
 instance SpecTranslate ctx (ConwayDelegCert c) where
   type SpecRep (ConwayDelegCert c) = Agda.TxCert
 
-  toSpecRep (ConwayRegCert _ _) = throwError "RegCert not supported" -- TODO Investigate why!
+  toSpecRep (ConwayRegCert c d) =
+    Agda.Delegate
+      <$> toSpecRep c
+      <*> pure Nothing
+      <*> pure Nothing
+      <*> strictMaybe (pure 0) toSpecRep d
   toSpecRep (ConwayUnRegCert c _) =
     Agda.Dereg <$> toSpecRep c
   toSpecRep (ConwayDelegCert c d) =

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg () where
+
+import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.Conway.Rules (
+  ConwayDelegEnv (..),
+  ConwayDelegPredFailure,
+ )
+import Cardano.Ledger.Conway.TxCert (
+  ConwayDelegCert (..),
+  getStakePoolDelegatee,
+  getVoteDelegatee,
+ )
+import Cardano.Ledger.Core
+import Cardano.Ledger.Keys (KeyHash (..))
+import Cardano.Ledger.Shelley.LedgerState (DState (..))
+import Cardano.Ledger.Shelley.Rules
+import Cardano.Ledger.UMap (dRepMap, rewardMap, sPoolMap)
+import qualified Data.Map.Strict as Map
+import qualified Lib as Agda
+import Test.Cardano.Ledger.Conformance (
+  hashToInteger,
+ )
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
+import Test.Cardano.Ledger.Conway.TreeDiff
+
+instance
+  ( SpecRep (PParamsHKD Identity era) ~ Agda.PParams
+  , SpecTranslate ctx (PParamsHKD Identity era)
+  ) =>
+  SpecTranslate ctx (ConwayDelegEnv era)
+  where
+  type SpecRep (ConwayDelegEnv era) = Agda.DelegEnv
+
+  toSpecRep ConwayDelegEnv {..} =
+    Agda.MkDelegEnv
+      <$> toSpecRep cdePParams
+      <*> toSpecRep (Map.mapKeys (hashToInteger . unKeyHash) cdePools)
+
+instance SpecTranslate ctx (ConwayDelegCert c) where
+  type SpecRep (ConwayDelegCert c) = Agda.TxCert
+
+  toSpecRep (ConwayRegCert _ _) = throwError "RegCert not supported" -- TODO Investigate why!
+  toSpecRep (ConwayUnRegCert c _) =
+    Agda.Dereg <$> toSpecRep c
+  toSpecRep (ConwayDelegCert c d) =
+    Agda.Delegate
+      <$> toSpecRep c
+      <*> toSpecRep (getVoteDelegatee d)
+      <*> toSpecRep (hashToInteger . unKeyHash <$> getStakePoolDelegatee d)
+      <*> pure 0
+  toSpecRep (ConwayRegDelegCert s d c) =
+    Agda.Delegate
+      <$> toSpecRep s
+      <*> toSpecRep (getVoteDelegatee d)
+      <*> toSpecRep (hashToInteger . unKeyHash <$> getStakePoolDelegatee d)
+      <*> toSpecRep c
+
+instance SpecTranslate ctx (ConwayDelegPredFailure era) where
+  type SpecRep (ConwayDelegPredFailure era) = OpaqueErrorString
+
+  toSpecRep e = pure . OpaqueErrorString . show $ toExpr e
+
+instance SpecTranslate ctx (DState era) where
+  type SpecRep (DState era) = Agda.DState
+
+  toSpecRep DState {..} =
+    Agda.MkDState
+      <$> toSpecRep (dRepMap dsUnified)
+      <*> toSpecRep (sPoolMap dsUnified)
+      <*> toSpecRep (rewardMap dsUnified)


### PR DESCRIPTION
# Description

In this PR, I:  
*  extracted the DELEG-related instances from `ExecSpecRule` and `SpecTranslate`   Base modules to the respective Deleg module.
* implemented the missing translation for `toSpecRep ConwayRegCert` 
* re-enabled ConwayRegCert in both CERT and Deleg ExecSpecRule modules   

Resolves https://github.com/IntersectMBO/cardano-ledger/issues/4465

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
