### PR TITLE
Fix failing tests in `cardano-ledger-alonzo-test`

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Evaluate.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Evaluate.hs
@@ -65,7 +65,7 @@ import Data.MapExtras (fromElems)
 import Data.Maybe (mapMaybe)
 import qualified Data.Set as Set
 import Data.Text (Text)
-import Debug.Trace (traceEvent)
+import qualified Debug.Trace as Debug
 import GHC.Generics
 import Lens.Micro
 import NoThunks.Class (NoThunks)
@@ -244,14 +244,14 @@ evalPlutusScriptsWithLogs (plutusWithContext : rest) =
           [ "[LEDGER][PLUTUS_SCRIPT]"
           , "BEGIN"
           ]
-      !res = traceEvent beginMsg $ runPlutusScriptWithLogs plutusWithContext
+      !res = Debug.traceEvent beginMsg $ runPlutusScriptWithLogs plutusWithContext
       endMsg =
         intercalate
           ","
           [ "[LEDGER][PLUTUS_SCRIPT]"
           , "END"
           ]
-   in traceEvent endMsg res <> evalPlutusScriptsWithLogs rest
+   in Debug.traceEvent endMsg res <> evalPlutusScriptsWithLogs rest
 
 -- | Script failures that can be returned by 'evalTxExUnitsWithLogs'.
 data TransactionScriptFailure era

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -99,7 +99,7 @@ import Data.List.NonEmpty (NonEmpty (..), nonEmpty)
 import qualified Data.List.NonEmpty as NE
 import Data.MapExtras (extractKeys)
 import Data.Text (Text)
-import Debug.Trace (traceEvent)
+import qualified Debug.Trace as Debug
 import GHC.Generics (Generic)
 import Lens.Micro
 import NoThunks.Class (NoThunks)
@@ -259,7 +259,7 @@ alonzoEvalScriptsTxValid = do
   let txBody = tx ^. bodyTxL
       genDelegs = dsGenDelegs (certDState certState)
 
-  () <- pure $! traceEvent validBegin ()
+  () <- pure $! Debug.traceEvent validBegin ()
 
   scriptsTransition slot pp tx utxo $ \case
     Fails _ps fs ->
@@ -269,7 +269,7 @@ alonzoEvalScriptsTxValid = do
           (FailedUnexpectedly (scriptFailureToFailureDescription <$> fs))
     Passes ps -> mapM_ (tellEvent . SuccessfulPlutusScriptsEvent) (nonEmpty ps)
 
-  () <- pure $! traceEvent validEnd ()
+  () <- pure $! Debug.traceEvent validEnd ()
 
   ppup' <-
     trans @(EraRule "PPUP" era) $
@@ -297,7 +297,7 @@ alonzoEvalScriptsTxInvalid = do
   TRC (UtxoEnv slot pp _, us@(UTxOState utxo _ fees _ _ _), tx) <- judgmentContext
   let txBody = tx ^. bodyTxL
 
-  () <- pure $! traceEvent invalidBegin ()
+  () <- pure $! Debug.traceEvent invalidBegin ()
 
   scriptsTransition slot pp tx utxo $ \case
     Passes _ps ->
@@ -307,7 +307,7 @@ alonzoEvalScriptsTxInvalid = do
       mapM_ (tellEvent . SuccessfulPlutusScriptsEvent) (nonEmpty ps)
       tellEvent (FailedPlutusScriptsEvent (scriptFailurePlutus <$> fs))
 
-  () <- pure $! traceEvent invalidEnd ()
+  () <- pure $! Debug.traceEvent invalidEnd ()
 
   {- utxoKeep = txBody ^. collateralInputsTxBodyL ⋪ utxo -}
   {- utxoDel  = txBody ^. collateralInputsTxBodyL ◁ utxo -}

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -92,7 +92,8 @@ import Data.Proxy (Proxy (..))
 import Data.Ratio ((%))
 import Data.Sequence.Strict (StrictSeq ((:|>)))
 import qualified Data.Sequence.Strict as Seq (fromList)
-import Data.Set as Set
+import Data.Set (Set)
+import qualified Data.Set as Set
 import Lens.Micro
 import Numeric.Natural (Natural)
 import qualified PlutusLedgerApi.Common as P (Data (..))
@@ -469,8 +470,8 @@ instance Mock c => EraGen (AlonzoEra c) where
           then
             if oldScriptWits == newWits
               then pure tx
-              else myDiscard "Random extra scriptwitness: genEraDone: AlonzoEraGen.hs"
-          else myDiscard "MinFee violation: genEraDone: AlonzoEraGen.hs"
+              else myDiscard $ "Random extra scriptwitness: genEraDone: " <> show newWits
+          else myDiscard $ "MinFee violation: genEraDone: " <> show theFee
 
   genEraTweakBlock pp txns =
     let txTotal, ppMax :: ExUnits
@@ -478,7 +479,12 @@ instance Mock c => EraGen (AlonzoEra c) where
         ppMax = pp ^. ppMaxBlockExUnitsL
      in if pointWiseExUnits (<=) txTotal ppMax
           then pure txns
