### PR TITLE
cabal.project: Bump index-states and remove allow-newer

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -35,9 +35,9 @@ source-repository-package
 
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2024-07-23T00:03:37Z
+  , hackage.haskell.org 2024-08-05T20:07:24Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2024-07-25T13:19:14Z
+  , cardano-haskell-packages 2024-08-01T16:18:12Z
 
 packages:
   eras/allegra/impl
@@ -109,10 +109,3 @@ benchmarks: true
 
 -- The only sensible test display option
 test-show-details: streaming
-
-allow-newer:
-  -- The maintainer of postgresql-simple seems unwilling to do a new release.
-  -- https://github.com/haskellari/postgresql-simple/issues/139
-  , postgresql-simple:template-haskell
-  , postgresql-simple:containers
-  , postgresql-simple:base

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1721915212,
-        "narHash": "sha256-itkbLG6DUX/L5XuoSXFPgPBf+9lFOM3ufc1T4BU4MYM=",
+        "lastModified": 1722918532,
+        "narHash": "sha256-MO3N6/YoJbuQOLrivuDlN8RzyLX9gd5lycpKfbvNiG8=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "2126fa53c45842719ee38040f4d5bee8fb17a09d",
+        "rev": "d738d3e323d71b658ef083b0e05310ec4cfb9436",
         "type": "github"
       },
       "original": {
@@ -260,11 +260,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1721263615,
-        "narHash": "sha256-J/VaA4xWMpp43HptVP2tpfLwIYCg+OrBova4Uh5R8C8=",
+        "lastModified": 1722903962,
+        "narHash": "sha256-4goM7fI9HR0cHYRIJ6yDK+uh8OnNRU3Gzq7X57OeFcU=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "beaee455c56dee413b33f89f6ebd0520ff435295",
+        "rev": "a3fca568c1d519843eb9aab1374dfe6166246894",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
An updated postgresql-simple has been released to Hackage.

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
