### PR TITLE
`constrained-generators`: some special-case hooks for the prettyprinter

### DIFF
--- a/libs/constrained-generators/src/Constrained/Base.hs
+++ b/libs/constrained-generators/src/Constrained/Base.hs
@@ -4839,7 +4839,17 @@ instance HasSpec fn a => Pretty (WithPrec (Term fn a)) where
     Lit n -> fromString $ showsPrec p n ""
     V x -> viaShow x
     App f Nil -> viaShow f
-    App f as -> parensIf (p > 10) $ viaShow f <+> align (fillSep (ppList @fn (prettyPrec 11) as))
+    App f as
+      | Just Equal <- extractFn @(EqFn fn) f
+      , a :> b :> _ <- as ->
+          parensIf (p > 9) $ prettyPrec 10 a <+> "==." <+> prettyPrec 10 b
+      | Just ToGeneric <- extractFn @(GenericsFn fn) f
+      , a :> _ <- as ->
+          prettyPrec p a
+      | Just FromGeneric <- extractFn @(GenericsFn fn) f
+      , a :> _ <- as ->
+          prettyPrec p a
+      | otherwise -> parensIf (p > 10) $ viaShow f <+> align (fillSep (ppList @fn (prettyPrec 11) as))
 
 instance HasSpec fn a => Pretty (Term fn a) where
   pretty = prettyPrec 0


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
