### PR TITLE
Byron: Force startTime in genesis data to be strict

### DIFF
--- a/eras/byron/ledger/impl/CHANGELOG.md
+++ b/eras/byron/ledger/impl/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Revision history for `cardano-ledger-byron`
 
-## 1.0.1.1
+## 1.0.2.0
 
-*
+* `force` `startTime` in the evaluation of genesis-data. #4574
 
 ## 1.0.1.0
 

--- a/eras/byron/ledger/impl/cardano-ledger-byron.cabal
+++ b/eras/byron/ledger/impl/cardano-ledger-byron.cabal
@@ -243,6 +243,7 @@ library
         contra-tracer,
         cryptonite,
         Cabal-syntax,
+        deepseq,
         digest,
         directory,
         filepath,

--- a/eras/byron/ledger/impl/cardano-ledger-byron.cabal
+++ b/eras/byron/ledger/impl/cardano-ledger-byron.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-byron
-version:            1.0.1.0
+version:            1.0.2.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -243,7 +243,6 @@ library
         contra-tracer,
         cryptonite,
         Cabal-syntax,
-        deepseq,
         digest,
         directory,
         filepath,

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Genesis/Data.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Genesis/Data.hs
@@ -29,6 +29,7 @@ import Cardano.Crypto (
  )
 import Cardano.Ledger.Binary
 import Cardano.Prelude
+import Control.DeepSeq ((<$!!>))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import Data.List (lookup)
@@ -48,6 +49,7 @@ import Text.JSON.Canonical (
   parseCanonicalJSON,
   renderCanonicalJSON,
  )
+import Prelude (id)
 
 -- | Genesis data contains all data which determines consensus rules. It must be
 --   same for all nodes. It's used to initialize global state, slotting, etc.
@@ -93,7 +95,7 @@ instance MonadError SchemaError m => FromJSON m GenesisData where
     GenesisData
       <$> fromJSField obj "bootStakeholders"
       <*> fromJSField obj "heavyDelegation"
-      <*> fromJSField obj "startTime"
+      <*> (id <$!!> fromJSField obj "startTime")
       <*> fromJSField obj "nonAvvmBalances"
       <*> fromJSField obj "blockVersionData"
       -- The above is called blockVersionData for backwards compatibility with

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Genesis/Data.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Genesis/Data.hs
@@ -29,7 +29,6 @@ import Cardano.Crypto (
  )
 import Cardano.Ledger.Binary
 import Cardano.Prelude
-import Control.DeepSeq ((<$!!>))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import Data.List (lookup)
@@ -49,7 +48,6 @@ import Text.JSON.Canonical (
   parseCanonicalJSON,
   renderCanonicalJSON,
  )
-import Prelude (id)
 
 -- | Genesis data contains all data which determines consensus rules. It must be
 --   same for all nodes. It's used to initialize global state, slotting, etc.
@@ -95,7 +93,7 @@ instance MonadError SchemaError m => FromJSON m GenesisData where
     GenesisData
       <$> fromJSField obj "bootStakeholders"
       <*> fromJSField obj "heavyDelegation"
-      <*> (id <$!!> fromJSField obj "startTime")
+      <*> (force <$> fromJSField obj "startTime")
       <*> fromJSField obj "nonAvvmBalances"
       <*> fromJSField obj "blockVersionData"
       -- The above is called blockVersionData for backwards compatibility with


### PR DESCRIPTION
# Description

Closes #3598 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
