### PR TITLE
Remove `minMajorPV` and `maxMajorPV` from `Constants`

### DIFF
--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-allegra
-version:            1.6.0.0
+version:            1.6.0.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -68,7 +68,7 @@ library
         cardano-crypto-class,
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-core ^>=1.14,
-        cardano-ledger-shelley ^>=1.13,
+        cardano-ledger-shelley >=1.13 && <1.15,
         cardano-strict-containers,
         cardano-slotting,
         cborg,

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-alonzo
-version:            1.10.2.0
+version:            1.10.2.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -81,7 +81,7 @@ library
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-core ^>=1.14,
         cardano-ledger-mary ^>=1.7,
-        cardano-ledger-shelley ^>=1.13,
+        cardano-ledger-shelley >=1.13 && <1.15,
         cardano-slotting,
         cardano-strict-containers,
         containers,

--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-alonzo-test
-version:       1.2.1.3
+version:       1.2.1.4
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK
@@ -48,8 +48,8 @@ library
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
         cardano-ledger-core:{cardano-ledger-core, testlib} >=1.11,
         cardano-ledger-allegra >=1.2,
-        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.6,
-        cardano-ledger-shelley-test >=1.2,
+        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.14,
+        cardano-ledger-shelley-test >=1.4.1,
         cardano-ledger-shelley-ma-test >=1.2,
         cardano-ledger-mary >=1.4,
         cardano-protocol-tpraos >=1.0,

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -341,13 +341,13 @@ genAlonzoPParams ::
   Constants ->
   Gen (PParams (AlonzoEra c))
 genAlonzoPParams constants = do
-  let constants' = constants {minMajorPV = natVersion @5}
   -- This ensures that "_d" field is not 0, and that the major protocol version
   -- is large enough to not trigger plutus script failures
   -- (no bultins are alllowed before major version 5).
-  maryPP <- Shelley.genPParams @(MaryEra c) constants'
+  maryPP' <- Shelley.genPParams @(MaryEra c) constants
+  let maryPP = maryPP' & ppProtocolVersionL .~ ProtVer (natVersion @5) 0
+      prices = Prices minBound minBound
   coinPerWord <- CoinPerWord . Coin <$> choose (1, 5)
-  let prices = Prices minBound minBound
   -- prices <- Prices <$> (Coin <$> choose (100, 5000)) <*> (Coin <$> choose (100, 5000))
   let maxTxExUnits = ExUnits (5 * bigMem + 1) (5 * bigStep + 1)
   -- maxTxExUnits <- ExUnits <$> (choose (100, 5000)) <*> (choose (100, 5000))

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-babbage
-version:            1.9.0.0
+version:            1.9.0.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -77,7 +77,7 @@ library
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-core ^>=1.14,
         cardano-ledger-mary ^>=1.7,
-        cardano-ledger-shelley ^>=1.13,
+        cardano-ledger-shelley >=1.13 && <1.15,
         cardano-strict-containers,
         containers,
         deepseq,

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -90,7 +90,7 @@ library
         cardano-ledger-babbage ^>=1.9,
         cardano-ledger-core ^>=1.14,
         cardano-ledger-mary ^>=1.7,
-        cardano-ledger-shelley ^>=1.13,
+        cardano-ledger-shelley >=1.13 && <1.15,
         cardano-slotting,
         cardano-strict-containers,
         containers,

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-mary
-version:            1.7.0.0
+version:            1.7.0.1
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -77,7 +77,7 @@ library
         cardano-ledger-allegra ^>=1.6,
         cardano-ledger-binary ^>=1.3,
         cardano-ledger-core ^>=1.14,
-        cardano-ledger-shelley ^>=1.13,
+        cardano-ledger-shelley >=1.13 && <1.15,
         containers,
         deepseq,
         groups,

