### PR TITLE
Ts additions prime spec cert steps

### DIFF
--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
@@ -460,7 +460,7 @@ genNextDelta
                           vkeyPairs
                           (mkScriptWits @era msigPairs mempty)
                           (hashAnnotated txBody)
-                  pure
+                  pure $
                     delta
                       { extraWitnesses = extraWitnesses <> newWits
                       , extraInputs = extraInputs <> Set.fromList inputs

--- a/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
+++ b/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
@@ -23,6 +23,7 @@ library
         Test.Cardano.Ledger.Conformance
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Core
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway
+        Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base
 
     hs-source-dirs:   src
     other-modules:
@@ -35,7 +36,6 @@ library
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Certs
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Gov
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.GovCert
-        Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Pool
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway.hs
@@ -1,5 +1,6 @@
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway (
   module X,
+  ConwayRatifyExecContext (..),
 ) where
 
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base as X (
@@ -11,7 +12,7 @@ import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base as X (
   nameGovAction,
  )
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert as X (nameTxCert)
-import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Certs as X ()
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Certs as X (nameCerts)
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg as X (nameDelegCert)
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Gov as X ()
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.GovCert as X (nameGovCert)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
@@ -10,16 +10,21 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Certs () where
+module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Certs (nameCerts) where
 
 import Cardano.Ledger.Conway
+import Cardano.Ledger.Conway.TxCert
+import Constrained
 import Data.Bifunctor (first)
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as Map
+import Data.Sequence (Seq)
 import qualified Data.Text as T
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base
 import Test.Cardano.Ledger.Constrained.Conway
+import Test.Cardano.Ledger.Imp.Common hiding (context)
 
 instance
   IsConwayUniv fn =>
@@ -29,11 +34,45 @@ instance
 
   environmentSpec _ = certsEnvSpec
 
-  stateSpec _ _ = certStateSpec
+  stateSpec context _ =
+    constrained $ \x ->
+      match x $ \vstate pstate dstate ->
+        [ satisfies vstate vStateSpec
+        , satisfies pstate pStateSpec
+        , -- temporary workaround because Spec does some extra tests, that the implementation does not, in the bootstrap phase.
+          satisfies dstate (bootstrapDStateSpec (ccecWithdrawals context))
+        ]
 
-  signalSpec _ _ _ = txCertsSpec
+  signalSpec _ env state = txCertsSpec env state
 
   runAgdaRule env st sig =
     first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
       . computationResultToEither
       $ Agda.certsStep' env st sig
+  classOf = Just . nameCerts
+
+  testConformance ctx env st sig = property $ do
+    -- The results of runConformance are Agda types, the `ctx` is a Haskell type, we extract and translate the Withdrawal keys.
+    specWithdrawalCredSet <-
+      translateWithContext () (Map.keysSet (Map.mapKeys snd (ccecWithdrawals ctx)))
+    (implResTest, agdaResTest) <- runConformance @"CERTS" @fn @Conway ctx env st sig
+    case (implResTest, agdaResTest) of
+      (Right haskell, Right spec) ->
+        checkConformance @"CERTS" @Conway @fn
+          ctx
+          env
+          st
+          sig
+          (Right (fixRewards specWithdrawalCredSet haskell))
+          (Right spec)
+        where
+          -- Zero out the rewards for credentials that are the key of some withdrawal
+          -- (found in the ctx) as this happens in the Spec, but not in the implementation.
+          fixRewards (Agda.MkHSSet creds) x =
+            x {Agda.dState' = (Agda.dState' x) {Agda.rewards' = zeroRewards (Agda.rewards' (Agda.dState' x))}}
+            where
+              zeroRewards (Agda.MkHSMap pairs) = Agda.MkHSMap (map (\(c, r) -> if elem c creds then (c, 0) else (c, r)) pairs)
+      _ -> checkConformance @"CERTS" @Conway @fn ctx env st sig implResTest agdaResTest
+
+nameCerts :: Seq (ConwayTxCert Conway) -> String
+nameCerts x = "Certs length " ++ show (length x)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
@@ -465,11 +465,10 @@ inputsGenerateWithin timeout =
   where
     aName = show (typeRep $ Proxy @rule)
 
--- | Translate a Haksell type 'a' whose translation context is 'ctx' into its Agda type, in the ImpTest monad.
+-- | Translate a Haskell type 'a' whose translation context is 'ctx' into its Agda type, in the ImpTest monad.
 translateWithContext :: SpecTranslate ctx a => ctx -> a -> ImpTestM era (SpecRep a)
 translateWithContext ctx x = do
   let
     expectRight' (Right y) = pure y
     expectRight' (Left e) = assertFailure (T.unpack e)
-  ans <- expectRight' . runSpecTransM ctx $ toSpecRep x
-  pure ans
+  expectRight' . runSpecTransM ctx $ toSpecRep x

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
@@ -20,6 +20,7 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
   runConformance,
   checkConformance,
   defaultTestConformance,
+  translateWithContext,
 ) where
 
 import Cardano.Ledger.BaseTypes (Inject (..), ShelleyBase)
@@ -463,3 +464,12 @@ inputsGenerateWithin timeout =
     genSig `generatesWithin` timeout
   where
     aName = show (typeRep $ Proxy @rule)
+
+-- | Translate a Haksell type 'a' whose translation context is 'ctx' into its Agda type, in the ImpTest monad.
+translateWithContext :: SpecTranslate ctx a => ctx -> a -> ImpTestM era (SpecRep a)
+translateWithContext ctx x = do
+  let
+    expectRight' (Right y) = pure y
+    expectRight' (Left e) = assertFailure (T.unpack e)
+  ans <- expectRight' . runSpecTransM ctx $ toSpecRep x
+  pure ans

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/ExecSpecRule/MiniTrace.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/ExecSpecRule/MiniTrace.hs
@@ -32,6 +32,7 @@ import Test.Cardano.Ledger.Generic.Proof
 
 -- \| This is where most of the ExecSpecRule instances are defined
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway (
+  nameCerts,
   nameDelegCert,
   nameEnact,
   nameEpoch,
@@ -76,7 +77,7 @@ minitraceEither witrule Proxy n0 = do
                 pure
                   ( Left
                       ( [ "\nSIGNAL = " ++ show (prettyA signal2)
-                        , "\nState = " ++ show (prettyA state)
+                        , "\nSTATE = " ++ show (prettyA state)
                         , "\nPredicateFailures"
                         ]
                           ++ map show (NE.toList ps)
@@ -163,6 +164,7 @@ spec = do
     prop "DELEG" (withMaxSuccess 50 (minitraceProp (DELEG Conway) (Proxy @ConwayFn) 50 nameDelegCert))
     prop "GOVCERT" (withMaxSuccess 50 (minitraceProp (GOVCERT Conway) (Proxy @ConwayFn) 50 nameGovCert))
     prop "CERT" (withMaxSuccess 50 (minitraceProp (CERT Conway) (Proxy @ConwayFn) 50 nameTxCert))
+    prop "CERTS" (withMaxSuccess 50 (minitraceProp (CERTS Conway) (Proxy @ConwayFn) 50 nameCerts))
     prop "RATIFY" (withMaxSuccess 50 (minitraceProp (RATIFY Conway) (Proxy @ConwayFn) 50 nameRatify))
     prop "ENACT" (withMaxSuccess 50 (minitraceProp (ENACT Conway) (Proxy @ConwayFn) 50 nameEnact))
     -- These properties do not have working 'signalSpec' Specifications yet.

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
@@ -31,9 +31,7 @@ spec = do
       prop "POOL" $ conformsToImpl @"POOL" @ConwayFn @Conway
       prop "CERT" $ conformsToImpl @"CERT" @ConwayFn @Conway
       prop "CERTS" $ conformsToImpl @"CERTS" @ConwayFn @Conway
-      -- FIX ME when the order of proposals is sorted correctly
-      -- PR 4584  change (xprop "GOV") to (prop "GOV")
-      xprop "GOV" $ conformsToImpl @"GOV" @ConwayFn @Conway
+      prop "GOV" $ conformsToImpl @"GOV" @ConwayFn @Conway
 
       xprop "UTXO" $ conformsToImpl @"UTXO" @ConwayFn @Conway
     describe "ImpTests" $ do

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
@@ -31,7 +31,10 @@ spec = do
       prop "POOL" $ conformsToImpl @"POOL" @ConwayFn @Conway
       prop "CERT" $ conformsToImpl @"CERT" @ConwayFn @Conway
       prop "CERTS" $ conformsToImpl @"CERTS" @ConwayFn @Conway
-      prop "GOV" $ conformsToImpl @"GOV" @ConwayFn @Conway
+      -- FIX ME when the order of proposals is sorted correctly
+      -- PR 4584  change (xprop "GOV") to (prop "GOV")
+      xprop "GOV" $ conformsToImpl @"GOV" @ConwayFn @Conway
+
       xprop "UTXO" $ conformsToImpl @"UTXO" @ConwayFn @Conway
     describe "ImpTests" $ do
       RatifyImp.spec

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
@@ -29,8 +29,8 @@ spec = do
       prop "DELEG" $ conformsToImpl @"DELEG" @ConwayFn @Conway
       prop "GOVCERT" $ conformsToImpl @"GOVCERT" @ConwayFn @Conway
       prop "POOL" $ conformsToImpl @"POOL" @ConwayFn @Conway
-      xprop "CERTS" $ conformsToImpl @"CERTS" @ConwayFn @Conway
       prop "CERT" $ conformsToImpl @"CERT" @ConwayFn @Conway
+      prop "CERTS" $ conformsToImpl @"CERTS" @ConwayFn @Conway
       prop "GOV" $ conformsToImpl @"GOV" @ConwayFn @Conway
       xprop "UTXO" $ conformsToImpl @"UTXO" @ConwayFn @Conway
     describe "ImpTests" $ do

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
@@ -25,8 +25,10 @@ certEnvSpec ::
   Specification fn (CertEnv (ConwayEra StandardCrypto))
 certEnvSpec =
   constrained $ \ce ->
-    match ce $ \_ pp _ _ _ ->
-      satisfies pp pparamsSpec
+    match ce $ \_slot pp _currEpoch _currCommittee proposals ->
+      [ satisfies pp pparamsSpec
+      , assert $ genHint 0 proposals
+      ]
 
 certStateSpec ::
   IsConwayUniv fn =>

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
@@ -25,9 +25,8 @@ certEnvSpec ::
   Specification fn (CertEnv (ConwayEra StandardCrypto))
 certEnvSpec =
   constrained $ \ce ->
-    match ce $ \_slot pp _currEpoch _currCommittee proposals ->
+    match ce $ \_slot pp _currEpoch _currCommittee _proposals ->
       [ satisfies pp pparamsSpec
-      , assert $ genHint 0 proposals
       ]
 
 certStateSpec ::

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
@@ -1,25 +1,177 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- | Specs necessary to generate, environment, state, and signal
 -- for the CERTS rule
 module Test.Cardano.Ledger.Constrained.Conway.Certs where
 
-import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), IsValid (..))
+import Cardano.Ledger.BaseTypes (Network (..), StrictMaybe (..))
+import Cardano.Ledger.CertState
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway (Conway)
 import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Conway.TxCert
-import Cardano.Ledger.Crypto (StandardCrypto)
+import Cardano.Ledger.Core
+import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
+import Cardano.Ledger.PoolParams (PoolParams (ppId))
+import Cardano.Ledger.UMap (dRepMap)
 import Constrained
-import Data.Sequence (Seq)
+import Constrained.Base (Pred (..))
+import Data.Default.Class
+import Data.Foldable (toList)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Sequence (Seq, fromList)
+import qualified Data.Set as Set
+import Data.Word (Word64)
+import Test.Cardano.Ledger.Constrained.Conway.Cert (txCertSpec)
+import Test.Cardano.Ledger.Constrained.Conway.Deleg (someZeros)
 import Test.Cardano.Ledger.Constrained.Conway.Instances
 import Test.Cardano.Ledger.Constrained.Conway.PParams (pparamsSpec)
+import Test.Cardano.Ledger.Generic.PrettyCore
+import Test.QuickCheck hiding (forAll)
+
+main :: IO ()
+main = do
+  context <- generate $ genFromSpec @ConwayFn (constrained $ \x -> sizeOf_ x ==. 3)
+  state <- generate $ genFromSpec @ConwayFn (bootstrapDStateSpec context)
+  putStrLn ("\n\nDRepDelegs\n" ++ show (prettyA (dRepMap (dsUnified state))))
+  putStrLn ("\n\nContext\n" ++ show (prettyA context))
+
+-- =======================================================
+
+-- The current spec is written to specify the phase when Voting goes into effect (the Post BootStrap phase)
+-- The implementation is written to implement the phase before Voting goes into effect (the BootStrap phase)
+-- This affects the Certs rule beacuse in the Post Bootstrap Phase, the spec tests that the (Credential 'Staking c)
+-- of every withdrawal, is delegated to some DRep, and that every Withdrawal is consistent with some Rewards entry.
+-- This is tested in the Spec, but it is not tested in implementation.
+-- A hardfork, sometime in the future will turn this test on.
+-- So to satisfy both we add this more refined DState spec, that make sure these post bootstrap tests are always True.
+-- The implementation does not test these, so the extra refinement has no effect here, the Spec will test them so refinement does matter there.
+-- Note that only the keyhash credentials need be delegated to a DRep.
+bootstrapDStateSpec ::
+  IsConwayUniv fn =>
+  CertsContext Conway ->
+  Specification fn (DState Conway)
+bootstrapDStateSpec withdrawals =
+  let isKey (ScriptHashObj _) = False
+      isKey (KeyHashObj _) = True
+      withdrawalPairs = Map.toList (Map.mapKeys snd (Map.map coinToWord64 withdrawals))
+      withdrawalKeys = Map.keysSet (Map.mapKeys snd withdrawals)
+   in constrained $ \ [var| dstate |] ->
+        match dstate $ \ [var| rewardMap |] _futureGenDelegs _genDelegs _rewards ->
+          [ assert $ sizeOf_ _futureGenDelegs ==. 0
+          , match _genDelegs $ \gd -> assert $ sizeOf_ gd ==. 0
+          , match _rewards $ \w x y z -> [sizeOf_ w ==. 0, sizeOf_ x ==. 0, y ==. lit mempty, z ==. lit mempty]
+          , match [var| rewardMap |] $ \ [var| rdMap |] [var| ptrMap |] [var| sPoolMap |] dRepDelegs ->
+              [ assertExplain (pure "dom sPoolMap is a subset of dom rdMap") $ dom_ sPoolMap `subset_` dom_ rdMap
+              , assertExplain (pure "dom ptrMap is empty") $ dom_ ptrMap ==. mempty
+              , assertExplain (pure "some rewards (not in withdrawals) are zero") $
+                  forAll rdMap $
+                    \ [var| keycoinpair |] -> match keycoinpair $ \cred [var| rdpair |] ->
+                      -- Apply this only to entries NOT IN the withdrawal set, since withdrawals already set the reward in the RDPair.
+                      whenTrue (not_ (member_ cred (lit withdrawalKeys))) (satisfies rdpair someZeros)
+              , forAll (lit (Set.filter isKey withdrawalKeys)) $ \cred -> assert $ member_ cred (dom_ dRepDelegs)
+              , forAll (lit withdrawalPairs) $ \ [var| pair |] ->
+                  match pair $ \ [var| cred |] [var| coin |] ->
+                    [ assert $ member_ cred (dom_ rdMap)
+                    , (caseOn (lookup_ cred rdMap))
+                        -- Nothing
+                        ( branch $ \_ -> FalsePred (pure ("credential " ++ show cred ++ " not in rdMap, bootstrapCertStateSpec"))
+                        )
+                        -- Just
+                        ( branch $ \ [var| rdpair |] ->
+                            match rdpair $ \rew _deposit -> assert $ rew ==. coin
+                        )
+                    ]
+              ]
+          ]
+
+coinToWord64 :: Coin -> Word64
+coinToWord64 (Coin n) = fromIntegral n
+
+type CertsContext era = (Map (Network, Credential 'Staking (EraCrypto era)) Coin)
+
+txZero :: AlonzoTx Conway
+txZero = AlonzoTx mkBasicTxBody mempty (IsValid True) def
 
 certsEnvSpec ::
   IsConwayUniv fn =>
-  Specification fn (CertsEnv (ConwayEra StandardCrypto))
-certsEnvSpec = constrained $ \env ->
-  match env $ \_ pp _ _ _ _ ->
-    satisfies pp pparamsSpec
+  Specification fn (CertsEnv Conway)
+certsEnvSpec = constrained $ \ce ->
+  match ce $ \tx pp _ _ a b ->
+    [ satisfies pp pparamsSpec
+    , assert $ tx ==. lit txZero
+    , assert $ a ==. lit SNothing
+    , assert $ sizeOf_ b ==. 0
+    ]
+
+-- | Project a CertEnv out of a CertsEnv (i.e drop the Tx)
+projectEnv :: CertsEnv Conway -> CertEnv Conway
+projectEnv x =
+  CertEnv
+    { cePParams = certsPParams x
+    , ceSlotNo = certsSlotNo x
+    , ceCurrentEpoch = certsCurrentEpoch x
+    , ceCurrentCommittee = certsCurrentCommittee x
+    , ceCommitteeProposals = certsCommitteeProposals x
+    }
+
+-- | Specify a pair of List and Seq, where they have essentially the same elements
+--   EXCEPT, the Seq has duplicate keys filtered out.
+listSeqPairSpec ::
+  IsConwayUniv fn =>
+  CertsEnv Conway ->
+  CertState Conway ->
+  Specification fn ([ConwayTxCert Conway], Seq (ConwayTxCert Conway))
+listSeqPairSpec env state =
+  constrained' $ \list seqs ->
+    [ assert $ sizeOf_ list <=. 5
+    , forAll list $ \x -> satisfies x (txCertSpec (projectEnv env) state)
+    , reify list (fromList . noSameKeys) (\x -> seqs ==. x)
+    ]
 
 txCertsSpec ::
-  Specification fn (Seq (ConwayTxCert (ConwayEra StandardCrypto)))
-txCertsSpec = TrueSpec
+  IsConwayUniv fn =>
+  CertsEnv Conway ->
+  CertState Conway ->
+  Specification fn (Seq (ConwayTxCert Conway))
+txCertsSpec env state =
+  constrained $ \seqs ->
+    exists
+      (\eval -> pure $ toList (eval seqs))
+      (\list -> satisfies (pair_ list seqs) (listSeqPairSpec env state))
+
+-- | Used to aggregate the key used in registering a Certificate. Different
+--   certificates use different kinds of Keys, that allows us to use one
+--   type to represent all kinds of keys (Similar to DepositPurpose)
+data CertKey c
+  = StakeKey !(Credential 'Staking c)
+  | PoolKey !(KeyHash 'StakePool c)
+  | DRepKey !(Credential 'DRepRole c)
+  | ColdKey !(Credential 'ColdCommitteeRole c)
+  deriving (Eq, Show, Ord)
+
+-- | Compute the aggregate key type of a Certificater
+txCertKey :: ConwayTxCert era -> CertKey (EraCrypto era)
+txCertKey (ConwayTxCertDeleg (ConwayRegCert x _)) = StakeKey x
+txCertKey (ConwayTxCertDeleg (ConwayUnRegCert x _)) = StakeKey x
+txCertKey (ConwayTxCertDeleg (ConwayDelegCert x _)) = StakeKey x
+txCertKey (ConwayTxCertDeleg (ConwayRegDelegCert x _ _)) = StakeKey x
+txCertKey (ConwayTxCertPool (RegPool x)) = PoolKey (ppId x)
+txCertKey (ConwayTxCertPool (RetirePool x _)) = PoolKey x
+txCertKey (ConwayTxCertGov (ConwayRegDRep x _ _)) = DRepKey x
+txCertKey (ConwayTxCertGov (ConwayUnRegDRep x _)) = DRepKey x
+txCertKey (ConwayTxCertGov (ConwayUpdateDRep x _)) = DRepKey x
+txCertKey (ConwayTxCertGov (ConwayAuthCommitteeHotKey x _)) = ColdKey x
+txCertKey (ConwayTxCertGov (ConwayResignCommitteeColdKey x _)) = ColdKey x
+
+noSameKeys :: [ConwayTxCert era] -> [ConwayTxCert era]
+noSameKeys [] = []
+noSameKeys (x : xs) = x : noSameKeys (filter (\y -> txCertKey x /= txCertKey y) xs)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
@@ -10,7 +10,7 @@
 module Test.Cardano.Ledger.Constrained.Conway.Certs where
 
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), IsValid (..))
-import Cardano.Ledger.BaseTypes (Network (..), StrictMaybe (..))
+import Cardano.Ledger.BaseTypes (Network (..))
 import Cardano.Ledger.CertState
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (Conway)
@@ -105,11 +105,10 @@ certsEnvSpec ::
   IsConwayUniv fn =>
   Specification fn (CertsEnv Conway)
 certsEnvSpec = constrained $ \ce ->
-  match ce $ \tx pp _ _ a b ->
+  match ce $ \tx pp _slot _currepoch _currcommittee commproposals ->
     [ satisfies pp pparamsSpec
     , assert $ tx ==. lit txZero
-    , assert $ a ==. lit SNothing
-    , assert $ sizeOf_ b ==. 0
+    , genHint 3 commproposals
     ]
 
 -- | Project a CertEnv out of a CertsEnv (i.e drop the Tx)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- | Specs necessary to generate, environment, state, and signal
 -- for the DELEG rule
@@ -28,18 +30,21 @@ import Test.Cardano.Ledger.Constrained.Conway.PParams (pparamsSpec)
 --   without this in the DState, it is hard to generate the ConwayUnRegCert
 --   certificate, since it requires a rewards balance of 0.
 someZeros :: forall fn. IsConwayUniv fn => Specification fn RDPair
-someZeros = constrained $ \rdpair ->
-  match rdpair $ \reward _deposit ->
-    satisfies reward (chooseSpec (1, constrained $ \x -> assert $ x ==. lit 0) (3, TrueSpec))
+someZeros = constrained $ \ [var| someRdpair |] ->
+  match someRdpair $ \ [var| reward |] _deposit ->
+    satisfies reward (chooseSpec (1, constrained $ \ [var| x |] -> assert $ x ==. lit 0) (3, TrueSpec))
 
 dStateSpec ::
   forall fn.
   IsConwayUniv fn =>
   Specification fn (DState (ConwayEra StandardCrypto))
-dStateSpec = constrained $ \ds ->
-  match ds $ \rewardMap _futureGenDelegs _genDelegs _rewards ->
-    match rewardMap $ \rdMap ptrMap sPoolMap _dRepMap ->
-      [ assertExplain (pure "dom sPoolMap is a subset of dom rdMap") $ dom_ sPoolMap `subset_` dom_ rdMap
+dStateSpec = constrained $ \ [var| dstate |] ->
+  match dstate $ \ [var| rewardMap |] _futureGenDelegs _genDelegs _rewards ->
+    match rewardMap $ \ [var| rdMap |] [var| ptrMap |] [var| sPoolMap |] _dRepMap ->
+      [ assert $ sizeOf_ _futureGenDelegs ==. 0
+      , match _genDelegs $ \gd -> assert $ sizeOf_ gd ==. 0
+      , match _rewards $ \w x y z -> [sizeOf_ w ==. 0, sizeOf_ x ==. 0, y ==. lit mempty, z ==. lit mempty]
+      , assertExplain (pure "dom sPoolMap is a subset of dom rdMap") $ dom_ sPoolMap `subset_` dom_ rdMap
       , assertExplain (pure "dom ptrMap is empty") $ dom_ ptrMap ==. mempty
       , assertExplain (pure "some rewards are zero") $
           forAll rdMap $

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/GovCert.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/GovCert.hs
@@ -9,7 +9,6 @@
 -- for the GOVCERT rule
 module Test.Cardano.Ledger.Constrained.Conway.GovCert where
 
-import Cardano.Ledger.BaseTypes (EpochNo (..))
 import Cardano.Ledger.CertState
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Governance
@@ -23,13 +22,19 @@ import Lens.Micro
 import Test.Cardano.Ledger.Constrained.Conway.Instances
 import Test.Cardano.Ledger.Constrained.Conway.PParams
 
+vStateSpec :: Specification fn (VState (ConwayEra StandardCrypto))
+vStateSpec = TrueSpec
+
+{- There are no hard constraints on VState, but sometimes when something fails we want to
+-- limit how big some of the fields of VState are. In that case one might use something
+-- like this. Note that genHint limits the size, but does not require an exact size.
 vStateSpec :: IsConwayUniv fn => Specification fn (VState (ConwayEra StandardCrypto))
--- vStateSpec = TrueSpec
-vStateSpec = constrained' $ \x y z ->
-  [ assert $ sizeOf_ x ==. 1
-  , match y $ \cs -> assert $ sizeOf_ cs ==. 1
-  , assert $ z ==. lit (EpochNo 4)
+vStateSpec = constrained' $ \ [var|_dreps|] [var|_commstate|] [var|dormantepochs|] ->
+  [ genHint 5 dreps -- assert $ sizeOf_ dreps >=. 1
+  , match commstate $ \ [var|committeestate|] -> genHint 5 committeestate
+  , assert $ dormantepochs >=. lit (EpochNo 4)
   ]
+-}
 
 govCertSpec ::
   IsConwayUniv fn =>
@@ -65,7 +70,7 @@ govCertSpec ConwayGovCertEnv {..} vs =
               assert $ elem_ (pair_ credUnreg coinUnreg) (lit (Map.toList deposits))
           )
           -- ConwayUpdateDRep
-          ( branchW 1 $ \keyupdate _ ->
+          ( branchW 1 $ \ [var|keyupdate|] _ ->
               member_ keyupdate reps
           )
           -- ConwayAuthCommitteeHotKey

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/GovCert.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/GovCert.hs
@@ -9,6 +9,7 @@
 -- for the GOVCERT rule
 module Test.Cardano.Ledger.Constrained.Conway.GovCert where
 
+import Cardano.Ledger.BaseTypes (EpochNo (..))
 import Cardano.Ledger.CertState
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Governance
@@ -22,8 +23,13 @@ import Lens.Micro
 import Test.Cardano.Ledger.Constrained.Conway.Instances
 import Test.Cardano.Ledger.Constrained.Conway.PParams
 
-vStateSpec :: Specification fn (VState (ConwayEra StandardCrypto))
-vStateSpec = TrueSpec
+vStateSpec :: IsConwayUniv fn => Specification fn (VState (ConwayEra StandardCrypto))
+-- vStateSpec = TrueSpec
+vStateSpec = constrained' $ \x y z ->
+  [ assert $ sizeOf_ x ==. 1
+  , match y $ \cs -> assert $ sizeOf_ cs ==. 1
+  , assert $ z ==. lit (EpochNo 4)
+  ]
 
 govCertSpec ::
   IsConwayUniv fn =>

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/PParams.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/PParams.hs
@@ -62,6 +62,7 @@ pparamsSpec =
             , assert $ cppPoolDeposit /=. lit (THKD mempty)
             , assert $ cppGovActionDeposit /=. lit (THKD mempty)
             , assert $ cppDRepDeposit /=. lit (THKD mempty)
+            , assert $ cppProtocolVersion ==. lit (ProtVer (natVersion @10) 0)
             , match cppEMax $ \epochInterval ->
-                lit (EpochInterval 0) <. epochInterval
+                lit (EpochInterval 5) <. epochInterval
             ]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Pool.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Pool.hs
@@ -39,9 +39,7 @@ pStateSpec ::
   Specification fn (PState (ConwayEra StandardCrypto))
 pStateSpec = constrained $ \ps ->
   match ps $ \stakePoolParams futureStakePoolParams retiring deposits ->
-    [ assert $ sizeOf_ stakePoolParams ==. lit 3
-    , assert $ sizeOf_ futureStakePoolParams ==. lit 1
-    , assertExplain (pure "dom of retiring is a subset of dom of stakePoolParams") $
+    [ assertExplain (pure "dom of retiring is a subset of dom of stakePoolParams") $
         dom_ retiring `subset_` dom_ stakePoolParams
     , assertExplain (pure "dom of deposits is dom of stakePoolParams") $
         dom_ deposits ==. dom_ stakePoolParams

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Pool.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Pool.hs
@@ -39,7 +39,9 @@ pStateSpec ::
   Specification fn (PState (ConwayEra StandardCrypto))
 pStateSpec = constrained $ \ps ->
   match ps $ \stakePoolParams futureStakePoolParams retiring deposits ->
-    [ assertExplain (pure "dom of retiring is a subset of dom of stakePoolParams") $
+    [ assert $ sizeOf_ stakePoolParams ==. lit 3
+    , assert $ sizeOf_ futureStakePoolParams ==. lit 1
+    , assertExplain (pure "dom of retiring is a subset of dom of stakePoolParams") $
         dom_ retiring `subset_` dom_ stakePoolParams
     , assertExplain (pure "dom of deposits is dom of stakePoolParams") $
         dom_ deposits ==. dom_ stakePoolParams

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -258,6 +258,7 @@ import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits (..))
 import Cardano.Ledger.Shelley.UTxO (ShelleyScriptsNeeded (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import Cardano.Ledger.UMap (
+  RDPair (..),
   dRepMap,
   depositMap,
   fromCompact,
@@ -3678,3 +3679,21 @@ instance Reflect era => PrettyA (CertState era) where
       , ("pState", prettyA certPState)
       , ("dState", prettyA certDState)
       ]
+
+instance PrettyA x => PrettyA (Seq x) where
+  prettyA x = prettyA (toList x)
+
+instance PrettyA (ConwayRules.CertsEnv era) where
+  prettyA (ConwayRules.CertsEnv _ _ slot epoch com prop) =
+    ppRecord
+      "CertsEnv"
+      [ ("Tx", ppString "Tx")
+      , ("pparams", ppString "PParams")
+      , ("slot", pcSlotNo slot)
+      , ("epoch", ppEpochNo epoch)
+      , ("committee", ppStrictMaybe pcCommittee com)
+      , ("proposals", ppMap pcGovPurposeId prettyA prop)
+      ]
+
+instance PrettyA RDPair where
+  prettyA (RDPair x y) = prettyA (fromCompact x, fromCompact y)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -81,9 +81,13 @@ stsPropertyV2 specEnv specState specSig prop =
                 pure $ case res of
                   Left pfailures -> counterexample (show $ prettyA pfailures) $ property False
                   Right st' ->
-                    counterexample (show $ ppString "st' = " <> prettyA st') $
-                      conformsToSpec @fn st' (specState env)
-                        .&&. prop env st sig st'
+                    counterexample
+                      ( show $
+                          ppString "st' = "
+                            <> prettyA st'
+                            <> ppString ("\nspec = \n" ++ show (specState env))
+                      )
+                      $ conformsToSpec @fn st' (specState env) .&&. prop env st sig st'
 
 -- STS properties ---------------------------------------------------------
 


### PR DESCRIPTION
Get the CERTS conformance rule working.
This is complicated because of slight differences between the implementation and the spec.
These difference come in two flavors
1. The spec makes more tests than the implementation using the withdrawals which are not part of the implementation. The solution to these difference is to randomly generate more refined inputs, which will make the spec tests pass, and will be ignored by the implementation.
2. The Spec zeros out the reward balances for the withdrawals. The solution to this is to "fixup" the implementation test by zeroing out its reward balances for the withdrawals before comparing the final states of the implementation and the spec.

This PR was complicated by a bug in the MAlonzo code, that has now been fixed.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