-          else myDiscard "TotExUnits violation: genEraTweakBlock: AlonzoEraGen.hs"
+          else
+            myDiscard $
+              "TotExUnits violation: genEraTweakBlock: "
+                <> show (unWrapExUnits txTotal)
+                <> " instead of "
+                <> show (unWrapExUnits ppMax)
 
   hasFailedScripts tx = IsValid False == tx ^. isValidTxL
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -76,7 +76,7 @@ import Control.State.Transition.Extended
 import Data.List.NonEmpty (nonEmpty)
 import qualified Data.Map.Strict as Map
 import Data.MapExtras (extractKeys)
-import Debug.Trace (traceEvent)
+import qualified Debug.Trace as Debug
 import Lens.Micro
 
 type instance EraRuleFailure "UTXOS" (BabbageEra c) = AlonzoUtxosPredFailure (BabbageEra c)
@@ -230,9 +230,9 @@ babbageEvalScriptsTxValid = do
     trans @(EraRule "PPUP" era) $
       TRC (PPUPEnv slot pp genDelegs, pup, txBody ^. updateTxBodyL)
 
-  () <- pure $! traceEvent validBegin ()
+  () <- pure $! Debug.traceEvent validBegin ()
   expectScriptsToPass pp tx utxo
-  () <- pure $! traceEvent validEnd ()
+  () <- pure $! Debug.traceEvent validEnd ()
 
   updateUTxOState
     pp
@@ -266,7 +266,7 @@ babbageEvalScriptsTxInvalid = do
   sysSt <- liftSTS $ asks systemStart
   ei <- liftSTS $ asks epochInfo
 
-  () <- pure $! traceEvent invalidBegin ()
+  () <- pure $! Debug.traceEvent invalidBegin ()
 
   case collectPlutusScriptsWithContext ei sysSt pp tx utxo of
     Right sLst ->
@@ -283,7 +283,7 @@ babbageEvalScriptsTxInvalid = do
             tellEvent (injectEvent $ FailedPlutusScriptsEvent (scriptFailurePlutus <$> fs))
     Left info -> failBecause (injectFailure $ CollectErrors info)
 
-  () <- pure $! traceEvent invalidEnd ()
+  () <- pure $! Debug.traceEvent invalidEnd ()
 
   {- utxoKeep = txBody ^. collateralInputsTxBodyL ⋪ utxo -}
   {- utxoDel  = txBody ^. collateralInputsTxBodyL ◁ utxo -}

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
@@ -66,7 +66,7 @@ import Cardano.Ledger.UTxO (EraUTxO (..), UTxO)
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended
 import Data.List.NonEmpty (NonEmpty)
-import Debug.Trace (traceEvent)
+import qualified Debug.Trace as Debug
 import GHC.Generics (Generic)
 import Lens.Micro
 import NoThunks.Class (NoThunks)
@@ -286,9 +286,9 @@ conwayEvalScriptsTxValid = do
     judgmentContext
   let txBody = tx ^. bodyTxL
 
-  () <- pure $! traceEvent validBegin ()
+  () <- pure $! Debug.traceEvent validBegin ()
   expectScriptsToPass pp tx utxo
-  () <- pure $! traceEvent validEnd ()
+  () <- pure $! Debug.traceEvent validEnd ()
 
   utxos' <-
     updateUTxOState

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Constants.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Constants.hs
@@ -120,13 +120,13 @@ defaultConstants =
     , frequencyKeyCredDelegation = 2
     , frequencyTxUpdates = 10
     , frequencyTxWithMetadata = 10
-    , minGenesisUTxOouts = 10
-    , maxGenesisUTxOouts = 100
+    , minGenesisUTxOouts = 100
+    , maxGenesisUTxOouts = 150
     , minGenesisOutputVal = 1000000
     , maxGenesisOutputVal = 100000000
     , maxCertsPerTx = 3
     , maxTxsPerBlock = 10
-    , numKeyPairs = 150 -- Must be >= maxGenesisUTxOouts
+    , numKeyPairs = 200 -- Must be >= maxGenesisUTxOouts
     , numBaseScripts = 3
     , numSimpleScripts = 20
     , frequencyNoWithdrawals = 75
@@ -143,6 +143,6 @@ defaultConstants =
     , maxTreasury = 10000000
     , minReserves = 1000000
     , maxReserves = 10000000
-    , genTxStableUtxoSize = 100 -- Needs to be between minGenesisUTxOouts and maxGenesisUTxOouts
+    , genTxStableUtxoSize = 125 -- Needs to be between minGenesisUTxOouts and maxGenesisUTxOouts
     , genTxUtxoIncrement = 3
     }

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Constants.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Constants.hs
@@ -55,16 +55,16 @@ data Constants = Constants
   -- ^ minimal number of genesis UTxO outputs
   , maxGenesisUTxOouts :: Int
   -- ^ maximal number of genesis UTxO outputs
-  , maxCertsPerTx :: Word64
-  -- ^ maximal number of certificates per transaction
-  , maxTxsPerBlock :: Word64
-  -- ^ maximal number of Txs per block
-  , maxNumKeyPairs :: Word64
-  -- ^ maximal numbers of generated keypairs
   , minGenesisOutputVal :: Integer
   -- ^ minimal coin value for generated genesis outputs
   , maxGenesisOutputVal :: Integer
   -- ^ maximal coin value for generated genesis outputs
