### PR TITLE
`constrained-generators`: Add a callback to saturate constraints

### DIFF
--- a/libs/constrained-generators/src/Constrained/Examples/Map.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Map.hs
@@ -3,11 +3,14 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Constrained.Examples.Map where
 
 import Data.Map (Map)
+import Data.Map qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Word
@@ -123,3 +126,7 @@ mapSetSmall :: Specification BaseFn (Map (Set Int) Int)
 mapSetSmall = constrained $ \x ->
   forAll (dom_ x) $ \d ->
     assert $ subset_ d $ lit (Set.fromList [3 .. 4])
+
+mapIsJust :: Specification BaseFn (Int, Int)
+mapIsJust = constrained' $ \ [var| x |] [var| y |] ->
+  assert $ cJust_ x ==. lookup_ y (lit $ Map.fromList [(z, z) | z <- [100 .. 102]])

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -71,6 +71,8 @@ tests nightly =
     -- so we need to figure something out about double-shrinking
     testSpecNoShrink "intSpec" intSpec
     testSpec "mapElemSpec" mapElemSpec
+    -- TODO: double shrinking
+    testSpecNoShrink "mapIsJust" mapIsJust
     testSpec "mapElemKeySpec" mapElemKeySpec
     testSpec "mapPairSpec" mapPairSpec
     testSpecNoShrink "mapEmptyDomainSpec" mapEmptyDomainSpec


### PR DESCRIPTION
# Description

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
