### PR TITLE
Alternative Agda cert- steps in conformance tests 

### DIFF
--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
@@ -36,7 +36,7 @@ instance
   runAgdaRule env st sig =
     first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
       . computationResultToEither
-      $ Agda.certStep env st sig
+      $ Agda.certStep' env st sig
 
   classOf = Just . nameTxCert
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
@@ -36,4 +36,4 @@ instance
   runAgdaRule env st sig =
     first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
       . computationResultToEither
-      $ Agda.certsStep env st sig
+      $ Agda.certsStep' env st sig

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
@@ -29,7 +29,7 @@ instance IsConwayUniv fn => ExecSpecRule fn "DELEG" Conway where
   runAgdaRule env st sig =
     first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
       . computationResultToEither
-      $ Agda.delegStep env st sig
+      $ Agda.delegStep' env st sig
 
   classOf = Just . nameDelegCert
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
@@ -39,7 +39,7 @@ instance IsConwayUniv fn => ExecSpecRule fn "GOVCERT" Conway where
   runAgdaRule env st sig =
     first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
       . computationResultToEither
-      $ Agda.govCertStep env st sig
+      $ Agda.govCertStep' env st sig
 
 nameGovCert :: ConwayGovCert c -> String
 nameGovCert (ConwayRegDRep {}) = "ConwayRegDRep"

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -8,7 +8,7 @@ module Test.Cardano.Ledger.Conformance.Orphans where
 
 import Data.Bifunctor (Bifunctor (..))
 import Data.Default.Class (Default)
-import Data.List (sortOn)
+import Data.List (nub, sortOn)
 import qualified Data.Set as Set
 import GHC.Generics (Generic)
 import Lib
@@ -398,13 +398,14 @@ instance FixupSpecRep Char where
   fixup = id
 
 instance
