### PR TITLE
Fix wording in the spec where unclaimed rewards go into treasury

### DIFF
--- a/eras/shelley/formal-spec/epoch.tex
+++ b/eras/shelley/formal-spec/epoch.tex
@@ -1408,8 +1408,7 @@ The $\fun{applyRUpd}$ function does the following:
         that have been deregistered after the reward update was created.
         \begin{itemize}
           \item Rewards for accounts that are still registered are added to the reward mappings.
-          \item The sum of the unregistered rewards are added to the reserves.
-            % TODO - We may want to add these to the treasury instead, to be consistent with our other choices.
+          \item The sum of the unregistered rewards are added to the treasury.
         \end{itemize}
     \end{itemize}
 


### PR DESCRIPTION
# Description

#1636 specified where unclaimed rewards should go and #1642 fixed it, but the wording was not fixed and TODO left hanging in the spec.

Implementation has changed since then, but I can confirm that this is still the case, any rewards that stake account accumulated will be transferred to the treasury, if that account unregistered prior to the epoch boundary in which distribution happens:

https://github.com/IntersectMBO/cardano-ledger/blob/ac9d9d6086de6fc20d7f777e39dc2c674f8c5f66/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/IncrementalStake.hs#L307

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
