### PR TITLE
Added minitracing over things with ExecSpecRule instances

### DIFF
--- a/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
+++ b/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
@@ -24,6 +24,8 @@ library
         Test.Cardano.Ledger.Conformance.ConformanceSpec
         Test.Cardano.Ledger.Conformance.Spec.Conway
         Test.Cardano.Ledger.Conformance.Utils
+        Test.Cardano.Ledger.Conformance.ExecSpecRule.MiniTrace
+        Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway
 
     hs-source-dirs:   src
     other-modules:
@@ -38,7 +40,6 @@ library
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Gov
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.GovCert
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Core
-        Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Pool

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway.hs
@@ -1,9 +1,21 @@
-module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway () where
+module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway (
+  nameTxCert,
+  nameGovCert,
+  namePoolCert,
+  nameDelegCert,
+  nameEpoch,
+  nameEnact,
+  nameGovAction,
+) where
 
-import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base ()
-import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert ()
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base (
+  nameEnact,
+  nameEpoch,
+  nameGovAction,
+ )
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert (nameTxCert)
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Certs ()
-import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg ()
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg (nameDelegCert)
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Gov ()
-import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.GovCert ()
-import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Pool ()
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.GovCert (nameGovCert)
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Pool (namePoolCert)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
@@ -10,17 +10,19 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert () where
+module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert (nameTxCert) where
 
 import Cardano.Ledger.Conway
-import Cardano.Ledger.Conway.TxCert
-import Constrained
+import Cardano.Ledger.Conway.TxCert (ConwayTxCert (..))
 import Data.Bifunctor (first)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg (nameDelegCert)
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.GovCert (nameGovCert)
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Pool (namePoolCert)
 import Test.Cardano.Ledger.Constrained.Conway
 
 instance
@@ -30,16 +32,15 @@ instance
   type ExecContext fn "CERT" Conway = ConwayCertExecContext Conway
   environmentSpec _ = certEnvSpec
   stateSpec _ _ = certStateSpec
-  signalSpec _ env st = txCertSpec env st <> constrained disableCerts
-    where
-      -- TODO Investigate why! During Adjustment.
-      disableCerts :: Term fn (ConwayTxCert Conway) -> Pred fn
-      disableCerts cert =
-        (caseOn cert)
-          (branch $ \_ -> True)
-          (branch $ \_ -> True)
-          (branch disableDRepRegCerts)
+  signalSpec _ env st = txCertSpec env st
   runAgdaRule env st sig =
     first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
       . computationResultToEither
       $ Agda.certStep env st sig
+
+  classOf = Just . nameTxCert
+
+nameTxCert :: ConwayTxCert Conway -> String
+nameTxCert (ConwayTxCertDeleg x) = nameDelegCert x
+nameTxCert (ConwayTxCertPool x) = namePoolCert x
+nameTxCert (ConwayTxCertGov x) = nameGovCert x

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
@@ -5,9 +5,10 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg () where
+module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg (nameDelegCert) where
 
 import Cardano.Ledger.Conway
+import Cardano.Ledger.Conway.TxCert (ConwayDelegCert (..))
 import Data.Bifunctor (first)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
@@ -29,3 +30,11 @@ instance IsConwayUniv fn => ExecSpecRule fn "DELEG" Conway where
     first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
       . computationResultToEither
       $ Agda.delegStep env st sig
+
+  classOf = Just . nameDelegCert
+
+nameDelegCert :: ConwayDelegCert c -> String
+nameDelegCert ConwayRegCert {} = "RegKey"
+nameDelegCert ConwayUnRegCert {} = "UnRegKey"
+nameDelegCert ConwayDelegCert {} = "DelegateWithKey"
+nameDelegCert ConwayRegDelegCert {} = "RegK&DelegateWithKey"

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
@@ -13,11 +13,10 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.GovCert () where
+module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.GovCert (nameGovCert) where
 
 import Cardano.Ledger.Conway
 import Cardano.Ledger.Conway.TxCert
