### PR TITLE
Made `conformsToImpl` discard generator failures

### DIFF
--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
@@ -154,6 +154,8 @@ instance Inject (ConwayCertExecContext era) (VotingProcedures era) where
 
 instance Era era => ToExpr (ConwayCertExecContext era)
 
+instance Era era => NFData (ConwayCertExecContext era)
+
 data ConwayRatifyExecContext era = ConwayRatifyExecContext
   { crecTreasury :: Coin
   , crecGovActionMap :: [GovActionState era]
@@ -190,6 +192,8 @@ instance
   , HasSpec fn (GovActionState era)
   ) =>
   HasSpec fn (ConwayRatifyExecContext era)
+
+instance EraPParams era => NFData (ConwayRatifyExecContext era)
 
 ratifyEnvSpec :: Specification fn (RatifyEnv era)
 ratifyEnvSpec = TrueSpec

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances.hs
@@ -122,6 +122,7 @@ import Constrained hiding (Value)
 import Constrained qualified as C
 import Constrained.Base (HasGenHint (..))
 import Constrained.Spec.Map
+import Control.DeepSeq (NFData)
 import Control.Monad.Trans.Fail.String
 import Crypto.Hash (Blake2b_224)
 import Data.ByteString qualified as BS
@@ -1171,6 +1172,8 @@ data ProposalsSplit = ProposalsSplit
   deriving (Show, Eq, Generic)
 
 instance ToExpr ProposalsSplit
+
+instance NFData ProposalsSplit
 
 proposalSplitSum :: ProposalsSplit -> Integer
 proposalSplitSum ProposalsSplit {..} =


### PR DESCRIPTION
# Description

I rewrote the `conformsToImpl` using the `Cont` monad to get rid of the staircasing and also made it discard the test case when the generator fails to generate a value instead of failing the whole test.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
