### PR TITLE
Fix `PParams` and `PParamsUpdate` field order for conformance tests

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,12 +13,28 @@ repository cardano-haskell-packages
 -- While using SRPs one can obtain the `--sha256` value for a package
 -- by first setting it to some random value and letting the tooling
 -- tell you what it should be, for example, using `nix develop` will
--- throw an error with the correct value to use
+-- throw an error with the correct value to use or alternatively
+-- you can run `nix-prefetch-url <url> --unpack`,
+-- e.g.: `nix-prefetch-url https://github.com/intersectmbo/formal-ledger-specifications/archive/841942c68993857fd40ca35cd62258cf82d160a5.zip --unpack`
+-- This might even be preferable, since this will give you the full hash
+-- rather than a shortened one.
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/cardano-ledger-executable-spec.git
-  tag: 888d91a65eeb6eb8a920edff87c5a4384dab4c29
-  --sha256: sha256-RzxivupVXUimVzeccL0fUI3jP6hdbKTGS3LWjkpTc8E=
+  location: https://github.com/IntersectMBO/formal-ledger-specifications.git
+  subdir: ledgerSrc/haskell/Ledger
+  tag: 841942c68993857fd40ca35cd62258cf82d160a5
+  --sha256: 0acbsfpa3f745abfagyivim3d2qp7i0xwv0lsg7j4ah4s2qx5vkc
+-- NOTE: If you would like to update the above, look for the available tags
+-- in the `formal-ledger-specifications` repo and pick the tag which marks
+-- the generated code that you want to include.
+-- The code is generated and pushed to a branch called `haskell-package` in
+-- the `formal-ledger-specifications` repo. However, upon each new generation
+-- and push, the old commit with the generated code gets removed, hence
+-- why we do the tagging to keep those references around so we can use them
+-- in this SRP. Also note, that we use the commit reference of the tag,
+-- which is a commit from the `haskell-package` branch as mentioned before,
+-- rather than the commit referenced in the title and the message of the tag,
+-- since those reference the commit on `master` which the code was generated from.
 
 index-state:
   -- Bump this if you need newer packages from Hackage

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -285,34 +285,39 @@ instance SpecTranslate ctx PoolVotingThresholds where
 instance SpecTranslate ctx (ConwayPParams Identity era) where
   type SpecRep (ConwayPParams Identity era) = Agda.PParams
 