+  , maxCertsPerTx :: Word64
+  -- ^ maximal number of certificates per transaction
+  , maxTxsPerBlock :: Word64
+  -- ^ maximal number of Txs per block
+  , numKeyPairs :: Word64
+  -- ^ Number of generated keypairs
   , numBaseScripts :: Int
   -- ^ Number of base scripts from which multi sig scripts are built.
   , numSimpleScripts :: Int
@@ -122,11 +122,11 @@ defaultConstants =
     , frequencyTxWithMetadata = 10
     , minGenesisUTxOouts = 10
     , maxGenesisUTxOouts = 100
-    , maxCertsPerTx = 3
-    , maxTxsPerBlock = 10
-    , maxNumKeyPairs = 150
     , minGenesisOutputVal = 1000000
     , maxGenesisOutputVal = 100000000
+    , maxCertsPerTx = 3
+    , maxTxsPerBlock = 10
+    , numKeyPairs = 150 -- Must be >= maxGenesisUTxOouts
     , numBaseScripts = 3
     , numSimpleScripts = 20
     , frequencyNoWithdrawals = 75
@@ -143,6 +143,6 @@ defaultConstants =
     , maxTreasury = 10000000
     , minReserves = 1000000
     , maxReserves = 10000000
-    , genTxStableUtxoSize = 100
+    , genTxStableUtxoSize = 100 -- Needs to be between minGenesisUTxOouts and maxGenesisUTxOouts
     , genTxUtxoIncrement = 3
     }

--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -86,7 +86,6 @@ library
         containers,
         data-default-class,
         deepseq,
-        hashable,
         microlens,
         mtl,
         nothunks,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
@@ -34,7 +34,6 @@ where
 import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.BaseTypes (Network (..), ShelleyBase, StrictMaybe)
-import qualified Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
 import qualified Cardano.Ledger.Crypto as CC (Crypto, HASH)
@@ -58,9 +57,7 @@ import Cardano.Ledger.UTxO (UTxO)
 import Cardano.Protocol.TPraos.BHeader (BHeader)
 import Cardano.Slotting.Slot (SlotNo)
 import Control.State.Transition.Extended (STS (..))
-import qualified Data.ByteString as BS
 import Data.Default.Class (Default)
-import Data.Hashable (Hashable (..))
 import Data.Map (Map)
 import Data.Sequence (Seq)
 import Data.Sequence.Strict (StrictSeq)
@@ -319,47 +316,22 @@ someScripts c lower upper = take <$> choose (lower, upper) <*> shuffle (allScrip
 --   Note that 'genEraTwoPhase3Arg' and 'genEraTwoPhase2Arg' may be the empty list ([]) in some Eras.
 allScripts :: forall era. EraGen era => Constants -> [(Script era, Script era)]
 allScripts c =
-  plutusPairs genEraTwoPhase3Arg genEraTwoPhase2Arg (take 3 simple)
-    ++ take (numSimpleScripts c) simple -- 10 means about 5% of allScripts are Plutus Scripts
+  concat
+    [ plutusPairs
+    , take (numSimpleScripts c) simpleScripts -- 10 means about 5% of allScripts are Plutus Scripts
     -- Plutus scripts in some Eras ([] in other Eras)
     -- [(payment,staking)] where the either payment or staking may be a plutus script
-    ++
     -- Simple scripts (key locked, Start-Finish timelocks)
-    combinedScripts @era c
+    , combinedScripts @era c
+    ]
   where
-    -- Quantifed scripts (All, Any, MofN)
-
-    simple = baseScripts @era c
-    plutusPairs ::
-      [TwoPhase3ArgInfo era] ->
-      [TwoPhase2ArgInfo era] ->
-      [(Script era, Script era)] ->
-      [(Script era, Script era)]
-    plutusPairs [] _ _ = []
-    plutusPairs _ [] _ = []
-    plutusPairs _ _ [] = []
-    plutusPairs args3 args2 ((pay, stake) : more) = pair : plutusPairs args3 args2 more
-      where
-        count3 = length args3 - 1
-        count2 = length args2 - 1
-        payBytes = Plain.serialize' pay
-        n = randomByHash 0 count3 $ Plain.serialize' stake
-        m = randomByHash 0 count2 payBytes
-        mode = randomByHash 1 3 payBytes
-        pair = case mode of
-          1 -> (getScript3 (args3 !! n), stake)
-          2 -> (pay, getScript2 (args2 !! m))
-          3 -> (getScript3 (args3 !! n), getScript2 (args2 !! m))
-          i -> error ("mod function returns value out of bounds: " ++ show i)
-
-randomByHash :: Int -> Int -> BS.ByteString -> Int
-randomByHash low high x = low + remainder
-  where
-    n = hash x
-    -- We don't really care about the hash, we only
-    -- use it to pseudo-randomly pick a number bewteen low and high
-    m = high - low + 1
-    remainder = mod n m -- mode==0 is a time leaf,  mode 1 or 2 is a signature leaf
+    simpleScripts = baseScripts @era c
+    plutusPairs :: [(Script era, Script era)]
+    plutusPairs = do
+      script3 <- getScript3 <$> genEraTwoPhase3Arg
+      script2 <- getScript2 <$> genEraTwoPhase2Arg
+      (payment, staking) <- take 3 simpleScripts
+      [(script3, staking), (payment, script2), (script3, script2)]
 
 -- =========================================================
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
@@ -268,16 +268,14 @@ class
  -----------------------------------------------------------------------------}
 
 -- | Select between _lower_ and _upper_ keys from 'keyPairs'
