### PR TITLE
Make better use of the GHA cache

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -80,6 +80,22 @@ jobs:
     - name: Cabal update
       run: cabal update
 
+    # We create a dependencies.txt file that can be used to index the cabal
+    # store cache.
+    #
+    # We do not use plan.json directly because adding a dependency to our
+    # Cabal files which was already present somewhere else would result in a
+    # diferent plan, even though the set of dependencies is the same.
+    - name: Record dependencies to be used as cache keys
+      id: record-deps
+      run: |
+        cabal build all --dry-run --minimize-conflict-set
+        cat dist-newstyle/cache/plan.json \
+        | jq '.["install-plan"][].id' \
+        | sort \
+        | uniq > dependencies.txt
+        cat dependencies.txt
+
     - name: Restore cache
       uses: actions/cache/restore@v4
       id: restore-cabal-cache
@@ -88,12 +104,14 @@ jobs:
       with:
         path: |
           ${{ steps.install-haskell.outputs.cabal-store }}
-        # cache is invalidated upon a change to a cabal file, cabal.project (and/or cabal.project.local), or a bump to
+        # A new cache is created upon a change to the cabal build plan,
+        # cabal.project (and/or cabal.project.local), or a bump to
         # CABAL_CACHE_VERSION.
-        key: ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('cabal.project*') }}
-        # Restoring attempts are from current branch then master. The key above is by default already a restore-key.
+        key: ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-${{ hashFiles('dependencies.txt') }}-${{ hashFiles('cabal.project*') }}
+        # Restoring attempts are from current branch then master. The key above
+        # is by default already a restore-key.
         restore-keys: |
-          ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-${{ hashFiles('**/*.cabal') }}-
+          ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-${{ hashFiles('dependencies.txt') }}
           ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-
 
     - name: Check workflow test matrix
@@ -242,6 +260,22 @@ jobs:
     - name: Unarchive working directory
       run: tar -xf state.tar && rm state.tar
 
+    # We create a dependencies.txt file that can be used to index the cabal
+    # store cache.
+    #
+    # We do not use plan.json directly because adding a dependency to our
+    # Cabal files which was already present somewhere else would result in a
+    # diferent plan, even though the set of dependencies is the same.
+    - name: Record dependencies to be used as cache keys
+      id: record-deps
+      run: |
+        cabal build all --dry-run --minimize-conflict-set
+        cat dist-newstyle/cache/plan.json \
+        | jq '.["install-plan"][].id' \
+        | sort \
+        | uniq > dependencies.txt
+        cat dependencies.txt
+
     - name: Restore cache
       uses: actions/cache/restore@v4
       id: restore-cabal-cache
@@ -250,7 +284,7 @@ jobs:
       with:
         path: |
           ${{ steps.install-haskell.outputs.cabal-store }}
-        key: ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('cabal.project*') }}
+        key: ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-${{ hashFiles('dependencies.txt') }}-${{ hashFiles('cabal.project*') }}
         # The cache with this specific key should have been created by the build
         # job. If the cache is missing, something is terribly wrong! We fail the
         # test job, or otherwise we would start rebuilding all the dependencies.

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -80,27 +80,41 @@ jobs:
     - name: Cabal update
       run: cabal update
 
-    - name: Cabal configure
-      run: cabal configure --enable-tests --enable-benchmarks --write-ghc-environment-files=always
-
-    - uses: actions/cache@v4
-      if: matrix.os != 'macos-latest'
-      name: Cache cabal store
+    - name: Restore cache
+      uses: actions/cache/restore@v4
+      id: restore-cabal-cache
+      env:
+        cache-name: cache-cabal-build
       with:
         path: |
           ${{ steps.install-haskell.outputs.cabal-store }}
