### PR TITLE
`constrained-generators`: turn off leaky test until we can fix it

### DIFF
--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -179,7 +179,7 @@ tests nightly =
         prop "[(Int, Int)]" $ prop_gen_sound @BaseFn @[(Int, Int)]
         prop "Map Bool Int" $ prop_gen_sound @BaseFn @(Map Bool Int)
       -- Slow tests that shouldn't run 1000 times
-      prop "Map (Set Int) Int" $ prop_gen_sound @BaseFn @(Map (Set Int) Int)
+      xprop "Map (Set Int) Int" $ prop_gen_sound @BaseFn @(Map (Set Int) Int)
       prop "[(Set Int, Set Bool)]" $ prop_gen_sound @BaseFn @[(Set Int, Set Bool)]
       prop "Set (Set Bool)" $ prop_gen_sound @BaseFn @(Set (Set Bool))
     negativeTests


### PR DESCRIPTION
# Description

It might take some time before we can figure this out so best to turn the test off for now to avoid flakyness in CI.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