-  toSpecRep x =
-    Agda.MkPParams
-      <$> toSpecRep (cppMinFeeA x)
-      <*> toSpecRep (cppMinFeeB x)
-      <*> pure (toInteger . unTHKD $ cppMaxBBSize x)
-      <*> pure (toInteger . unTHKD $ cppMaxTxSize x)
-      <*> pure (toInteger . unTHKD $ cppMaxBHSize x)
-      <*> pure (toInteger . unTHKD $ cppMaxValSize x)
-      <*> pure 0 -- minUTxOValue has been deprecated and is not supported in Conway
-      <*> toSpecRep (cppPoolDeposit x)
-      <*> toSpecRep (cppKeyDeposit x)
-      <*> toSpecRep (cppEMax x)
-      <*> toSpecRep (toInteger . unTHKD $ cppNOpt x)
-      <*> toSpecRep (cppProtocolVersion x)
-      <*> toSpecRep (cppPoolVotingThresholds x)
-      <*> toSpecRep (cppDRepVotingThresholds x)
-      <*> toSpecRep (cppGovActionLifetime x)
-      <*> toSpecRep (cppGovActionDeposit x)
-      <*> toSpecRep (cppDRepDeposit x)
-      <*> toSpecRep (cppDRepActivity x)
-      <*> pure (toInteger . unTHKD $ cppCommitteeMinSize x)
-      <*> pure (toInteger . unEpochInterval . unTHKD $ cppCommitteeMaxTermLength x)
-      <*> toSpecRep (cppCostModels x)
-      <*> toSpecRep (cppPrices x)
-      <*> toSpecRep (cppMaxTxExUnits x)
-      <*> toSpecRep (cppMaxBlockExUnits x)
-      <*> toSpecRep (cppCoinsPerUTxOByte x)
-      <*> pure (toInteger . unTHKD $ cppMaxCollateralInputs x)
+  toSpecRep (ConwayPParams {..}) = do
+    ppA <- toSpecRep cppMinFeeA
+    ppB <- toSpecRep cppMinFeeB
+    let
+      ppMaxBlockSize = toInteger . unTHKD $ cppMaxBBSize
+      ppMaxTxSize = toInteger . unTHKD $ cppMaxTxSize
+      ppMaxHeaderSize = toInteger . unTHKD $ cppMaxBHSize
+    ppKeyDeposit <- toSpecRep cppKeyDeposit
+    ppPoolDeposit <- toSpecRep cppPoolDeposit
+    ppEmax <- toSpecRep cppEMax
+    ppNopt <- toSpecRep (toInteger . unTHKD $ cppNOpt)
+    ppPv <- toSpecRep cppProtocolVersion
+    let
+      ppMinUTxOValue = 0 -- minUTxOValue has been deprecated and is not supported in Conway
+    ppCoinsPerUTxOByte <- toSpecRep cppCoinsPerUTxOByte
+    ppCostmdls <- toSpecRep cppCostModels
+    ppPrices <- toSpecRep cppPrices
+    ppMaxTxExUnits <- toSpecRep cppMaxTxExUnits
+    ppMaxBlockExUnits <- toSpecRep cppMaxBlockExUnits
+    let
+      ppMaxValSize = toInteger . unTHKD $ cppMaxValSize
+      ppMaxCollateralInputs = toInteger . unTHKD $ cppMaxCollateralInputs
+    ppPoolVotingThresholds <- toSpecRep cppPoolVotingThresholds
+    ppDrepVotingThresholds <- toSpecRep cppDRepVotingThresholds
+    let
+      ppCCMinSize = toInteger . unTHKD $ cppCommitteeMinSize
+      ppCCMaxTermLength = toInteger . unEpochInterval . unTHKD $ cppCommitteeMaxTermLength
+    ppGovActionLifetime <- toSpecRep cppGovActionLifetime
+    ppGovActionDeposit <- toSpecRep cppGovActionDeposit
+    ppDrepDeposit <- toSpecRep cppDRepDeposit
+    ppDrepActivity <- toSpecRep cppDRepActivity
+
+    pure $ Agda.MkPParams {..}
 
 instance
   SpecTranslate ctx (PParamsHKD Identity era) =>

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -688,35 +688,40 @@ instance SpecTranslate ctx (VotingProcedures era) where
 instance SpecTranslate ctx (ConwayPParams StrictMaybe era) where
   type SpecRep (ConwayPParams StrictMaybe era) = Agda.PParamsUpdate
 
