### PR TITLE
fix both reproduceable failures

### DIFF
--- a/libs/constrained-generators/src/Constrained/GenT.hs
+++ b/libs/constrained-generators/src/Constrained/GenT.hs
@@ -29,7 +29,6 @@
 
 module Constrained.GenT where
 
-import Control.Applicative
 import Control.Monad
 import Data.Foldable
 import Data.List.NonEmpty qualified as NE
@@ -79,12 +78,6 @@ instance Monad GE where
   FatalError es err >>= _ = FatalError es err
   GenError es err >>= _ = GenError es err
   Result _ a >>= k = k a
-
-instance Alternative GE where
-  empty = GenError [] (pure "Not a real error. makes GE have Alternative instance")
-  m@FatalError {} <|> _ = m
-  GenError {} <|> m = m
-  Result es x <|> _ = Result es x
 
 instance MonadGenError GE where
   genError neStr = GenError [] neStr

--- a/libs/constrained-generators/src/Constrained/Spec/Map.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Map.hs
@@ -50,7 +50,7 @@ import Test.QuickCheck (Arbitrary (..), frequency, genericShrink, shrinkList)
 instance Ord a => Sized (Map.Map a b) where
   sizeOf = toInteger . Map.size
   liftSizeSpec sz cant = typeSpec $ defaultMapSpec {mapSpecSize = TypeSpec sz cant}
-  liftMemberSpec xs = typeSpec $ defaultMapSpec {mapSpecSize = MemberSpec xs}
+  liftMemberSpec xs = typeSpec $ defaultMapSpec {mapSpecSize = MemberSpec (nubOrd xs)}
   sizeOfTypeSpec (MapSpec _ mustk mustv size _ _) =
     geqSpec (sizeOf mustk)
       <> geqSpec (sizeOf mustv)
@@ -334,7 +334,7 @@ instance BaseUniverse fn => Functions (MapFn fn) fn where
           | HOLE :? Value (m :: Map k v) :> Nil <- ctx ->
               if Nothing `conformsToSpec` spec
                 then notMemberSpec [k | (k, v) <- Map.toList m, not $ Just v `conformsToSpec` spec]
-                else MemberSpec $ Map.keys $ Map.filter (`conformsToSpec` spec) (Just <$> m)
+                else MemberSpec $ nubOrd $ Map.keys $ Map.filter (`conformsToSpec` spec) (Just <$> m)
           | Value k :! NilCtx HOLE <- ctx
           , Evidence <- prerequisites @fn @(Map k v) ->
               constrained $ \m ->

--- a/libs/constrained-generators/src/Constrained/Spec/Pairs.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Pairs.hs
@@ -24,6 +24,7 @@ import Constrained.Base
 import Constrained.Core
 import Constrained.List
 import Constrained.Univ
+import Data.List (nub)
 import qualified Data.List.NonEmpty as NE
 import Test.QuickCheck
 
@@ -107,7 +108,7 @@ instance BaseUniverse fn => Functions (PairFn fn) fn where
                   -- TODO: better error message
                   | otherwise ->
                       ErrorSpec (NE.fromList ["propagateSpecFun (Pair a b) has conformance failure on b", show sb])
-                MemberSpec es -> MemberSpec (sameSnd es)
+                MemberSpec es -> MemberSpec $ nub (sameSnd es)
       | Value a :! NilCtx HOLE <- ctx ->
           let sameFst ps = [b | Prod a' b <- ps, a == a']
            in case spec of
@@ -116,7 +117,7 @@ instance BaseUniverse fn => Functions (PairFn fn) fn where
                   -- TODO: better error message
                   | otherwise ->
                       ErrorSpec (NE.fromList ["propagateSpecFun (Pair a b) has conformance failure on a", show sa])
-                MemberSpec es -> MemberSpec (sameFst es)
+                MemberSpec es -> MemberSpec $ nub (sameFst es)
 
   rewriteRules Fst ((pairView -> Just (x, _)) :> Nil) = Just x
   rewriteRules Snd ((pairView -> Just (_, y)) :> Nil) = Just y


### PR DESCRIPTION
Resolves #4588
Fixed two different problems that result in suchThat failures.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
