### PR TITLE
GHA: fix cabal version mismatch between build and test job

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -87,7 +87,7 @@ jobs:
       uses: input-output-hk/actions/haskell@latest
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: 3.10.3.0
+        cabal-version: 3.12.1.0
 
     - name: Configure to use libsodium
       run: |
@@ -236,7 +236,7 @@ jobs:
       uses: input-output-hk/actions/haskell@latest
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: latest
+        cabal-version: 3.12.1.0
 
     - name: Set up Ruby 2.7
       uses: ruby/setup-ruby@v1
@@ -276,8 +276,12 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: state-${{ matrix.ghc }}-${{ matrix.os }}
+
     - name: Unarchive working directory
       run: tar -xf state.tar && rm state.tar
+
+    - name: Cabal update
+      run: cabal update
 
     # A dependencies.txt file should have been created by the build job, so we
     # check if it exists and is not empty.
@@ -299,9 +303,6 @@ jobs:
         # job. If the cache is missing, something is terribly wrong! We fail the
         # test job, or otherwise we would start rebuilding all the dependencies.
         fail-on-cache-miss: true
-
-    - name: Cabal update
-      run: cabal update
 
     - name: Run tests
       run: |

--- a/flake.nix
+++ b/flake.nix
@@ -101,7 +101,7 @@
             # tools we want in our shell, from hackage
             tools =
               {
-                cabal = "3.10.3.0";
+                cabal = "3.12.1.0";
                 ghcid = "0.8.9";
               }
               // lib.optionalAttrs (config.compiler-nix-name == defaultCompiler) {


### PR DESCRIPTION
# Description

The `test` job was using a cabal version `latest`, i.e., `3.12.1.0`, whereas the build job was using `3.10.3.0`. I've changed both to `3.12.1.0`. This may explain why some of the `test` jobs rebuild dependencies and the `cardano-ledger` packages, even if they were already successfully built in the `build` job

It might help to put the cabal version in the cache hash as well, because then the `test` job would fail with an error. I might add this into this PR later

Another idea: set a timeout for GHA jobs. The default timeout is 360 minutes (IIRC), and could be brought down so that a `test` job will time out if it spends a lot of time rebuilding dependencies and packages instead of running tests

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