-  ( Ord k
+  ( Eq v
+  , Ord k
   , FixupSpecRep k
   , FixupSpecRep v
   ) =>
   FixupSpecRep (HSMap k v)
   where
-  fixup (MkHSMap l) = MkHSMap . sortOn fst $ bimap fixup fixup <$> l
+  fixup (MkHSMap l) = MkHSMap . sortOn fst $ bimap fixup fixup <$> nub l
 
 instance (Ord a, FixupSpecRep a) => FixupSpecRep (HSSet a) where
   fixup (MkHSSet l) = MkHSSet . Set.toList . Set.fromList $ fixup <$> l

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -39,13 +39,21 @@ deriving instance Generic DepositPurpose
 
 deriving instance Generic CertEnv
 
+deriving instance Generic CertEnv'
+
 deriving instance Generic PState
 
 deriving instance Generic DState
 
+deriving instance Generic DState'
+
 deriving instance Generic GState
 
+deriving instance Generic GState'
+
 deriving instance Generic CertState
+
+deriving instance Generic CertState'
 
 deriving instance Generic RatifyEnv
 
@@ -56,6 +64,8 @@ deriving instance Generic StakeDistrs
 deriving instance Generic EnactEnv
 
 deriving instance Generic DelegEnv
+
+deriving instance Generic DelegEnv'
 
 deriving instance Generic PoolThresholds
 
@@ -76,6 +86,8 @@ deriving instance Generic Acnt
 deriving instance Generic RewardUpdate
 
 deriving instance Generic NewEpochState
+
+deriving instance Ord DepositPurpose
 
 deriving instance Ord Tag
 
@@ -141,13 +153,21 @@ deriving instance Eq DepositPurpose
 
 deriving instance Eq CertEnv
 
+deriving instance Eq CertEnv'
+
 deriving instance Eq DState
+
+deriving instance Eq DState'
 
 deriving instance Eq PState
 
 deriving instance Eq GState
 
+deriving instance Eq GState'
+
 deriving instance Eq CertState
+
+deriving instance Eq CertState'
 
 deriving instance Eq RatifyState
 
@@ -221,13 +241,21 @@ instance NFData DepositPurpose
 
 instance NFData CertEnv
 
+instance NFData CertEnv'
+
 instance NFData PState
 
 instance NFData DState
 
+instance NFData DState'
+
 instance NFData GState
 
+instance NFData GState'
+
 instance NFData CertState
+
+instance NFData CertState'
 
 instance NFData StakeDistrs
 
@@ -238,6 +266,8 @@ instance NFData RatifyState
 instance NFData EnactEnv
 
 instance NFData DelegEnv
+
+instance NFData DelegEnv'
 
 instance NFData NewEpochEnv
 
@@ -314,13 +344,21 @@ instance ToExpr DepositPurpose
 
 instance ToExpr CertEnv
 
+instance ToExpr CertEnv'
+
 instance ToExpr DState
+
+instance ToExpr DState'
 
 instance ToExpr PState
 
 instance ToExpr GState
 
+instance ToExpr GState'
+
 instance ToExpr CertState
+
+instance ToExpr CertState'
 
 instance ToExpr StakeDistrs
 
@@ -331,6 +369,8 @@ instance ToExpr RatifyState
 instance ToExpr EnactEnv
 
 instance ToExpr DelegEnv
+
+instance ToExpr DelegEnv'
 
 instance ToExpr NewEpochEnv
 
@@ -392,13 +432,21 @@ instance FixupSpecRep GovRole
 
 instance FixupSpecRep VDeleg
 
+instance FixupSpecRep DepositPurpose
+
 instance FixupSpecRep DState
+
+instance FixupSpecRep DState'
 
 instance FixupSpecRep PState
 
 instance FixupSpecRep GState
 
+instance FixupSpecRep GState'
+
 instance FixupSpecRep CertState
+
+instance FixupSpecRep CertState'
 
 instance FixupSpecRep Vote
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -20,7 +20,6 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (
-  emptyDeposits,
   SpecTranslate (..),
   SpecTranslationError,
   ConwayExecEnactEnv (..),
@@ -1060,8 +1059,3 @@ instance SpecTranslate ctx (ConwayExecEnactEnv era) where
       <$> toSpecRep ceeeGid
       <*> toSpecRep ceeeTreasury
       <*> toSpecRep ceeeEpoch
-
--- Temporary value to use where the map of all deposits is required,
--- until we build and translate the real map
-emptyDeposits :: Agda.HSMap Agda.DepositPurpose Agda.Coin
-emptyDeposits = Agda.MkHSMap []

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -24,6 +24,7 @@ module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (
   SpecTranslate (..),
   SpecTranslationError,
   ConwayExecEnactEnv (..),
+  DepositPurpose (..),
 ) where
 
 import Cardano.Crypto.DSIGN (DSIGNAlgorithm (..), SignedDSIGN (..))
@@ -1066,3 +1067,26 @@ committeeCredentialToStrictMaybe ::
   StrictMaybe (Credential 'HotCommitteeRole c)
 committeeCredentialToStrictMaybe (CommitteeHotCredential c) = SJust c
 committeeCredentialToStrictMaybe (CommitteeMemberResigned _) = SNothing
+
+data DepositPurpose c
+  = CredentialDeposit !(Credential 'Staking c)
+  | PoolDeposit !(KeyHash 'StakePool c)
+  | DRepDeposit !(Credential 'DRepRole c)
+  | GovActionDeposit !(GovActionId c)
+  deriving (Generic, Eq, Show, Ord)
+
+instance ToExpr (DepositPurpose c)
+instance Crypto c => NFData (DepositPurpose c)
+instance HasSimpleRep (DepositPurpose c)
+instance (IsConwayUniv fn, Crypto c) => HasSpec fn (DepositPurpose c)
+
+instance SpecTranslate ctx (DepositPurpose c) where
+  type SpecRep (DepositPurpose c) = Agda.DepositPurpose
+  toSpecRep (CredentialDeposit cred) =
+    Agda.CredentialDeposit <$> toSpecRep cred
+  toSpecRep (PoolDeposit kh) =
+    Agda.PoolDeposit <$> toSpecRep kh
+  toSpecRep (DRepDeposit cred) =
+    Agda.DRepDeposit <$> toSpecRep cred
+  toSpecRep (GovActionDeposit gid) =
+    Agda.GovActionDeposit <$> toSpecRep gid

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -20,6 +20,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (
+  committeeCredentialToStrictMaybe,
   SpecTranslate (..),
   SpecTranslationError,
   ConwayExecEnactEnv (..),
@@ -1059,3 +1060,9 @@ instance SpecTranslate ctx (ConwayExecEnactEnv era) where
       <$> toSpecRep ceeeGid
       <*> toSpecRep ceeeTreasury
       <*> toSpecRep ceeeEpoch
+
+committeeCredentialToStrictMaybe ::
+  CommitteeAuthorization c ->
+  StrictMaybe (Credential 'HotCommitteeRole c)
+committeeCredentialToStrictMaybe (CommitteeHotCredential c) = SJust c
+committeeCredentialToStrictMaybe (CommitteeMemberResigned _) = SNothing

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
@@ -24,6 +24,7 @@ import Cardano.Ledger.Credential
 import Cardano.Ledger.EpochBoundary
 import Cardano.Ledger.Keys
 import Cardano.Ledger.Shelley.LedgerState
+import Cardano.Ledger.UMap (dRepMap, rewardMap, sPoolMap)
 import Data.Functor.Identity (Identity)
 import Data.Map.Strict (Map)
 import qualified Data.VMap as VMap
@@ -85,7 +86,21 @@ instance
     Agda.MkLedgerState
       <$> toSpecRep lsUTxOState
       <*> toSpecRep (utxosGovState lsUTxOState ^. proposalsGovStateL)
-      <*> toSpecRep lsCertState
+      <*> agdaCertState lsCertState
+    where
+      agdaCertState (CertState (VState {..}) pState (DState {..})) =
+        Agda.MkCertState
+          <$> ( Agda.MkDState
+                  <$> toSpecRep (dRepMap dsUnified)
+                  <*> toSpecRep (sPoolMap dsUnified)
+                  <*> toSpecRep (rewardMap dsUnified)
+              )
+          <*> toSpecRep pState
+          <*> ( Agda.MkGState
+                  <$> toSpecRep (drepExpiry <$> vsDReps)
+                  <*> toSpecRep
+                    (committeeCredentialToStrictMaybe <$> csCommitteeCreds vsCommitteeState)
+              )
 
 instance
   ( EraPParams era

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
@@ -30,7 +30,7 @@ import qualified Data.VMap as VMap
 import Lens.Micro
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (emptyDeposits)
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.GovCert ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool ()
@@ -44,22 +44,20 @@ instance
   ) =>
   SpecTranslate ctx (CertEnv era)
   where
-  type SpecRep (CertEnv era) = Agda.CertEnv
+  type SpecRep (CertEnv era) = Agda.CertEnv'
   toSpecRep CertEnv {..} = do
     votes <- askCtx @(VotingProcedures era)
     withdrawals <- askCtx @(Map (Network, Credential 'Staking (EraCrypto era)) Coin)
-    Agda.MkCertEnv
+    Agda.MkCertEnv'
       <$> toSpecRep ceCurrentEpoch
       <*> toSpecRep cePParams
       <*> toSpecRep votes
       <*> toSpecRep withdrawals
-      -- TODO: replace with actual deposits map
-      <*> pure emptyDeposits
 
 instance SpecTranslate ctx (CertState era) where
-  type SpecRep (CertState era) = Agda.CertState
+  type SpecRep (CertState era) = Agda.CertState'
   toSpecRep CertState {..} =
-    Agda.MkCertState
+    Agda.MkCertState'
       <$> toSpecRep certDState
       <*> toSpecRep certPState
       <*> toSpecRep certVState

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
@@ -24,7 +24,6 @@ import Data.Functor.Identity (Identity)
 import Data.Map.Strict (Map)
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (emptyDeposits)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool ()
 import Test.Cardano.Ledger.Conway.TreeDiff
@@ -41,14 +40,12 @@ instance
   ) =>
   SpecTranslate ctx (CertsEnv era)
   where
-  type SpecRep (CertsEnv era) = Agda.CertEnv
+  type SpecRep (CertsEnv era) = Agda.CertEnv'
   toSpecRep CertsEnv {..} = do
     votes <- askCtx @(VotingProcedures era)
     withdrawals <- askCtx @(Map (Network, Credential 'Staking (EraCrypto era)) Coin)
-    Agda.MkCertEnv
+    Agda.MkCertEnv'
       <$> toSpecRep certsCurrentEpoch
       <*> toSpecRep certsPParams
       <*> toSpecRep votes
       <*> toSpecRep withdrawals
-      -- TODO: replace with actual deposits map
-      <*> pure emptyDeposits

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
@@ -23,7 +23,7 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Keys (KeyHash (..))
 import Cardano.Ledger.Shelley.LedgerState (DState (..))
 import Cardano.Ledger.Shelley.Rules
-import Cardano.Ledger.UMap (dRepMap, rewardMap, sPoolMap)
+import qualified Cardano.Ledger.UMap as UMap
 import qualified Data.Map.Strict as Map
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance (
@@ -82,7 +82,10 @@ instance SpecTranslate ctx (DState era) where
 
   toSpecRep DState {..} =
     Agda.MkDState'
-      <$> toSpecRep (dRepMap dsUnified)
-      <*> toSpecRep (sPoolMap dsUnified)
-      <*> toSpecRep (rewardMap dsUnified)
-      <*> undefined
+      <$> toSpecRep (UMap.dRepMap dsUnified)
+      <*> toSpecRep (UMap.sPoolMap dsUnified)
+      <*> toSpecRep (UMap.rewardMap dsUnified)
+      <*> toSpecRep deposits
+    where
+      deposits =
+        Map.mapKeys CredentialDeposit (UMap.depositMap dsUnified)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
@@ -29,7 +29,7 @@ import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance (
   hashToInteger,
  )
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (emptyDeposits)
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
 import Test.Cardano.Ledger.Conway.TreeDiff
 
@@ -39,14 +39,12 @@ instance
   ) =>
   SpecTranslate ctx (ConwayDelegEnv era)
   where
-  type SpecRep (ConwayDelegEnv era) = Agda.DelegEnv
+  type SpecRep (ConwayDelegEnv era) = Agda.DelegEnv'
 
   toSpecRep ConwayDelegEnv {..} =
-    Agda.MkDelegEnv
+    Agda.MkDelegEnv'
       <$> toSpecRep cdePParams
       <*> toSpecRep (Map.mapKeys (hashToInteger . unKeyHash) cdePools)
-      -- TODO: replace with actual deposits map
-      <*> pure emptyDeposits
 
 instance SpecTranslate ctx (ConwayDelegCert c) where
   type SpecRep (ConwayDelegCert c) = Agda.TxCert
@@ -80,10 +78,11 @@ instance SpecTranslate ctx (ConwayDelegPredFailure era) where
   toSpecRep e = pure . OpaqueErrorString . show $ toExpr e
 
 instance SpecTranslate ctx (DState era) where
-  type SpecRep (DState era) = Agda.DState
+  type SpecRep (DState era) = Agda.DState'
 
   toSpecRep DState {..} =
-    Agda.MkDState
+    Agda.MkDState'
       <$> toSpecRep (dRepMap dsUnified)
       <*> toSpecRep (sPoolMap dsUnified)
       <*> toSpecRep (rewardMap dsUnified)
+      <*> undefined

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
@@ -95,10 +95,11 @@ instance SpecTranslate ctx (VState era) where
 
   toSpecRep VState {..} =
     Agda.MkGState'
-      <$> toSpecRep (drepExpiry <$> vsDReps)
+      <$> toSpecRep (updateExpiry . drepExpiry <$> vsDReps)
       <*> toSpecRep
         (committeeCredentialToStrictMaybe <$> csCommitteeCreds vsCommitteeState)
       <*> toSpecRep deposits
     where
       deposits =
         Map.mapKeys DRepDeposit (drepDeposit <$> vsDReps)
+      updateExpiry = binOpEpochNo (+) vsNumDormantEpochs

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
@@ -15,7 +15,6 @@ module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.GovCert () where
 
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.CertState (
-  CommitteeAuthorization (..),
   csCommitteeCreds,
   drepExpiry,
  )
@@ -98,9 +97,3 @@ instance SpecTranslate ctx (VState era) where
       <*> toSpecRep
         (committeeCredentialToStrictMaybe <$> csCommitteeCreds vsCommitteeState)
       <*> undefined
-
-committeeCredentialToStrictMaybe ::
-  CommitteeAuthorization c ->
-  StrictMaybe (Credential 'HotCommitteeRole c)
-committeeCredentialToStrictMaybe (CommitteeHotCredential c) = SJust c
-committeeCredentialToStrictMaybe (CommitteeMemberResigned _) = SNothing

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
@@ -16,6 +16,7 @@ module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.GovCert () where
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.CertState (
   csCommitteeCreds,
+  drepDeposit,
   drepExpiry,
  )
 import Cardano.Ledger.Coin (Coin (..))
@@ -33,6 +34,7 @@ import Cardano.Ledger.Keys (KeyRole (..))
 import Cardano.Ledger.Shelley.LedgerState
 import Data.Functor.Identity (Identity)
 import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
@@ -96,4 +98,7 @@ instance SpecTranslate ctx (VState era) where
       <$> toSpecRep (drepExpiry <$> vsDReps)
       <*> toSpecRep
         (committeeCredentialToStrictMaybe <$> csCommitteeCreds vsCommitteeState)
-      <*> undefined
+      <*> toSpecRep deposits
+    where
+      deposits =
+        Map.mapKeys DRepDeposit (drepDeposit <$> vsDReps)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
@@ -35,7 +35,7 @@ import Cardano.Ledger.Shelley.LedgerState
 import Data.Functor.Identity (Identity)
 import Data.Map.Strict (Map)
 import qualified Lib as Agda
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (emptyDeposits)
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
 import Test.Cardano.Ledger.Conway.TreeDiff (showExpr)
 
@@ -73,18 +73,16 @@ instance
   ) =>
   SpecTranslate ctx (ConwayGovCertEnv era)
   where
-  type SpecRep (ConwayGovCertEnv era) = Agda.CertEnv
+  type SpecRep (ConwayGovCertEnv era) = Agda.CertEnv'
 
   toSpecRep ConwayGovCertEnv {..} = do
     votes <- askCtx @(VotingProcedures era)
     withdrawals <- askCtx @(Map (Network, Credential 'Staking (EraCrypto era)) Coin)
-    Agda.MkCertEnv
+    Agda.MkCertEnv'
       <$> toSpecRep cgceCurrentEpoch
       <*> toSpecRep cgcePParams
       <*> toSpecRep votes
       <*> toSpecRep withdrawals
-      -- TODO: replace with actual deposits map
-      <*> pure emptyDeposits
 
 instance SpecTranslate ctx (ConwayGovCertPredFailure era) where
   type SpecRep (ConwayGovCertPredFailure era) = OpaqueErrorString
@@ -92,13 +90,14 @@ instance SpecTranslate ctx (ConwayGovCertPredFailure era) where
   toSpecRep = pure . OpaqueErrorString . showExpr
 
 instance SpecTranslate ctx (VState era) where
-  type SpecRep (VState era) = Agda.GState
+  type SpecRep (VState era) = Agda.GState'
 
   toSpecRep VState {..} =
-    Agda.MkGState
+    Agda.MkGState'
       <$> toSpecRep (drepExpiry <$> vsDReps)
       <*> toSpecRep
         (committeeCredentialToStrictMaybe <$> csCommitteeCreds vsCommitteeState)
+      <*> undefined
 
 committeeCredentialToStrictMaybe ::
   CommitteeAuthorization c ->

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/ExecSpecRule/MiniTrace.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/ExecSpecRule/MiniTrace.hs
@@ -157,7 +157,7 @@ spec = do
   describe "50 MiniTrace tests with trace length of 50" $ do
     prop "POOL" (withMaxSuccess 50 (minitraceProp (POOL Conway) (Proxy @ConwayFn) 50 namePoolCert))
     prop "DELEG" (withMaxSuccess 50 (minitraceProp (DELEG Conway) (Proxy @ConwayFn) 50 nameDelegCert))
-    prop "COVCERT" (withMaxSuccess 50 (minitraceProp (GOVCERT Conway) (Proxy @ConwayFn) 50 nameGovCert))
+    prop "GOVCERT" (withMaxSuccess 50 (minitraceProp (GOVCERT Conway) (Proxy @ConwayFn) 50 nameGovCert))
     prop "CERT" (withMaxSuccess 50 (minitraceProp (CERT Conway) (Proxy @ConwayFn) 50 nameTxCert))
     prop "RATIFY" (withMaxSuccess 50 (minitraceProp (RATIFY Conway) (Proxy @ConwayFn) 50 nameRatify))
     prop "ENACT" (withMaxSuccess 50 (minitraceProp (ENACT Conway) (Proxy @ConwayFn) 50 nameEnact))

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
@@ -41,7 +41,7 @@ spec = do
       xprop "EPOCH" $ conformsToImpl @"EPOCH" @ConwayFn @Conway
       xprop "NEWEPOCH" $ conformsToImpl @"NEWEPOCH" @ConwayFn @Conway
     describe "Blocks transition graph" $ do
-      xprop "DELEG" $ conformsToImpl @"DELEG" @ConwayFn @Conway
+      prop "DELEG" $ conformsToImpl @"DELEG" @ConwayFn @Conway
       -- GOVCERT is disabled because the Agda MALONZO code has a bug
       -- when accessing the PParams DRepActivity field. When that is fixed
       -- we can turn xprop to prop for "GOVCERT"

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
@@ -42,16 +42,10 @@ spec = do
       xprop "NEWEPOCH" $ conformsToImpl @"NEWEPOCH" @ConwayFn @Conway
     describe "Blocks transition graph" $ do
       prop "DELEG" $ conformsToImpl @"DELEG" @ConwayFn @Conway
-      -- GOVCERT is disabled because the Agda MALONZO code has a bug
-      -- when accessing the PParams DRepActivity field. When that is fixed
-      -- we can turn xprop to prop for "GOVCERT"
-      xprop "GOVCERT" $ conformsToImpl @"GOVCERT" @ConwayFn @Conway
+      prop "GOVCERT" $ conformsToImpl @"GOVCERT" @ConwayFn @Conway
       prop "POOL" $ conformsToImpl @"POOL" @ConwayFn @Conway
-      -- The PParams DRepActivity field bug in Agda means we must also
-      -- turn off the "CERT" conformance test because "CERT" contains "GOVCERT"
-      -- When that is fixed we can turn xprop to prop for "CERT"
-      xprop "CERT" $ conformsToImpl @"CERT" @ConwayFn @Conway
       xprop "CERTS" $ conformsToImpl @"CERTS" @ConwayFn @Conway
+      prop "CERT" $ conformsToImpl @"CERT" @ConwayFn @Conway
       prop "GOV" $ conformsToImpl @"GOV" @ConwayFn @Conway
       xprop "UTXO" $ conformsToImpl @"UTXO" @ConwayFn @Conway
     describe "ImpTests" $ do

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FlexibleContexts #-}
+
 -- | Specs necessary to generate, environment, state, and signal
 -- for the CERTS rule
 module Test.Cardano.Ledger.Constrained.Conway.Certs where
@@ -8,10 +10,15 @@ import Cardano.Ledger.Conway.TxCert
 import Cardano.Ledger.Crypto (StandardCrypto)
 import Constrained
 import Data.Sequence (Seq)
+import Test.Cardano.Ledger.Constrained.Conway.Instances
+import Test.Cardano.Ledger.Constrained.Conway.PParams (pparamsSpec)
 
 certsEnvSpec ::
+  IsConwayUniv fn =>
   Specification fn (CertsEnv (ConwayEra StandardCrypto))
-certsEnvSpec = TrueSpec
+certsEnvSpec = constrained $ \env ->
+  match env $ \_ pp _ _ _ _ ->
+    satisfies pp pparamsSpec
 
 txCertsSpec ::
   Specification fn (Seq (ConwayTxCert (ConwayEra StandardCrypto)))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/PParams.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/PParams.hs
@@ -1,5 +1,7 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Cardano.Ledger.Constrained.Conway.PParams where
 
@@ -30,7 +32,7 @@ pparamsSpec =
          _cppA0
          _cppRho
          _cppTau
-         _cppProtocolVersion
+         cppProtocolVersion
          _cppMinPoolCost
          _cppCoinsPerUTxOByte
          _cppCostModels
@@ -49,7 +51,8 @@ pparamsSpec =
          cppDRepDeposit
          _cppDRepActivity
          _cppMinFeeRefScriptCoinsPerByte ->
-            [ assert $ cppMaxBBSize /=. lit (THKD 0)
+            [ assert $ cppProtocolVersion ==. lit (ProtVer (natVersion @10) 0)
+            , assert $ cppMaxBBSize /=. lit (THKD 0)
             , assert $ cppMaxTxSize /=. lit (THKD 0)
             , assert $ cppMaxBHSize /=. lit (THKD 0)
             , assert $ cppMaxValSize /=. lit (THKD 0)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | Specs necessary to generate, environment, state, and signal
 -- for the UTXO rule
@@ -51,7 +52,7 @@ utxoEnvSpec =
                  _cppA0
                  _cppRho
                  _cppTau
-                 _cppProtocolVersion
+                 cppProtocolVersion
                  _cppMinPoolCost
                  _cppCoinsPerUTxOByte
                  _cppCostModels
@@ -72,7 +73,8 @@ utxoEnvSpec =
                  _cppMinFeeRefScriptCoinsPerByte ->
                     -- NOTE: this is for testing only! We should figure out a nicer way
                     -- of splitting generation and checking constraints here!
-                    [ assert $ lit (THKD 3000) ==. cppMaxTxSize
+                    [ assert $ cppProtocolVersion ==. lit (ProtVer (natVersion @10) 0)
+                    , assert $ lit (THKD 3000) ==. cppMaxTxSize
                     ]
           ]
 


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

Updates and fixes that allow us to re-enable DELEG, GOVCERT and CERTS rule: 
 * Integrate the alternative agda steps: `delegStep'`, `govCertStep'`, `certStep'` and required adjustments
 * Deduplicate `MkHSMap`  so that it's comparable with translated ledger maps
 * Adjusts  VState translation to account for number of dormant epochs 
 * Extend conformance framework to allow changing the result of running the agda rule before comparing with the ledger result


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
