### PR TITLE
Fix `fourmolu` version for `pre-commit` shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,7 @@
 
         # see flake `variants` below for alternative compilers
         defaultCompiler = "ghc966";
+        fourmoluVersion = "0.16.2.0";
         # We use cabalProject' to ensure we don't build the plan for
         # all systems.
         cabalProject = nixpkgs.haskell-nix.cabalProject' ({config, ...}: {
@@ -106,7 +107,7 @@
               }
               // lib.optionalAttrs (config.compiler-nix-name == defaultCompiler) {
                 # tools that work only with default compiler
-                fourmolu = "0.16.2.0";
+                fourmolu = fourmoluVersion;
                 hlint = "3.8";
                 haskell-language-server = "2.9.0.0";
               };
@@ -249,6 +250,9 @@
                   src = ./.;
                   hooks = {
                     fourmolu.enable = true;
+                  };
+                  tools = {
+                    fourmolu = p.tool "fourmolu" fourmoluVersion;
                   };
                 };
               in


### PR DESCRIPTION
# Description
Although the executable in the shell was pointing to the correct store location, the entry field in `.pre-commit-config.yaml` was referencing a different version.
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