-someKeyPairs :: CC.Crypto c => Constants -> Int -> Int -> Gen (KeyPairs c)
-someKeyPairs c lower upper =
-  take
-    <$> choose (lower, upper)
-    <*> shuffle (keyPairs c)
+someKeyPairs :: CC.Crypto c => Constants -> (Int, Int) -> Gen (KeyPairs c)
+someKeyPairs c range = take <$> choose range <*> shuffle (keyPairs c)
 
 genUtxo0 :: forall era. EraGen era => GenEnv era -> Gen (UTxO era)
 genUtxo0 ge@(GenEnv _ _ c@Constants {minGenesisUTxOouts, maxGenesisUTxOouts}) = do
-  genesisKeys <- someKeyPairs c minGenesisUTxOouts maxGenesisUTxOouts
-  genesisScripts <- someScripts @era c minGenesisUTxOouts maxGenesisUTxOouts
+  let range = (minGenesisUTxOouts `div` 2, maxGenesisUTxOouts `div` 2)
+  genesisKeys <- someKeyPairs c range
+  genesisScripts <- someScripts @era c range
   outs <-
     (genEraTxOut @era ge)
       (genGenesisValue @era ge)
@@ -306,10 +304,9 @@ someScripts ::
   forall era.
   EraGen era =>
   Constants ->
-  Int ->
-  Int ->
+  (Int, Int) ->
   Gen [(Script era, Script era)]
-someScripts c lower upper = take <$> choose (lower, upper) <*> shuffle (allScripts @era c)
+someScripts c range = take <$> choose range <*> shuffle (allScripts @era c)
 
 -- | A list of all possible kinds of scripts in the current Era.
 --   Might include Keylocked scripts, Start-Finish Timelock scripts, Quantified scripts (All, Any, MofN), Plutus Scripts

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/ScriptClass.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/ScriptClass.hs
@@ -229,7 +229,7 @@ combinedScripts c@(Constants {numBaseScripts}) =
 
 -- | Constant list of KeyPairs intended to be used in the generators.
 keyPairs :: Crypto c => Constants -> KeyPairs c
-keyPairs Constants {maxNumKeyPairs} = mkKeyPairs <$> [1 .. maxNumKeyPairs]
+keyPairs Constants {numKeyPairs} = mkKeyPairs <$> [1 .. numKeyPairs]
 
 mkKeyPairs ::
   DSIGNAlgorithm (DSIGN c) =>

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
@@ -640,7 +640,7 @@ pickRandomFromMap n' initMap = go (min (max 0 n') (Map.size initMap)) [] initMap
     go n !acc !m
       | n <= 0 = pure acc
       | otherwise = do
