### PR TITLE
Stop reporting invalid refund when stake credential is not registered

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
@@ -179,18 +179,18 @@ conwayDelegTransition = do
       checkStakeKeyNotRegistered stakeCred dsUnified
       pure $ dState {dsUnified = registerStakeCredential stakeCred dsUnified}
     ConwayUnRegCert stakeCred sMayDeposit -> do
+      forM_ sMayDeposit $ checkDepositAgainstPaidDeposit stakeCred dsUnified
       checkStakeKeyIsRegistered stakeCred dsUnified
       checkStakeKeyHasZeroRewardBalance stakeCred dsUnified
-      forM_ sMayDeposit $ checkDepositAgainstPaidDeposit stakeCred dsUnified
       pure $ dState {dsUnified = UM.domDeleteAll (Set.singleton stakeCred) dsUnified}
     ConwayDelegCert stakeCred delegatee -> do
-      checkStakeDelegateeRegistered pools delegatee
       checkStakeKeyIsRegistered stakeCred dsUnified
+      checkStakeDelegateeRegistered pools delegatee
       pure $ dState {dsUnified = processDelegation stakeCred delegatee dsUnified}
     ConwayRegDelegCert stakeCred delegatee deposit -> do
       checkDepositAgainstPParams deposit
-      checkStakeDelegateeRegistered pools delegatee
       checkStakeKeyNotRegistered stakeCred dsUnified