-import Constrained
 import Data.Bifunctor (Bifunctor (..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
@@ -33,17 +32,18 @@ instance IsConwayUniv fn => ExecSpecRule fn "GOVCERT" Conway where
 
   stateSpec _ctx _env = vStateSpec
 
-  signalSpec _ctx env st =
-    govCertSpec env st
-      <> constrained disableDRepRegCerts
+  signalSpec _ctx env st = govCertSpec env st
 
-  classOf (ConwayRegDRep {}) = Just "ConwayRegDRep"
-  classOf (ConwayUnRegDRep {}) = Just "ConwayUnRegDRep"
-  classOf (ConwayUpdateDRep {}) = Just "ConwayUpdateDRep"
-  classOf (ConwayAuthCommitteeHotKey {}) = Just "ConwayAuthCommitteeHotKey"
-  classOf (ConwayResignCommitteeColdKey {}) = Just "ConwayResignCommitteeColdKey"
+  classOf = Just . nameGovCert
 
   runAgdaRule env st sig =
     first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
       . computationResultToEither
       $ Agda.govCertStep env st sig
+
+nameGovCert :: ConwayGovCert c -> String
+nameGovCert (ConwayRegDRep {}) = "ConwayRegDRep"
+nameGovCert (ConwayUnRegDRep {}) = "ConwayUnRegDRep"
+nameGovCert (ConwayUpdateDRep {}) = "ConwayUpdateDRep"
+nameGovCert (ConwayAuthCommitteeHotKey {}) = "ConwayAuthCommitteeHotKey"
+nameGovCert (ConwayResignCommitteeColdKey {}) = "ConwayResignCommitteeColdKey"

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Pool.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Pool.hs
@@ -8,6 +8,7 @@
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Pool where
 
 import Cardano.Ledger.Conway
+import Cardano.Ledger.Core (PoolCert (..))
 import Data.Bifunctor (first)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
@@ -29,3 +30,9 @@ instance IsConwayUniv fn => ExecSpecRule fn "POOL" Conway where
     first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
       . computationResultToEither
       $ Agda.poolStep env st sig
+
+  classOf = Just . namePoolCert
+
+namePoolCert :: PoolCert c -> String
+namePoolCert RegPool {} = "RegPool"
+namePoolCert RetirePool {} = "RetirePool"

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/MiniTrace.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/MiniTrace.hs
@@ -1,0 +1,170 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Test.Cardano.Ledger.Conformance.ExecSpecRule.MiniTrace where
+
+import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..))
+import Cardano.Ledger.BaseTypes (Inject (..))
+import Cardano.Ledger.Conway.Governance (
+  RatifySignal (..),
+  VotingProcedures (..),
+ )
+import Cardano.Ledger.Conway.Rules (GovSignal (..))
+import Cardano.Ledger.Core (EraRule)
+import Constrained hiding (inject)
+import Control.State.Transition.Extended (STS (..))
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as Map
+import qualified Data.OSet.Strict as OSet
+import Data.Proxy
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Conformance
+import Test.Cardano.Ledger.Constrained.Conway.Instances (ConwayFn)
+import Test.Cardano.Ledger.Generic.PrettyCore (PrettyA (..))
+import Test.Cardano.Ledger.Generic.Proof
+
+-- \| This is where most of the ExecSpecRule instances are defined
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway (
+  nameDelegCert,
+  nameEnact,
+  nameEpoch,
+  nameGovCert,
+  namePoolCert,
+  nameTxCert,
+ )
+
+-- ====================================================================
+
+-- | Generate either a list of signals, or a list of error messages
+minitraceEither ::
+  forall fn s e.
+  ( ExecSpecRule fn s e
+  , ExecState fn s e ~ State (EraRule s e)
+  , PrettyA (Signal (EraRule s e))
+  ) =>
+  WitRule s e ->
+  Proxy fn ->
+  Int ->
+  Gen (Either [String] [Signal (EraRule s e)])
+minitraceEither witrule Proxy n0 = do
+  ctxt <- genExecContext @fn @s @e
+  env <- genFromSpec @fn (environmentSpec @fn @s @e ctxt)
+  let env2 :: Environment (EraRule s e)
+      env2 = inject env
+  !state0 <- genFromSpec @fn (stateSpec @fn @s @e ctxt env)
+  let go :: State (EraRule s e) -> Int -> Gen (Either [String] [Signal (EraRule s e)])
+      go _ 0 = pure (Right [])
+      go state n = do
+        signal <- genFromSpec @fn (signalSpec @fn @s @e ctxt env state)
+        let signal2 :: Signal (EraRule s e)
+            signal2 = inject signal
+        goSTS
+          witrule
+          env2
+          state
+          signal2
+          ( \x -> case x of
+              Left ps ->
+                pure
+                  ( Left
+                      ( [ "\nSIGNAL = " ++ show (prettyA signal2)
+                        , "\nPredicateFailures"
+                        ]
+                          ++ map show (NE.toList ps)
+                      )
+                  )
+              Right !state2 -> do
+                ans <- go state2 (n - 1)
+                case ans of
+                  Left xs -> pure (Left xs)
+                  Right more -> pure (Right (inject signal : more))
+          )
+  go state0 n0
+
+minitrace ::
+  forall fn s e.
+  ( ExecSpecRule fn s e
+  , ExecState fn s e ~ State (EraRule s e)
+  , PrettyA (Signal (EraRule s e))
+  ) =>
+  WitRule s e ->
+  Proxy fn ->
+  Int ->
+  Gen [Signal (EraRule s e)]
+minitrace witrule Proxy n0 = do
+  ans <- minitraceEither @fn @s @e witrule Proxy n0
+  case ans of
+    Left zs -> pure $ error (unlines zs)
+    Right zs -> pure zs
+
+minitraceProp ::
+  forall s e.
+  ( ExecSpecRule ConwayFn s e
+  , ExecState ConwayFn s e ~ State (EraRule s e)
+  , PrettyA (Signal (EraRule s e))
+  ) =>
+  WitRule s e ->
+  Proxy ConwayFn ->
+  Int ->
+  (Signal (EraRule s e) -> String) ->
+  Gen Property
+minitraceProp witrule Proxy n0 namef = do
+  ans <- minitraceEither @ConwayFn @s @e witrule Proxy n0
+  case ans of
+    Left zs -> pure $ counterexample (unlines zs) (property False)
+    Right sigs -> pure $ classifyFirst namef sigs $ property True
+
+-- =======================================================
+-- Classifying what is in a trace requires a function that
+-- lifts a Signal to a String
+-- =======================================================
+
+classifyMany :: (x -> String) -> [x] -> Property -> Property
+classifyMany _ [] p = p
+classifyMany f (x : xs) p = classifyMany f xs (classify True (f x) p)
+
+classifyFirst :: (x -> String) -> [x] -> Property -> Property
+classifyFirst _ [] p = p
+classifyFirst f (x : _) p = classify True (f x) p
+
+classifyFirst' :: (x -> Maybe String) -> [x] -> Property -> Property
+classifyFirst' _ [] p = p
+classifyFirst' f (x : _) p = maybe p (\s -> classify True s p) (f x)
+
+nameRatify :: RatifySignal era -> String
+nameRatify (RatifySignal xs) = show (length xs) ++ " GovActionStates"
+
+nameGovSignal :: GovSignal (ConwayEra StandardCrypto) -> String
+nameGovSignal (GovSignal (VotingProcedures m) os cs) = show (Map.size m) ++ " " ++ show (OSet.size os) ++ " " ++ show (length cs)
+
+nameAlonzoTx :: AlonzoTx era -> String
+nameAlonzoTx (AlonzoTx _body _wits isV _auxdata) = show isV
+
+-- | Run one check
+check :: IO ()
+check = quickCheck (withMaxSuccess 50 (minitraceProp (CERT Conway) (Proxy @ConwayFn) 50 nameTxCert))
+
+-- | Run a minitrace for every instance of ExecRuleSpec
+spec :: Spec
+spec = do
+  describe "50 MiniTrace tests with trace length of 50" $ do
+    prop "POOL" (withMaxSuccess 50 (minitraceProp (POOL Conway) (Proxy @ConwayFn) 50 namePoolCert))
+    prop "DELEG" (withMaxSuccess 50 (minitraceProp (DELEG Conway) (Proxy @ConwayFn) 50 nameDelegCert))
+    prop "COVCERT" (withMaxSuccess 50 (minitraceProp (GOVCERT Conway) (Proxy @ConwayFn) 50 nameGovCert))
+    prop "CERT" (withMaxSuccess 50 (minitraceProp (CERT Conway) (Proxy @ConwayFn) 50 nameTxCert))
+    prop "RATIFY" (withMaxSuccess 50 (minitraceProp (RATIFY Conway) (Proxy @ConwayFn) 50 nameRatify))
+    prop "ENACT" (withMaxSuccess 50 (minitraceProp (ENACT Conway) (Proxy @ConwayFn) 50 nameEnact))
+    -- These properties do not have working 'signalSpec' Specifications yet.
+    xprop "GOV" (withMaxSuccess 50 (minitraceProp (GOV Conway) (Proxy @ConwayFn) 50 nameGovSignal))
+    xprop "UTXO" (withMaxSuccess 50 (minitraceProp (UTXO Conway) (Proxy @ConwayFn) 50 nameAlonzoTx))
+    xprop "EPOCH" (withMaxSuccess 50 (minitraceProp (EPOCH Conway) (Proxy @ConwayFn) 50 nameEpoch))
+    xprop
+      "NEWEPOCH"
+      (withMaxSuccess 50 (minitraceProp (NEWEPOCH Conway) (Proxy @ConwayFn) 50 nameEpoch))

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
@@ -8,12 +8,14 @@ import Cardano.Ledger.Conway (Conway)
 import qualified Constrained as CV2
 import Test.Cardano.Ledger.Conformance (ExecSpecRule (..), conformsToImpl, generatesWithin)
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway ()
+import qualified Test.Cardano.Ledger.Conformance.ExecSpecRule.MiniTrace as MiniTrace
 import Test.Cardano.Ledger.Constrained.Conway
 import Test.Cardano.Ledger.Conway.ImpTest ()
 import Test.Cardano.Ledger.Imp.Common
 
 spec :: Spec
 spec = do