-          i <- QC.choose (0, n - 1)
+          i <- QC.choose (0, Map.size m - 1)
           let (k, y) = Map.elemAt i m
           go (n - 1) ((k, y) : acc) (Map.deleteAt i m)
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
@@ -73,7 +73,7 @@ import Data.Sequence.Strict (StrictSeq)
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 import qualified Data.Vector as V
-import Debug.Trace (trace)
+import qualified Debug.Trace as Debug
 import Lens.Micro
 import NoThunks.Class ()
 import Test.Cardano.Ledger.Core.KeyPair (
@@ -108,7 +108,7 @@ import qualified Test.QuickCheck as QC
 -- Instances only
 
 myDiscard :: [Char] -> a
-myDiscard message = trace ("\nDiscarded trace: " ++ message) discard
+myDiscard message = Debug.trace ("\nDiscarded trace: " ++ message) discard
 
 -- ====================================================
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
@@ -227,7 +227,10 @@ genTx
         genRecipients @era (length inputs + n) ksKeyPairs ksMSigScripts
           >>= genPtrAddrs (certDState dpState')
 
-      !_ <- when (coin spendingBalance < mempty) $ myDiscard "Negative spending balance"
+      !_ <-
+        when (coin spendingBalance < mempty) $
+          myDiscard $
+            "Negative spending balance " <> show (coin spendingBalance)
 
       -------------------------------------------------------------------------
       -- Build a Draft Tx and repeatedly add to Delta until all fees are
@@ -243,7 +246,7 @@ genTx
       -- Occasionally we have a transaction generated with insufficient inputs
       -- to cover the deposits. In this case we discard the test case.
       let enough = sumVal (getMinCoinTxOut pparams <$> draftOutputs)
-      !_ <- when (coin spendingBalance < enough) (myDiscard "No inputs left. Utxo.hs")
+      !_ <- when (coin spendingBalance < enough) $ myDiscard $ "No inputs left. Utxo.hs " <> show enough
 
       (draftTxBody, additionalScripts) <-
         genEraTxBody
@@ -280,7 +283,8 @@ genTx
       let txOuts = tx ^. bodyTxL . outputsTxBodyL
       !_ <-
         when (any (\txOut -> getMinCoinTxOut pparams txOut > txOut ^. coinTxOutL) txOuts) $
-          myDiscard "TxOut value is too small"
+          myDiscard $
+            "TxOut value is too small " <> show txOuts
       pure tx
 
 -- | Collect additional inputs (and witnesses and keys and scripts) to make
@@ -447,7 +451,7 @@ genNextDelta
                   -- If it does happen, It is NOT a test failure, but an inadequacy in the
                   -- testing framework to generate almost-random transactions that always succeed every time.
                   -- Experience suggests that this happens less than 1% of the time, and does not lead to backtracking.
-                  !_ <- when (null inputs) (myDiscard "NoMoneyleft Utxo.hs")
+                  !_ <- when (null inputs) $ myDiscard $ "NoMoneyleft Utxo.hs " <> show (coin value)
                   let newWits =
                         mkTxWits @era
                           (utxo, txBody, scriptinfo)
@@ -456,7 +460,7 @@ genNextDelta
                           vkeyPairs
                           (mkScriptWits @era msigPairs mempty)
                           (hashAnnotated txBody)
-                  pure $
+                  pure
                     delta
                       { extraWitnesses = extraWitnesses <> newWits
                       , extraInputs = extraInputs <> Set.fromList inputs

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
@@ -850,14 +850,12 @@ genRecipients ::
   Gen [Addr (EraCrypto era)]
 genRecipients len keys scripts = do
   n' <-
-    QC.frequency
-      ( (if len > 1 then [(1, pure (len - 1))] else [])
-          -- contract size of UTxO (only if at least 2 inputs are chosen)
-          ++ [(2, pure len)]
-          -- keep size
-          ++ [(1, pure $ len + 1)]
-      )
-  -- expand size of UTxO
+    min 1
+      <$> QC.frequency
+        [ (1, pure (len - 1)) -- contract size of UTxO
+        , (2, pure len) -- keep size
+        , (1, pure (len + 1)) -- expand size of UTxO
+        ]
 
   -- choose m scripts and n keys as recipients
   -- We want to choose more Keys than Scripts by a factor of 2 or more.

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -81,12 +82,14 @@ import Test.Control.State.Transition.Trace.Generator.QuickCheck (
  )
 import qualified Test.Control.State.Transition.Trace.Generator.QuickCheck as QC
 import Test.QuickCheck (
+  Confidence (certainty),
   Property,
-  checkCoverage,
+  checkCoverageWith,
   conjoin,
   cover,
   forAllBlind,
   property,
+  stdConfidence,
   withMaxSuccess,
  )
 import Test.Tasty (TestTree)
@@ -109,7 +112,7 @@ relevantCasesAreCovered n =
   where
     prop = do
       let tl = 100
-      checkCoverage $
+      checkCoverageWith stdConfidence {certainty = 1_000_000} $
         forAllBlind
           (traceFromInitState @(CHAIN era) testGlobals tl (genEnv p defaultConstants) genesisChainSt)
           relevantCasesAreCoveredForTrace

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
@@ -183,7 +183,7 @@ relevantCasesAreCoveredForTrace tr = do
           , 60
           )
         ,
-          ( "at least 10% of transactions have script TxOuts"
+          ( "at least 10% of TxOuts are scripts"
           , 0.1 < txScriptOutputsRatio (view outputsTxBodyL . view bodyTxL <$> txs)
           , 20
           )

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Examples.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Examples.hs
@@ -28,7 +28,7 @@ import Control.Monad (when)
 import Data.Default.Class (Default (..))
 import Data.Map (Map)
 import Data.Ratio ((%))
-import Debug.Trace (trace)
+import qualified Debug.Trace as Debug
 import Test.Cardano.Ledger.Constrained.Ast
 import Test.Cardano.Ledger.Constrained.Classes (OrdCond (..))
 import Test.Cardano.Ledger.Constrained.Env
@@ -99,7 +99,7 @@ genMaybeCounterExample proof _testname loud order cs target = do
             ]
   result <-
     if loud
-      then trace (unlines messages1) (genDependGraph loud proof graph)
+      then Debug.trace (unlines messages1) (genDependGraph loud proof graph)
       else genDependGraph loud proof graph
   subst <- case result of
     Left msgs -> error (unlines msgs)
@@ -118,7 +118,7 @@ genMaybeCounterExample proof _testname loud order cs target = do
           then Nothing -- Indicates success, nothing bad happened
           else Just ("Some conditions fail\n" ++ explainBad bad subst)
   if loud
-    then trace (unlines (messages2 : messages3)) (pure ans)
+    then Debug.trace (unlines (messages2 : messages3)) (pure ans)
     else pure ans
 
 -- | Test that 'cs' :: [Pred] has a solution
@@ -152,7 +152,7 @@ failn proof message loud order cs target = do
               else pure ()
     )
     ( \(ErrorCall msg) ->
-        trace
+        Debug.trace
           ( if loud
               then ("Fails as expected\n" ++ msg ++ "\nOK")
               else ("Fails as expected OK")

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Rewrite.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Rewrite.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-unused-binds #-}
-{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module Test.Cardano.Ledger.Constrained.Rewrite (
   rewrite,
@@ -32,13 +31,7 @@ module Test.Cardano.Ledger.Constrained.Rewrite (
   rename,
 ) where
 
-import Cardano.Ledger.Address (Addr (..))
-import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Conway.Governance (GovAction (..))
-import Cardano.Ledger.Core (EraTxOut (..), TxOut, coinTxOutL)
-import Cardano.Ledger.Crypto (StandardCrypto)
-import Cardano.Ledger.Era (Era (EraCrypto))
-import Cardano.Ledger.Val (Val (coin, modifyCoin))
+import Cardano.Ledger.Era (Era)
 import qualified Data.Array as A
 import Data.Foldable (toList)
 import Data.Graph (Graph, SCC (AcyclicSCC, CyclicSCC), Vertex, graphFromEdges, stronglyConnComp)
@@ -49,9 +42,6 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Data.Void (Void)
-import qualified Debug.Trace as Debug
-import Lens.Micro (Lens', lens, (&), (.~), (^.))
 import Test.Cardano.Ledger.Constrained.Ast
 import Test.Cardano.Ledger.Constrained.Combinators (setSized)
 import Test.Cardano.Ledger.Constrained.Env (
@@ -61,17 +51,11 @@ import Test.Cardano.Ledger.Constrained.Env (
   Field (..),
   Name (..),
   V (..),
-  pV,
   sameName,
  )
 import Test.Cardano.Ledger.Constrained.Monad (HasConstraint (With), Typed (..), failT, monadTyped)
-import Test.Cardano.Ledger.Constrained.Size
-import Test.Cardano.Ledger.Constrained.Size (genFromSize)
+import Test.Cardano.Ledger.Constrained.Size (Size (SzExact), genFromSize)
 import Test.Cardano.Ledger.Constrained.TypeRep
-import Test.Cardano.Ledger.Constrained.Vars
-import Test.Cardano.Ledger.Generic.Fields
-import Test.Cardano.Ledger.Generic.Proof
-import Test.Cardano.Ledger.Generic.Updaters (newTxOut)
 import Test.QuickCheck
 import Type.Reflection (typeRep)
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Rewrite.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Rewrite.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-unused-binds #-}
 
 module Test.Cardano.Ledger.Constrained.Rewrite (
   rewrite,
@@ -89,15 +88,15 @@ csumeq (SumList x) (SumList y) = cteq x y
 csumeq _ _ = False
 
 -- | Conservative (and unsound for Constr and Invert) Target equality
-ctareq :: Era era => RootTarget era r t -> RootTarget era r t -> Bool
-ctareq (Constr x _) (Constr y _) = x == y
-ctareq (Invert x _ _) (Invert y _ _) = x == y
-ctareq (Simple x) (Simple y) = cteq x y
-ctareq (x :$ (Simple xs)) (y :$ (Simple ys)) =
+_ctareq :: Era era => RootTarget era r t -> RootTarget era r t -> Bool
+_ctareq (Constr x _) (Constr y _) = x == y
+_ctareq (Invert x _ _) (Invert y _ _) = x == y
+_ctareq (Simple x) (Simple y) = cteq x y
+_ctareq (x :$ (Simple xs)) (y :$ (Simple ys)) =
   case testEql (termRep xs) (termRep ys) of
-    Just Refl -> ctareq x y && cteq xs ys
+    Just Refl -> _ctareq x y && cteq xs ys
     Nothing -> False
-ctareq _ _ = False
+_ctareq _ _ = False
 
 -- | Conservative Term equality
 cteq :: Era era => Term era t -> Term era t -> Bool
@@ -137,7 +136,7 @@ cpeq (SubMap x xs) (SubMap y ys) = typedEq x y && typedEq xs ys
 cpeq (NotMember x xs) (NotMember y ys) = typedEq x y && typedEq xs ys
 {- TODO FIX ME
 cpeq (x :<-: xs) (y :<-: ys) = case testEql (termRep x) (termRep y) of
-  Just Refl -> typedEq x y && ctareq xs ys
+  Just Refl -> typedEq x y && _ctareq xs ys
   Nothing -> False
 -}
 cpeq x y = sumsEq x y
@@ -297,11 +296,11 @@ freshPair m0 (tar, ps) = (m1, subitems, target2, ps2)
     ps2 = map (substPred subst) ps
 
 -- | Used to rename targets and preds, where they are embeded in a Triple, where the first component is the frequency
-freshTriples ::
+_freshTriples ::
   ((Int, SubItems era), [(Int, RootTarget era r t, [Pred era])]) ->
   (Int, RootTarget era r t, [Pred era]) ->
   ((Int, SubItems era), [(Int, RootTarget era r t, [Pred era])])
-freshTriples (xx, ans) (i, tar, ps) = (yy, (i, target2, ps2) : ans)
+_freshTriples (xx, ans) (i, tar, ps) = (yy, (i, target2, ps2) : ans)
   where
     yy@(_, subitems) = fresh xx tar
     subst = itemsToSubst subitems
@@ -354,8 +353,8 @@ nUniqueFromM n m
       Set.toList
         <$> setSized ["from Choose", "nUniqueFromM " ++ show n ++ " " ++ show m] n (choose (0, m))
 
-pickNunique :: Int -> [a] -> Gen [a]
-pickNunique n xs = do
+_pickNunique :: Int -> [a] -> Gen [a]
+_pickNunique n xs = do
   indexes <- nUniqueFromM n (length xs - 1)
   pure [xs !! i | i <- indexes]
 
@@ -418,7 +417,7 @@ List w [w1,w2]
 rewritePred m0 (ListWhere (Lit SizeR sz) (Var v) tar ps) = do
   count <- genFromSize sz
   (ps1, m1) <- pure (ps, m0) -- removeExpandablePred ([], m0) ps
-  let ((m2, subb), ps3) = List.foldl' freshPairs ((m1, []), []) (take count (repeat (tar, ps1)))
+  let ((m2, _subb), ps3) = List.foldl' freshPairs ((m1, []), []) (take count (repeat (tar, ps1)))
       (vs, m3) = freshVars2 m2 count v -- [v.1, v.2, v.3 ...]
       renamedPred = map snd ps3
       renamedTargets = map fst ps3
@@ -622,7 +621,6 @@ mkDependGraph count prev prevNames (n : more) badchoices cs =
           )
   where
     !defined = HashSet.insert n prevNames
-    (poss, notposs) = partitionE okE cs
     okE :: Pred era -> Either ([Name era], Pred era) (Pred era)
     okE p@(SumSplit _ t _ ns) =
       let rhsNames = List.foldl' varsOfSum HashSet.empty ns
@@ -642,11 +640,11 @@ partitionE f (x : xs) = case (f x, partitionE f xs) of
   (Left b, (bs, as)) -> (b : bs, as)
   (Right a, (bs, as)) -> (bs, a : as)
 
-firstE :: (a -> Either b a) -> [a] -> (Maybe b, [a])
-firstE _ [] = (Nothing, [])
-firstE f (x : xs) = case f x of
+_firstE :: (a -> Either b a) -> [a] -> (Maybe b, [a])
+_firstE _ [] = (Nothing, [])
+_firstE f (x : xs) = case f x of
   Left b -> (Just b, xs)
-  Right a -> case firstE f xs of
+  Right a -> case _firstE f xs of
     (Nothing, as) -> (Nothing, a : as)
     (Just b, as) -> (Just b, a : as)
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Rewrite.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Rewrite.hs
@@ -50,7 +50,7 @@ import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Void (Void)
-import Debug.Trace
+import qualified Debug.Trace as Debug
 import Lens.Micro (Lens', lens, (&), (.~), (^.))
 import Test.Cardano.Ledger.Constrained.Ast
 import Test.Cardano.Ledger.Constrained.Combinators (setSized)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Solver.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Solver.hs
@@ -21,7 +21,7 @@ import qualified Data.Map.Strict as Map
 import Data.Pulse (foldlM')
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Debug.Trace (trace)
+import qualified Debug.Trace as Debug
 import GHC.Stack (HasCallStack)
 import Lens.Micro (Lens', (^.))
 import qualified Lens.Micro as Lens
@@ -94,7 +94,7 @@ import Test.QuickCheck hiding (Fixed, getSize, total)
 
 ifTrace :: Bool -> String -> a -> a
 ifTrace traceOn message a = case traceOn of
-  True -> trace message a
+  True -> Debug.trace message a
   False -> a
 
 -- ==================================================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Spec.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Spec.hs
@@ -31,7 +31,7 @@ import qualified Data.Maybe as Maybe
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Word (Word64)
-import Debug.Trace (trace)
+import qualified Debug.Trace as Debug
 import Lens.Micro hiding (set)
 import Test.Cardano.Ledger.Constrained.Ast (Pred (..), Sum (..), Term (..), runPred)
 import Test.Cardano.Ledger.Constrained.Classes (
@@ -887,7 +887,8 @@ testMergeRngSpec :: Gen Property
 testMergeRngSpec = do
   (s1, s2) <- genConsistentRngSpec 3 (choose (1, 1000)) Word64R CoinR (SomeLens word64CoinL)
   case s1 <> s2 of
-    RngNever _ -> trace ("inconsistent RngSpec " ++ show s1 ++ " " ++ show s2) (pure (counterexample "" True))
+    RngNever _ ->
+      Debug.trace ("inconsistent RngSpec " ++ show s1 ++ " " ++ show s2) (pure (counterexample "" True))
     s3 -> do
       let size = sizeForRng s3
       n <- genFromSize size

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/DrepCertTx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/DrepCertTx.hs
@@ -51,7 +51,7 @@ import Data.Foldable (toList)
 import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict (StrictMaybe (..))
 import qualified Data.Set as Set
-import Debug.Trace (trace)
+import qualified Debug.Trace as Debug
 import Lens.Micro
 import Test.Cardano.Ledger.Constrained.Ast (RootTarget (..), (^$))
 import Test.Cardano.Ledger.Constrained.Classes (TxF (..), TxOutF (..))
@@ -175,7 +175,7 @@ drepCertTxForTrace maxFeeEstimate proof = do
 drepTree :: TestTree
 drepTree =
   testGroup
-    "DRep property traces"
+    "DRep property Debug.traces"
     [ testProperty
         "All Tx are valid on traces of length 150."
         $ withMaxSuccess 20
@@ -262,7 +262,7 @@ showMap :: (Show k, Show v) => String -> Map.Map k v -> String
 showMap msg m = unlines (msg : map show (Map.toList m))
 
 traceMap :: (Show k, Show v) => String -> Map.Map k v -> a -> a
-traceMap s m x = trace (showMap s m) x
+traceMap s m x = Debug.trace (showMap s m) x
 
 showPotObl :: ConwayEraGov era => NewEpochState era -> String
 showPotObl nes =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/SimpleTx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/SimpleTx.hs
@@ -41,7 +41,7 @@ import qualified Data.Map.Strict as Map
 import Data.Sequence.Strict (StrictSeq (Empty, (:<|)))
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Debug.Trace
+import qualified Debug.Trace as Debug
 import Lens.Micro
 import qualified PlutusLedgerApi.V1 as PV1
 import Test.Cardano.Ledger.Constrained.Ast (runTarget, runTerm)
@@ -157,7 +157,7 @@ simpleTxBody proof feeEstimate = do
     zs <- liftGen (shuffle utxopairs)
     case zs of
       [] ->
-        trace
+        Debug.trace
           ( "There are no entries in the UTxO that are big enough for the feeEstimate: "
               ++ show feeEstimate
               ++ " Discard"
@@ -222,7 +222,7 @@ completeTxBody proof maxFeeEstimate txBody = do
           (liftUTxO u)
           (GenDelegs gd)
       initialfee = computeFinalFee pp (TxF proof tx) u
-  let loop _ _ fee _ | fee >= maxFeeEstimate = trace ("LOOP: fee >= maxFeeEstimate, Discard") $ discard
+  let loop _ _ fee _ | fee >= maxFeeEstimate = Debug.trace ("LOOP: fee >= maxFeeEstimate, Discard") $ discard
       loop count txx fee hash = do
         let adjustedtx = adjustTxForFee proof fee txx
             txb = adjustedtx ^. bodyTxL
@@ -244,7 +244,7 @@ completeTxBody proof maxFeeEstimate txBody = do
           else
             if count > (0 :: Int)
               then loop (count - 1) completedtx newfee hash2
-              else trace ("LOOP: count <= 0, fee is osccilating, Discard") $ discard
+              else Debug.trace "LOOP: count <= 0, fee is oscillating, Discard" discard
   loop 10 tx initialfee hash1
 
 -- ========================================================================================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
@@ -69,7 +69,7 @@ import qualified Data.Sequence.Strict as SS
 import qualified Data.Set as Set
 import Data.Vector (Vector, (!))
 import qualified Data.Vector as Vector
-import Debug.Trace
+import qualified Debug.Trace as Debug
 import GHC.Word (Word64)
 import Lens.Micro ((&), (.~), (^.))
 import Prettyprinter (hsep, parens, vsep)
@@ -415,7 +415,7 @@ instance
     case runShelleyBase (applySTSTest (TRC @(MOCKCHAIN era) ((), mcs, mockblock))) of
       Left pdfs ->
         let txsl = Fold.toList txs
-         in trace
+         in Debug.trace
               (raiseMockError lastSlot nextSlotNo epochstate pdfs txsl gs)
               ( error . unlines $
                   "sigGen in (HasTrace (MOCKCHAIN era) (Gen1 era)) FAILS" : map show (Fold.toList pdfs)
@@ -437,7 +437,7 @@ mapProportion epochnum lastSlot count m =
       -- sometimes as we move into the 3rd epoch, however stakeDistr is computed becomes empty. This is probably
       -- because there is no action in Test.Cardano.Ledger.Constrained.Trace.Actions for the epoch boundary.
       -- This temporary fix is good enough for now. But the annoying trace message reminds us to fix this.
-      trace
+      Debug.trace
         ( "There are no stakepools to choose an issuer from"
             ++ ", epoch="
             ++ show epochnum

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -1,19 +1,15 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ImportQualifiedPost #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -269,25 +265,26 @@ testSpecNoShrink :: HasSpec fn a => String -> Specification fn a -> Spec
 testSpecNoShrink = testSpec' False
 
 testSpec' :: HasSpec fn a => Bool -> String -> Specification fn a -> Spec
-testSpec' withShrink n s =
+testSpec' withShrink n s = do
+  let checkCoverage' = checkCoverageWith stdConfidence {certainty = 1_000_000}
   describe n $ do
     prop "prop_sound" $
       within 10_000_000 $
-        checkCoverage $
+        checkCoverage' $
           prop_sound s
     prop "prop_constrained_satisfies_sound" $
       within 10_000_000 $
-        checkCoverage $
+        checkCoverage' $
           prop_constrained_satisfies_sound s
     prop "prop_constrained_explained" $
       within 10_000_0000 $
-        checkCoverage $
+        checkCoverage' $
           QC.forAll arbitrary $ \es ->
             prop_sound $ constrained $ \x -> explanation es $ x `satisfies` s
     when withShrink $
       prop "prop_shrink_sound" $
         within 10_000_000 $
-          checkCoverage $
+          checkCoverage' $
             prop_shrink_sound s
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
# Description

A temporary fix until the real cause was found was to constrain the version of `hashable` in `cabal.project`:

```
constraints:
  , hashable == 1.4.4.0
allow-older:
  , aeson:hashable
  , strict:hashable
```

However, the real problem was in the way we generate lists of scripts to test with, which used `hashable` to select the list. When `hashable` started producing different hash values, the list changed slightly and the tests that were passing before by pure luck now broke.

Fixing the list of scripts, however, breaks a number of other tests (including non-nightly ones) that were passing by luck.

Closes #4538

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
