### PR TITLE
Update `formal-ledger-specifications` SRP note

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -24,17 +24,14 @@ source-repository-package
   subdir: ledgerSrc/haskell/Ledger
   tag: 841942c68993857fd40ca35cd62258cf82d160a5
   --sha256: 0acbsfpa3f745abfagyivim3d2qp7i0xwv0lsg7j4ah4s2qx5vkc
--- NOTE: If you would like to update the above, look for the available tags
--- in the `formal-ledger-specifications` repo and pick the tag which marks
--- the generated code that you want to include.
--- The code is generated and pushed to a branch called `haskell-package` in
--- the `formal-ledger-specifications` repo. However, upon each new generation
--- and push, the old commit with the generated code gets removed, hence
--- why we do the tagging to keep those references around so we can use them
--- in this SRP. Also note, that we use the commit reference of the tag,
--- which is a commit from the `haskell-package` branch as mentioned before,
--- rather than the commit referenced in the title and the message of the tag,
--- since those reference the commit on `master` which the code was generated from.
+-- NOTE: If you would like to update the above, look for the `haskell-package`
+-- branch in the `formal-ledger-specifications` repo where the HEAD contains
+-- the generated code based on the most recent commit on `master`.
+-- !IMPORTANT!: MAKE SURE TO TAG THE COMMIT IN `formal-ledger-specifications`
+-- WHENEVER YOU UPDATE THIS SRP! Otherwise this could break, since each push
+-- to `haskell-package` removes the old commits. With tagging, we are making
+-- sure to keep the `formal-ledger-specifications` commits we are referencing,
+-- otherwise they would be garbage collected by git.
 
 index-state:
   -- Bump this if you need newer packages from Hackage


### PR DESCRIPTION
# Description
Follow up to https://github.com/IntersectMBO/formal-ledger-specifications/pull/524.
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
