### PR TITLE
Updated translation of `UnRegDRep` deposit

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -22,8 +22,8 @@ source-repository-package
   type: git
   location: https://github.com/IntersectMBO/formal-ledger-specifications.git
   subdir: generated
-  tag: d12f11db8ba86df1a20b5649292c95f254f1e40c
-  --sha256: 0dk9n4abxbdhd8w3zacvzh4dyxpr68n5iafhnv39yhb8hx6kwggs
+  tag: 58f4b078a7e0df0c49264b78090122e75679585f
+  --sha256: sha256-iEqucpja/0/5Tvnjr2drFlz58f3x3kUpInVjZfcePBQ=
 -- NOTE: If you would like to update the above, look for the `MAlonzo-code`
 -- branch in the `formal-ledger-specifications` repo and copy the SHA of
 -- the commit you need. The `MAlonzo-code` branch functions like an alternative

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
@@ -47,9 +47,10 @@ instance SpecTranslate ctx (ConwayGovCert c) where
       <$> toSpecRep c
       <*> toSpecRep d
       <*> pure ()
-  toSpecRep (ConwayUnRegDRep c _) =
+  toSpecRep (ConwayUnRegDRep c d) =
     Agda.DeRegDRep
       <$> toSpecRep c
+      <*> toSpecRep d
   toSpecRep (ConwayUpdateDRep c _) =
     Agda.RegDRep
       <$> toSpecRep c


### PR DESCRIPTION
# Description

This PR updates the translation of `ConwayUnRegDRepCert` to also translate the deposit field which was previously missing from the spec type.

This will also let us merge IntersectMBO/formal-ledger-specifications#513

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
