### PR TITLE
Bump plutus to 1.32.0.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -37,7 +37,7 @@ index-state:
   -- Bump this if you need newer packages from Hackage
   , hackage.haskell.org 2024-08-05T20:07:24Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2024-08-01T16:18:12Z
+  , cardano-haskell-packages 2024-08-07T21:42:21Z
 
 packages:
   eras/allegra/impl

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -90,7 +90,7 @@ library
         mtl,
         microlens,
         nothunks,
-        plutus-ledger-api ^>=1.31,
+        plutus-ledger-api ^>=1.32,
         set-algebra >=1.0,
         small-steps >=1.1,
         text,

--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -59,7 +59,7 @@ library
         containers,
         data-default-class,
         microlens,
-        plutus-ledger-api ^>=1.31,
+        plutus-ledger-api ^>=1.32,
         QuickCheck,
         random,
         serialise,

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -83,7 +83,7 @@ library
         deepseq,
         microlens,
         nothunks,
-        plutus-ledger-api ^>=1.31,
+        plutus-ledger-api ^>=1.32,
         set-algebra,
         small-steps >=1.1,
         text,

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -97,7 +97,7 @@ library
         deepseq,
         microlens,
         nothunks,
-        plutus-ledger-api ^>=1.31,
+        plutus-ledger-api ^>=1.32,
         set-algebra,
         small-steps >=1.1,
         text,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1722918532,
-        "narHash": "sha256-MO3N6/YoJbuQOLrivuDlN8RzyLX9gd5lycpKfbvNiG8=",
+        "lastModified": 1723068470,
+        "narHash": "sha256-I3afsEv18Uspc61hRTUgE86HM8q7NZZzkMrjfJHNQEA=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "d738d3e323d71b658ef083b0e05310ec4cfb9436",
+        "rev": "7b7fa5b21ae6e06489b26eddd1fb5e925f1595c3",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -67,7 +67,7 @@ library
         network,
         nothunks,
         primitive,
-        plutus-ledger-api >=1.27.0 && <1.32.0,
+        plutus-ledger-api >=1.27.0 && <1.33.0,
         recursion-schemes,
         serialise,
         tagged,

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -114,7 +114,7 @@ library
         measures,
         microlens,
         network,
-        nothunks ^>=0.2,
+        nothunks >=0.1.5 && <0.3,
         partial-order,
         plutus-core,
         plutus-ledger-api,

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -114,7 +114,7 @@ library
         measures,
         microlens,
         network,
-        nothunks ^>=0.1.5,
+        nothunks ^>=0.2,
         partial-order,
         plutus-core,
         plutus-ledger-api,


### PR DESCRIPTION
# Description

I had to bump also nothunks to `^>=0.2` (fixes #4504) because plutus switched to that version;
it seems to compile fine. 

I don't need to add to your CHANGELOG, right?

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
