### PR TITLE
Increased the probability of generating the same hash more than once

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -24,8 +24,8 @@ source-repository-package
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `MAlonzo-code` BEFORE MERGE!
   subdir: generated
-  tag: d14f4b3f8f33a73890806dd1680069c7cfa8e54f
-  --sha256: sha256-OLJKEJ0u1v1Zah8qZ2nQD+ILsvG4BDoojWs+lKOcsIs=
+  tag: 0b269ddbab4044a834554e94b3f9d1311a6ae06b
+  --sha256: sha256-M0ikZWKH8JCY+sSuujDILeFIsTzOsOfc9EilskHdWTU=
 -- NOTE: If you would like to update the above, look for the `MAlonzo-code`
 -- branch in the `formal-ledger-specifications` repo and copy the SHA of
 -- the commit you need. The `MAlonzo-code` branch functions like an alternative

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.2.0
 
+* Add `showGovActionType`, `acceptedByEveryone`
 * Added `unRatifySignal`
 * Added lenses:
   * `ratifySignalL`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -167,6 +167,7 @@ module Cardano.Ledger.Conway.Governance (
   TreeMaybe (..),
   toGovRelationTree,
   toGovRelationTreeEither,
+  showGovActionType,
 ) where
 
 import Cardano.Ledger.BaseTypes (

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
@@ -53,6 +53,7 @@ module Cardano.Ledger.Conway.Governance.Procedures (
   Constitution (..),
   constitutionAnchorL,
   constitutionScriptL,
+  showGovActionType,
   -- Lenses
   pProcDepositL,
   pProcGovActionL,
@@ -822,6 +823,15 @@ data GovAction era
       !(Constitution era)
   | InfoAction
   deriving (Generic, Ord)
+
+showGovActionType :: GovAction era -> String
+showGovActionType NewConstitution {} = "NewConstitution"
+showGovActionType ParameterChange {} = "ParameterChange"
+showGovActionType HardForkInitiation {} = "HardForkInitiation"
+showGovActionType TreasuryWithdrawals {} = "TreasuryWithdrawals"
+showGovActionType NoConfidence {} = "NoConfidence"
+showGovActionType UpdateCommittee {} = "UpdateCommittee"
+showGovActionType InfoAction {} = "InfoAction"
 
 deriving instance EraPParams era => Show (GovAction era)
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance.hs
@@ -1,10 +1,6 @@
-module Test.Cardano.Ledger.Conformance (
-  module Test.Cardano.Ledger.Conformance.ExecSpecRule.Core,
-  module Test.Cardano.Ledger.Conformance.SpecTranslate.Core,
-  module Test.Cardano.Ledger.Conformance.Utils,
-) where
+module Test.Cardano.Ledger.Conformance (module X) where
 
-import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core
-import Test.Cardano.Ledger.Conformance.Orphans ()
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
-import Test.Cardano.Ledger.Conformance.Utils
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core as X
+import Test.Cardano.Ledger.Conformance.Orphans as X ()
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Core as X
+import Test.Cardano.Ledger.Conformance.Utils as X

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Ratify.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Ratify.hs
@@ -3,7 +3,8 @@
 
 module Test.Cardano.Ledger.Conformance.Imp.Ratify (spec) where
 
-import Cardano.Ledger.BaseTypes (StrictMaybe (..), natVersion)
+import qualified Data.List.NonEmpty as NE
+import Cardano.Ledger.BaseTypes (StrictMaybe (..), natVersion, addEpochInterval, EpochInterval (..))
 import Cardano.Ledger.Conway (Conway)
 import Cardano.Ledger.Conway.Governance (
   GovAction (..),
@@ -16,13 +17,14 @@ import Cardano.Ledger.Conway.PParams (
   dvtMotionNoConfidenceL,
   ppDRepVotingThresholdsL,
   ppPoolVotingThresholdsL,
-  pvtMotionNoConfidenceL,
+  pvtMotionNoConfidenceL, ppCommitteeMaxTermLengthL,
  )
 import Cardano.Ledger.Shelley.LedgerState (
   asTreasuryL,
   epochStateGovStateL,
   esAccountStateL,
   nesEsL,
+  nesELL,
  )
 import qualified Data.Sequence.Strict as SSeq
 import Lens.Micro ((&), (.~))
@@ -34,9 +36,11 @@ import Test.Cardano.Ledger.Constrained.Conway (ConwayFn)
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Core.Rational (IsRatio (..))
 import Test.Cardano.Ledger.Imp.Common
+import Cardano.Ledger.Credential (Credential(..))
+import qualified Data.Map as Map
 
 spec :: Spec
-spec = describe "RATIFY" . withImpStateWithProtVer (natVersion @10) $
+spec = describe "RATIFY" . withImpStateWithProtVer @Conway (natVersion @10) $ do
   it "NoConfidence accepted conforms" $ do
     modifyPParams $ \pp ->
       pp
@@ -64,3 +68,51 @@ spec = describe "RATIFY" . withImpStateWithProtVer (natVersion @10) $
         ratEnv
         ratSt
         (RatifySignal (noConfidenceGAS SSeq.:<| SSeq.Empty))
+  it "Duplicate CC hot keys count as separate votes" $ do
+    let maxTermLength = EpochInterval 10
+    modifyPParams $ \pp ->
+      pp
+        & ppCommitteeMaxTermLengthL .~ maxTermLength
+    (credDRep, _, _) <- setupSingleDRep 100
+    ccCold0 <- KeyHashObj <$> freshKeyHash
+    ccCold1 <- KeyHashObj <$> freshKeyHash
+    hotKey <- KeyHashObj <$> freshKeyHash
+    curEpoch <- getsNES nesELL
+    let
+      ccExpiry = curEpoch `addEpochInterval` maxTermLength
+      committee = Map.fromList
+        [ (ccCold0, ccExpiry)
+        , (ccCold1, ccExpiry)
+        ]
+
+    logEntry "Electing the committee"
+    committeeId <- submitGovAction $ UpdateCommittee SNothing mempty committee maxBound
+    submitYesVote_ (DRepVoter credDRep) committeeId
+    logAcceptedRatio committeeId
+    passNEpochs 2
+    getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId committeeId)
+
+    logEntry "Registering hotkeys"
+    _ <- registerCommitteeHotKeys (pure hotKey) (ccCold0 NE.:| [ccCold1])
+
+    logEntry "Proposing a new constitution"
+    newConstitution <- arbitrary
+    constitutionId <- submitGovAction $ NewConstitution SNothing newConstitution
+    submitYesVote_ (CommitteeVoter hotKey) constitutionId
+    submitYesVote_ (DRepVoter credDRep) constitutionId
+    constitutionGAS <- getGovActionState constitutionId
+
+    logEntry "Testing conformance"
+    treasury <- getsNES $ nesEsL . esAccountStateL . asTreasuryL
+    let execCtx = ConwayRatifyExecContext treasury [constitutionGAS]
+    ratEnv <- getRatifyEnv
+    govSt <- getsNES $ nesEsL . epochStateGovStateL
+    let
+      ratSt = getRatifyState govSt
+      result =
+        testConformance @ConwayFn @"RATIFY" @Conway
+          execCtx
+          ratEnv
+          ratSt
+          (RatifySignal (constitutionGAS SSeq.:<| mempty))
+    pure result

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances.hs
@@ -301,7 +301,7 @@ instance (IsConwayUniv fn, Typeable r, Crypto c) => HasSpec fn (KeyHash r c) whe
   genFromTypeSpec _ =
     pureGen $
       oneof
-        [ pickFromFixedPool 100
+        [ pickFromFixedPool 20
         , arbitrary
         ]
   cardinalTypeSpec _ = TrueSpec
@@ -621,7 +621,7 @@ instance (IsConwayUniv fn, HashAlgorithm a, Typeable b) => HasSpec fn (Hash a b)
   genFromTypeSpec _ =
     pureGen $
       oneof
-        [ pickFromFixedPool 100
+        [ pickFromFixedPool 20
         , arbitrary
         ]
   cardinalTypeSpec _ = TrueSpec

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances.hs
@@ -298,7 +298,12 @@ instance (IsConwayUniv fn, Typeable r, Crypto c) => HasSpec fn (KeyHash r c) whe
   type TypeSpec fn (KeyHash r c) = ()
   emptySpec = ()
   combineSpec _ _ = TrueSpec
-  genFromTypeSpec _ = pureGen arbitrary
+  genFromTypeSpec _ =
+    pureGen $
+      oneof
+        [ pickFromFixedPool 100
+        , arbitrary
+        ]
   cardinalTypeSpec _ = TrueSpec
   shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
@@ -602,11 +607,23 @@ cScriptHashObj = con @"ScriptHashObj"
 instance HasSimpleRep (ScriptHash c)
 instance (IsConwayUniv fn, Crypto c) => HasSpec fn (ScriptHash c)
 
+pickFromFixedPool :: Arbitrary a => Int -> Gen a
+pickFromFixedPool n =
+  oneof
+    [ variant seed arbitrary
+    | seed <- [0 .. n]
+    ]
+
 instance (IsConwayUniv fn, HashAlgorithm a, Typeable b) => HasSpec fn (Hash a b) where
   type TypeSpec fn (Hash a b) = ()
   emptySpec = ()
   combineSpec _ _ = TrueSpec
-  genFromTypeSpec _ = pureGen arbitrary
+  genFromTypeSpec _ =
+    pureGen $
+      oneof
+        [ pickFromFixedPool 100
+        , arbitrary
+        ]
   cardinalTypeSpec _ = TrueSpec
   shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True


### PR DESCRIPTION
# Description

This is supposed to make it easier to find a counterexample for IntersectMBO/formal-ledger-specifications#514

I managed to catch the bug with the modified generators by making it more likely to generate the same credential in multiple places. I also created an ImpTest that uses a manually constructed state to reproduce the bug.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