+  describe "MiniTrace" MiniTrace.spec
   describe "Generators" $ do
     let
       genEnv = do
@@ -39,8 +41,14 @@ spec = do
       xprop "NEWEPOCH" $ conformsToImpl @"NEWEPOCH" @ConwayFn @Conway
     describe "Blocks transition graph" $ do
       xprop "DELEG" $ conformsToImpl @"DELEG" @ConwayFn @Conway
+      -- GOVCERT is disabled because the Agda MALONZO code has a bug
+      -- when accessing the PParams DRepActivity field. When that is fixed
+      -- we can turn xprop to prop for "GOVCERT"
       xprop "GOVCERT" $ conformsToImpl @"GOVCERT" @ConwayFn @Conway
       prop "POOL" $ conformsToImpl @"POOL" @ConwayFn @Conway
+      -- The PParams DRepActivity field bug in Agda means we must also
+      -- turn off the "CERT" conformance test because "CERT" contains "GOVCERT"
+      -- When that is fixed we can turn xprop to prop for "CERT"
       xprop "CERT" $ conformsToImpl @"CERT" @ConwayFn @Conway
       xprop "CERTS" $ conformsToImpl @"CERTS" @ConwayFn @Conway
       prop "GOV" $ conformsToImpl @"GOV" @ConwayFn @Conway

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -1013,6 +1013,7 @@ instance SpecTranslate ctx (EpochExecEnv era) where
 
   toSpecRep _ = pure ()
 
