### PR TITLE
cardano-node-9.1 backport: Implement a fix for inability to deserialize pointers in Conway

### DIFF
--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-shelley`
 
+## 1.12.3.0
+
+* Fix deserialization of `IncrementalStake` in Conway era: #4591
+
 ## 1.12.2.0
 
 *

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-shelley
-version:            1.12.2.0
+version:            1.12.3.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -213,7 +213,7 @@ instance Arbitrary AccountState where
   shrink = genericShrink
 
 instance Crypto c => Arbitrary (IncrementalStake c) where
-  arbitrary = IStake <$> arbitrary <*> arbitrary
+  arbitrary = IStake <$> arbitrary <*> pure mempty -- Once in Conway Ptrs Map will be removed
   shrink = genericShrink
 
 ------------------------------------------------------------------------------------------


### PR DESCRIPTION
# Description

This is a backport of https://github.com/IntersectMBO/cardano-ledger/pull/4589 for `cardano-node-9.1`

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
