### PR TITLE
Drep registration expiration fix

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Version history for `cardano-ledger-conway`
 
-## 1.16.1.0
+## 1.17.0.0
 
+* Replace GOVCERT `updateDRepExpiry` with `computeDRepExpiry`
 * Added `Eq`, `Show`, `NFData` and `Generic` instances for `CertsEnv`
 * Add `delegateToDRep` and `redelegateDRep`
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
@@ -54,7 +54,7 @@ import Cardano.Ledger.Conway.Governance (
  )
 import Cardano.Ledger.Conway.Rules.Cert (CertEnv (CertEnv), ConwayCertEvent, ConwayCertPredFailure)
 import Cardano.Ledger.Conway.Rules.Deleg (ConwayDelegPredFailure)
-import Cardano.Ledger.Conway.Rules.GovCert (ConwayGovCertPredFailure, updateDRepExpiry)
+import Cardano.Ledger.Conway.Rules.GovCert (ConwayGovCertPredFailure, computeDRepExpiry)
 import Cardano.Ledger.DRep (drepExpiryL)
 import Cardano.Ledger.Shelley.API (
   CertState (..),
@@ -236,7 +236,10 @@ conwayCertsTransition = do
             Map.foldlWithKey'
               ( \dreps voter _ -> case voter of
                   DRepVoter cred ->
-                    Map.adjust (updateDRepExpiry drepActivity currentEpoch numDormantEpochs) cred dreps
+                    Map.adjust
+                      (drepExpiryL .~ computeDRepExpiry drepActivity currentEpoch numDormantEpochs)
+                      cred
+                      dreps
                   _ -> dreps
               )
               vsDReps

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
@@ -53,6 +53,7 @@ import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.DRep (DRepState (..), drepAnchorL, drepDepositL, drepExpiryL)
 import Cardano.Ledger.Keys (KeyRole (ColdCommitteeRole, DRepRole))
+import qualified Cardano.Ledger.Shelley.HardForks as HF (bootstrapPhase)
 import Cardano.Slotting.Slot (EpochInterval, binOpEpochNo)
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended (
@@ -235,7 +236,15 @@ conwayGovCertTransition = do
           { vsDReps =
               Map.insert
                 cred
-                (DRepState (addEpochInterval cgceCurrentEpoch ppDRepActivity) mAnchor ppDRepDeposit)
+                ( DRepState
+                    ( computeDRepExpiryVersioned
+                        cgcePParams
+                        cgceCurrentEpoch
+                        (vState ^. vsNumDormantEpochsL)
+                    )
+                    mAnchor
+                    ppDRepDeposit
+                )
                 vsDReps
           }
     ConwayUnRegDRep cred refund -> do
@@ -273,6 +282,22 @@ conwayGovCertTransition = do
       case pProcGovAction gasProposalProcedure of
         UpdateCommittee _ _ newMembers _ -> Map.member coldCred newMembers
         _ -> False
+
+computeDRepExpiryVersioned ::
+  ConwayEraPParams era =>
+  PParams era ->
+  -- | Current epoch
+  EpochNo ->
+  -- | The count of the dormant epochs
+  EpochNo ->
+  EpochNo
+computeDRepExpiryVersioned pp currentEpoch numDormantEpochs
+  -- Starting with version 10, we correctly take into account the number of dormant epochs
+  -- when registering a drep
+  | HF.bootstrapPhase (pp ^. ppProtocolVersionL) =
+      addEpochInterval currentEpoch (pp ^. ppDRepActivityL)
+  | otherwise =
+      computeDRepExpiry (pp ^. ppDRepActivityL) currentEpoch numDormantEpochs
 
 computeDRepExpiry ::
   -- | DRepActivity PParam

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -58,7 +58,7 @@ library
         cardano-ledger-alonzo >=1.9 && <1.11,
         cardano-ledger-babbage ^>=1.9,
         cardano-ledger-binary ^>=1.3,
-        cardano-ledger-conway >=1.13 && <1.17,
+        cardano-ledger-conway >=1.13 && <1.18,
         cardano-ledger-core ^>=1.14,
         cardano-ledger-mary ^>=1.7,
         cardano-ledger-shelley ^>=1.13,


### PR DESCRIPTION
# Description

Registering a drep at a time when there were dormant epochs results in the drep expiry to be set greater than expected (ppDrepActivity + currentEpoch + vsNumDormantEpochs). 

This PR changes this value, by setting the expiration using the same calculation as for UpdateDrep signal, namely: ppDrepActivity + currentEpoch - vsNumDormantEpochs,  since the latter value is going to be added to the computation by CERTS,if there are proposals in the transaction. 

 

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