-        # cache is invalidated upon a change to cabal.project (and/or cabal.project.local), a bump to
-        # CABAL_CACHE_VERSION or after a week of inactivity
-        key: cache-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-${{ hashFiles('cabal.project*') }}
-        # Restoring attempts are from current branch then master
+        # cache is invalidated upon a change to a cabal file, cabal.project (and/or cabal.project.local), or a bump to
+        # CABAL_CACHE_VERSION.
+        key: ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('cabal.project*') }}
+        # Restoring attempts are from current branch then master. The key above is by default already a restore-key.
         restore-keys: |
-          cache-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-${{ hashFiles('cabal.project*') }}
+          ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-${{ hashFiles('**/*.cabal') }}-
+          ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-
 
     - name: Check workflow test matrix
       run: cabal build all --dry-run && scripts/check-workflow-test-matrix.hs
 
     - name: Build dependencies
+      id: build-dependencies
       run: cabal build all --only-dependencies
+
+    # Save the cache of built dependencies early, so that it is available for
+    # the next GHA run if the Build step fails.
+    - name: Save cache
+      uses: actions/cache/save@v4
+      id: save-cabal-cache
+      # Note: cache-hit will be set to true only when cache hit occurs for the
+      # exact key match. For a partial key match via restore-keys or a cache
+      # miss, it will be set to false.
+      if: steps.build-dependencies.outcome == 'success' && steps.restore-cabal-cache.outputs.cache-hit != 'true'
+      with:
+        path: ${{ steps.install-haskell.outputs.cabal-store }}
+        key:  ${{ steps.restore-cabal-cache.outputs.cache-primary-key }}
 
     - name: Build
       run: cabal build all
@@ -228,18 +242,19 @@ jobs:
     - name: Unarchive working directory
       run: tar -xf state.tar && rm state.tar
 
-    - uses: actions/cache@v4
-      if: matrix.os != 'macos-latest'
-      name: Cache cabal store
+    - name: Restore cache
+      uses: actions/cache/restore@v4
+      id: restore-cabal-cache
+      env:
+        cache-name: cache-cabal-build
       with:
         path: |
           ${{ steps.install-haskell.outputs.cabal-store }}
-        # cache is invalidated upon a change to cabal.project (and/or cabal.project.local), a bump to
-        # CABAL_CACHE_VERSION or after a week of inactivity
-        key: cache-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-${{ hashFiles('cabal.project*') }}
-        # Restoring attempts are from current branch then master
-        restore-keys: |
-          cache-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-${{ hashFiles('cabal.project*') }}
+        key: ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('cabal.project*') }}
+        # The cache with this specific key should have been created by the build
+        # job. If the cache is missing, something is terribly wrong! We fail the
+        # test job, or otherwise we would start rebuilding all the dependencies.
+        fail-on-cache-miss: true
 
     - name: Cabal update
       run: cabal update

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -93,7 +93,7 @@ jobs:
         cat dist-newstyle/cache/plan.json \
         | jq '.["install-plan"][].id' \
         | sort \
-        | uniq
+        | uniq \
         | tee dependencies.txt
 
     - name: Restore cache

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -89,12 +89,12 @@ jobs:
     - name: Record dependencies to be used as cache keys
       id: record-deps
       run: |
-        cabal build all --dry-run --minimize-conflict-set
+        cabal build all --enable-tests --dry-run --minimize-conflict-set
         cat dist-newstyle/cache/plan.json \
         | jq '.["install-plan"][].id' \
         | sort \
-        | uniq > dependencies.txt
-        cat dependencies.txt
+        | uniq
+        | tee dependencies.txt
 
     - name: Restore cache
       uses: actions/cache/restore@v4
@@ -260,21 +260,12 @@ jobs:
     - name: Unarchive working directory
       run: tar -xf state.tar && rm state.tar
 
