### PR TITLE
Fix enacted `Set` in `GovInfoEvent`

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Version history for `cardano-ledger-conway`
 
 ## 1.17.0.0
+
 * Changed `ConwayWdrlNotDelegatedToDRep` to wrap `NonEmpty`
 * Add `showGovActionType`, `acceptedByEveryone`
 * Added `unRatifySignal`
@@ -12,6 +13,7 @@
   * `reDRepStateL`
   * `reCurrentEpochL`
   * `reCommitteeStateL`
+* Add a new field to `GovInfoEvent`
 
 ### `testlib`
 

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -141,13 +141,8 @@ library testlib
     build-depends:
         base,
         bytestring,
-        cardano-data:{cardano-data, testlib},
-        containers,
-        cuddle >=0.3.0.0,
-        plutus-ledger-api,
-        deepseq,
-        microlens,
         cardano-crypto-class,
+        cardano-data:{cardano-data, testlib},
         cardano-ledger-allegra,
         cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
         cardano-ledger-binary,
@@ -157,13 +152,18 @@ library testlib
         cardano-ledger-mary,
         cardano-ledger-shelley,
         cardano-strict-containers,
+        containers,
+        cuddle >=0.3.0.0,
         data-default-class,
+        deepseq,
         FailT,
         generic-random,
+        microlens,
         microlens-mtl,
         mtl,
-        text,
-        small-steps >=1.1
+        plutus-ledger-api,
+        small-steps >=1.1,
+        text
 
 executable huddle-cddl
     main-is:          Main.hs

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -145,7 +145,7 @@ library testlib
         cardano-data:{cardano-data, testlib},
         cardano-ledger-allegra,
         cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
-        cardano-ledger-binary,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
         cardano-ledger-babbage:{cardano-ledger-babbage, testlib} >=1.8.2,
         cardano-ledger-conway,
         cardano-ledger-core:{cardano-ledger-core, testlib},

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Proposals.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Proposals.hs
@@ -64,11 +64,11 @@ spec = do
         \( ProposalsForEnactment {pfeProposals, pfeToEnact, pfeToRemove, pfeToRetain} ::
             ProposalsForEnactment Conway
           ) -> do
