### PR TITLE
Fix transTxCert always setting deposit to Nothing for TxCertRegStaking & TxCertUnRegStaking

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
@@ -492,14 +492,14 @@ transTxCert = \case
     PV3.TxCertPoolRegister (transKeyHash ppId) (PV3.PubKeyHash (PV3.toBuiltin (hashToBytes ppVrf)))
   RetirePoolTxCert poolId retireEpochNo ->
     PV3.TxCertPoolRetire (transKeyHash poolId) (transEpochNo retireEpochNo)
-  RegTxCert stakeCred ->
-    PV3.TxCertRegStaking (transCred stakeCred) Nothing
-  UnRegTxCert stakeCred ->
-    PV3.TxCertUnRegStaking (transCred stakeCred) Nothing
   RegDepositTxCert stakeCred deposit ->
     PV3.TxCertRegStaking (transCred stakeCred) (Just (transCoinToLovelace deposit))
   UnRegDepositTxCert stakeCred refund ->
     PV3.TxCertUnRegStaking (transCred stakeCred) (Just (transCoinToLovelace refund))
+  RegTxCert stakeCred ->
+    PV3.TxCertRegStaking (transCred stakeCred) Nothing
+  UnRegTxCert stakeCred ->
+    PV3.TxCertUnRegStaking (transCred stakeCred) Nothing
   DelegTxCert stakeCred delegatee ->
     PV3.TxCertDelegStaking (transCred stakeCred) (transDelegatee delegatee)
   RegDepositDelegTxCert stakeCred delegatee deposit ->


### PR DESCRIPTION
  Doing some testing on my end, I noticed that deposits were always missing from TxCertRegStaking & TxCertUnRegStaking. However, they ought to be `Just` something when present; or more specifically when mapping a `ConwayRegCert` or `ConwayUnRegCert` to their Plutus counterpart.

  The deposit should, in principle, only be set to zero when presented with a legacy certificate format. However, if we take the following certificate:

  ```hs
  ConwayTxCertDeleg (ConwayRegCert
    (KeyHashObj (KeyHash {unKeyHash = "00000000000000000000000000000000000000000000000000000000"}))
    (SJust (Coin 3000000))
  )
  ```

  Using [`transTxCert`](https://github.com/IntersectMBO/cardano-ledger/blob/a36c0147772f9f5ef0d5640e6b3de297e929d840/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs#L489-L516) we obtain:

  ```hs
  TxCertRegStaking
    (PubKeyCredential 00000000000000000000000000000000000000000000000000000000)
    Nothing
  ```

  And similarly for `ConwayUnRegCert`. This seems due to the order of clauses in the pattern match inside `transTxCert` which causes `RegTxCert` and`UnRegTxCert` to be matched even in the presence of a deposit. Swapping the pattern match clauses fixes the issue and return:

  ```hs
  TxCertRegStaking
    (PubKeyCredential 00000000000000000000000000000000000000000000000000000000)
    (Just 3000000)
  ```

  The writing of a regression test to capture this is left as an excercise for the maintainers :grimacing:

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