-    # We create a dependencies.txt file that can be used to index the cabal
-    # store cache.
-    #
-    # We do not use plan.json directly because adding a dependency to our
-    # Cabal files which was already present somewhere else would result in a
-    # diferent plan, even though the set of dependencies is the same.
-    - name: Record dependencies to be used as cache keys
-      id: record-deps
+    # A dependencies.txt file should have been created by the build job, so we
+    # check if it exists and is not empty.
+    - name: Check dependencies to be used as cache keys
+      id: check-deps
       run: |
-        cabal build all --dry-run --minimize-conflict-set
-        cat dist-newstyle/cache/plan.json \
-        | jq '.["install-plan"][].id' \
-        | sort \
-        | uniq > dependencies.txt
-        cat dependencies.txt
+        ./scripts/file-not-null.sh dependencies.txt
 
     - name: Restore cache
       uses: actions/cache/restore@v4

--- a/scripts/file-not-null.sh
+++ b/scripts/file-not-null.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ ! -f "$1" ]; then
+  echo "Error: $1 does not exist!"
+  exit 1
+fi
+
+if [ ! -s "$1" ]; then
+  echo "Error: $1 is empty!"
+  exit 1
+fi
+
+echo "$1 exists and is non-empty. Printing..."
+cat "$1"


### PR DESCRIPTION
# Description

This PR aims to improve the cache effects of the GHA jobs. I've noticed that the GHA jobs spend considerable time building dependencies, and I have a proposed fix for that.

First, some observations using [cardano-ledger#4488](https://github.com/IntersectMBO/cardano-ledger/pull/4488) as an example. This PR changes only a GitHub workflow file, but we can observe:
* Build jobs like [build (8.10.7, ubuntu-latest)](https://github.com/IntersectMBO/cardano-ledger/actions/runs/9880346192/job/27288666154) spend 21m 41s building dependencies
* Test jobs like [byron-spec-chain-8.10.7-ubuntu-latest](https://github.com/IntersectMBO/cardano-ledger/actions/runs/9880346192/job/27292318031) also spend a considerable amount of time on building dependencies, even though the previous build job has already built it. 
* Moreover, a test job like [byron-spec-ledger-8.10.7-ubuntu-latest](https://github.com/IntersectMBO/cardano-ledger/actions/runs/9880346192/job/27292319020) is also building those same dependencies as the previous one, so the reduced cache effect is compounded by having separate test jobs.

What I'd expect here is that these jobs would be able to restore a cache holding all the already built dependencies, assuming that an appropriate cache was created by a job that was run previously

The solution is to make the cache keys more expressive. Currently, a new cache is only created when the `CABAL_CACHE_VERSION` environment variable is changed, or if a `cabal.project*` file is changed. This does not account for dependencies changing (or other parts of the cabal files changing). As such, if a dependency is changed, then the built dependencies of the new build plan are not stored in a new cache (keys are never overwritten). Subsequent jobs will therefore also restore an old cache, and also build the new dependencies

As an aside, I've used the newer `restore`/`save` actions, which allow the cache of dependencies to be saved earlier than normal: right after building the dependencies, instead of at the end of the job.

Note:

* New caches add dependencies to old caches, so the size of new caches grows over time. There is a limit on how many bytes of cache can be used by a repo, and so there might be a high degree of evicted caches if the individual caches become too large. The `CABAL_CACHE_VERSION` environment can be changed manually to reset all the caches, or one could reset the caches automatically once in a set time period like we [do in consensus](https://github.com/IntersectMBO/ouroboros-consensus/blob/main/.github/workflows/ci.yml#L97-L99)
* With the proposed solution, any change to a cabal file would result in a new cache. I personally don't think it's a problem, but if you want to have fewer new caches, you could make the cache depend only on the dependency list like we [do in consensus](https://github.com/IntersectMBO/ouroboros-consensus/blob/main/.github/workflows/ci.yml#L88-L95)
* I think at some point `cardano-ledger` also cached the `dist-newstyle` folder. You could reconsider also caching that (if it isn't too large that it takes up significant cache space) to reduce build times. The build job for `ghc-8.10.7` in particular seems to be costly

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
