### PR TITLE
Use compression for archiving

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -204,7 +204,7 @@ jobs:
         - set-algebra
         - small-steps
         - vector-map
-        ghc: ["8.10.7", "9.2.8", "9.6.6", "9.8.2"]
+        ghc: ["8.10.7", "9.2.8", "9.6.6", "9.8.2", "9.10.1"]
         os: [ubuntu-latest]
       fail-fast: false
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -160,14 +160,14 @@ jobs:
     - name: Archive working directory
       # pax format is needed to avoid unnecessary rebuilding, because the
       # default format uses a one-second resolution for timestamps
-      run: tar --format pax -cf /var/tmp/state.tar . && mv /var/tmp/state.tar .
+      run: tar --use-compress-program zstdmt --format pax -cf /var/tmp/state.tzst . && mv /var/tmp/state.tzst .
     - name: Upload working directory archive
       # upload-artifact is pinned to avoid a bug in download-artifact
       # See https://github.com/actions/download-artifact/issues/328
       uses: actions/upload-artifact@v4.2.0
       with:
         name: state-${{ matrix.ghc }}-${{ matrix.os }}
-        path: state.tar
+        path: state.tzst
         overwrite: true
         retention-days: 1
 
@@ -297,7 +297,7 @@ jobs:
         name: state-${{ matrix.ghc }}-${{ matrix.os }}
 
     - name: Unarchive working directory
-      run: tar -xf state.tar && rm state.tar
+      run: tar -xf state.tzst --use-compress-program unzstd && rm state.tzst
 
     - name: Cabal update
       run: cabal update

--- a/cabal.project
+++ b/cabal.project
@@ -13,16 +13,16 @@ repository cardano-haskell-packages
 -- While using SRPs one can obtain the `--sha256` value for a package
 -- by first setting it to some random value and letting the tooling
 -- tell you what it should be, for example, using `nix develop` will
--- throw an error with the correct value to use or alternatively
--- you can run `nix-prefetch-url <url> --unpack`,
--- e.g.: `nix-prefetch-url https://github.com/intersectmbo/formal-ledger-specifications/archive/841942c68993857fd40ca35cd62258cf82d160a5.zip --unpack`
--- This might even be preferable, since this will give you the full hash
--- rather than a shortened one.
+-- throw an error with the correct value to use or even better you
+-- can use `nix-prefetch-git`:
+--
+-- $ nix-shell -p nix-prefetch-git
+-- $ nix-prefetch-git https://github.com/intersectmbo/formal-ledger-specifications --rev <GIT_SHA> | jq .hash
 source-repository-package
   type: git
   location: https://github.com/IntersectMBO/formal-ledger-specifications.git
   subdir: generated
-  tag: 58f4b078a7e0df0c49264b78090122e75679585f
+  tag: b5a8d47aebbdad92773be96c459f241d773d4771
   --sha256: sha256-iEqucpja/0/5Tvnjr2drFlz58f3x3kUpInVjZfcePBQ=
 -- NOTE: If you would like to update the above, look for the `MAlonzo-code`
 -- branch in the `formal-ledger-specifications` repo and copy the SHA of

--- a/cabal.project
+++ b/cabal.project
@@ -22,6 +22,8 @@ source-repository-package
   type: git
   location: https://github.com/IntersectMBO/formal-ledger-specifications.git
   subdir: generated
+  -- !WARNING!:
+  -- MAKE SURE THIS POINTS TO A COMMIT IN `MAlonzo-code` BEFORE MERGE!
   tag: b5a8d47aebbdad92773be96c459f241d773d4771
   --sha256: sha256-iEqucpja/0/5Tvnjr2drFlz58f3x3kUpInVjZfcePBQ=
 -- NOTE: If you would like to update the above, look for the `MAlonzo-code`


### PR DESCRIPTION
# Description

This PR slightly improves the speed of archive uploading/downloading by using the same fast compression algorithm used by caching step

It also enables tests for ghc-9.10.1

It also fixes the SRP for formal ledger spec

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
