### PR TITLE
Conformance tests - Deposits in Cert environment

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -22,7 +22,8 @@ source-repository-package
   type: git
   location: https://github.com/IntersectMBO/formal-ledger-specifications.git
   subdir: ledgerSrc/haskell/Ledger
-  tag: 79637b65e241537efbbad1a1125b7f7af8945b07
+  tag: 8e2dbbf5bc897ec89922a7e75e282d5bb5dda650
+  --sha256: sha256-jfphBcaojCyiHTsetEVqXzqkBxIo8UJ/GGOLD80iW+k=
   --sha256: sha256-L0oi+hFjFw8BE75jWtD+jAtBwaIDrMb8rqJGfBhSELE=
 -- NOTE: If you would like to update the above, look for the `haskell-package`
 -- branch in the `formal-ledger-specifications` repo where the HEAD contains

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
@@ -20,8 +20,6 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base (
-  ConwayCertExecContext (..),
-  ConwayRatifyExecContext (..),
   nameEpoch,
   nameEnact,
   nameGovAction,
@@ -50,7 +48,6 @@ import Cardano.Ledger.Conway.Governance (
   RatifyEnv (..),
   RatifySignal (..),
   RatifyState (..),
-  VotingProcedures,
   gasAction,
  )
 import Cardano.Ledger.Conway.Rules (
@@ -66,7 +63,6 @@ import Cardano.Ledger.Conway.Tx (AlonzoTx)
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.DRep (DRep (..))
 import Cardano.Ledger.Keys (KeyRole (..))
-import Cardano.Ledger.PoolDistr (IndividualPoolStake (..))
 import Constrained
 import Constrained.Base (fromList_)
 import Data.Bifunctor (Bifunctor (..))
@@ -155,33 +151,6 @@ instance
     first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
       . computationResultToEither
       $ Agda.utxoStep env st sig
-
-data ConwayCertExecContext era = ConwayCertExecContext
-  { ccecWithdrawals :: !(Map (Network, Credential 'Staking (EraCrypto era)) Coin)
-  , ccecVotes :: !(VotingProcedures era)
-  }
-  deriving (Generic, Eq, Show)
-
-instance Era era => Arbitrary (ConwayCertExecContext era) where
-  arbitrary =
-    ConwayCertExecContext
-      <$> arbitrary
-      <*> arbitrary
-
-instance
-  c ~ EraCrypto era =>
-  Inject
-    (ConwayCertExecContext era)
-    (Map (Network, Credential 'Staking c) Coin)
-  where
-  inject = ccecWithdrawals
-
-instance Inject (ConwayCertExecContext era) (VotingProcedures era) where
-  inject = ccecVotes
-
-instance Era era => ToExpr (ConwayCertExecContext era)
-
-instance Era era => NFData (ConwayCertExecContext era)
 
 data ConwayRatifyExecContext era = ConwayRatifyExecContext
   { crecTreasury :: Coin

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
@@ -23,12 +23,12 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base (
   nameEpoch,
   nameEnact,
   nameGovAction,
+  ConwayRatifyExecContext (..),
 ) where
 
 import Cardano.Ledger.BaseTypes (
   EpochNo (..),
   Inject (..),
-  Network,
   StrictMaybe (..),
   natVersion,
  )
@@ -60,15 +60,13 @@ import Cardano.Ledger.Conway.Rules (
   spoAcceptedRatio,
  )
 import Cardano.Ledger.Conway.Tx (AlonzoTx)
-import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.DRep (DRep (..))
-import Cardano.Ledger.Keys (KeyRole (..))
+import Cardano.Ledger.PoolDistr (IndividualPoolStake (..))
 import Constrained
 import Constrained.Base (fromList_)
 import Data.Bifunctor (Bifunctor (..))
 import Data.Foldable (Foldable (..))
 import qualified Data.List.NonEmpty as NE
-import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Ratio ((%))
 import qualified Data.Sequence.Strict as SSeq

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
@@ -12,6 +12,7 @@
 
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert (nameTxCert) where
 
+import Cardano.Ledger.BaseTypes (inject)
 import Cardano.Ledger.Conway
 import Cardano.Ledger.Conway.TxCert (ConwayTxCert (..))
 import Data.Bifunctor (first)
@@ -30,9 +31,11 @@ instance
   ExecSpecRule fn "CERT" Conway
   where
   type ExecContext fn "CERT" Conway = ConwayCertExecContext Conway
-  environmentSpec _ = certEnvSpec
+  type ExecEnvironment fn "CERT" Conway = CertExecEnv Conway
+
+  environmentSpec _ = certExecEnvSpec
   stateSpec _ _ = certStateSpec
-  signalSpec _ env st = txCertSpec env st
+  signalSpec _ env = txCertSpec (inject env)
   runAgdaRule env st sig =
     first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
       . computationResultToEither

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
@@ -31,7 +31,7 @@ instance
   ExecSpecRule fn "CERT" Conway
   where
   type ExecContext fn "CERT" Conway = ConwayCertExecContext Conway
-  type ExecEnvironment fn "CERT" Conway = CertExecEnv Conway
+  type ExecEnvironment fn "CERT" Conway = CertsExecEnv Conway
 
   environmentSpec _ = certExecEnvSpec
   stateSpec _ _ = certStateSpec

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
@@ -2,11 +2,8 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -20,7 +17,6 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
-import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg (nameDelegCert)
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.GovCert (nameGovCert)
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Pool (namePoolCert)
@@ -30,7 +26,6 @@ instance
   IsConwayUniv fn =>
   ExecSpecRule fn "CERT" Conway
   where
-  type ExecContext fn "CERT" Conway = ConwayCertExecContext Conway
   type ExecEnvironment fn "CERT" Conway = CertsExecEnv Conway
 
   environmentSpec _ = certExecEnvSpec

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
@@ -26,8 +26,9 @@ instance
   ExecSpecRule fn "CERTS" Conway
   where
   type ExecContext fn "CERTS" Conway = ConwayCertExecContext Conway
+  type ExecEnvironment fn "CERTS" Conway = CertsExecEnv Conway
 
-  environmentSpec _ = certsEnvSpec
+  environmentSpec _ = certsExecEnvSpec
 
   stateSpec _ _ = certStateSpec
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
@@ -2,11 +2,8 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -18,14 +15,13 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
-import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway ()
 import Test.Cardano.Ledger.Constrained.Conway
 
 instance
   IsConwayUniv fn =>
   ExecSpecRule fn "CERTS" Conway
   where
-  type ExecContext fn "CERTS" Conway = ConwayCertExecContext Conway
   type ExecEnvironment fn "CERTS" Conway = CertsExecEnv Conway
 
   environmentSpec _ = certsExecEnvSpec

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
@@ -2,11 +2,13 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg (nameDelegCert) where
 
+import Cardano.Ledger.BaseTypes (inject)
 import Cardano.Ledger.Conway
 import Cardano.Ledger.Conway.TxCert (ConwayDelegCert (..))
 import Data.Bifunctor (first)
@@ -20,11 +22,13 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 import Test.Cardano.Ledger.Constrained.Conway
 
 instance IsConwayUniv fn => ExecSpecRule fn "DELEG" Conway where
-  environmentSpec _ = delegEnvSpec
+  type ExecEnvironment fn "DELEG" Conway = DelegExecEnv Conway
+
+  environmentSpec _ = delegExecEnvSpec
 
   stateSpec _ _ = dStateSpec
 
-  signalSpec _ = delegCertSpec
+  signalSpec _ env = delegCertSpec (inject env)
 
   runAgdaRule env st sig =
     first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
@@ -2,15 +2,18 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg (nameDelegCert) where
 
-import Cardano.Ledger.BaseTypes (inject)
 import Cardano.Ledger.Conway
+import Cardano.Ledger.Conway.Rules (ConwayDelegEnv (..))
 import Cardano.Ledger.Conway.TxCert (ConwayDelegCert (..))
+import Cardano.Ledger.Shelley.LedgerState (DState)
+import Constrained
 import Data.Bifunctor (first)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
@@ -20,15 +23,23 @@ import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 import Test.Cardano.Ledger.Constrained.Conway
+import Test.Cardano.Ledger.Constrained.Conway.DeltaDeposit (DeltaExecEnv (..))
 
 instance IsConwayUniv fn => ExecSpecRule fn "DELEG" Conway where
-  type ExecEnvironment fn "DELEG" Conway = DelegExecEnv Conway
+  type
+    ExecContext fn "DELEG" Conway =
+      (ConwayDelegEnv Conway, DState Conway)
 
-  environmentSpec _ = delegExecEnvSpec
+  genExecContext = genDELEGDeltaEnv
 
-  stateSpec _ _ = dStateSpec
+  type ExecEnvironment fn "DELEG" Conway = DeltaExecEnv (ConwayDelegEnv Conway) Conway
 
-  signalSpec _ env = delegCertSpec (inject env)
+  environmentSpec context = delegExecEnvSpec context
+
+  stateSpec (_env, state) _deltaExecEnv = constrained $ \x -> x ==. lit state
+
+  signalSpec (denv, _state) _deltaExecEnv state =
+    constrained $ \sig -> satisfies sig (conwayDelegCertSpec denv state)
 
   runAgdaRule env st sig =
     first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
@@ -41,4 +52,4 @@ nameDelegCert :: ConwayDelegCert c -> String
 nameDelegCert ConwayRegCert {} = "RegKey"
 nameDelegCert ConwayUnRegCert {} = "UnRegKey"
 nameDelegCert ConwayDelegCert {} = "DelegateWithKey"
-nameDelegCert ConwayRegDelegCert {} = "RegK&DelegateWithKey"
+nameDelegCert ConwayRegDelegCert {} = "RegKey&Delegate"

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
@@ -15,6 +15,7 @@
 
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.GovCert (nameGovCert) where
 
+import Cardano.Ledger.BaseTypes (inject)
 import Cardano.Ledger.Conway
 import Cardano.Ledger.Conway.TxCert
 import Data.Bifunctor (Bifunctor (..))
@@ -27,12 +28,13 @@ import Test.Cardano.Ledger.Constrained.Conway
 
 instance IsConwayUniv fn => ExecSpecRule fn "GOVCERT" Conway where
   type ExecContext fn "GOVCERT" Conway = ConwayCertExecContext Conway
+  type ExecEnvironment fn "GOVCERT" Conway = CertExecEnv Conway
 
-  environmentSpec _ctx = govCertEnvSpec
+  environmentSpec _ctx = certExecEnvSpec
 
   stateSpec _ctx _env = vStateSpec
 
-  signalSpec _ctx env st = govCertSpec env st
+  signalSpec _ctx env st = govCertSpec (inject env) st
 
   classOf = Just . nameGovCert
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
@@ -1,15 +1,9 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -23,11 +17,10 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
-import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway ()
 import Test.Cardano.Ledger.Constrained.Conway
 
 instance IsConwayUniv fn => ExecSpecRule fn "GOVCERT" Conway where
-  type ExecContext fn "GOVCERT" Conway = ConwayCertExecContext Conway
   type ExecEnvironment fn "GOVCERT" Conway = CertsExecEnv Conway
 
   environmentSpec _ctx = certExecEnvSpec

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
@@ -28,7 +28,7 @@ import Test.Cardano.Ledger.Constrained.Conway
 
 instance IsConwayUniv fn => ExecSpecRule fn "GOVCERT" Conway where
   type ExecContext fn "GOVCERT" Conway = ConwayCertExecContext Conway
-  type ExecEnvironment fn "GOVCERT" Conway = CertExecEnv Conway
+  type ExecEnvironment fn "GOVCERT" Conway = CertsExecEnv Conway
 
   environmentSpec _ctx = certExecEnvSpec
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Pool.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Pool.hs
@@ -2,13 +2,17 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Pool where
 
+import Cardano.Ledger.CertState (PState (..))
 import Cardano.Ledger.Conway
 import Cardano.Ledger.Core (PoolCert (..))
+import Cardano.Ledger.Shelley.Rules (PoolEnv (..))
+import Constrained
 import Data.Bifunctor (first)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
@@ -18,13 +22,21 @@ import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool ()
 import Test.Cardano.Ledger.Constrained.Conway
+import Test.Cardano.Ledger.Constrained.Conway.DeltaDeposit (DeltaExecEnv (..))
 
 instance IsConwayUniv fn => ExecSpecRule fn "POOL" Conway where
-  environmentSpec _ = poolEnvSpec
+  type ExecContext fn "POOL" Conway = (PoolEnv Conway, PState Conway)
 
-  stateSpec _ _ = pStateSpec
+  genExecContext = genPOOLEnv
 
-  signalSpec _ env st = poolCertSpec env st
+  type ExecEnvironment fn "POOL" Conway = DeltaExecEnv (PoolEnv Conway) Conway
+
+  environmentSpec (env, state) = poolExecEnvSpec (env, state)
+
+  stateSpec (_env, state) _deltaExecEnv = constrained $ \x -> x ==. lit state
+
+  signalSpec (env, _state) _deltaExecEnv state =
+    constrained $ \sig -> satisfies sig (poolCertSpec env state)
 
   runAgdaRule env st sig =
     first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -17,6 +17,8 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Core (FixupSpecRep (..), Op
 import Test.Cardano.Ledger.Conformance.Utils
 import Test.Cardano.Ledger.Conway.TreeDiff (Expr (..), ToExpr (..))
 
+-- import qualified Test.Cardano.Ledger.Constrained.Conway.DeltaDeposit as Delta
+
 deriving instance Generic (HSSet a)
 
 deriving instance Generic GovActionState
@@ -35,7 +37,7 @@ deriving instance Generic GovEnv
 
 deriving instance Generic EnactState
 
-deriving instance Generic DepositPurpose
+deriving instance Generic Lib.DepositPurpose
 
 deriving instance Generic CertEnv
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -20,7 +20,6 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (
-  emptyDeposits,
   SpecTranslate (..),
   SpecTranslationError,
   ConwayExecEnactEnv (..),
@@ -1060,8 +1059,3 @@ instance SpecTranslate ctx (ConwayExecEnactEnv era) where
       <$> toSpecRep ceeeGid
       <*> toSpecRep ceeeTreasury
       <*> toSpecRep ceeeEpoch
-
--- Temporary value to use where the map of all deposits is required,
--- until we build and translate the real map
-emptyDeposits :: Agda.HSMap Agda.DepositPurpose Agda.Coin
-emptyDeposits = Agda.MkHSMap []

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
@@ -15,46 +15,20 @@ module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert () where
 
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.CertState
-import Cardano.Ledger.Coin
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Conway.TxCert
-import Cardano.Ledger.Credential
 import Cardano.Ledger.EpochBoundary
-import Cardano.Ledger.Keys
 import Cardano.Ledger.Shelley.LedgerState
 import Data.Functor.Identity (Identity)
-import Data.Map.Strict (Map)
 import qualified Data.VMap as VMap
 import Lens.Micro
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (emptyDeposits)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.GovCert ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool ()
 import Test.Cardano.Ledger.Conway.TreeDiff
-
-instance
-  ( SpecTranslate ctx (PParamsHKD Identity era)
-  , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , Inject ctx (VotingProcedures era)
-  , Inject ctx (Map (Network, Credential 'Staking (EraCrypto era)) Coin)
-  ) =>
-  SpecTranslate ctx (CertEnv era)
-  where
-  type SpecRep (CertEnv era) = Agda.CertEnv
-  toSpecRep CertEnv {..} = do
-    votes <- askCtx @(VotingProcedures era)
-    withdrawals <- askCtx @(Map (Network, Credential 'Staking (EraCrypto era)) Coin)
-    Agda.MkCertEnv
-      <$> toSpecRep ceCurrentEpoch
-      <*> toSpecRep cePParams
-      <*> toSpecRep votes
-      <*> toSpecRep withdrawals
-      -- TODO: replace with actual deposits map
-      <*> pure emptyDeposits
 
 instance SpecTranslate ctx (CertState era) where
   type SpecRep (CertState era) = Agda.CertState

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
@@ -28,6 +28,7 @@ import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool ()
+import Test.Cardano.Ledger.Constrained.Conway.DeltaDeposit (DeltaExecEnv (..))
 import Test.Cardano.Ledger.Conway.TreeDiff
 
 instance SpecTranslate ctx (CertState era) where
@@ -147,3 +148,19 @@ instance
 instance SpecTranslate ctx (ConwayNewEpochPredFailure era) where
   type SpecRep (ConwayNewEpochPredFailure era) = OpaqueErrorString
   toSpecRep = pure . OpaqueErrorString . show . toExpr
+
+instance
+  ( SpecTranslate ctx (PParamsHKD Identity era)
+  , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
+  ) =>
+  SpecTranslate ctx (DeltaExecEnv (CertEnv era) era)
+  where
+  type SpecRep (DeltaExecEnv (CertEnv era) era) = Agda.CertEnv
+
+  toSpecRep DeltaExecEnv {..} = do
+    Agda.MkCertEnv
+      <$> toSpecRep (ceCurrentEpoch deeEnv)
+      <*> toSpecRep (cePParams deeEnv)
+      <*> toSpecRep deeVotes
+      <*> toSpecRep deeWithdrawals
+      <*> toSpecRep deeDeposits

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
@@ -13,42 +13,16 @@
 
 module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Certs () where
 
-import Cardano.Ledger.BaseTypes
-import Cardano.Ledger.Coin
 import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Conway.Rules
-import Cardano.Ledger.Credential
-import Cardano.Ledger.Keys
-import Data.Functor.Identity (Identity)
-import Data.Map.Strict (Map)
-import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (emptyDeposits)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool ()
 import Test.Cardano.Ledger.Conway.TreeDiff
 
-instance ToExpr (PredicateFailure (EraRule "CERT" era)) => SpecTranslate ctx (ConwayCertsPredFailure era) where
+instance
+  ToExpr (PredicateFailure (EraRule "CERT" era)) =>
+  SpecTranslate ctx (ConwayCertsPredFailure era)
+  where
   type SpecRep (ConwayCertsPredFailure era) = OpaqueErrorString
   toSpecRep = pure . OpaqueErrorString . show . toExpr
-
-instance
-  ( SpecTranslate ctx (PParamsHKD Identity era)
-  , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , Inject ctx (VotingProcedures era)
-  , Inject ctx (Map (Network, Credential 'Staking (EraCrypto era)) Coin)
-  ) =>
-  SpecTranslate ctx (CertsEnv era)
-  where
-  type SpecRep (CertsEnv era) = Agda.CertEnv
-  toSpecRep CertsEnv {..} = do
-    votes <- askCtx @(VotingProcedures era)
-    withdrawals <- askCtx @(Map (Network, Credential 'Staking (EraCrypto era)) Coin)
-    Agda.MkCertEnv
-      <$> toSpecRep certsCurrentEpoch
-      <*> toSpecRep certsPParams
-      <*> toSpecRep votes
-      <*> toSpecRep withdrawals
-      -- TODO: replace with actual deposits map
-      <*> pure emptyDeposits

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
@@ -15,10 +15,29 @@ module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Certs () where
 
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Rules
+import Control.Monad.Identity
+import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool ()
+import Test.Cardano.Ledger.Constrained.Conway (CertsExecEnv (..))
 import Test.Cardano.Ledger.Conway.TreeDiff
+
+instance
+  ( SpecTranslate ctx (PParamsHKD Identity era)
+  , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
+  ) =>
+  SpecTranslate ctx (CertsExecEnv era)
+  where
+  type SpecRep (CertsExecEnv era) = Agda.CertEnv
+
+  toSpecRep CertsExecEnv {..} = do
+    Agda.MkCertEnv
+      <$> toSpecRep (certsCurrentEpoch ceeCertEnv)
+      <*> toSpecRep (certsPParams ceeCertEnv)
+      <*> toSpecRep ceeVotes
+      <*> toSpecRep ceeWithdrawals
+      <*> toSpecRep ceeDeposits
 
 instance
   ToExpr (PredicateFailure (EraRule "CERT" era)) =>

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
@@ -33,20 +33,23 @@ import Test.Cardano.Ledger.Conformance (
  )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.GovCert ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
-import Test.Cardano.Ledger.Constrained.Conway.Deleg
+
+-- import Test.Cardano.Ledger.Constrained.Conway.Deleg
+
+import Test.Cardano.Ledger.Constrained.Conway.DeltaDeposit (DeltaExecEnv (..))
 import Test.Cardano.Ledger.Conway.TreeDiff
 
 instance
   ( SpecRep (PParamsHKD Identity era) ~ Agda.PParams
   , SpecTranslate ctx (PParamsHKD Identity era)
   ) =>
-  SpecTranslate ctx (DelegExecEnv era)
+  SpecTranslate ctx (DeltaExecEnv (ConwayDelegEnv era) era)
   where
-  type SpecRep (DelegExecEnv era) = Agda.DelegEnv
-  toSpecRep DelegExecEnv {..} = do
+  type SpecRep (DeltaExecEnv (ConwayDelegEnv era) era) = Agda.DelegEnv
+  toSpecRep DeltaExecEnv {..} = do
     Agda.MkDelegEnv
-      <$> toSpecRep (cdePParams deeDelegEnv)
-      <*> toSpecRep (Map.mapKeys (hashToInteger . unKeyHash) (cdePools deeDelegEnv))
+      <$> toSpecRep (cdePParams deeEnv)
+      <*> toSpecRep (Map.mapKeys (hashToInteger . unKeyHash) (cdePools deeEnv))
       <*> toSpecRep deeDeposits
 
 instance SpecTranslate ctx (ConwayDelegCert c) where

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -29,24 +31,23 @@ import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance (
   hashToInteger,
  )
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (emptyDeposits)
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.GovCert ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
+import Test.Cardano.Ledger.Constrained.Conway.Deleg
 import Test.Cardano.Ledger.Conway.TreeDiff
 
 instance
   ( SpecRep (PParamsHKD Identity era) ~ Agda.PParams
   , SpecTranslate ctx (PParamsHKD Identity era)
   ) =>
-  SpecTranslate ctx (ConwayDelegEnv era)
+  SpecTranslate ctx (DelegExecEnv era)
   where
-  type SpecRep (ConwayDelegEnv era) = Agda.DelegEnv
-
-  toSpecRep ConwayDelegEnv {..} =
+  type SpecRep (DelegExecEnv era) = Agda.DelegEnv
+  toSpecRep DelegExecEnv {..} = do
     Agda.MkDelegEnv
-      <$> toSpecRep cdePParams
-      <*> toSpecRep (Map.mapKeys (hashToInteger . unKeyHash) cdePools)
-      -- TODO: replace with actual deposits map
-      <*> pure emptyDeposits
+      <$> toSpecRep (cdePParams deeDelegEnv)
+      <*> toSpecRep (Map.mapKeys (hashToInteger . unKeyHash) (cdePools deeDelegEnv))
+      <*> toSpecRep deeDeposits
 
 instance SpecTranslate ctx (ConwayDelegCert c) where
   type SpecRep (ConwayDelegCert c) = Agda.TxCert

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
@@ -22,10 +22,7 @@ import Cardano.Ledger.CertState (
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
-import Cardano.Ledger.Conway.Rules (
-  ConwayGovCertEnv (..),
-  ConwayGovCertPredFailure,
- )
+import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Conway.TxCert (
   ConwayGovCert (..),
  )
@@ -35,9 +32,41 @@ import Cardano.Ledger.Shelley.LedgerState
 import Data.Functor.Identity (Identity)
 import Data.Map.Strict (Map)
 import qualified Lib as Agda
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (emptyDeposits)
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
+import Test.Cardano.Ledger.Constrained.Conway.GovCert
 import Test.Cardano.Ledger.Conway.TreeDiff (showExpr)
+
+instance SpecTranslate ctx (DepositPurpose c) where
+  type SpecRep (DepositPurpose c) = Agda.DepositPurpose
+  toSpecRep (CredentialDeposit cred) =
+    Agda.CredentialDeposit <$> toSpecRep cred
+  toSpecRep (PoolDeposit kh) =
+    Agda.PoolDeposit <$> toSpecRep kh
+  toSpecRep (DRepDeposit cred) =
+    Agda.DRepDeposit <$> toSpecRep cred
+  toSpecRep (GovActionDeposit gid) =
+    Agda.GovActionDeposit <$> toSpecRep gid
+
+instance
+  ( SpecTranslate ctx (PParamsHKD Identity era)
+  , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
+  , Inject ctx (VotingProcedures era)
+  , Inject ctx (Map (Network, Credential 'Staking (EraCrypto era)) Coin)
+  ) =>
+  SpecTranslate ctx (CertExecEnv era)
+  where
+  type SpecRep (CertExecEnv era) = Agda.CertEnv
+
+  toSpecRep CertExecEnv {..} = do
+    votes <- askCtx @(VotingProcedures era)
+    withdrawals <- askCtx @(Map (Network, Credential 'Staking (EraCrypto era)) Coin)
+    Agda.MkCertEnv
+      <$> toSpecRep (ceCurrentEpoch ceeCertEnv)
+      <*> toSpecRep (cePParams ceeCertEnv)
+      <*> toSpecRep votes
+      <*> toSpecRep withdrawals
+      <*> toSpecRep ceeDeposits
 
 instance SpecTranslate ctx (ConwayGovCert c) where
   type SpecRep (ConwayGovCert c) = Agda.TxCert
@@ -63,27 +92,6 @@ instance SpecTranslate ctx (ConwayGovCert c) where
     Agda.CCRegHot
       <$> toSpecRep c
       <*> toSpecRep (SNothing @(Credential _ _))
-
-instance
-  ( SpecTranslate ctx (PParamsHKD Identity era)
-  , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , Inject ctx (VotingProcedures era)
-  , Inject ctx (Map (Network, Credential 'Staking (EraCrypto era)) Coin)
-  ) =>
-  SpecTranslate ctx (ConwayGovCertEnv era)
-  where
-  type SpecRep (ConwayGovCertEnv era) = Agda.CertEnv
-
-  toSpecRep ConwayGovCertEnv {..} = do
-    votes <- askCtx @(VotingProcedures era)
-    withdrawals <- askCtx @(Map (Network, Credential 'Staking (EraCrypto era)) Coin)
-    Agda.MkCertEnv
-      <$> toSpecRep cgceCurrentEpoch
-      <*> toSpecRep cgcePParams
-      <*> toSpecRep votes
-      <*> toSpecRep withdrawals
-      -- TODO: replace with actual deposits map
-      <*> pure emptyDeposits
 
 instance SpecTranslate ctx (ConwayGovCertPredFailure era) where
   type SpecRep (ConwayGovCertPredFailure era) = OpaqueErrorString

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -19,9 +18,7 @@ import Cardano.Ledger.CertState (
   csCommitteeCreds,
   drepExpiry,
  )
-import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Conway.TxCert (
   ConwayGovCert (..),
@@ -30,7 +27,6 @@ import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Keys (KeyRole (..))
 import Cardano.Ledger.Shelley.LedgerState
 import Data.Functor.Identity (Identity)
-import Data.Map.Strict (Map)
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
@@ -51,21 +47,17 @@ instance SpecTranslate ctx (DepositPurpose c) where
 instance
   ( SpecTranslate ctx (PParamsHKD Identity era)
   , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , Inject ctx (VotingProcedures era)
-  , Inject ctx (Map (Network, Credential 'Staking (EraCrypto era)) Coin)
   ) =>
   SpecTranslate ctx (CertsExecEnv era)
   where
   type SpecRep (CertsExecEnv era) = Agda.CertEnv
 
   toSpecRep CertsExecEnv {..} = do
-    votes <- askCtx @(VotingProcedures era)
-    withdrawals <- askCtx @(Map (Network, Credential 'Staking (EraCrypto era)) Coin)
     Agda.MkCertEnv
       <$> toSpecRep (certsCurrentEpoch ceeCertEnv)
       <*> toSpecRep (certsPParams ceeCertEnv)
-      <*> toSpecRep votes
-      <*> toSpecRep withdrawals
+      <*> toSpecRep ceeVotes
+      <*> toSpecRep ceeWithdrawals
       <*> toSpecRep ceeDeposits
 
 instance SpecTranslate ctx (ConwayGovCert c) where

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
@@ -54,16 +54,16 @@ instance
   , Inject ctx (VotingProcedures era)
   , Inject ctx (Map (Network, Credential 'Staking (EraCrypto era)) Coin)
   ) =>
-  SpecTranslate ctx (CertExecEnv era)
+  SpecTranslate ctx (CertsExecEnv era)
   where
-  type SpecRep (CertExecEnv era) = Agda.CertEnv
+  type SpecRep (CertsExecEnv era) = Agda.CertEnv
 
-  toSpecRep CertExecEnv {..} = do
+  toSpecRep CertsExecEnv {..} = do
     votes <- askCtx @(VotingProcedures era)
     withdrawals <- askCtx @(Map (Network, Credential 'Staking (EraCrypto era)) Coin)
     Agda.MkCertEnv
-      <$> toSpecRep (ceCurrentEpoch ceeCertEnv)
-      <*> toSpecRep (cePParams ceeCertEnv)
+      <$> toSpecRep (certsCurrentEpoch ceeCertEnv)
+      <*> toSpecRep (certsPParams ceeCertEnv)
       <*> toSpecRep votes
       <*> toSpecRep withdrawals
       <*> toSpecRep ceeDeposits

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
@@ -30,8 +30,10 @@ import Data.Functor.Identity (Identity)
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
-import Test.Cardano.Ledger.Constrained.Conway.DeltaDeposit (DepositPurpose (..))
-import Test.Cardano.Ledger.Constrained.Conway.GovCert
+import Test.Cardano.Ledger.Constrained.Conway.DeltaDeposit (
+  DeltaExecEnv (..),
+  DepositPurpose (..),
+ )
 import Test.Cardano.Ledger.Conway.TreeDiff (showExpr)
 
 instance SpecTranslate ctx (DepositPurpose c) where
@@ -49,17 +51,17 @@ instance
   ( SpecTranslate ctx (PParamsHKD Identity era)
   , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
   ) =>
-  SpecTranslate ctx (CertsExecEnv era)
+  SpecTranslate ctx (DeltaExecEnv (ConwayGovCertEnv era) era)
   where
-  type SpecRep (CertsExecEnv era) = Agda.CertEnv
+  type SpecRep (DeltaExecEnv (ConwayGovCertEnv era) era) = Agda.CertEnv
 
-  toSpecRep CertsExecEnv {..} = do
+  toSpecRep DeltaExecEnv {..} = do
     Agda.MkCertEnv
-      <$> toSpecRep (certsCurrentEpoch ceeCertEnv)
-      <*> toSpecRep (certsPParams ceeCertEnv)
-      <*> toSpecRep ceeVotes
-      <*> toSpecRep ceeWithdrawals
-      <*> toSpecRep ceeDeposits
+      <$> toSpecRep (cgceCurrentEpoch deeEnv)
+      <*> toSpecRep (cgcePParams deeEnv)
+      <*> toSpecRep deeVotes
+      <*> toSpecRep deeWithdrawals
+      <*> toSpecRep deeDeposits
 
 instance SpecTranslate ctx (ConwayGovCert c) where
   type SpecRep (ConwayGovCert c) = Agda.TxCert

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
@@ -30,6 +30,7 @@ import Data.Functor.Identity (Identity)
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
+import Test.Cardano.Ledger.Constrained.Conway.DeltaDeposit (DepositPurpose (..))
 import Test.Cardano.Ledger.Constrained.Conway.GovCert
 import Test.Cardano.Ledger.Conway.TreeDiff (showExpr)
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
@@ -18,6 +18,7 @@ import Data.Map.Strict (mapKeys)
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
+import Test.Cardano.Ledger.Constrained.Conway.DeltaDeposit
 import Test.Cardano.Ledger.Conway.TreeDiff
 
 instance
@@ -54,3 +55,15 @@ instance SpecTranslate ctx (PoolCert c) where
     Agda.RetirePool
       <$> toSpecRep ppHash
       <*> toSpecRep e
+
+instance
+  ( SpecRep (PParamsHKD Identity era) ~ Agda.PParams
+  , SpecTranslate ctx (PParamsHKD Identity era)
+  ) =>
+  SpecTranslate ctx (DeltaExecEnv (PoolEnv era) era)
+  where
+  type SpecRep (DeltaExecEnv (PoolEnv era) era) = Agda.PParams
+  toSpecRep DeltaExecEnv {..} = toSpecRep (getPParams deeEnv)
+
+getPParams :: PoolEnv era -> PParams era
+getPParams (PoolEnv _ pp) = pp

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/ExecSpecRule/MiniTrace.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/ExecSpecRule/MiniTrace.hs
@@ -48,6 +48,7 @@ minitraceEither ::
   ( ExecSpecRule fn s e
   , ExecState fn s e ~ State (EraRule s e)
   , PrettyA (Signal (EraRule s e))
+  , PrettyA (State (EraRule s e))
   ) =>
   WitRule s e ->
   Proxy fn ->
@@ -78,6 +79,7 @@ minitraceEither witrule Proxy n0 = do
                         , "\nPredicateFailures"
                         ]
                           ++ map show (NE.toList ps)
+                          ++ [show $ prettyA state]
                       )
                   )
               Right !state2 -> do
@@ -93,6 +95,7 @@ minitrace ::
   ( ExecSpecRule fn s e
   , ExecState fn s e ~ State (EraRule s e)
   , PrettyA (Signal (EraRule s e))
+  , PrettyA (State (EraRule s e))
   ) =>
   WitRule s e ->
   Proxy fn ->
@@ -109,6 +112,7 @@ minitraceProp ::
   ( ExecSpecRule ConwayFn s e
   , ExecState ConwayFn s e ~ State (EraRule s e)
   , PrettyA (Signal (EraRule s e))
+  , PrettyA (State (EraRule s e))
   ) =>
   WitRule s e ->
   Proxy ConwayFn ->
@@ -149,7 +153,7 @@ nameAlonzoTx (AlonzoTx _body _wits isV _auxdata) = show isV
 
 -- | Run one check
 check :: IO ()
-check = quickCheck (withMaxSuccess 50 (minitraceProp (CERT Conway) (Proxy @ConwayFn) 50 nameTxCert))
+check = quickCheck (withMaxSuccess 50 (minitraceProp (GOVCERT Conway) (Proxy @ConwayFn) 50 nameGovCert))
 
 -- | Run a minitrace for every instance of ExecRuleSpec
 spec :: Spec

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -66,6 +66,7 @@ library
         Test.Cardano.Ledger.Constrained.Conway.PParams
         Test.Cardano.Ledger.Constrained.Conway.Pool
         Test.Cardano.Ledger.Constrained.Conway.Utxo
+        Test.Cardano.Ledger.Constrained.Conway.DeltaDeposit
         Test.Cardano.Ledger.Examples.BabbageFeatures
         Test.Cardano.Ledger.Examples.AlonzoValidTxUTXOW
         Test.Cardano.Ledger.Examples.AlonzoBBODY

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
@@ -20,6 +20,10 @@ import Test.Cardano.Ledger.Constrained.Conway.Instances
 import Test.Cardano.Ledger.Constrained.Conway.PParams
 import Test.Cardano.Ledger.Constrained.Conway.Pool
 
+certExecEnvSpec ::
+  Specification fn (CertExecEnv (ConwayEra StandardCrypto))
+certExecEnvSpec = TrueSpec
+
 certEnvSpec ::
   IsConwayUniv fn =>
   Specification fn (CertEnv (ConwayEra StandardCrypto))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
@@ -21,7 +21,7 @@ import Test.Cardano.Ledger.Constrained.Conway.PParams
 import Test.Cardano.Ledger.Constrained.Conway.Pool
 
 certExecEnvSpec ::
-  Specification fn (CertExecEnv (ConwayEra StandardCrypto))
+  Specification fn (CertsExecEnv (ConwayEra StandardCrypto))
 certExecEnvSpec = TrueSpec
 
 certEnvSpec ::

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- | Specs necessary to generate, environment, state, and signal
 -- for the CERT rule
@@ -12,17 +15,18 @@ import Cardano.Ledger.Shelley.API.Types
 
 import Constrained
 
-import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway (Conway, ConwayEra)
 import Cardano.Ledger.Crypto (StandardCrypto)
 import Test.Cardano.Ledger.Constrained.Conway.Deleg
+import Test.Cardano.Ledger.Constrained.Conway.DeltaDeposit (
+  DeltaExecEnv (..),
+  agdaDepositFromCertstate,
+ )
 import Test.Cardano.Ledger.Constrained.Conway.GovCert
 import Test.Cardano.Ledger.Constrained.Conway.Instances
 import Test.Cardano.Ledger.Constrained.Conway.PParams
 import Test.Cardano.Ledger.Constrained.Conway.Pool
-
-certExecEnvSpec ::
-  Specification fn (CertsExecEnv (ConwayEra StandardCrypto))
-certExecEnvSpec = TrueSpec
+import Test.QuickCheck (Gen)
 
 certEnvSpec ::
   IsConwayUniv fn =>
@@ -54,10 +58,31 @@ txCertSpec (CertEnv slot pp ce cc cp) CertState {..} =
       txCert
       -- These weights try to make it equally likely that each of the many certs
       -- across the 3 categories are chosen at similar frequencies.
-      (branchW 3 $ \delegCert -> satisfies delegCert $ delegCertSpec delegEnv certDState)
+      (branchW 3 $ \delegCert -> satisfies delegCert $ conwayDelegCertSpec delegEnv certDState)
       (branchW 1 $ \poolCert -> satisfies poolCert $ poolCertSpec poolEnv certPState)
       (branchW 3 $ \govCert -> satisfies govCert $ govCertSpec govCertEnv certVState)
   where
     delegEnv = ConwayDelegEnv pp (psStakePoolParams certPState)
     poolEnv = PoolEnv slot pp
     govCertEnv = ConwayGovCertEnv pp ce cc cp
+
+-- =================================================================
+
+certExecEnvSpec ::
+  IsConwayUniv fn =>
+  (CertEnv Conway, CertState Conway) ->
+  Specification fn (DeltaExecEnv (CertEnv Conway) Conway)
+certExecEnvSpec (certEnv, certState) = constrained $ \ [var| deEnv |] ->
+  match deEnv $ \ [var|env|] [var|deposits|] [var|withdrawal|] [var|votes|] ->
+    [ assert $ env ==. lit certEnv
+    , match votes $ \m -> sizeOf_ m ==. 0
+    , assert $ deposits ==. lit (agdaDepositFromCertstate certState)
+    , genHint 3 withdrawal -- Not sure if this is needed for CERT
+    --    , assert $ forAll withdrawal (\p -> elem_ p (lit (possibleWithdrawal dstate)))
+    ]
+
+genCERTEnv :: Gen (CertEnv Conway, CertState Conway)
+genCERTEnv = do
+  env <- genFromSpec @ConwayFn certEnvSpec
+  state <- genFromSpec @ConwayFn certStateSpec
+  pure (env, state)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
@@ -1,13 +1,119 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
+
 -- | Specs necessary to generate, environment, state, and signal
 -- for the CERTS rule
 module Test.Cardano.Ledger.Constrained.Conway.Certs where
 
+import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.CertState (CertState (..), DState (..), PState (..), VState (..), drepDeposit)
+import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway.Governance
+import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Conway.TxCert
+import Cardano.Ledger.Core
+import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Crypto (StandardCrypto)
+import Cardano.Ledger.Keys (KeyRole (..))
+import Cardano.Ledger.UMap as UMap
 import Constrained
+import Control.DeepSeq (NFData)
+import Data.Functor.Identity
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.OMap.Strict as OMap
 import Data.Sequence (Seq)
-import Test.Cardano.Ledger.Constrained.Conway.GovCert (CertsExecEnv)
+import GHC.Generics (Generic)
+import Lens.Micro
+import Test.Cardano.Ledger.Constrained.Conway.DeltaDeposit (DepositPurpose (..))
+import Test.Cardano.Ledger.Constrained.Conway.Instances (IsConwayUniv)
+import Test.Cardano.Ledger.Conway.TreeDiff (ToExpr)
+
+-- ==============================================================
+
+data CertsExecEnv era = CertsExecEnv
+  { ceeCertEnv :: !(CertsEnv era)
+  , ceeDeposits :: !(Map (DepositPurpose (EraCrypto era)) Coin)
+  , ceeWithdrawals :: !(Map (Network, Credential 'Staking (EraCrypto era)) Coin)
+  , ceeVotes :: !(VotingProcedures era)
+  }
+  deriving (Generic)
+
+deriving instance (EraPParams era, Eq (Tx era)) => Eq (CertsExecEnv era)
+deriving instance (EraPParams era, Show (Tx era)) => Show (CertsExecEnv era)
+
+instance
+  ( Era era
+  , ToExpr (Tx era)
+  , ToExpr (PParamsHKD StrictMaybe era)
+  , ToExpr (PParamsHKD Identity era)
+  ) =>
+  ToExpr (CertsExecEnv era)
+instance (EraPParams era, NFData (Tx era)) => NFData (CertsExecEnv era)
+instance HasSimpleRep (CertsExecEnv era)
+instance
+  ( Eq (Tx era)
+  , Show (Tx era)
+  , IsConwayUniv fn
+  , EraPParams era
+  , HasSpec fn (CertsEnv era)
+  , HasSpec fn (CertEnv era)
+  ) =>
+  HasSpec fn (CertsExecEnv era)
+
+instance Inject (CertsExecEnv era) (CertsEnv era) where
+  inject = ceeCertEnv
+
+instance Inject (CertsExecEnv era) (CertEnv era) where
+  inject CertsExecEnv {..} =
+    CertEnv
+      (certsSlotNo ceeCertEnv)
+      (certsPParams ceeCertEnv)
+      (certsCurrentEpoch ceeCertEnv)
+      (certsCurrentCommittee ceeCertEnv)
+      (certsCommitteeProposals ceeCertEnv)
+
+instance Inject (CertsExecEnv era) (ConwayGovCertEnv era) where
+  inject CertsExecEnv {..} =
+    ConwayGovCertEnv
+      (certsPParams ceeCertEnv)
+      (certsCurrentEpoch ceeCertEnv)
+      (certsCurrentCommittee ceeCertEnv)
+      (certsCommitteeProposals ceeCertEnv)
+
+toDeposits ::
+  ConwayEraGov era =>
+  CertState era ->
+  GovState era ->
+  Map (DepositPurpose (EraCrypto era)) Coin
+toDeposits CertState {..} govState =
+  Map.unions
+    [ Map.mapKeys CredentialDeposit credDeposits
+    , Map.mapKeys PoolDeposit poolDeposits
+    , Map.mapKeys DRepDeposit drepDeposits
+    , Map.mapKeys GovActionDeposit proposalDeposits
+    ]
+  where
+    credDeposits = depositMap (dsUnified certDState)
+    poolDeposits = psDeposits certPState
+    drepDeposits = drepDeposit <$> vsDReps certVState
+    proposalDeposits =
+      Map.map
+        (^. gasProposalProcedureL . pProcDepositL)
+        (OMap.toMap (govState ^. proposalsGovStateL . pPropsL))
+
+-- ===================================================
 
 certsExecEnvSpec ::
   Specification fn (CertsExecEnv (ConwayEra StandardCrypto))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
@@ -3,15 +3,15 @@
 module Test.Cardano.Ledger.Constrained.Conway.Certs where
 
 import Cardano.Ledger.Conway (ConwayEra)
-import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Conway.TxCert
 import Cardano.Ledger.Crypto (StandardCrypto)
 import Constrained
 import Data.Sequence (Seq)
+import Test.Cardano.Ledger.Constrained.Conway.GovCert (CertsExecEnv)
 
-certsEnvSpec ::
-  Specification fn (CertsEnv (ConwayEra StandardCrypto))
-certsEnvSpec = TrueSpec
+certsExecEnvSpec ::
+  Specification fn (CertsExecEnv (ConwayEra StandardCrypto))
+certsExecEnvSpec = TrueSpec
 
 txCertsSpec ::
   Specification fn (Seq (ConwayTxCert (ConwayEra StandardCrypto)))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
@@ -3,17 +3,19 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- | Specs necessary to generate, environment, state, and signal
 -- for the DELEG rule
 module Test.Cardano.Ledger.Constrained.Conway.Deleg where
 
-import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.CertState
 import Cardano.Ledger.Conway (Conway, ConwayEra)
 import Cardano.Ledger.Conway.Rules (ConwayDelegEnv (..))
@@ -21,38 +23,18 @@ import Cardano.Ledger.Conway.TxCert
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (StandardCrypto)
 import Cardano.Ledger.Shelley.API.Types
-import Cardano.Ledger.UMap (RDPair (..), fromCompact, unUnify)
+import Cardano.Ledger.UMap (RDPair (..), fromCompact, rewardMap, unUnify)
 import Constrained
-import Control.DeepSeq (NFData)
-import Data.Functor.Identity (Identity)
 import qualified Data.Map as Map
-import GHC.Generics (Generic)
 import Lens.Micro
-import Test.Cardano.Ledger.Constrained.Conway.DeltaDeposit (DepositPurpose (..))
+import Test.Cardano.Ledger.Constrained.Conway.DeltaDeposit (
+  DeltaExecEnv (..),
+  agdaDepositFromDstate,
+ )
 import Test.Cardano.Ledger.Constrained.Conway.Instances
 import Test.Cardano.Ledger.Constrained.Conway.PParams (pparamsSpec)
-import Test.Cardano.Ledger.Conway.TreeDiff (ToExpr)
-
-data DelegExecEnv era = DelegExecEnv
-  { deeDelegEnv :: !(ConwayDelegEnv era)
-  , deeDeposits :: !(Map.Map (DepositPurpose (EraCrypto era)) Coin)
-  }
-  deriving (Generic)
-
-deriving instance Eq (PParamsHKD Identity era) => Eq (DelegExecEnv era)
-deriving instance Show (PParamsHKD Identity era) => Show (DelegExecEnv era)
-instance ToExpr (PParamsHKD Identity era) => ToExpr (DelegExecEnv era)
-instance EraPParams era => NFData (DelegExecEnv era)
-instance HasSimpleRep (DelegExecEnv era)
-instance
-  ( IsConwayUniv fn
-  , EraPParams era
-  , HasSpec fn (PParams era)
-  ) =>
-  HasSpec fn (DelegExecEnv era)
-
-instance Inject (DelegExecEnv era) (ConwayDelegEnv era) where
-  inject = deeDelegEnv
+import Test.Cardano.Ledger.Generic.PrettyCore (PrettyA (prettyA))
+import Test.QuickCheck (Gen, generate)
 
 -- | Specify that some of the rewards in the RDPair's are zero.
 --   without this in the DState, it is hard to generate the ConwayUnRegCert
@@ -67,8 +49,8 @@ dStateSpec ::
   IsConwayUniv fn =>
   Specification fn (DState (ConwayEra StandardCrypto))
 dStateSpec = constrained $ \ds ->
-  match ds $ \rewardMap _futureGenDelegs _genDelegs _rewards ->
-    match rewardMap $ \rdMap ptrMap sPoolMap _dRepMap ->
+  match ds $ \rewardmap _futureGenDelegs _genDelegs _rewards ->
+    match rewardmap $ \rdMap ptrMap sPoolMap _dRepMap ->
       [ assertExplain (pure "dom sPoolMap is a subset of dom rdMap") $ dom_ sPoolMap `subset_` dom_ rdMap
       , assertExplain (pure "dom ptrMap is empty") $ dom_ ptrMap ==. mempty
       , assertExplain (pure "some rewards are zero") $
@@ -76,18 +58,18 @@ dStateSpec = constrained $ \ds ->
             \p -> match p $ \_cred rdpair -> satisfies rdpair someZeros
       ]
 
-delegCertSpec ::
+conwayDelegCertSpec ::
   forall fn.
   IsConwayUniv fn =>
   ConwayDelegEnv (ConwayEra StandardCrypto) ->
   DState (ConwayEra StandardCrypto) ->
   Specification fn (ConwayDelegCert StandardCrypto)
-delegCertSpec (ConwayDelegEnv pp pools) ds =
-  let rewardMap = unUnify $ rewards ds
+conwayDelegCertSpec (ConwayDelegEnv pp pools) ds =
+  let rewardmap = unUnify $ rewards ds
       delegMap = unUnify $ delegations ds
       zeroReward = (== 0) . fromCompact . rdReward
       depositOf k =
-        case fromCompact . rdDeposit <$> Map.lookup k rewardMap of
+        case fromCompact . rdDeposit <$> Map.lookup k rewardmap of
           Just d | d > 0 -> SJust d
           _ -> SNothing
       delegateeInPools :: Term fn (Delegatee StandardCrypto) -> Pred fn
@@ -108,7 +90,7 @@ delegCertSpec (ConwayDelegEnv pp pools) ds =
           -- ConwayUnRegCert !(StakeCredential c) !(StrictMaybe Coin)
           ( branchW 2 $ \sc mc ->
               [ -- You can only unregister things with 0 reward
-                assert $ elem_ sc $ lit (Map.keys $ Map.filter zeroReward rewardMap)
+                assert $ elem_ sc $ lit (Map.keys $ Map.filter zeroReward rewardmap)
               , assert $ elem_ sc $ lit (Map.keys delegMap)
               , -- The `StrictMaybe` needs to be precisely what is in the delegation map
                 reify sc depositOf (==. mc)
@@ -123,17 +105,48 @@ delegCertSpec (ConwayDelegEnv pp pools) ds =
           -- ConwayRegDelegCert !(StakeCredential c) !(Delegatee c) !Coin
           ( branchW 1 $ \sc delegatee c ->
               [ assert $ c ==. lit (pp ^. ppKeyDepositL)
-              , assert $ not_ (member_ sc (lit (Map.keysSet rewardMap)))
+              , assert $ not_ (member_ sc (lit (Map.keysSet rewardmap)))
               , delegateeInPools delegatee
               ]
           )
 
-delegEnvSpec ::
+conwayDelegEnvSpec ::
   IsConwayUniv fn =>
   Specification fn (ConwayDelegEnv Conway)
-delegEnvSpec = constrained $ \env ->
+conwayDelegEnvSpec = constrained $ \env ->
   match env $ \pp _ ->
     pp `satisfies` pparamsSpec
 
-delegExecEnvSpec :: Specification fn (DelegExecEnv Conway)
-delegExecEnvSpec = TrueSpec
+-- ===============================================================
+
+delegExecEnvSpec ::
+  forall fn.
+  IsConwayUniv fn =>
+  (ConwayDelegEnv Conway, DState Conway) ->
+  Specification fn (DeltaExecEnv (ConwayDelegEnv Conway) Conway)
+delegExecEnvSpec (denv, dstate) = constrained $ \ [var| deEnv |] ->
+  match deEnv $ \ [var|env|] [var|deposits|] [var|withdrawal|] [var|votes|] ->
+    [ assert $ env ==. lit denv
+    , match votes $ \m -> sizeOf_ m ==. 0
+    , assert $ sizeOf_ withdrawal ==. 0 -- DELEG rule ignores withdrawals
+    , assert $ deposits ==. lit (agdaDepositFromDstate dstate)
+    -- , assert $ forAll withdrawal (\p -> elem_ p (lit (possibleWithdrawal dstate)))
+    ]
+
+genDELEGDeltaEnv :: Gen (ConwayDelegEnv Conway, DState Conway)
+genDELEGDeltaEnv = do
+  denv <- genFromSpec @ConwayFn conwayDelegEnvSpec
+  dstate <- genFromSpec @ConwayFn dStateSpec
+  pure (denv, dstate)
+
+main :: IO ()
+main = do
+  (a, b) <- generate $ genDELEGDeltaEnv
+  putStrLn ("\nENV\n" ++ show (prettyA a))
+  putStrLn ("\nSTATE\n" ++ show (prettyA b))
+
+possibleWithdrawal :: DState era -> [((Network, Credential 'Staking (EraCrypto era)), Coin)]
+possibleWithdrawal dstate =
+  filter (\(_, Coin n) -> n /= 0) $
+    Map.toList $
+      Map.mapKeys (\x -> (Testnet, x)) (rewardMap (dsUnified dstate))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
@@ -28,7 +28,7 @@ import Data.Functor.Identity (Identity)
 import qualified Data.Map as Map
 import GHC.Generics (Generic)
 import Lens.Micro
-import Test.Cardano.Ledger.Constrained.Conway.GovCert (DepositPurpose (..))
+import Test.Cardano.Ledger.Constrained.Conway.DeltaDeposit (DepositPurpose (..))
 import Test.Cardano.Ledger.Constrained.Conway.Instances
 import Test.Cardano.Ledger.Constrained.Conway.PParams (pparamsSpec)
 import Test.Cardano.Ledger.Conway.TreeDiff (ToExpr)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/DeltaDeposit.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/DeltaDeposit.hs
@@ -1,0 +1,250 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | The Spec and the STS rules differ on where Deposits for Certificates are
+--   recorded in the Spec.  In the Spec Deposits are recorded in the UTXO rule
+--   in the STS rules (in ConwayEra) they are recorded in the "CERT rule.
+--   This module helps track those differences.
+module Test.Cardano.Ledger.Constrained.Conway.DeltaDeposit where
+
+import Cardano.Ledger.BaseTypes (Inject (..), Network)
+import Cardano.Ledger.CertState
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway.Governance (GovActionId (..), VotingProcedures)
+import Cardano.Ledger.Conway.Rules (CertEnv (..), CertsEnv (..), ConwayDelegEnv (..))
+import Cardano.Ledger.Conway.TxCert
+import Cardano.Ledger.Core
+import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
+import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
+import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.UMap (CompactForm (CompactCoin), RDPair (..))
+import qualified Cardano.Ledger.UMap as UMap
+import Constrained (HasSimpleRep (..), HasSpec (..))
+import Control.DeepSeq (NFData)
+import Data.Foldable (Foldable (..))
+import qualified Data.Map as Map
+import Data.Map.Strict (Map)
+import Data.Maybe.Strict (StrictMaybe (..))
+import Data.Sequence (Seq)
+import GHC.Generics (Generic)
+import Lens.Micro
+import Test.Cardano.Ledger.Constrained.Conway.Instances (IsConwayUniv)
+import Test.Cardano.Ledger.Conway.TreeDiff (ToExpr)
+import Test.QuickCheck (Gen)
+
+-- ==============================================================
+
+-- A Sum type of all the different ways Deposits are recorded.
+-- In the STS rules each kind of deposit is stored in map with
+-- Credential or KeyHash or GovActionId as the key, Using this type
+-- we can use a single Map with DepositPurpose as the key. This is
+-- how the Spec does it, rather than in 4 maps in different parts of the Spec.
+data DepositPurpose c
+  = CredentialDeposit !(Credential 'Staking c)
+  | PoolDeposit !(KeyHash 'StakePool c)
+  | DRepDeposit !(Credential 'DRepRole c)
+  | GovActionDeposit !(GovActionId c)
+  deriving (Generic, Eq, Show, Ord)
+
+instance ToExpr (DepositPurpose c)
+instance Crypto c => NFData (DepositPurpose c)
+instance HasSimpleRep (DepositPurpose c)
+instance (IsConwayUniv fn, Crypto c) => HasSpec fn (DepositPurpose c)
+
+-- ======================================================================================
+
+-- Deposits are recorded when the deposit is made (registering) and refunded (deregistering)
+data DepositKind = MakeDeposit Coin | RefundDeposit Coin deriving (Show)
+
+-- Tracks the difference between the Spec and the STS rules.
+newtype DeltaDeposit c = DeltaDeposit (Map (DepositPurpose c) DepositKind)
+
+-- | There are no differences
+emptyDeltaDeposit :: DeltaDeposit c
+emptyDeltaDeposit = DeltaDeposit Map.empty
+
+-- ========================================================================
+
+-- | Extend a DeltaDeposit from the deposits in a group of Certs
+deltaFromCerts ::
+  (EraPParams era, Foldable t) =>
+  PParams era ->
+  DeltaDeposit (EraCrypto era) ->
+  t (ConwayTxCert era) ->
+  DeltaDeposit (EraCrypto era)
+deltaFromCerts pp dd x = foldl' accum dd x
+  where
+    accum ans (ConwayTxCertDeleg (ConwayRegCert cred (SJust dep))) =
+      insertCert (CredentialDeposit cred) (MakeDeposit dep) ans
+    accum ans (ConwayTxCertDeleg (ConwayUnRegCert cred (SJust dep))) =
+      insertCert (CredentialDeposit cred) (RefundDeposit dep) ans
+    accum ans (ConwayTxCertDeleg _) = ans
+    accum ans (ConwayTxCertPool (RegPool (PoolParams {ppId = poolhash}))) =
+      insertCert (PoolDeposit poolhash) (MakeDeposit (pp ^. ppPoolDepositL)) ans
+    accum ans (ConwayTxCertPool _) = ans
+    accum ans (ConwayTxCertGov (ConwayRegDRep cred dep _)) =
+      insertCert (DRepDeposit cred) (MakeDeposit dep) ans
+    accum ans (ConwayTxCertGov (ConwayUnRegDRep cred dep)) =
+      insertCert (DRepDeposit cred) (RefundDeposit dep) ans
+    accum ans (ConwayTxCertGov _) = ans
+
+-- | insert a DepositKind for a Cert with key DepositPurpose into a DeltaDepositMap
+--   If the key is already in the map, then the two DepositKind's MUST be inverses with matching amounts.
+--   This is because one can only pay a deposit once, and can only refund it once,
+--   and the payment and refund must be the same. If the inverses cancel each other, then the key is removed.
+insertCert :: DepositPurpose c -> DepositKind -> DeltaDeposit c -> DeltaDeposit c
+insertCert key depositkind (DeltaDeposit m) = DeltaDeposit (Map.alter (alterF key depositkind) key m)
+
+-- | implements the logic described for the function 'insertCert' above.
+alterF :: DepositPurpose c -> DepositKind -> Maybe DepositKind -> Maybe DepositKind
+-- The key is not present, just insert.
+alterF _ depkind Nothing = Just depkind
+-- Inverse kinds
+alterF key x@(MakeDeposit (Coin n)) (Just y@(RefundDeposit (Coin m))) =
+  if n == m
+    then Nothing
+    else
+      error
+        ("Non Matching Coin in inverse DepositKinds " ++ show x ++ " " ++ show y ++ " at key " ++ show key)
+-- Inverse kinds
+alterF key x@(RefundDeposit (Coin m)) (Just y@(MakeDeposit (Coin n))) =
+  if n == m
+    then Nothing
+    else
+      error
+        ("Non Matching Coin in inverse DepositKinds " ++ show x ++ " " ++ show y ++ " at key " ++ show key)
+-- Registering the same key twice
+alterF key x@(MakeDeposit _) (Just y@(MakeDeposit _)) =
+  error ("Double Deposit " ++ show x ++ " " ++ show y ++ " for same key " ++ show key)
+-- DeRegistration of the same key twice.
+alterF key x@(RefundDeposit _) (Just y@(RefundDeposit _)) =
+  error ("Double Refund " ++ show x ++ " " ++ show y ++ " for same key " ++ show key)
+
+-- ========================================================================
+
+applyDeltaDepositDState :: DeltaDeposit (EraCrypto era) -> DState era -> DState era
+applyDeltaDepositDState (DeltaDeposit dd) ds = ds {dsUnified = Map.foldlWithKey' accum (dsUnified ds) dd}
+  where
+    accum um (CredentialDeposit cred) depkind = UMap.adjust fixRDPair cred (UMap.RewDepUView um)
+      where
+        fixRDPair (RDPair reward deposit) = case depkind of
+          -- The 'deposit' is computed by the STS rule, and should match the coin in the DepositKind computed by deltaFormCerts
+          MakeDeposit coin ->
+            if UMap.fromCompact deposit == coin
+              then -- Keep the Rewards, but delete the deposit
+                (RDPair reward (CompactCoin 0))
+              else error ("Deposit in UMap " ++ show deposit ++ " does not match the DepositKind: " ++ show depkind)
+          RefundDeposit coin ->
+            if UMap.fromCompact deposit == coin
+              then -- The Rewards should be deleted, but the deposit should remain
+                (RDPair (CompactCoin 0) deposit)
+              else error ("Deposit in UMap  " ++ show deposit ++ " does not match the DepositKind: " ++ show depkind)
+    accum um _ _ = um
+
+applyDeltaDepositVState :: DeltaDeposit (EraCrypto era) -> VState era -> VState era
+applyDeltaDepositVState (DeltaDeposit dd) (VState drepmap y z) = VState (Map.foldlWithKey' accum drepmap dd) y z
+  where
+    accum dmap (DRepDeposit cred) depkind = Map.adjust fixDRepstate cred dmap
+      where
+        fixDRepstate (DRepState expiry anchor deposit) = case depkind of
+          --- The 'deposit' is computed by the STS rule, and should match the coin in the DepositKind computed by deltaFormCerts
+          MakeDeposit coin ->
+            if deposit == coin
+              then -- Zero out the deposit
+                DRepState expiry anchor (Coin 0)
+              else
+                error
+                  ( "Deposit in VState DRepState "
+                      ++ show deposit
+                      ++ " does not match the DepositKind: "
+                      ++ show depkind
+                  )
+          RefundDeposit coin ->
+            if deposit == coin
+              then -- the deposit should remain
+                DRepState expiry anchor deposit
+              else
+                error
+                  ( "Deposit in VState DRepState "
+                      ++ show deposit
+                      ++ " does not match the DepositKind: "
+                      ++ show depkind
+                  )
+    accum dmap _ _ = dmap
+
+applyDeltaDepositPState :: DeltaDeposit (EraCrypto era) -> PState era -> PState era
+applyDeltaDepositPState (DeltaDeposit dd) ps = ps {psDeposits = Map.foldlWithKey' accum (psDeposits ps) dd}
+  where
+    accum pmap (PoolDeposit cred) depkind = Map.alter fixPoolDeposits cred pmap
+      where
+        fixPoolDeposits Nothing = Nothing
+        fixPoolDeposits (Just deposit) = case depkind of
+          -- The 'deposit' is computed by the STS rule, and should match the coin in the DepositKind computed by deltaFormCerts
+          MakeDeposit coin ->
+            if deposit == coin
+              then -- Zero out the deposit
+                Nothing -- Means delete that entry from the map
+              else error ("Deposit in PState " ++ show deposit ++ " does not match the DepositKind: " ++ show depkind)
+          RefundDeposit coin ->
+            if deposit == coin
+              then -- the deposit should remain
+                Just deposit
+              else error ("Deposit in PState " ++ show deposit ++ " does not match the DepositKind: " ++ show depkind)
+    accum pmap _ _ = pmap
+
+applyDeltaDepositCertState :: DeltaDeposit (EraCrypto era) -> CertState era -> CertState era
+applyDeltaDepositCertState dd cs =
+  cs
+    { certVState = applyDeltaDepositVState dd (certVState cs)
+    , certPState = applyDeltaDepositPState dd (certPState cs)
+    , certDState = applyDeltaDepositDState dd (certDState cs)
+    }
+
+-- =======================================================
+
+-- | In order to impose exactly the same structure on every ExecEnv that needs
+--   the DeltaDeposit trick, we define a type parameterized by the env, signal, and state
+--   that adds exactly the same Delta stuff for every use.
+data DeltaExecEnv env state signal era = DeltaExecEnv
+  { deeEnv :: env
+  , deeSignal :: signal
+  , deeState :: state
+  , deeDeposits :: !(Map (DepositPurpose (EraCrypto era)) Coin) -- A function of deeSignal
+  , deeWithdrawals :: !(Map (Network, Credential 'Staking (EraCrypto era)) Coin)
+  , deeVotes :: !(VotingProcedures era)
+  }
+
+-- All the ExexSpecRule environment types are type synonym correctly parameterized.
+type DelegExecEnv era =
+  DeltaExecEnv (ConwayDelegEnv era) (DState era) (ConwayDelegCert StandardCrypto) era
+type GovCertExecEnv era =
+  DeltaExecEnv (PParams era) (VState era) (ConwayGovCert StandardCrypto) era
+type CertExecEnv era = DeltaExecEnv (CertEnv era) (CertState era) (ConwayTxCert era) era
+type CertsExecEnv era = DeltaExecEnv (CertsEnv era) (CertState era) (Seq (ConwayTxCert era)) era
+
+-- Here are all the Inject instances.
+instance Inject (DelegExecEnv era) (ConwayDelegEnv era) where inject = deeEnv
+instance Inject (GovCertExecEnv era) (PParams era) where inject = deeEnv
+instance Inject (CertExecEnv era) (CertEnv era) where inject = deeEnv
+instance Inject (CertsExecEnv era) (CertsEnv era) where inject = deeEnv
+
+-- Here are all the ExecSpecRule State generators
+genDeltaExecState :: () -> DeltaExecEnv env state signal era -> Gen state
+genDeltaExecState () x = pure (deeState x)
+
+-- Here are all the ExecSpecRule Signal generators
+genDeltaExecSignal :: () -> DeltaExecEnv env state signal era -> state -> Gen signal
+genDeltaExecSignal () x _ = pure (deeSignal x)
+
+{-
+-- All we need now is to write tne ExecSpecRule Env generators!
+genDELEGDeltaEnv :: () -> Gen (DelegExecEnv era)
+genGOVCERTDeltaEnv :: () -> Gen (GovCertExecEnv era)
+genCERTDeltaEnv :: () -> Gen (CertExecEnv era)
+genCERTSDeltaEnv :: () -> Gen (CertsExecEnv era)
+-}

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/GovCert.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/GovCert.hs
@@ -25,8 +25,8 @@ import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Conway.TxCert
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..))
-import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
-import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
+import Cardano.Ledger.Crypto (StandardCrypto)
+import Cardano.Ledger.Keys (KeyRole (..))
 import Constrained
 import Control.DeepSeq (NFData)
 import Data.Functor.Identity
@@ -34,21 +34,12 @@ import qualified Data.Map as Map
 import Data.Map.Strict (Map)
 import GHC.Generics (Generic)
 import Lens.Micro
+import Test.Cardano.Ledger.Constrained.Conway.DeltaDeposit (DepositPurpose (..))
 import Test.Cardano.Ledger.Constrained.Conway.Instances
 import Test.Cardano.Ledger.Constrained.Conway.PParams
 import Test.Cardano.Ledger.Conway.TreeDiff (ToExpr)
 
-data DepositPurpose c
-  = CredentialDeposit !(Credential 'Staking c)
-  | PoolDeposit !(KeyHash 'StakePool c)
-  | DRepDeposit !(Credential 'DRepRole c)
-  | GovActionDeposit !(GovActionId c)
-  deriving (Generic, Eq, Show, Ord)
-
-instance ToExpr (DepositPurpose c)
-instance Crypto c => NFData (DepositPurpose c)
-instance HasSimpleRep (DepositPurpose c)
-instance (IsConwayUniv fn, Crypto c) => HasSpec fn (DepositPurpose c)
+-- =========================================================
 
 data CertsExecEnv era = CertsExecEnv
   { ceeCertEnv :: !(CertsEnv era)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/GovCert.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/GovCert.hs
@@ -53,6 +53,8 @@ instance (IsConwayUniv fn, Crypto c) => HasSpec fn (DepositPurpose c)
 data CertsExecEnv era = CertsExecEnv
   { ceeCertEnv :: !(CertsEnv era)
   , ceeDeposits :: !(Map (DepositPurpose (EraCrypto era)) Coin)
+  , ceeWithdrawals :: !(Map (Network, Credential 'Staking (EraCrypto era)) Coin)
+  , ceeVotes :: !(VotingProcedures era)
   }
   deriving (Generic)
 
@@ -60,7 +62,8 @@ deriving instance (EraPParams era, Eq (Tx era)) => Eq (CertsExecEnv era)
 deriving instance (EraPParams era, Show (Tx era)) => Show (CertsExecEnv era)
 
 instance
-  ( ToExpr (Tx era)
+  ( Era era
+  , ToExpr (Tx era)
   , ToExpr (PParamsHKD StrictMaybe era)
   , ToExpr (PParamsHKD Identity era)
   ) =>

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -178,9 +178,9 @@ prop_CERT =
 prop_DELEG :: Property
 prop_DELEG =
   stsPropertyV2 @"DELEG" @ConwayFn
-    delegEnvSpec
+    conwayDelegEnvSpec
     (\_env -> dStateSpec)
-    delegCertSpec
+    conwayDelegCertSpec
     $ \_env _st _sig _st' -> True
 
 prop_POOL :: Property


### PR DESCRIPTION
# Description

This PR is part of the work to accommodate the change in the spec that introduces deposits in the environment of GOVCERT, CERT and DELEG rules, as follows: 

* CERTS, CERT, GOVCERT conformance instances  share a new `ExecEnvironment` type: `CertsExecEnv`, which holds a CertsEnv and the new deposits map. This type is then adjusted to each rule to build the required environment (which contains less than the CertsEnv)
* DELEG conformance instance has a new `ExecEnvironment` type: `DelegExecEnv`, which holds a DelegEnv and the new deposits map.
* In all the translations for rules mentioned above, the new deposits map is then passed to build the Agda type (replacing the temporary `emptyDeposts`) 
* `ConwayExecContext`  no long exists, and its two fields (withdrawals and votes) are now part of the new `CertsExecEnv`.

The missing part of accommodating this work is:  accounting for the fact that in the spec, the value of the deposits doesn't get modified by these rules, whereas in the implementation it does.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
