### PR TITLE
Free up disk space in the GHA CI runner before building

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -58,6 +58,25 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Free up disk space
+      run: |
+        # Remove software and language runtimes we're not using
+        sudo rm -rf \
+          "$AGENT_TOOLSDIRECTORY" \
+          /opt/google/chrome \
+          /opt/microsoft/msedge \
+          /opt/microsoft/powershell \
+          /opt/pipx \
+          /usr/lib/mono \
+          /usr/local/julia* \
+          /usr/local/lib/android \
+          /usr/local/lib/node_modules \
+          /usr/local/share/chromium \
+          /usr/local/share/powershell \
+          /usr/share/dotnet \
+          /usr/share/swift
+        df -h /
+
     - name: Install system dependencies
       uses: input-output-hk/actions/base@latest
       with:


### PR DESCRIPTION
Some of our matrix builds start out with less than 12GB which is less than twice the size of `dist-newstyle` for these builds. We then don't have space to make a tar archive to be used as an artifact to pass build results to the test jobs.

Was: Debug out-of-disk-space errors in CI