+-- | This type is used as the Env only in the Agda Spec
 data ConwayExecEnactEnv era = ConwayExecEnactEnv
   { ceeeGid :: GovActionId (EraCrypto era)
   , ceeeTreasury :: Coin
@@ -1020,6 +1021,7 @@ data ConwayExecEnactEnv era = ConwayExecEnactEnv
   }
   deriving (Generic, Eq, Show)
 
+-- | Here we inject the Agda Spec Env into the STS rule Environment, which is ().
 instance Inject (ConwayExecEnactEnv era) () where
   inject _ = ()
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
@@ -48,9 +48,11 @@ txCertSpec (CertEnv slot pp ce cc cp) CertState {..} =
   constrained $ \txCert ->
     caseOn
       txCert
-      (branch $ \delegCert -> satisfies delegCert $ delegCertSpec delegEnv certDState)
-      (branch $ \poolCert -> satisfies poolCert $ poolCertSpec poolEnv certPState)
-      (branch $ \govCert -> satisfies govCert $ govCertSpec govCertEnv certVState)
+      -- These weights try to make it equally likely that each of the many certs
+      -- across the 3 categories are chosen at similar frequencies.
+      (branchW 3 $ \delegCert -> satisfies delegCert $ delegCertSpec delegEnv certDState)
+      (branchW 1 $ \poolCert -> satisfies poolCert $ poolCertSpec poolEnv certPState)
+      (branchW 3 $ \govCert -> satisfies govCert $ govCertSpec govCertEnv certVState)
   where
     delegEnv = ConwayDelegEnv pp (psStakePoolParams certPState)
     poolEnv = PoolEnv slot pp

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Proof.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Proof.hs
@@ -215,6 +215,13 @@ data WitRule (s :: Symbol) (e :: Type) where
   ENACT :: Proof era -> WitRule "ENACT" era
   TALLY :: Proof era -> WitRule "TALLY" era
   EPOCH :: Proof era -> WitRule "EPOCH" era
