### PR TITLE
Enable `QuerySpec` in cardano-ledger-api for both Conway versions

### DIFF
--- a/libs/cardano-ledger-api/test/Tests.hs
+++ b/libs/cardano-ledger-api/test/Tests.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Main where
 
+import Cardano.Ledger.BaseTypes (natVersion)
 import Cardano.Ledger.Conway (Conway)
 import qualified Test.Cardano.Ledger.Api.State.Imp.QuerySpec as ImpQuery (spec)
 import qualified Test.Cardano.Ledger.Api.State.QuerySpec as StateQuery (spec)
@@ -9,7 +11,7 @@ import qualified Test.Cardano.Ledger.Api.Tx as Tx (spec)
 import qualified Test.Cardano.Ledger.Api.Tx.Body as TxBody (spec)
 import qualified Test.Cardano.Ledger.Api.Tx.Out as TxOut (spec)
 import Test.Cardano.Ledger.Common
-import Test.Cardano.Ledger.Conway.ImpTest (withImpState)
+import Test.Cardano.Ledger.Conway.ImpTest (withImpStateWithProtVer)
 
 -- ====================================================================================
 
@@ -22,8 +24,10 @@ apiSpec =
       TxBody.spec
     describe "State" $ do
       StateQuery.spec
-    describe "Imp" $ withImpState @Conway $ do
-      ImpQuery.spec @Conway
+    describe "Imp" $
+      forM_ [natVersion @9, natVersion @10] $ \v ->
+        withImpStateWithProtVer @Conway v $ do
+          ImpQuery.spec @Conway
 
 main :: IO ()
 main = ledgerTestMain apiSpec


### PR DESCRIPTION
and adjust failing tests

# Description

When writing a test for the drep registration expiry, I had to implement different checks for version 9 and 10. 
I noticed that these tests are running only for version 9, so I enabled them to run also for 10.
I had to make some adjustments to two tests to make them pass, since they haven't been running for a while, so a few things diverged since they were written and executed.  

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