-  toSpecRep x =
-    Agda.MkPParamsUpdate
-      <$> toSpecRep (cppMinFeeA x)
-      <*> toSpecRep (cppMinFeeB x)
-      <*> pure (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxBBSize x)
-      <*> pure (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxTxSize x)
-      <*> pure (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxBHSize x)
-      <*> pure (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxValSize x)
-      <*> pure Nothing -- minUTxOValue has been deprecated and is not supported in Conway
-      <*> toSpecRep (cppPoolDeposit x)
-      <*> toSpecRep (cppKeyDeposit x)
-      <*> toSpecRep (cppEMax x)
-      <*> toSpecRep (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppNOpt x)
-      <*> pure Nothing
-      <*> toSpecRep (cppPoolVotingThresholds x)
-      <*> toSpecRep (cppDRepVotingThresholds x)
-      <*> toSpecRep (cppGovActionLifetime x)
-      <*> toSpecRep (cppGovActionDeposit x)
-      <*> toSpecRep (cppDRepDeposit x)
-      <*> toSpecRep (cppDRepActivity x)
-      <*> pure (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppCommitteeMinSize x)
-      <*> pure
-        (fmap (toInteger . unEpochInterval) . strictMaybeToMaybe . unTHKD $ cppCommitteeMaxTermLength x)
-      <*> toSpecRep (cppCostModels x)
-      <*> toSpecRep (cppPrices x)
-      <*> toSpecRep (cppMaxTxExUnits x)
-      <*> toSpecRep (cppMaxBlockExUnits x)
-      <*> toSpecRep (cppCoinsPerUTxOByte x)
-      <*> pure (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxCollateralInputs x)
+  toSpecRep (ConwayPParams {..}) = do
+    ppuA <- toSpecRep cppMinFeeA
+    ppuB <- toSpecRep cppMinFeeB
+    let
+      ppuMaxBlockSize = fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxBBSize
+      ppuMaxTxSize = fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxTxSize
+      ppuMaxHeaderSize = fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxBHSize
+    ppuKeyDeposit <- toSpecRep (cppKeyDeposit)
+    ppuPoolDeposit <- toSpecRep (cppPoolDeposit)
+    ppuEmax <- toSpecRep (cppEMax)
+    ppuNopt <- toSpecRep (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppNOpt)
+    let
+      ppuPv = Nothing
+      ppuMinUTxOValue = Nothing -- minUTxOValue has been deprecated and is not supported in Conway
+    ppuCoinsPerUTxOByte <- toSpecRep (cppCoinsPerUTxOByte)
+    ppuCostmdls <- toSpecRep (cppCostModels)
+    ppuPrices <- toSpecRep (cppPrices)
+    ppuMaxTxExUnits <- toSpecRep (cppMaxTxExUnits)
+    ppuMaxBlockExUnits <- toSpecRep (cppMaxBlockExUnits)
+    let
+      ppuMaxValSize = fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxValSize
+      ppuMaxCollateralInputs = (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxCollateralInputs)
+    ppuPoolVotingThresholds <- toSpecRep (cppPoolVotingThresholds)
+    ppuDrepVotingThresholds <- toSpecRep (cppDRepVotingThresholds)
+    let
+      ppuCCMinSize = (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppCommitteeMinSize)
+      ppuCCMaxTermLength =
+        (fmap (toInteger . unEpochInterval) . strictMaybeToMaybe . unTHKD $ cppCommitteeMaxTermLength)
+    ppuGovActionLifetime <- toSpecRep (cppGovActionLifetime)
+    ppuGovActionDeposit <- toSpecRep (cppGovActionDeposit)
+    ppuDrepDeposit <- toSpecRep (cppDRepDeposit)
+    ppuDrepActivity <- toSpecRep (cppDRepActivity)
+
+    pure $ Agda.MkPParamsUpdate {..}
 
 instance
   SpecTranslate ctx (PParamsHKD StrictMaybe era) =>

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -285,17 +285,17 @@ instance SpecTranslate ctx PoolVotingThresholds where
 instance SpecTranslate ctx (ConwayPParams Identity era) where
   type SpecRep (ConwayPParams Identity era) = Agda.PParams
 
-  toSpecRep (ConwayPParams {..}) = do
+  toSpecRep ConwayPParams {..} = do
     ppA <- toSpecRep cppMinFeeA
     ppB <- toSpecRep cppMinFeeB
     let
-      ppMaxBlockSize = toInteger . unTHKD $ cppMaxBBSize
-      ppMaxTxSize = toInteger . unTHKD $ cppMaxTxSize
-      ppMaxHeaderSize = toInteger . unTHKD $ cppMaxBHSize
+      ppMaxBlockSize = toInteger $ unTHKD cppMaxBBSize
+      ppMaxTxSize = toInteger $ unTHKD cppMaxTxSize
+      ppMaxHeaderSize = toInteger $ unTHKD cppMaxBHSize
     ppKeyDeposit <- toSpecRep cppKeyDeposit
     ppPoolDeposit <- toSpecRep cppPoolDeposit
     ppEmax <- toSpecRep cppEMax
-    ppNopt <- toSpecRep (toInteger . unTHKD $ cppNOpt)
+    ppNopt <- toSpecRep (toInteger $ unTHKD cppNOpt)
     ppPv <- toSpecRep cppProtocolVersion
     let
       ppMinUTxOValue = 0 -- minUTxOValue has been deprecated and is not supported in Conway
