### PR TITLE
Update Plutus deps: 1.31

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -24,7 +24,7 @@ index-state:
   -- Bump this if you need newer packages from Hackage
   , hackage.haskell.org 2024-06-06T00:00:00Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2024-06-18T00:00:00Z
+  , cardano-haskell-packages 2024-07-23T08:58:13Z
 
 packages:
   eras/allegra/impl

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -90,7 +90,7 @@ library
         mtl,
         microlens,
         nothunks,
-        plutus-ledger-api ^>=1.30,
+        plutus-ledger-api ^>=1.31,
         set-algebra >=1.0,
         small-steps >=1.1,
         text,

--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -59,7 +59,7 @@ library
         containers,
         data-default-class,
         microlens,
-        plutus-ledger-api ^>=1.30,
+        plutus-ledger-api ^>=1.31,
         QuickCheck,
         random,
         serialise,

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -83,7 +83,7 @@ library
         deepseq,
         microlens,
         nothunks,
-        plutus-ledger-api ^>=1.30,
+        plutus-ledger-api ^>=1.31,
         set-algebra,
         small-steps >=1.1,
         text,

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -99,7 +99,7 @@ library
         deepseq,
         microlens,
         nothunks,
-        plutus-ledger-api ^>=1.30,
+        plutus-ledger-api ^>=1.31,
         set-algebra,
         small-steps >=1.1,
         text,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1718628684,
-        "narHash": "sha256-UAyiQYotlXmZdANSqO+J/TTtITPTA7VvDfST6I5FE7Y=",
+        "lastModified": 1721726553,
+        "narHash": "sha256-AmrMW6CX29f+NqcZQgN1tH9XgAm6aqdAUUaprTxgc1Q=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "86bcc75d40ea283e0934cd3f3cced70db1493920",
+        "rev": "239640006b22b90976d0d18d49d96bac6ad63b77",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -67,7 +67,7 @@ library
         network,
         nothunks,
         primitive,
-        plutus-ledger-api >=1.27.0 && <1.31.0,
+        plutus-ledger-api >=1.27.0 && <1.32.0,
         recursion-schemes,
         serialise,
         tagged,


### PR DESCRIPTION
# Description

- Update CHaP index
- Use [updated Plutus dependencies](https://github.com/IntersectMBO/cardano-haskell-packages/pull/840)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section 
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
