### PR TITLE
`constrained-generators`: fix map generator for simple cases

### DIFF
--- a/libs/constrained-generators/src/Constrained/GenT.hs
+++ b/libs/constrained-generators/src/Constrained/GenT.hs
@@ -246,3 +246,11 @@ tryGen g = do
     FatalError es err -> foldr explain (fatalError err) es
     GenError _ _ -> pure Nothing
     Result _ a -> pure $ Just a
+
+tryGen' :: MonadGenError m => GenT GE a -> GenT m (Maybe a)
+tryGen' g = do
+  r <- pureGen $ runGenT g Strict
+  case r of
+    FatalError es err -> foldr explain (fatalError err) es
+    GenError _ _ -> pure Nothing
+    Result _ a -> pure $ Just a

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -146,10 +146,9 @@ tests nightly =
     testSpec "elemSpec" elemSpec
     testSpec "lookupSpecific" lookupSpecific
     testSpec "specificElemConstraints" lookupSpecific
-    -- TODO: fixme in a follow-up PR
-    -- testSpec "mapRestrictedValues" mapRestrictedValues
-    -- testSpec "mapRestrictedValues" mapRestrictedValuesThree
-    -- testSpec "mapRestrictedValues" mapRestrictedValuesBool
+    testSpec "mapRestrictedValues" mapRestrictedValues
+    testSpec "mapRestrictedValuesThree" mapRestrictedValuesThree
+    testSpec "mapRestrictedValuesBool" mapRestrictedValuesBool
     testSpec "mapSetSmall" mapSetSmall
     testSpecNoShrink "powersetPickOne" powersetPickOne
     numberyTests


### PR DESCRIPTION
# Description

This simplifies the generator for map when we have only "simple" constraints on size and key-value relationship.
