### PR TITLE
Fix cddl hash data comment

### DIFF
--- a/eras/conway/impl/cddl-files/conway.cddl
+++ b/eras/conway/impl/cddl-files/conway.cddl
@@ -422,10 +422,13 @@ script = [0, native_script //
 ; 
 ;     Finally, note that in the case that a transaction includes datums but does not
 ;     include the redeemers field, the script data format becomes (in hex):
-;     [ 80 | datums | A0 ]
-;     corresponding to a CBOR empty list and an empty map.
-;     Note that a transaction might include the redeemers field and  it to the
-;     empty map, in which case the user supplied encoding of the empty map is used.
+;     [ A0 | datums | A0 ]
+;     corresponding to a CBOR empty map and an empty map for language view.
+;     This empty redeeemer case has changed from the previous eras, since default
+;     representation for redeemers has been changed to a map. Also whenever redeemers are
+;     supplied either as a map or as an array they must contain at least one element,
+;     therefore there is no way to override this behavior by providing a custom
+;     representation for empty redeemers.
 script_data_hash = $hash32
 
 script_ref = #6.24(bytes .cbor script)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/CDDL.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/CDDL.hs
@@ -366,11 +366,13 @@ script_data_hash =
 
     Finally, note that in the case that a transaction includes datums but does not
     include the redeemers field, the script data format becomes (in hex):
-    [ 80 | datums | A0 ]
-    corresponding to a CBOR empty list and an empty map.
-    Note that a transaction might include the redeemers field and  it to the
-    empty map, in which case the user supplied encoding of the empty map is used.
-
+    [ A0 | datums | A0 ]
+    corresponding to a CBOR empty map and an empty map for language view.
+    This empty redeeemer case has changed from the previous eras, since default
+    representation for redeemers has been changed to a map. Also whenever redeemers are
+    supplied either as a map or as an array they must contain at least one element,
+    therefore there is no way to override this behavior by providing a custom
+    representation for empty redeemers.
   |]
     $ "script_data_hash" =:= hash32
 


### PR DESCRIPTION
# Description

Default representation for empty redeemers has changed in Conway, we need to reflect it in the CDDL comment.  

```haskell
ghci> originalBytes (mempty :: Redeemers Babbage) == [0x80]
True
ghci> originalBytes (mempty :: Redeemers Conway) == [0xA0]
True
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
