### PR TITLE
Remove duplicate testing of Alonzo and Shelley in Conway

### DIFF
--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -194,7 +194,6 @@ test-suite tests
         cardano-ledger-alonzo,
         cardano-ledger-babbage,
         cardano-ledger-conway,
-        cardano-ledger-shelley:testlib,
         cardano-ledger-core,
         cardano-ledger-binary:testlib,
         cardano-slotting:testlib,

--- a/eras/conway/impl/test/Main.hs
+++ b/eras/conway/impl/test/Main.hs
@@ -5,7 +5,6 @@ module Main where
 import Cardano.Ledger.Conway (Conway)
 import qualified Test.Cardano.Ledger.Alonzo.Binary.CostModelsSpec as CostModelsSpec
 import qualified Test.Cardano.Ledger.Alonzo.Binary.TxWitsSpec as TxWitsSpec
-import qualified Test.Cardano.Ledger.Alonzo.Imp as AlonzoImp
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Conway.Binary.CddlSpec as Cddl
 import qualified Test.Cardano.Ledger.Conway.Binary.Regression as Regression
@@ -19,7 +18,6 @@ import Test.Cardano.Ledger.Conway.Plutus.PlutusSpec as PlutusSpec
 import qualified Test.Cardano.Ledger.Conway.Proposals as Proposals
 import qualified Test.Cardano.Ledger.Conway.Spec as Spec
 import Test.Cardano.Ledger.Core.JSON (roundTripJsonEraSpec)
-import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 
 main :: IO ()
 main =
@@ -35,9 +33,7 @@ main =
       GovActionReorder.spec
       roundTripJsonEraSpec @Conway
       describe "Imp" $ do
-        AlonzoImp.spec @Conway
         ConwayImp.spec @Conway
-        ShelleyImp.spec @Conway
       describe "CostModels" $ do
         CostModelsSpec.spec @Conway
       describe "TxWits" $ do


### PR DESCRIPTION
# Description

Each era's `ImpTest`s are run by the succeeding era, so there's no need for Conway to run Alonzo or Shelley explicitly. Alonzo will be run by Babbage, and Shelley will be run by Allegra.

This will shave a few seconds off the Conway tests. (About 20s on my machine.)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