--- a/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
+++ b/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-ledger-shelley-ma-test
-version:       1.2.2.3
+version:       1.2.2.4
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK
@@ -49,7 +49,7 @@ library
         containers,
         hashable,
         cardano-ledger-shelley-test >=1.1,
-        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.12 && <1.14,
+        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.12 && <1.15,
         cardano-strict-containers,
         microlens,
         mtl,

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Version history for `cardano-ledger-shelley`
 
-## 1.13.1.0
+## 1.14.0.0
 
 * Added `EncCBOR` instances for:
   * `UtxoEnv`
   * `CertEnv`
+
+### `testlib`
+
+* Remove `minMajorPV` and `maxMajorPV` from `Constants`
 
 ## 1.13.0.0
 

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-shelley
-version:            1.13.1.0
+version:            1.14.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Constants.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Constants.hs
@@ -7,7 +7,6 @@ module Test.Cardano.Ledger.Shelley.Constants (
 )
 where
 
-import Cardano.Ledger.BaseTypes (Version, natVersion)
 import Cardano.Ledger.Coin (Coin (..))
 import Data.Word (Word64)
 
@@ -93,8 +92,6 @@ data Constants = Constants
   , maxTreasury :: Integer
   , minReserves :: Integer
   , maxReserves :: Integer
-  , minMajorPV :: Version
-  , maxMajorPV :: Version
   , genTxStableUtxoSize :: Int
   -- ^ When generating Tx, we want the UTxO size to fluctuate around this point. If
   --   it gets too small, we can't balance the fee, too large it gets too complicated.
@@ -146,8 +143,6 @@ defaultConstants =
     , maxTreasury = 10000000
     , minReserves = 1000000
     , maxReserves = 10000000
-    , minMajorPV = natVersion @2
-    , maxMajorPV = maxBound
     , genTxStableUtxoSize = 100
     , genTxUtxoIncrement = 3
     }

--- a/eras/shelley/test-suite/CHANGELOG.md
+++ b/eras/shelley/test-suite/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Version history for `cardano-ledger-shelley-test`
 
-## 1.4.0.4
+## 1.4.1.0
 
 *
 

--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-shelley-test
-version:            1.4.0.3
+version:            1.4.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -79,7 +79,7 @@ library
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.3,
         cardano-ledger-byron,
         cardano-ledger-core:{cardano-ledger-core, testlib} >=1.11 && <1.15,
-        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.12 && <1.14,
+        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.14,
         cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib} >=1.0.1,
         cardano-slotting:{cardano-slotting, testlib},
         cborg,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Update.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Update.hs
@@ -99,10 +99,13 @@ genIntervalInThousands lower upper =
   unsafeBoundRational <$> genRationalInThousands lower upper
 
 genPParams ::
+  forall era.
   (EraPParams era, ProtVerAtMost era 4, ProtVerAtMost era 6) =>
   Constants ->
   Gen (PParams era)
-genPParams c@Constants {maxMinFeeA, maxMinFeeB, minMajorPV, maxMajorPV} = do
+genPParams c@Constants {maxMinFeeA, maxMinFeeB} = do
+  let lowMajorPV = eraProtVerLow @era
+      highMajorPV = eraProtVerHigh @era
   minFeeA <- genInteger 0 (unCoin maxMinFeeA)
   minFeeB <- genInteger 0 (unCoin maxMinFeeB)
   (maxBBSize, maxTxSize, maxBHSize) <- szGen
@@ -115,7 +118,7 @@ genPParams c@Constants {maxMinFeeA, maxMinFeeB, minMajorPV, maxMajorPV} = do
   tau <- genTau
   d <- genDecentralisationParam
   extraEntropy <- genExtraEntropy
-  protocolVersion <- genProtocolVersion minMajorPV maxMajorPV
+  protocolVersion <- genProtocolVersion lowMajorPV highMajorPV
   minUTxOValue <- genMinUTxOValue
   minPoolCost <- genMinPoolCost
   pure $
