### PR TITLE
Upgrade to ghc966 and other deps

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -328,7 +328,7 @@ jobs:
 
     - name: Install fourmolu
       run: |
-        FOURMOLU_VERSION="0.14.0.0"
+        FOURMOLU_VERSION="0.16.2.0"
         mkdir -p "$HOME/.local/bin"
         curl -sL "https://github.com/fourmolu/fourmolu/releases/download/v${FOURMOLU_VERSION}/fourmolu-${FOURMOLU_VERSION}-linux-x86_64" -o "$HOME/.local/bin/fourmolu"
         chmod a+x "$HOME/.local/bin/fourmolu"

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -36,7 +36,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ghc: ["8.10.7", "9.2.8", "9.6.5", "9.8.2", "9.10.1"]
+        ghc: ["8.10.7", "9.2.8", "9.6.6", "9.8.2", "9.10.1"]
         os: [ubuntu-latest]
       fail-fast: false
 
@@ -185,7 +185,7 @@ jobs:
         - set-algebra
         - small-steps
         - vector-map
-        ghc: ["8.10.7", "9.2.8", "9.6.5", "9.8.2"]
+        ghc: ["8.10.7", "9.2.8", "9.6.6", "9.8.2"]
         os: [ubuntu-latest]
       fail-fast: false
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -68,7 +68,7 @@ jobs:
       uses: input-output-hk/actions/haskell@latest
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: latest
+        cabal-version: 3.10.3.0
 
     - name: Configure to use libsodium
       run: |

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
@@ -209,16 +209,14 @@ alonzoBbodyTransition =
           == fromIntegral (bhviewBSize bh)
             ?! injectFailure
               ( ShelleyInAlonzoBbodyPredFailure
-                  ( WrongBlockBodySizeBBODY actualBodySize (fromIntegral $ bhviewBSize bh)
-                  )
+                  (WrongBlockBodySizeBBODY actualBodySize (fromIntegral $ bhviewBSize bh))
               )
 
         actualBodyHash
           == bhviewBHash bh
             ?! injectFailure
               ( ShelleyInAlonzoBbodyPredFailure
-                  ( InvalidBodyHashBBODY @era actualBodyHash (bhviewBHash bh)
-                  )
+                  (InvalidBodyHashBBODY @era actualBodyHash (bhviewBHash bh))
               )
 
         ls' <-

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
@@ -179,11 +179,11 @@ getAlonzoTxAuxDataScripts AlonzoTxAuxData {atadTimelock = timelocks, atadPlutus 
   mconcat $
     (TimelockScript <$> timelocks)
       : [ StrictSeq.fromList $
-          -- It is fine to filter out unsupported languages with mapMaybe, because the invariant for
-          -- AlonzoTxAuxData is that it does not contain scripts with languages that are not
-          -- supported in this era
-          mapMaybe (fmap PlutusScript . mkBinaryPlutusScript lang) $
-            NE.toList plutusScripts
+            -- It is fine to filter out unsupported languages with mapMaybe, because the invariant for
+            -- AlonzoTxAuxData is that it does not contain scripts with languages that are not
+            -- supported in this era
+            mapMaybe (fmap PlutusScript . mkBinaryPlutusScript lang) $
+              NE.toList plutusScripts
         | lang <- [PlutusV1 .. eraMaxLanguage @era]
         , Just plutusScripts <- [Map.lookup lang plutus]
         ]

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Update/Validation/Endorsement.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Update/Validation/Endorsement.hs
@@ -162,20 +162,20 @@ register env st endorsement =
         then
           if numberOfEndorsements >= adoptionThreshold
             then -- Register the endorsement and adopt the proposal in the next epoch
-            do
-              let cpu =
-                    CandidateProtocolUpdate
-                      { cpuSlot = currentSlot
-                      , cpuProtocolVersion = pv
-                      , cpuProtocolParameters = pps'
-                      }
-                  cpus' =
-                    updateCandidateProtocolUpdates candidateProtocolVersions cpu
-              pure
-                $ State
-                  { candidateProtocolVersions = cpus'
-                  , registeredEndorsements = registeredEndorsements'
-                  }
+              do
+                let cpu =
+                      CandidateProtocolUpdate
+                        { cpuSlot = currentSlot
+                        , cpuProtocolVersion = pv
+                        , cpuProtocolParameters = pps'
+                        }
+                    cpus' =
+                      updateCandidateProtocolUpdates candidateProtocolVersions cpu
+                pure
+                  $ State
+                    { candidateProtocolVersions = cpus'
+                    , registeredEndorsements = registeredEndorsements'
+                    }
             else -- Just register the endorsement if we cannot adopt
               pure $ st {registeredEndorsements = registeredEndorsements'}
         else -- Ignore the endorsement if the registration isn't stable

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Update/Validation/Interface.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Update/Validation/Interface.hs
@@ -506,7 +506,6 @@ registerEpoch env st lastSeenEpoch = do
     else -- We have a new protocol version, so we update the current protocol
     -- version and parameters, and we perform a cleanup of the state
     -- variables.
-
       st
         { adoptedProtocolVersion = adoptedProtocolVersion'
         , adoptedProtocolParameters = nextProtocolParameters'

--- a/eras/mary/impl/test/Test/Cardano/Ledger/Mary/ValueSpec.hs
+++ b/eras/mary/impl/test/Test/Cardano/Ledger/Mary/ValueSpec.hs
@@ -108,13 +108,13 @@ propCanonicalConstructionAgrees xs ys = property $ do
   let mb1@(MultiAsset b1) =
         mconcat
           [ MultiAsset $
-            canonicalInsert const pid (canonicalInsert const an i mempty) mempty
+              canonicalInsert const pid (canonicalInsert const an i mempty) mempty
           | (pid, an, i) <- xs
           ]
       mb2@(MultiAsset b2) =
         mconcat
           [ MultiAsset $
-            canonicalInsert const pid (canonicalInsert const an i mempty) mempty
+              canonicalInsert const pid (canonicalInsert const an i mempty) mempty
           | (pid, an, i) <- ys
           ]
   expectValidMap b1

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
@@ -344,8 +344,7 @@ goldenEncodingTestsMary =
         "multiasset_with_negative"
         (MultiAsset $ Map.singleton policyID1 (Map.singleton (AssetName assetName1) (-19)))
         ( T
-            ( TkMapLen 1
-            )
+            (TkMapLen 1)
             <> S policyID1
             <> T
               ( TkMapLen 1

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
@@ -109,8 +109,7 @@ deriving instance
 -------------------------------------------------------------------------------}
 
 type ShelleyBasedEra' era =
-  ( PraosCrypto (EraCrypto era)
-  )
+  (PraosCrypto (EraCrypto era))
 
 defaultShelleyLedgerExamples ::
   forall era.

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Core.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Core.hs
@@ -153,8 +153,7 @@ import qualified Test.QuickCheck as QC
 
 -- | For use in the Serialisation and Example Tests, which assume Shelley, Allegra, or Mary Eras.
 type PreAlonzo era =
-  ( TxWits era ~ ShelleyTxWits era
-  )
+  (TxWits era ~ ShelleyTxWits era)
 
 -- =========================================
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
@@ -409,7 +409,6 @@ genNextDelta
      in if remainingFee <= Coin 0 -- we've paid for all the fees
           then pure delta -- we're done
           else -- the change covers what we need, so shift Coin from change to dfees.
-
             if remainingFee <= (changeAmount <-> minAda)
               then
                 pure $
@@ -421,50 +420,50 @@ genNextDelta
                           change
                     }
               else -- add a new input to cover the fee
-              do
-                let txBody = tx ^. bodyTxL
-                    inputsInUse = txBody ^. inputsTxBodyL <> extraInputs
-                    utxo' :: UTxO era
-                    utxo' =
-                      -- Remove possible inputs from Utxo, if they already
-                      -- appear in inputs.
-                      UTxO $
-                        Map.filterWithKey
-                          ( \k v ->
-                              (k `Set.notMember` inputsInUse) && genEraGoodTxOut v
-                          )
-                          -- filter out UTxO entries where the TxOut are not
-                          -- appropriate for this Era (i.e. Keylocked in
-                          -- AlonzoEra)
-                          (unUTxO utxo)
-                (inputs, value, (vkeyPairs, msigPairs)) <-
-                  genInputs (1, 1) ksIndexedPaymentKeys ksIndexedPayScripts utxo'
-                -- It is possible that the Utxo has no possible inputs left, so
-                -- fail. We try and keep this from happening by using feedback:
-                -- adding to the number of ouputs (in the call to genRecipients)
-                -- in genTx above. Adding to the outputs means in the next cycle
-                -- the size of the UTxO will grow. In rare cases, this cannot be avoided
-                -- So we discard this test case. This should happen very rarely.
-                -- If it does happen, It is NOT a test failure, but an inadequacy in the
-                -- testing framework to generate almost-random transactions that always succeed every time.
-                -- Experience suggests that this happens less than 1% of the time, and does not lead to backtracking.
-                !_ <- when (null inputs) (myDiscard "NoMoneyleft Utxo.hs")
-                let newWits =
-                      mkTxWits @era
-                        (utxo, txBody, scriptinfo)
-                        ksIndexedPaymentKeys
-                        ksIndexedStakingKeys
-                        vkeyPairs
-                        (mkScriptWits @era msigPairs mempty)
-                        (hashAnnotated txBody)
-                pure $
-                  delta
-                    { extraWitnesses = extraWitnesses <> newWits
-                    , extraInputs = extraInputs <> Set.fromList inputs
-                    , change = deltaChange (<+> value) change -- <+> is plus of the Val class
-                    , deltaVKeys = vkeyPairs <> deltaVKeys delta
-                    , deltaScripts = msigPairs <> deltaScripts delta
-                    }
+                do
+                  let txBody = tx ^. bodyTxL
+                      inputsInUse = txBody ^. inputsTxBodyL <> extraInputs
+                      utxo' :: UTxO era
+                      utxo' =
+                        -- Remove possible inputs from Utxo, if they already
+                        -- appear in inputs.
+                        UTxO $
+                          Map.filterWithKey
+                            ( \k v ->
+                                (k `Set.notMember` inputsInUse) && genEraGoodTxOut v
+                            )
+                            -- filter out UTxO entries where the TxOut are not
+                            -- appropriate for this Era (i.e. Keylocked in
+                            -- AlonzoEra)
+                            (unUTxO utxo)
+                  (inputs, value, (vkeyPairs, msigPairs)) <-
+                    genInputs (1, 1) ksIndexedPaymentKeys ksIndexedPayScripts utxo'
+                  -- It is possible that the Utxo has no possible inputs left, so
+                  -- fail. We try and keep this from happening by using feedback:
+                  -- adding to the number of ouputs (in the call to genRecipients)
+                  -- in genTx above. Adding to the outputs means in the next cycle
+                  -- the size of the UTxO will grow. In rare cases, this cannot be avoided
+                  -- So we discard this test case. This should happen very rarely.
+                  -- If it does happen, It is NOT a test failure, but an inadequacy in the
+                  -- testing framework to generate almost-random transactions that always succeed every time.
+                  -- Experience suggests that this happens less than 1% of the time, and does not lead to backtracking.
+                  !_ <- when (null inputs) (myDiscard "NoMoneyleft Utxo.hs")
+                  let newWits =
+                        mkTxWits @era
+                          (utxo, txBody, scriptinfo)
+                          ksIndexedPaymentKeys
+                          ksIndexedStakingKeys
+                          vkeyPairs
+                          (mkScriptWits @era msigPairs mempty)
+                          (hashAnnotated txBody)
+                  pure $
+                    delta
+                      { extraWitnesses = extraWitnesses <> newWits
+                      , extraInputs = extraInputs <> Set.fromList inputs
+                      , change = deltaChange (<+> value) change -- <+> is plus of the Val class
+                      , deltaVKeys = vkeyPairs <> deltaVKeys delta
+                      , deltaScripts = msigPairs <> deltaScripts delta
+                      }
     where
       deltaChange ::
         (Value era -> Value era) ->

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Deleg.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Deleg.hs
@@ -184,12 +184,10 @@ checkInstantaneousRewards
               "a ReservesMIR certificate should add the total value to the `irwd` map, overwriting any existing entries"
               ( if HardForks.allowMIRTransfer . view ppProtocolVersionL $ ppDE denv
                   then -- In the Alonzo era, repeated fields are added
-
                     fold (iRReserves $ dsIRewards source)
                       `addDeltaCoin` fold irwd
                       == fold (iRReserves $ dsIRewards target)
                   else -- Prior to the Alonzo era, repeated fields overridden
-
                     fold (iRReserves (dsIRewards source) Map.\\ irwd)
                       `addDeltaCoin` fold irwd
                       == fold (iRReserves $ dsIRewards target)
@@ -204,12 +202,10 @@ checkInstantaneousRewards
               "a TreasuryMIR certificate should add* the total value to the `irwd` map"
               ( if HardForks.allowMIRTransfer . view ppProtocolVersionL . ppDE $ denv
                   then -- In the Alonzo era, repeated fields are added
-
                     fold (iRTreasury $ dsIRewards source)
                       `addDeltaCoin` fold irwd
                       == fold (iRTreasury $ dsIRewards target)
                   else -- Prior to the Alonzo era, repeated fields overridden
-
                     fold (iRTreasury (dsIRewards source) Map.\\ irwd)
                       `addDeltaCoin` fold irwd
                       == fold (iRTreasury $ dsIRewards target)

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -155,7 +155,6 @@ poolRegistrationProp
                   (eval (hk ∉ dom (psRetiring targetSt)) :: Bool)
               ]
           else -- first registration
-
             conjoin
               [ counterexample
                   "New PoolParams are registered in pParams"

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/SafeHash.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/SafeHash.hs
@@ -75,13 +75,11 @@ test1 =
 test2 =
   testCase
     "newtype==underlyingtype"
-    ( assertEqual "A newtype and its underlying type dont hash the same" shorthash (castSafeHash foohash)
-    )
+    (assertEqual "A newtype and its underlying type dont hash the same" shorthash (castSafeHash foohash))
 test3 =
   testCase
     "short==long"
-    ( assertEqual "ShortByteString and ByteString don't hash the same" shorthashT (castSafeHash longhashT)
-    )
+    (assertEqual "ShortByteString and ByteString don't hash the same" shorthashT (castSafeHash longhashT))
 test4 =
   testCase
     "newtype==underlyingtype"

--- a/flake.nix
+++ b/flake.nix
@@ -107,7 +107,7 @@
               // lib.optionalAttrs (config.compiler-nix-name == defaultCompiler) {
                 # tools that work only with default compiler
                 fourmolu = "0.16.2.0";
-                hlint = "3.6.1";
+                hlint = "3.8";
                 haskell-language-server = "2.9.0.0";
               };
 

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
         inherit (nixpkgs) lib;
 
         # see flake `variants` below for alternative compilers
-        defaultCompiler = "ghc965";
+        defaultCompiler = "ghc966";
         # We use cabalProject' to ensure we don't build the plan for
         # all systems.
         cabalProject = nixpkgs.haskell-nix.cabalProject' ({config, ...}: {
@@ -241,9 +241,9 @@
 
           devShells = let
             mkDevShells = p: {
-              # `nix develop .#profiling` (or `.#ghc965.profiling): a shell with profiling enabled
+              # `nix develop .#profiling` (or `.#ghc966.profiling): a shell with profiling enabled
               profiling = (p.appendModule {modules = [{enableLibraryProfiling = true;}];}).shell;
-              # `nix develop .#pre-commit` (or `.#ghc965.pre-commit): a shell with pre-commit enabled
+              # `nix develop .#pre-commit` (or `.#ghc966.pre-commit): a shell with pre-commit enabled
               pre-commit = let
                 pre-commit-check = inputs.pre-commit-hooks.lib.${system}.run {
                   src = ./.;

--- a/flake.nix
+++ b/flake.nix
@@ -106,7 +106,7 @@
               }
               // lib.optionalAttrs (config.compiler-nix-name == defaultCompiler) {
                 # tools that work only with default compiler
-                fourmolu = "0.14.0.0";
+                fourmolu = "0.16.2.0";
                 hlint = "3.6.1";
                 haskell-language-server = "2.9.0.0";
               };

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
@@ -294,8 +294,7 @@ propNextEpoch nes = do
         `shouldSatisfy` (\res -> Map.keysSet res == nextComMembers `Set.difference` comMembers)
 
       filterNext ToBeRemoved noFilterResult
-        `shouldSatisfy` ( \res -> Map.keysSet res == (comMembers `Set.union` comStateMembers) `Set.difference` nextComMembers
-                        )
+        `shouldSatisfy` (\res -> Map.keysSet res == (comMembers `Set.union` comStateMembers) `Set.difference` nextComMembers)
 
       -- members who are both in current and nextCommittee are either ToBeExpired, TermAdjusted or NoChangeExpected
       Set.unions

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Plutus/ScriptTestContext.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Plutus/ScriptTestContext.hs
@@ -21,7 +21,8 @@ data PlutusArgs = PlutusArgs
 
 instance NFData PlutusArgs
 
-data ScriptTestContext = forall l.
+data ScriptTestContext
+  = forall l.
   PlutusLanguage l =>
   ScriptTestContext
   { stcScript :: Plutus l

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/EpochBoundary.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/EpochBoundary.hs
@@ -69,8 +69,8 @@ txOutUnstaked =
 txOutsFromCreds :: [StakeCredential TestCrypto] -> [TxOut TestEra]
 txOutsFromCreds creds =
   [ TxOutCompact
-    (compactAddr $ Addr Testnet payCred (StakeRefBase cred))
-    coinVal
+      (compactAddr $ Addr Testnet payCred (StakeRefBase cred))
+      coinVal
   | cred <- creds
   ]
   where
@@ -79,8 +79,8 @@ txOutsFromCreds creds =
 txOutsFromPtrs :: [Ptr] -> [TxOut TestEra]
 txOutsFromPtrs ptrs =
   [ TxOutCompact
-    (compactAddr $ Addr Testnet payCred (StakeRefPtr ptr))
-    coinVal
+      (compactAddr $ Addr Testnet payCred (StakeRefPtr ptr))
+      coinVal
   | ptr <- ptrs
   ]
   where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
@@ -74,8 +74,7 @@ delegCertSpec (ConwayDelegEnv pp pools) ds =
           -- that each branch is choosen with similar frequency
 
           -- ConwayRegCert !(StakeCredential c) !(StrictMaybe Coin)
-          ( branchW 2 $ \_ mc -> mc ==. lit (SJust (pp ^. ppKeyDepositL))
-          )
+          (branchW 2 $ \_ mc -> mc ==. lit (SJust (pp ^. ppKeyDepositL)))
           -- ConwayUnRegCert !(StakeCredential c) !(StrictMaybe Coin)
           ( branchW 2 $ \sc mc ->
               [ -- You can only unregister things with 0 reward

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
@@ -134,7 +134,9 @@ utxoTxSpec env st =
                     [ (reify ctbSpendInputs)
                         ( \actualInputs ->
                             fold
-                              [ c | i <- Set.toList actualInputs, BabbageTxOut _ (MaryValue c _) _ _ <- maybeToList . txinLookup i . utxosUtxo $ st
+                              [ c
+                              | i <- Set.toList actualInputs
+                              , BabbageTxOut _ (MaryValue c _) _ _ <- maybeToList . txinLookup i . utxosUtxo $ st
                               ]
                         )
                         $ \totalValueConsumed ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Examples.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Examples.hs
@@ -878,7 +878,7 @@ testPreds name proof preds = do
       ( pure emptySubst
           >>= toolChainSub proof standardOrderInfo preds
           >>= (\subst -> monadTyped $ substToEnv subst emptyEnv)
-        )
+      )
     let pairs = map (tryPred env) preds
     pure (property (and (map snd pairs)))
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
@@ -835,7 +835,7 @@ genTxAndLedger sizes proof = do
         >>= certsStage sizes proof
         >>= ledgerStateStage sizes proof
         >>= txBodyStage sizes proof
-      )
+    )
   env0 <- monadTyped $ substToEnv subst emptyEnv
   env1 <- monadTyped $ adjustFeeInput env0
   env2 <- errorTyped $ adjustColInput env1
@@ -858,7 +858,7 @@ genTxAndNewEpoch sizes proof = do
         >>= txBodyStage sizes proof
         >>= epochStateStage proof
         >>= newEpochStateStage proof
-      )
+    )
   env0 <- monadTyped $ substToEnv subst emptyEnv
   env1 <- monadTyped $ adjustFeeInput env0
   env2 <- errorTyped $ adjustColInput env1

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Solver.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Solver.hs
@@ -879,14 +879,16 @@ dispatch v1@(V nam r1 _) preds = explain ("Solving for variable " ++ nam ++ "\n"
     set <- simplify expr
     let msgs = ("Solving for variable " ++ nam) : map show preds
     if Set.null set
-      then failT (("The set is empty " ++ synopsis (termRep expr) set ++ ", can't find an element.") : msgs)
+      then
+        failT (("The set is empty " ++ synopsis (termRep expr) set ++ ", can't find an element.") : msgs)
       else pure (fst <$> itemFromSet msgs set)
   [Member (Right (Var v2@(V _ r2 _))) expr] | Name v1 == Name v2 -> do
     Refl <- sameRep r1 r2
     set <- simplify expr
     let msgs = ("Solving for variable " ++ nam) : map show preds
     if Set.null set
-      then failT (("The set is empty " ++ synopsis (termRep expr) set ++ ", can't find an element.") : msgs)
+      then
+        failT (("The set is empty " ++ synopsis (termRep expr) set ++ ", can't find an element.") : msgs)
       else pure (fst <$> itemFromSet msgs set)
   [NotMember (Var v2@(V _ r2 _)) expr] | Name v1 == Name v2 -> do
     Refl <- sameRep r1 r2
@@ -900,7 +902,8 @@ dispatch v1@(V nam r1 _) preds = explain ("Solving for variable " ++ nam ++ "\n"
     let m2 = Map.filter (== v) m
     let msgs = ("Solving for variable " ++ nam) : map show preds
     if Map.null m2
-      then failT (("The value: " ++ synopsis (termRep exprVal) v ++ " is not in the range of the map.") : msgs)
+      then
+        failT (("The value: " ++ synopsis (termRep exprVal) v ++ " is not in the range of the map.") : msgs)
       else pure (fst <$> itemFromSet msgs (Map.keysSet m2))
   [MapMember exprKey (Var v2@(V _ r2 _)) exprMap] | Name v1 == Name v2 -> do
     Refl <- sameRep r1 r2

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1498,8 +1498,7 @@ ppConwayCertPredFailure proof x = case x of
     Conway -> ppSexp "GovCertFailure" [ppConwayGovCertPredFailure pf] -- (PredicateFailure (EraRule "GOVCERT" era))
     _ ->
       error
-        ( "Only the ConwayEra has a (PredicateFailure (EraRule \"GOVCERT\" era)). This Era is " ++ show proof
-        )
+        ("Only the ConwayEra has a (PredicateFailure (EraRule \"GOVCERT\" era)). This Era is " ++ show proof)
 
 instance Reflect era => PrettyA (ConwayRules.ConwayCertPredFailure era) where
   prettyA = ppConwayCertPredFailure reify

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
@@ -691,7 +691,6 @@ genTxCerts slot = do
                     else -- In order to Delegate, the delegCred must exist in rewards.
                     -- so if it is not there, we put it there, otherwise we may
                     -- never generate a valid delegation.
-
                       ( (RegTxCert delegCred) : dcs
                       , Map.insert delegCred (Coin 99) regCreds
                       )
@@ -762,9 +761,9 @@ genCollateralUTxO collateralAddresses (Coin fee) utxo = do
               if null ecs'
                 then -- This is the last input, so most of the time, put something (val > 0)
                 -- extra in it or we will always have a ColReturn with zero in it.
-                do
-                  excess <- lift genPositiveVal
-                  genNewCollateral ec coll um ((minCollTotal <-> curCollTotal) <+> excess)
+                  do
+                    excess <- lift genPositiveVal
+                    genNewCollateral ec coll um ((minCollTotal <-> curCollTotal) <+> excess)
                 else elementsT [genCollateral ec coll Map.empty, genCollateral ec coll um]
             go ecs' coll' (curCollTotal <+> c) um'
   (collaterals, excessColCoin) <-
@@ -918,8 +917,8 @@ genAlonzoTxAndInfo proof slot = do
       proof
       Spending
       [ (\dh cred -> (lookupByKeyM "datum" dh gsDatums, cred))
-        <$> mDatumHash
-        <*> Just credential
+          <$> mDatumHash
+          <*> Just credential
       | (_, coretxout) <- Map.toAscList toSpendNoCollateral
       , let (credentials, mDatumHash) = txoutEvidence proof coretxout
       , credential <- credentials

--- a/libs/constrained-generators/src/Constrained/Base.hs
+++ b/libs/constrained-generators/src/Constrained/Base.hs
@@ -1235,8 +1235,8 @@ saturatePred p =
 mergeSolverStage :: SolverStage fn -> [SolverStage fn] -> [SolverStage fn]
 mergeSolverStage (SolverStage x ps spec) plan =
   [ case eqVar x y of
-    Just Refl -> SolverStage y (ps ++ ps') (spec <> spec')
-    Nothing -> stage
+      Just Refl -> SolverStage y (ps ++ ps') (spec <> spec')
+      Nothing -> stage
   | stage@(SolverStage y ps' spec') <- plan
   ]
 
@@ -2174,8 +2174,10 @@ letSubexpressionElimination :: BaseUniverse fn => Pred fn -> Pred fn
 letSubexpressionElimination = go []
   where
     adjustSub x sub =
-      [ x' := t | x' := t <- sub, isNothing $ eqVar x x',
-      -- TODO: possibly freshen the binder where
+      [ x' := t
+      | x' := t <- sub
+      , isNothing $ eqVar x x'
+      , -- TODO: possibly freshen the binder where
       -- `x` appears instead?
       not $ Name x `appearsIn` t
       ]

--- a/libs/constrained-generators/src/Constrained/Examples/Basic.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Basic.hs
@@ -223,12 +223,9 @@ three :: Specification BaseFn Three
 three = constrained $ \o ->
   [ caseOn
       o
-      ( branchW 1 $ \_ -> True
-      )
-      ( branchW 1 $ \_ -> True
-      )
-      ( branchW 1 $ \_ -> True
-      )
+      (branchW 1 $ \_ -> True)
+      (branchW 1 $ \_ -> True)
+      (branchW 1 $ \_ -> True)
   , monitor $ \eval -> QC.cover 30 True (show $ eval o)
   ]
 
@@ -239,12 +236,9 @@ threeSpecific :: Specification BaseFn Three
 threeSpecific = constrained $ \o ->
   [ caseOn
       o
-      ( branchW 1 $ \_ -> True
-      )
-      ( branchW 1 $ \_ -> True
-      )
-      ( branchW 2 $ \_ -> True
-      )
+      (branchW 1 $ \_ -> True)
+      (branchW 1 $ \_ -> True)
+      (branchW 2 $ \_ -> True)
   , monitor $ \eval ->
       QC.coverTable "TheValue" [("One", 22), ("Two", 22), ("Three", 47)]
         . QC.tabulate "TheValue" [show $ eval o]

--- a/libs/constrained-generators/src/Constrained/Graph.hs
+++ b/libs/constrained-generators/src/Constrained/Graph.hs
@@ -68,8 +68,7 @@ irreflexiveDependencyOn xs ys =
     deps =
       Graph
         (Map.fromDistinctAscList [(x, Set.delete x ys) | x <- Set.toList xs])
-        ( Map.fromDistinctAscList [(a, Set.delete a xs) | a <- Set.toList ys]
-        )
+        (Map.fromDistinctAscList [(a, Set.delete a xs) | a <- Set.toList ys])
 
 transitiveDependencies :: Ord node => node -> Graph node -> Set node
 transitiveDependencies x (Graph e _) = go (Set.singleton x) x


### PR DESCRIPTION
# Description

This PR update default compiler to GHC-9.6.6

Also `fourmolu` is updated to newest version (When we were on GHC-9.2.8 we could not update, now we can)

This PR also downgrades to `cabal-3.10.3.0` on GithubActions CI, since newly added version causes problems: https://github.com/input-output-hk/actions/issues/27 Once that problem is fixed we'll be able to upgrade to `cabal-3.12` on GithubActions and in nix

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