+  NEWEPOCH :: Proof era -> WitRule "NEWEPOCH" era
+  CERT :: Proof era -> WitRule "CERT" era
+  CERTS :: Proof era -> WitRule "CERTS" era
+  DELEG :: Proof era -> WitRule "DELEG" era
+  POOL :: Proof era -> WitRule "POOL" era
+  GOVCERT :: Proof era -> WitRule "GOVCERT" era
+  GOV :: Proof era -> WitRule "GOV" era
 
 ruleProof :: WitRule s e -> Proof e
 ruleProof (UTXO p) = p
@@ -227,6 +234,13 @@ ruleProof (RATIFY p) = p
 ruleProof (ENACT p) = p
 ruleProof (TALLY p) = p
 ruleProof (EPOCH p) = p
+ruleProof (NEWEPOCH p) = p
+ruleProof (CERT p) = p
+ruleProof (CERTS p) = p
+ruleProof (DELEG p) = p
+ruleProof (POOL p) = p
+ruleProof (GOVCERT p) = p
+ruleProof (GOV p) = p
 
 runSTS ::
   forall s e ans.
@@ -246,7 +260,14 @@ runSTS (MOCKCHAIN _proof) x cont = cont (runShelleyBase (applySTSTest x))
 runSTS (RATIFY _proof) x cont = cont (runShelleyBase (applySTSTest x))
 runSTS (ENACT _proof) x cont = cont (runShelleyBase (applySTSTest x))
 runSTS (TALLY _proof) x cont = cont (runShelleyBase (applySTSTest x))
-runSTS (_proof) x cont = cont (runShelleyBase (applySTSTest x))
+runSTS (EPOCH _proof) x cont = cont (runShelleyBase (applySTSTest x))
+runSTS (NEWEPOCH _proof) x cont = cont (runShelleyBase (applySTSTest x))
+runSTS (CERT _proof) x cont = cont (runShelleyBase (applySTSTest x))
+runSTS (CERTS _proof) x cont = cont (runShelleyBase (applySTSTest x))
+runSTS (DELEG _proof) x cont = cont (runShelleyBase (applySTSTest x))
+runSTS (POOL _proof) x cont = cont (runShelleyBase (applySTSTest x))
+runSTS (GOVCERT _proof) x cont = cont (runShelleyBase (applySTSTest x))
+runSTS (GOV _proof) x cont = cont (runShelleyBase (applySTSTest x))
 
 runSTS' ::
   forall s e.