-          let (ps', enacted, removedDueToEnactment, expiredRemoved) = proposalsApplyEnactment pfeToEnact Set.empty pfeProposals
-          expiredRemoved `shouldSatisfy` Map.null
-          enacted `shouldBe` fromElems gasId pfeToEnact
-          Map.keysSet removedDueToEnactment `shouldBe` pfeToRemove
-          proposalsSize ps' `shouldBe` Set.size pfeToRetain
+            let (ps', enacted, removedDueToEnactment, expiredRemoved) = proposalsApplyEnactment pfeToEnact Set.empty pfeProposals
+            expiredRemoved `shouldSatisfy` Map.null
+            enacted `shouldBe` fromElems gasId pfeToEnact
+            Map.keysSet removedDueToEnactment `shouldBe` pfeToRemove
+            proposalsSize ps' `shouldBe` Set.size pfeToRetain
       prop "Enacting non-member nodes throws an AssertionFailure" $
         \(ProposalsNewActions ps actions :: ProposalsNewActions Conway) ->
           (evaluate . force) (proposalsApplyEnactment (fromList actions) Set.empty ps)
@@ -77,16 +77,16 @@ spec = do
         \( ProposalsForEnactment {pfeProposals, pfeToEnact, pfeToRemove, pfeToRetain} ::
             ProposalsForEnactment Conway
           ) -> do
-          let (ps', enacted, removedDueToEnactment, expiredRemoved) =
-                proposalsApplyEnactment Seq.Empty pfeToRemove pfeProposals
-          enacted `shouldBe` mempty
-          removedDueToEnactment `shouldBe` mempty
-          Map.keysSet expiredRemoved `shouldBe` pfeToRemove
-          ps' `shouldBe` fst (proposalsRemoveWithDescendants pfeToRemove pfeProposals)
-          let enactMap = fromElems gasId pfeToEnact
-          let (emptyProposals, enactedMap) = proposalsRemoveWithDescendants (Map.keysSet enactMap) ps'
-          proposalsSize emptyProposals `shouldBe` Set.size pfeToRetain
-          enactedMap `shouldBe` enactMap
+            let (ps', enacted, removedDueToEnactment, expiredRemoved) =
+                  proposalsApplyEnactment Seq.Empty pfeToRemove pfeProposals
+            enacted `shouldBe` mempty
+            removedDueToEnactment `shouldBe` mempty
+            Map.keysSet expiredRemoved `shouldBe` pfeToRemove
+            ps' `shouldBe` fst (proposalsRemoveWithDescendants pfeToRemove pfeProposals)
+            let enactMap = fromElems gasId pfeToEnact
+            let (emptyProposals, enactedMap) = proposalsRemoveWithDescendants (Map.keysSet enactMap) ps'
+            proposalsSize emptyProposals `shouldBe` Set.size pfeToRetain
+            enactedMap `shouldBe` enactMap
       prop "Expiring non-member nodes throws an AssertionFailure" $
         \(ProposalsNewActions ps actions :: ProposalsNewActions Conway) ->
           (evaluate . force) (proposalsApplyEnactment Seq.Empty (Set.fromList $ gasId <$> actions) ps)
@@ -95,8 +95,8 @@ spec = do
         \( ProposalsForEnactment {pfeProposals, pfeToEnact, pfeToRemove, pfeToRetain} ::
             ProposalsForEnactment Conway
           ) -> do
-          let (ps', enacted, enactedRemoved, expiredRemoved) = proposalsApplyEnactment pfeToEnact pfeToRemove pfeProposals
-          Map.keysSet expiredRemoved `shouldBe` pfeToRemove
-          enactedRemoved `shouldBe` mempty
-          enacted `shouldBe` fromElems gasId pfeToEnact
-          proposalsSize ps' `shouldBe` Set.size pfeToRetain
+            let (ps', enacted, enactedRemoved, expiredRemoved) = proposalsApplyEnactment pfeToEnact pfeToRemove pfeProposals
+            Map.keysSet expiredRemoved `shouldBe` pfeToRemove
+            enactedRemoved `shouldBe` mempty
+            enacted `shouldBe` fromElems gasId pfeToEnact
+            proposalsSize ps' `shouldBe` Set.size pfeToRetain

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
@@ -74,7 +74,9 @@ import qualified Data.Set as Set
 import qualified Data.Vector as V
 import Lens.Micro
 import NoThunks.Class ()
+import Test.Cardano.Ledger.Binary.Random (QC (..))
 import Test.Cardano.Ledger.Common (tracedDiscard)
+import Test.Cardano.Ledger.Core.Arbitrary (uniformSubMapElems)
 import Test.Cardano.Ledger.Core.KeyPair (
   KeyPair,
   KeyPairs,
@@ -634,14 +636,7 @@ genIndices k (l', u')
 -- | Select @n@ random key value pairs from the supplied map. Order of keys with
 -- respect to each other will also be random, i.e. not sorted.
 pickRandomFromMap :: Int -> Map.Map k t -> Gen [(k, t)]
-pickRandomFromMap n' initMap = go (min (max 0 n') (Map.size initMap)) [] initMap
-  where
-    go n !acc !m
-      | n <= 0 = pure acc
-      | otherwise = do
-          i <- QC.choose (0, Map.size m - 1)
-          let (k, y) = Map.elemAt i m
-          go (n - 1) ((k, y) : acc) (Map.deleteAt i m)
+pickRandomFromMap n initMap = uniformSubMapElems (\k v -> ((k, v) :)) (Just n) initMap QC
 
 mkScriptWits ::
   forall era.

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -5,6 +5,11 @@
 * Add `credKeyHash` to `Credential`
 * Remove `maxMajorPV` from `Globals`
 
+### `testlib`
+
+* Add `uniformSubMap` and `uniformSubMapElems`
+* Rename `uniformSubset` to `uniformSubSet`
+
 ## 1.14.0.0
 
 * Add `EncCBOR` instance for `PoolCert`

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Combinators.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Combinators.hs
@@ -8,13 +8,13 @@
 module Test.Cardano.Ledger.Constrained.Combinators where
 
 import Cardano.Ledger.Coin (Coin (..))
-import Data.Foldable as F (foldl')
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
 import GHC.Stack (HasCallStack)
-import Test.Cardano.Ledger.Core.Arbitrary ()
+import Test.Cardano.Ledger.Binary.Random (QC (..))
+import Test.Cardano.Ledger.Core.Arbitrary (uniformSubMap)
 import Test.QuickCheck hiding (Fixed, total)
 
 -- ==========================================================================
@@ -234,8 +234,4 @@ genFromMap msgs m
     n = Map.size m
 
 subMapFromMapWithSize :: Ord k => Int -> Map k a -> Gen (Map k a)
-subMapFromMapWithSize n m = do
-  let indexes = [0 .. Map.size m - 1]
-      accum ans i = let (k, v) = Map.elemAt i m in Map.insert k v ans
-  shuffled <- shuffle indexes
-  pure (F.foldl' accum Map.empty (take n shuffled))
+subMapFromMapWithSize n m = uniformSubMap (Just n) m QC

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Combinators.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Combinators.hs
@@ -14,7 +14,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import GHC.Stack (HasCallStack)
 import Test.Cardano.Ledger.Binary.Random (QC (..))
-import Test.Cardano.Ledger.Core.Arbitrary (uniformSubMap)
+import Test.Cardano.Ledger.Core.Arbitrary (uniformSubMap, uniformSubSet)
 import Test.QuickCheck hiding (Fixed, total)
 
 -- ==========================================================================
@@ -122,18 +122,7 @@ subsetFromSetWithSize mess set n
             ++ show (Set.size set)
         )
         mess
-  -- It is faster to remove extra elements, when we need to drop more than a half
-  | Set.size set `div` 2 < n = fst <$> help (flip const) set Set.empty (Set.size set - n)
-  -- It is faster to pick out random elements when we only need under a half of the original set.
-  | otherwise = snd <$> help seq set Set.empty n
-  where
-    help optSeq !source target count
-      | count <= 0 = pure (source, target)
-      | otherwise = do
-          (item, source') <- itemFromSet (("subsetFromSetWithSize " ++ show n) : mess) source
-          -- To avoid a memory leak we only force the target when it is the set we want to keep.
-          let target' = Set.insert item target
-          target' `optSeq` help optSeq source' target' (count - 1)
+  | otherwise = uniformSubSet (Just n) set QC
 
 -- | Generate a larger map, from a smaller map 'subset'. The new larger map, should have all the
 --   keys and values of the smaller map.

--- a/libs/ledger-state/bench/Performance.hs
+++ b/libs/ledger-state/bench/Performance.hs
@@ -42,7 +42,7 @@ import Lens.Micro ((^.))
 import System.Environment (getEnv)
 import System.Random.Stateful
 import Test.Cardano.Ledger.Api.State.Query (getFilteredDelegationsAndRewardAccounts)
-import Test.Cardano.Ledger.Core.Arbitrary (uniformSubset)
+import Test.Cardano.Ledger.Core.Arbitrary (uniformSubSet)
 
 main :: IO ()
 main = do
@@ -120,7 +120,7 @@ main = do
     , env (pure es) $ \newEpochState ->
         let umap = dsUnified . certDState . lsCertState . esLState $ nesEs newEpochState
             elems = umElems umap
-            creds = runStateGen_ stdGen (uniformSubset (Just 10) (Map.keysSet elems))
+            creds = runStateGen_ stdGen (uniformSubSet (Just 10) (Map.keysSet elems))
          in bgroup
               ( "GetFilteredDelegationsAndRewardAccounts ("
                   ++ show (Set.size creds)


### PR DESCRIPTION
# Description

Fix #4602

Besides the fix to `GovInfoEvent` this PR also:
* Reduced duplication by consolidating to one implementation for generating uniform sub-Map and the same for uniform sub-Set. Three alternative implementations have been removed
* Fixes implementation of `uniformSubset`. It had a really dumb bug (CC @neilmayhew see if you can spot this bug that I made in a very similar funciton :smile:)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
