### PR TITLE
Use `motionNoConfidence` drep thresholds to ratify `NoConfidence`

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.16.1.0
 
 * Added `Eq`, `Show`, `NFData` and `Generic` instances for `CertsEnv`
+* Add `delegateToDRep` and `redelegateDRep`
 
 ### testlib
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Internal.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Internal.hs
@@ -505,6 +505,7 @@ votingDRepThresholdInternal pp isElectedCommittee action =
   let thresholds@DRepVotingThresholds
         { dvtCommitteeNoConfidence
         , dvtCommitteeNormal
+        , dvtMotionNoConfidence
         , dvtUpdateToConstitution
         , dvtHardForkInitiation
         , dvtTreasuryWithdrawal
@@ -512,7 +513,7 @@ votingDRepThresholdInternal pp isElectedCommittee action =
           | HF.bootstrapPhase (pp ^. ppProtocolVersionL) = def
           | otherwise = pp ^. ppDRepVotingThresholdsL
    in case action of
-        NoConfidence {} -> VotingThreshold dvtCommitteeNoConfidence
+        NoConfidence {} -> VotingThreshold dvtMotionNoConfidence
         UpdateCommittee {} ->
           VotingThreshold $
             if isElectedCommittee


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

* Fixes the problem of using the incorrect drep threshold value for no confidence  actions
* Implements one task of issue https://github.com/IntersectMBO/cardano-ledger/issues/3152: 
> If a stake credential delegates to a pre-defined DRep (abstain or no confidence), their stake is accounted for in ratification

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