@@ -236,7 +239,8 @@ genShelleyPParamsUpdate ::
   Constants ->
   PParams era ->
   Gen (PParamsUpdate era)
-genShelleyPParamsUpdate c@Constants {maxMinFeeA, maxMinFeeB, maxMajorPV} pp = do
+genShelleyPParamsUpdate c@Constants {maxMinFeeA, maxMinFeeB} pp = do
+  let highMajorPV = succ (eraProtVerHigh @era)
   -- TODO generate Maybe types so not all updates are full
   minFeeA <- genM $ genInteger 0 (unCoin maxMinFeeA)
   minFeeB <- genM $ genInteger 0 (unCoin maxMinFeeB)
@@ -253,7 +257,7 @@ genShelleyPParamsUpdate c@Constants {maxMinFeeA, maxMinFeeB, maxMajorPV} pp = do
   tau <- genM genTau
   d <- genM genDecentralisationParam
   extraEntropy <- genM genExtraEntropy
-  protocolVersion <- genM $ genNextProtocolVersion pp maxMajorPV
+  protocolVersion <- genM $ genNextProtocolVersion pp highMajorPV
   minUTxOValue <- genM genMinUTxOValue
   minPoolCost <- genM genMinPoolCost
   pure $

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/IncrementalStake.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/IncrementalStake.hs
@@ -23,7 +23,6 @@ import Test.Cardano.Ledger.Shelley.Rules.TestChain (
  )
 
 import Cardano.Ledger.Address (Addr (..))
-import Cardano.Ledger.BaseTypes (natVersion)
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Core
@@ -54,7 +53,7 @@ import qualified Data.Map.Strict as Map
 import Data.Proxy
 import qualified Data.VMap as VMap
 import Lens.Micro hiding (ix)
-import Test.Cardano.Ledger.Shelley.Constants (defaultConstants, maxMajorPV)
+import Test.Cardano.Ledger.Shelley.Constants (defaultConstants)
 import Test.Cardano.Ledger.Shelley.Generator.Core (GenEnv)
 import Test.Cardano.Ledger.Shelley.Generator.EraGen (EraGen (..))
 import Test.Cardano.Ledger.Shelley.Generator.ShelleyEraGen ()
@@ -87,7 +86,7 @@ incrStakeComputationTest ::
   TestTree
 incrStakeComputationTest =
   testProperty "incremental stake calc" $
-    forAllChainTrace @era longTraceLen defaultConstants {maxMajorPV = natVersion @8} $ \tr -> do
+    forAllChainTrace @era longTraceLen defaultConstants $ \tr -> do
       let ssts = sourceSignalTargets tr
 
       conjoin . concat $
@@ -152,7 +151,7 @@ incrStakeComparisonTest ::
   TestTree
 incrStakeComparisonTest Proxy =
   testProperty "Incremental stake distribution at epoch boundaries agrees" $
-    forAllChainTrace traceLen (defaultConstants {maxMajorPV = natVersion @8}) $ \tr ->
+    forAllChainTrace traceLen defaultConstants $ \tr ->
       conjoin $
         map (\(SourceSignalTarget _ target _) -> checkIncrementalStake @era ((nesEs . chainNes) target)) $
           filter (not . sameEpoch) (sourceSignalTargets tr)

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -61,7 +61,7 @@ library
         cardano-ledger-conway >=1.13 && <1.18,
         cardano-ledger-core ^>=1.14,
         cardano-ledger-mary ^>=1.7,
-        cardano-ledger-shelley ^>=1.13,
+        cardano-ledger-shelley >=1.13 && <1.15,
         cardano-strict-containers,
         containers,
         FailT,


### PR DESCRIPTION
# Description

We no longer need to specify the correct protocol version values for a specific era, we have this information available at the type level.

Moreover it was totally wrong to generate protocol version values for `PParamsUpdate` too far into the future of a particular era, eg. major protocol version 9 makes no sense in Shelley era.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