@@ -317,7 +317,7 @@ instance SpecTranslate ctx (ConwayPParams Identity era) where
     ppDrepDeposit <- toSpecRep cppDRepDeposit
     ppDrepActivity <- toSpecRep cppDRepActivity
 
-    pure $ Agda.MkPParams {..}
+    pure Agda.MkPParams {..}
 
 instance
   SpecTranslate ctx (PParamsHKD Identity era) =>
@@ -695,33 +695,33 @@ instance SpecTranslate ctx (ConwayPParams StrictMaybe era) where
       ppuMaxBlockSize = fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxBBSize
       ppuMaxTxSize = fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxTxSize
       ppuMaxHeaderSize = fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxBHSize
-    ppuKeyDeposit <- toSpecRep (cppKeyDeposit)
-    ppuPoolDeposit <- toSpecRep (cppPoolDeposit)
-    ppuEmax <- toSpecRep (cppEMax)
+    ppuKeyDeposit <- toSpecRep cppKeyDeposit
+    ppuPoolDeposit <- toSpecRep cppPoolDeposit
+    ppuEmax <- toSpecRep cppEMax
     ppuNopt <- toSpecRep (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppNOpt)
     let
       ppuPv = Nothing
       ppuMinUTxOValue = Nothing -- minUTxOValue has been deprecated and is not supported in Conway
-    ppuCoinsPerUTxOByte <- toSpecRep (cppCoinsPerUTxOByte)
-    ppuCostmdls <- toSpecRep (cppCostModels)
-    ppuPrices <- toSpecRep (cppPrices)
-    ppuMaxTxExUnits <- toSpecRep (cppMaxTxExUnits)
-    ppuMaxBlockExUnits <- toSpecRep (cppMaxBlockExUnits)
+    ppuCoinsPerUTxOByte <- toSpecRep cppCoinsPerUTxOByte
+    ppuCostmdls <- toSpecRep cppCostModels
+    ppuPrices <- toSpecRep cppPrices
+    ppuMaxTxExUnits <- toSpecRep cppMaxTxExUnits
+    ppuMaxBlockExUnits <- toSpecRep cppMaxBlockExUnits
     let
       ppuMaxValSize = fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxValSize
-      ppuMaxCollateralInputs = (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxCollateralInputs)
+      ppuMaxCollateralInputs = fmap toInteger . strictMaybeToMaybe . unTHKD $ cppMaxCollateralInputs
     ppuPoolVotingThresholds <- toSpecRep (cppPoolVotingThresholds)
     ppuDrepVotingThresholds <- toSpecRep (cppDRepVotingThresholds)
     let
-      ppuCCMinSize = (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppCommitteeMinSize)
+      ppuCCMinSize = fmap toInteger . strictMaybeToMaybe $ unTHKD cppCommitteeMinSize
       ppuCCMaxTermLength =
-        (fmap (toInteger . unEpochInterval) . strictMaybeToMaybe . unTHKD $ cppCommitteeMaxTermLength)
-    ppuGovActionLifetime <- toSpecRep (cppGovActionLifetime)
-    ppuGovActionDeposit <- toSpecRep (cppGovActionDeposit)
-    ppuDrepDeposit <- toSpecRep (cppDRepDeposit)
-    ppuDrepActivity <- toSpecRep (cppDRepActivity)
+        fmap (toInteger . unEpochInterval) . strictMaybeToMaybe $ unTHKD cppCommitteeMaxTermLength
+    ppuGovActionLifetime <- toSpecRep cppGovActionLifetime
+    ppuGovActionDeposit <- toSpecRep cppGovActionDeposit
+    ppuDrepDeposit <- toSpecRep cppDRepDeposit
+    ppuDrepActivity <- toSpecRep cppDRepActivity
 
-    pure $ Agda.MkPParamsUpdate {..}
+    pure Agda.MkPParamsUpdate {..}
 
 instance
   SpecTranslate ctx (PParamsHKD StrictMaybe era) =>


### PR DESCRIPTION
# Description
Related to: https://github.com/IntersectMBO/formal-ledger-specifications/issues/507
Should be merged after: https://github.com/IntersectMBO/formal-ledger-specifications/pull/521
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