+      checkStakeDelegateeRegistered pools delegatee
       pure $
         dState
           { dsUnified = processDelegation stakeCred delegatee $ registerStakeCredential stakeCred dsUnified

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
@@ -166,18 +166,14 @@ conwayDelegTransition = do
     ppKeyDeposit = pp ^. ppKeyDepositL
     checkDepositAgainstPParams deposit =
       deposit == ppKeyDeposit ?! IncorrectDepositDELEG deposit
-    registerStakeCredential stakeCred dsUnified =
-      -- This looks like it should have been a right-biased union, so that the (reward, deposit) pair would be inserted
-      -- (or overwritten) in the UMap. But since we are sure that the stake credential isn't a member yet
-      -- it will still work. The reason we cannot use a right-biased union here is because UMap treats deposits specially
-      -- in right-biased unions, and is unable to accept new deposits.
-      UM.RewDepUView dsUnified
-        UM.∪ (stakeCred, UM.RDPair (UM.CompactCoin 0) (UM.compactCoinOrError ppKeyDeposit))
+    registerStakeCredential stakeCred =
+      let rdPair = UM.RDPair (UM.CompactCoin 0) (UM.compactCoinOrError ppKeyDeposit)
+       in UM.insert stakeCred rdPair $ UM.RewDepUView dsUnified
   case c of
     ConwayRegCert stakeCred sMayDeposit -> do
       forM_ sMayDeposit checkDepositAgainstPParams
       checkStakeKeyNotRegistered stakeCred dsUnified
-      pure $ dState {dsUnified = registerStakeCredential stakeCred dsUnified}
+      pure $ dState {dsUnified = registerStakeCredential stakeCred}
     ConwayUnRegCert stakeCred sMayDeposit -> do
       forM_ sMayDeposit $ checkDepositAgainstPaidDeposit stakeCred dsUnified
       checkStakeKeyIsRegistered stakeCred dsUnified
@@ -193,7 +189,7 @@ conwayDelegTransition = do
       checkStakeDelegateeRegistered pools delegatee
       pure $
         dState
-          { dsUnified = processDelegation stakeCred delegatee $ registerStakeCredential stakeCred dsUnified
+          { dsUnified = processDelegation stakeCred delegatee $ registerStakeCredential stakeCred
           }
   where
     checkStakeDelegateeRegistered pools =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
@@ -21,7 +21,7 @@ module Cardano.Ledger.Conway.Rules.Deleg (
   ConwayDelegEnv (..),
 ) where
 
-import Cardano.Ledger.BaseTypes (ShelleyBase)
+import Cardano.Ledger.BaseTypes (ShelleyBase, StrictMaybe (..))
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders (
   Decode (From, Invalid, SumD, Summands),
@@ -44,7 +44,7 @@ import Cardano.Ledger.PoolParams (PoolParams)
 import Cardano.Ledger.Shelley.LedgerState (DState (..))
 import qualified Cardano.Ledger.UMap as UM
 import Control.DeepSeq (NFData)
-import Control.Monad (forM_)
+import Control.Monad (forM_, guard)
 import Control.State.Transition (
   BaseM,
   Environment,
@@ -55,6 +55,7 @@ import Control.State.Transition (
   State,
   TRC (TRC),
   TransitionRule,
+  failOnJust,
   judgmentContext,
   transitionRules,
   (?!),
@@ -174,8 +175,16 @@ conwayDelegTransition = do
       forM_ sMayDeposit checkDepositAgainstPParams
       checkStakeKeyNotRegistered stakeCred dsUnified
       pure $ dState {dsUnified = registerStakeCredential stakeCred}
-    ConwayUnRegCert stakeCred sMayDeposit -> do
-      forM_ sMayDeposit $ checkDepositAgainstPaidDeposit stakeCred dsUnified
+    ConwayUnRegCert stakeCred sMayRefund -> do
+      let mRDPair = UM.lookup stakeCred $ UM.RewDepUView dsUnified
+          checkInvalidRefund = do
+            SJust suppliedRefund <- Just sMayRefund
+            -- we don't want to report invalid refund when stake credential is not registered:
+            UM.RDPair _ actualRefund <- mRDPair
+            -- we return offending refund only when it doesn't match the expected one:
+            guard (suppliedRefund /= UM.fromCompact actualRefund)
+            Just suppliedRefund
+      failOnJust checkInvalidRefund IncorrectDepositDELEG
       checkStakeKeyIsRegistered stakeCred dsUnified
       checkStakeKeyHasZeroRewardBalance stakeCred dsUnified
       pure $ dState {dsUnified = UM.domDeleteAll (Set.singleton stakeCred) dsUnified}
@@ -208,10 +217,6 @@ conwayDelegTransition = do
         DelegStake sPool -> delegStake stakeCred sPool dsUnified
         DelegVote dRep -> delegVote stakeCred dRep dsUnified
         DelegStakeVote sPool dRep -> delegVote stakeCred dRep $ delegStake stakeCred sPool dsUnified
-    checkDepositAgainstPaidDeposit stakeCred dsUnified deposit =
-      Just deposit
-        == fmap (UM.fromCompact . UM.rdDeposit) (UM.lookup stakeCred $ UM.RewDepUView dsUnified)
-          ?! IncorrectDepositDELEG deposit
     checkStakeKeyNotRegistered stakeCred dsUnified =
       UM.notMember stakeCred (UM.RewDepUView dsUnified) ?! StakeKeyRegisteredDELEG stakeCred
     checkStakeKeyIsRegistered stakeCred dsUnified =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
@@ -62,6 +62,7 @@ import Control.State.Transition (
  )
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (isJust)
 import qualified Data.Set as Set
 import Data.Void (Void)
 import GHC.Generics (Generic)
@@ -184,9 +185,13 @@ conwayDelegTransition = do
             -- we return offending refund only when it doesn't match the expected one:
             guard (suppliedRefund /= UM.fromCompact actualRefund)
             Just suppliedRefund
+          checkStakeKeyHasZeroRewardBalance = do
+            UM.RDPair compactReward _ <- mRDPair
+            guard (compactReward /= mempty)
+            Just $ UM.fromCompact compactReward
       failOnJust checkInvalidRefund IncorrectDepositDELEG
-      checkStakeKeyIsRegistered stakeCred dsUnified
-      checkStakeKeyHasZeroRewardBalance stakeCred dsUnified
+      isJust mRDPair ?! StakeKeyNotRegisteredDELEG stakeCred
+      failOnJust checkStakeKeyHasZeroRewardBalance StakeKeyHasNonZeroRewardAccountBalanceDELEG
       pure $ dState {dsUnified = UM.domDeleteAll (Set.singleton stakeCred) dsUnified}
     ConwayDelegCert stakeCred delegatee -> do
       checkStakeKeyIsRegistered stakeCred dsUnified
@@ -221,6 +226,3 @@ conwayDelegTransition = do
       UM.notMember stakeCred (UM.RewDepUView dsUnified) ?! StakeKeyRegisteredDELEG stakeCred
     checkStakeKeyIsRegistered stakeCred dsUnified =
       UM.member stakeCred (UM.RewDepUView dsUnified) ?! StakeKeyNotRegisteredDELEG stakeCred
-    checkStakeKeyHasZeroRewardBalance stakeCred dsUnified =
-      let mReward = UM.rdReward <$> UM.lookup stakeCred (UM.RewDepUView dsUnified)
-       in forM_ mReward $ \r -> r == mempty ?! StakeKeyHasNonZeroRewardAccountBalanceDELEG (UM.fromCompact r)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
@@ -166,11 +166,18 @@ conwayDelegTransition = do
     ppKeyDeposit = pp ^. ppKeyDepositL
     checkDepositAgainstPParams deposit =
       deposit == ppKeyDeposit ?! IncorrectDepositDELEG deposit
+    registerStakeCredential stakeCred dsUnified =
+      -- This looks like it should have been a right-biased union, so that the (reward, deposit) pair would be inserted
+      -- (or overwritten) in the UMap. But since we are sure that the stake credential isn't a member yet
+      -- it will still work. The reason we cannot use a right-biased union here is because UMap treats deposits specially
+      -- in right-biased unions, and is unable to accept new deposits.
+      UM.RewDepUView dsUnified
+        UM.∪ (stakeCred, UM.RDPair (UM.CompactCoin 0) (UM.compactCoinOrError ppKeyDeposit))
   case c of
     ConwayRegCert stakeCred sMayDeposit -> do
       forM_ sMayDeposit checkDepositAgainstPParams
-      dsUnified' <- checkAndAcceptDepositForStakeCred stakeCred ppKeyDeposit dsUnified
-      pure $ dState {dsUnified = dsUnified'}
+      checkStakeKeyNotRegistered stakeCred dsUnified
+      pure $ dState {dsUnified = registerStakeCredential stakeCred dsUnified}
     ConwayUnRegCert stakeCred sMayDeposit -> do
       checkStakeKeyIsRegistered stakeCred dsUnified
       checkStakeKeyHasZeroRewardBalance stakeCred dsUnified
@@ -183,8 +190,11 @@ conwayDelegTransition = do
     ConwayRegDelegCert stakeCred delegatee deposit -> do
       checkDepositAgainstPParams deposit
       checkStakeDelegateeRegistered pools delegatee
-      dsUnified' <- checkAndAcceptDepositForStakeCred stakeCred deposit dsUnified
-      pure $ dState {dsUnified = processDelegation stakeCred delegatee dsUnified'}
+      checkStakeKeyNotRegistered stakeCred dsUnified
+      pure $
+        dState
+          { dsUnified = processDelegation stakeCred delegatee $ registerStakeCredential stakeCred dsUnified
+          }
   where
     checkStakeDelegateeRegistered pools =
       let checkPoolRegistered targetPool =
@@ -193,16 +203,6 @@ conwayDelegTransition = do
             DelegStake targetPool -> checkPoolRegistered targetPool
             DelegStakeVote targetPool _ -> checkPoolRegistered targetPool
             DelegVote _ -> pure ()
-    -- Whenever we want to accept new deposit, we must always check if the stake credential isn't already registered.
-    checkAndAcceptDepositForStakeCred stakeCred deposit dsUnified = do
-      checkStakeKeyNotRegistered stakeCred dsUnified
-      -- This looks like it should have been a right-biased union, so that the (reward, deposit) pair would be inserted
-      -- (or overwritten) in the UMap. But since we are sure that the stake credential isn't a member yet
-      -- it will still work. The reason we cannot use a right-biased union here is because UMap treats deposits specially
-      -- in right-biased unions, and is unable to accept new deposits.
-      pure $
-        UM.RewDepUView dsUnified
-          UM.∪ (stakeCred, UM.RDPair (UM.CompactCoin 0) (UM.compactCoinOrError deposit))
     delegStake stakeCred sPool dsUnified =
       UM.SPoolUView dsUnified UM.⨃ Map.singleton stakeCred sPool
     delegVote stakeCred dRep dsUnified =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
@@ -161,7 +161,7 @@ conwayDelegTransition = do
   TRC
     ( ConwayDelegEnv pp pools
       , dState@DState {dsUnified}
-      , c
+      , cert
       ) <-
     judgmentContext
   let
@@ -171,10 +171,30 @@ conwayDelegTransition = do
     registerStakeCredential stakeCred =
       let rdPair = UM.RDPair (UM.CompactCoin 0) (UM.compactCoinOrError ppKeyDeposit)
        in UM.insert stakeCred rdPair $ UM.RewDepUView dsUnified
-  case c of
+    delegStake stakeCred sPool umap =
+      UM.SPoolUView umap UM.⨃ Map.singleton stakeCred sPool
+    delegVote stakeCred dRep umap =
+      UM.DRepUView umap UM.⨃ Map.singleton stakeCred dRep
+    processDelegation stakeCred delegatee =
+      case delegatee of
+        DelegStake sPool -> delegStake stakeCred sPool
+        DelegVote dRep -> delegVote stakeCred dRep
+        DelegStakeVote sPool dRep -> delegVote stakeCred dRep . delegStake stakeCred sPool
+    checkStakeKeyNotRegistered stakeCred =
+      UM.notMember stakeCred (UM.RewDepUView dsUnified) ?! StakeKeyRegisteredDELEG stakeCred
+    checkStakeKeyIsRegistered stakeCred =
+      UM.member stakeCred (UM.RewDepUView dsUnified) ?! StakeKeyNotRegisteredDELEG stakeCred
+    checkStakeDelegateeRegistered =
+      let checkPoolRegistered targetPool =
+            targetPool `Map.member` pools ?! DelegateeNotRegisteredDELEG targetPool
+       in \case
+            DelegStake targetPool -> checkPoolRegistered targetPool
+            DelegStakeVote targetPool _ -> checkPoolRegistered targetPool
+            DelegVote _ -> pure ()
+  case cert of
     ConwayRegCert stakeCred sMayDeposit -> do
       forM_ sMayDeposit checkDepositAgainstPParams
-      checkStakeKeyNotRegistered stakeCred dsUnified
+      checkStakeKeyNotRegistered stakeCred
       pure $ dState {dsUnified = registerStakeCredential stakeCred}
     ConwayUnRegCert stakeCred sMayRefund -> do
       let mRDPair = UM.lookup stakeCred $ UM.RewDepUView dsUnified
@@ -194,35 +214,14 @@ conwayDelegTransition = do
       failOnJust checkStakeKeyHasZeroRewardBalance StakeKeyHasNonZeroRewardAccountBalanceDELEG
       pure $ dState {dsUnified = UM.domDeleteAll (Set.singleton stakeCred) dsUnified}
     ConwayDelegCert stakeCred delegatee -> do
-      checkStakeKeyIsRegistered stakeCred dsUnified
-      checkStakeDelegateeRegistered pools delegatee
+      checkStakeKeyIsRegistered stakeCred
+      checkStakeDelegateeRegistered delegatee
       pure $ dState {dsUnified = processDelegation stakeCred delegatee dsUnified}
     ConwayRegDelegCert stakeCred delegatee deposit -> do
       checkDepositAgainstPParams deposit
-      checkStakeKeyNotRegistered stakeCred dsUnified
-      checkStakeDelegateeRegistered pools delegatee
+      checkStakeKeyNotRegistered stakeCred
+      checkStakeDelegateeRegistered delegatee
       pure $
         dState
           { dsUnified = processDelegation stakeCred delegatee $ registerStakeCredential stakeCred
           }
-  where
-    checkStakeDelegateeRegistered pools =
-      let checkPoolRegistered targetPool =
-            targetPool `Map.member` pools ?! DelegateeNotRegisteredDELEG targetPool
-       in \case
-            DelegStake targetPool -> checkPoolRegistered targetPool
-            DelegStakeVote targetPool _ -> checkPoolRegistered targetPool
-            DelegVote _ -> pure ()
-    delegStake stakeCred sPool dsUnified =
-      UM.SPoolUView dsUnified UM.⨃ Map.singleton stakeCred sPool
-    delegVote stakeCred dRep dsUnified =
-      UM.DRepUView dsUnified UM.⨃ Map.singleton stakeCred dRep
-    processDelegation stakeCred delegatee dsUnified =
-      case delegatee of
-        DelegStake sPool -> delegStake stakeCred sPool dsUnified
-        DelegVote dRep -> delegVote stakeCred dRep dsUnified
-        DelegStakeVote sPool dRep -> delegVote stakeCred dRep $ delegStake stakeCred sPool dsUnified
-    checkStakeKeyNotRegistered stakeCred dsUnified =
-      UM.notMember stakeCred (UM.RewDepUView dsUnified) ?! StakeKeyRegisteredDELEG stakeCred
-    checkStakeKeyIsRegistered stakeCred dsUnified =
-      UM.member stakeCred (UM.RewDepUView dsUnified) ?! StakeKeyNotRegisteredDELEG stakeCred

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
@@ -228,8 +228,12 @@ conwayGovCertTransition = do
         failOnJust coldCredResigned ConwayCommitteeHasPreviouslyResigned
         let isCurrentMember =
               strictMaybe False (Map.member coldCred . committeeMembers) cgceCurrentCommittee
+            committeeUpdateContainsColdCred GovActionState {gasProposalProcedure} =
+              case pProcGovAction gasProposalProcedure of
+                UpdateCommittee _ _ newMembers _ -> Map.member coldCred newMembers
+                _ -> False
             isPotentialFutureMember =
-              any (committeeUpdateContainsColdCred coldCred) cgceCommitteeProposals
+              any committeeUpdateContainsColdCred cgceCommitteeProposals
         isCurrentMember || isPotentialFutureMember ?! ConwayCommitteeIsUnknown coldCred
         pure
           vState
@@ -288,11 +292,6 @@ conwayGovCertTransition = do
       checkAndOverwriteCommitteeMemberState coldCred $ CommitteeHotCredential hotCred
     ConwayResignCommitteeColdKey coldCred anchor ->
       checkAndOverwriteCommitteeMemberState coldCred $ CommitteeMemberResigned anchor
-  where
-    committeeUpdateContainsColdCred coldCred GovActionState {gasProposalProcedure} =
-      case pProcGovAction gasProposalProcedure of
-        UpdateCommittee _ _ newMembers _ -> Map.member coldCred newMembers
-        _ -> False
 
 computeDRepExpiryVersioned ::
   ConwayEraPParams era =>


### PR DESCRIPTION
# Description

@teodanciu pointed out to me today that we report an invalid refund `IncorrectDepositDELEG` predicate failure whenever stake credential is not registered. This is at the very least confusing, so this PR fixes this.

Besides this fix this PR also improves performance:
* by avoiding redundant UMap lookups and by making validations lazy
* and improving performance of replay without validation, since it will not trigger those lookups.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