@@ -266,6 +287,8 @@ runSTS' (RATIFY _proof) x = runShelleyBase (applySTSTest x)
 runSTS' (ENACT _proof) x = runShelleyBase (applySTSTest x)
 runSTS' (TALLY _proof) x = runShelleyBase (applySTSTest x)
 runSTS' (EPOCH _proof) x = runShelleyBase (applySTSTest x)
+runSTS' (NEWEPOCH _proof) x = runShelleyBase (applySTSTest x)
+runSTS' _ x = runShelleyBase (applySTSTest x)
 
 -- | Like runSTS, but makes the components of the TRC triple explicit.
 --   in case you can't remember, in ghci type
@@ -315,6 +338,20 @@ goSTS (ENACT _proof) env state sig cont =
 goSTS (TALLY _proof) env state sig cont =
   cont (runShelleyBase (applySTSTest (TRC @(EraRule s e) (env, state, sig))))
 goSTS (EPOCH _proof) env state sig cont =
+  cont (runShelleyBase (applySTSTest (TRC @(EraRule s e) (env, state, sig))))
+goSTS (NEWEPOCH _proof) env state sig cont =
+  cont (runShelleyBase (applySTSTest (TRC @(EraRule s e) (env, state, sig))))
+goSTS (CERT _proof) env state sig cont =
+  cont (runShelleyBase (applySTSTest (TRC @(EraRule s e) (env, state, sig))))
+goSTS (CERTS _proof) env state sig cont =
+  cont (runShelleyBase (applySTSTest (TRC @(EraRule s e) (env, state, sig))))
+goSTS (DELEG _proof) env state sig cont =
+  cont (runShelleyBase (applySTSTest (TRC @(EraRule s e) (env, state, sig))))
+goSTS (POOL _proof) env state sig cont =
+  cont (runShelleyBase (applySTSTest (TRC @(EraRule s e) (env, state, sig))))
+goSTS (GOVCERT _proof) env state sig cont =
+  cont (runShelleyBase (applySTSTest (TRC @(EraRule s e) (env, state, sig))))
+goSTS (GOV _proof) env state sig cont =
   cont (runShelleyBase (applySTSTest (TRC @(EraRule s e) (env, state, sig))))
 
 -- ================================================================

--- a/libs/constrained-generators/src/Constrained/GenT.hs
+++ b/libs/constrained-generators/src/Constrained/GenT.hs
@@ -273,3 +273,11 @@ tryGen' g = do
     FatalError es err -> foldr explain (fatalError err) es
     GenError _ _ -> pure Nothing
     Result _ a -> pure $ Just a
+
+catchGenT :: GenT GE a -> Gen (Either [String] a)
+catchGenT g = genFromGenT $ do
+  r <- pureGen $ runGenT g Loose
+  case r of
+    FatalError es e -> pure $ Left (NE.toList $ foldr1 (<>) es <> e)
+    GenError es e -> pure $ Left (NE.toList $ foldr1 (<>) es <> e)
+    Result _ a -> pure $ Right a


### PR DESCRIPTION
Define minitrace, which iterates over 
  1) generating at state, 
  2) generating a signal,
  3) applying the signal to get a new state, then repeating from 2). 
This identified several rare bugs, and helped adjust the generators so all Signals are generated with
roughly the same frequency. This improves how we sample the test space.

It removes screening out some Signals. They were screened out because of bugs in the Agda MAlonzo code, or
because the conformance tests could not handle differences between the Spec and The Implementation.
An example of this was screening out the RetirePool  PoolCert because the implementation and the spec changed the state in
different rules. This caused all sorts of problems by breaking the generators given unlucky inputs. So now all signals are generated fairly, and and broken conformance tests are moved from 'prop' to 'xprop' until the MAlonzo code is fixed, or differences can be adjusted.  

<!-- Add your description here, if it fixes a particular issue please provide
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
