### PR TITLE
Stop generation of haddock for internal modules

### DIFF
--- a/scripts/haddocks.sh
+++ b/scripts/haddocks.sh
@@ -29,7 +29,9 @@ CABAL_OPTS=(
 
 # Generate  `doc-index.json` and `doc-index.html` per package, to assemble them later at the top level.
 HADDOCK_OPTS=(
-  --haddock-all
+  --haddock-executables
+  --haddock-tests
+  --haddock-benchmarks
   --haddock-html
   --haddock-hyperlink-source
   --haddock-option "--show-all"


### PR DESCRIPTION
# Description

Disable `--haddock-all`

Closes #3582 

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
