### PR TITLE
Added method to compute over-the-wire CBOR encoded transaction size

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Tx.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Tx.hs
@@ -33,6 +33,7 @@ import Cardano.Ledger.Shelley.Tx (
   mkBasicShelleyTx,
   shelleyMinFeeTx,
   sizeShelleyTxF,
+  wireSizeShelleyTxF,
   witsShelleyTxL,
  )
 import qualified Data.Set as Set (map)
@@ -58,6 +59,9 @@ instance Crypto c => EraTx (AllegraEra c) where
 
   sizeTxF = sizeShelleyTxF
   {-# INLINE sizeTxF #-}
+
+  wireSizeTxF = wireSizeShelleyTxF
+  {-# INLINE wireSizeTxF #-}
 
   validateNativeScript = validateTimelock
   {-# INLINE validateNativeScript #-}

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.10.1.0
 
+* Added `wireSizeAlonzoTxF`
+
 ### `testlib`
 
 * Export `fixupRedeemerIndices` from `Alonzo.ImpTest`

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
@@ -50,6 +50,9 @@ instance Crypto c => EraTx (BabbageEra c) where
   sizeTxF = sizeAlonzoTxF
   {-# INLINE sizeTxF #-}
 
+  wireSizeTxF = wireSizeAlonzoTxF
+  {-# INLINE wireSizeTxF #-}
+
   validateNativeScript = validateTimelock
   {-# INLINE validateNativeScript #-}
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
@@ -21,6 +21,7 @@ import Cardano.Ledger.Alonzo.Tx (
   isValidAlonzoTxL,
   mkBasicAlonzoTx,
   sizeAlonzoTxF,
+  wireSizeAlonzoTxF,
   witsAlonzoTxL,
  )
 import Cardano.Ledger.Alonzo.TxSeq (
@@ -64,6 +65,9 @@ instance Crypto c => EraTx (ConwayEra c) where
 
   sizeTxF = sizeAlonzoTxF
   {-# INLINE sizeTxF #-}
+
+  wireSizeTxF = wireSizeAlonzoTxF
+  {-# INLINE wireSizeTxF #-}
 
   validateNativeScript = validateTimelock
   {-# INLINE validateNativeScript #-}

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Tx.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Tx.hs
@@ -23,6 +23,7 @@ import Cardano.Ledger.Shelley.Tx (
   mkBasicShelleyTx,
   shelleyMinFeeTx,
   sizeShelleyTxF,
+  wireSizeShelleyTxF,
   witsShelleyTxL,
  )
 
@@ -46,6 +47,9 @@ instance Crypto c => EraTx (MaryEra c) where
 
   sizeTxF = sizeShelleyTxF
   {-# INLINE sizeTxF #-}
+
+  wireSizeTxF = wireSizeShelleyTxF
+  {-# INLINE wireSizeTxF #-}
 
   validateNativeScript = validateTimelock
   {-# INLINE validateNativeScript #-}

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Add `translateToShelleyLedgerStateFromUtxo`
 
+* Added `wireSizeShelleyTxF`
+
 ### `testlib`
 
 * Add `submitFailingTxM`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Change default implementation of `translateEra`
 * Add `EraGenesis` and `Genesis` type family. New `NoGenesis` type to be used for eras that do not have a genesis file
 * Move `ensureMinCoinTxOut` from `cardano-ledger-api` to `Cardano.Ledger.Tools`
+* Add `wireSizeTxF` to `EraTx` class
 
 ### `testlib`
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -118,7 +118,7 @@ import Data.Maybe.Strict (StrictMaybe)
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import Data.Void (Void)
-import Data.Word (Word64)
+import Data.Word (Word32, Word64)
 import GHC.Stack (HasCallStack)
 import Lens.Micro
 import NoThunks.Class (NoThunks)
@@ -153,7 +153,11 @@ class
 
   auxDataTxL :: Lens' (Tx era) (StrictMaybe (AuxiliaryData era))
 
+  -- | For fee calculation and estimations of impact on block space
   sizeTxF :: SimpleGetter (Tx era) Integer
+
+  -- | For end use by eg. diffusion layer in transaction submission protocol
+  wireSizeTxF :: SimpleGetter (Tx era) Word32
 
   -- | Using information from the transaction validate the supplied native script.
   validateNativeScript :: Tx era -> NativeScript era -> Bool


### PR DESCRIPTION
# Description

A method for computing the true size of cbor encoded transactions is proposed which is useful and convenient for the upcoming changes to the diffusion layer.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
