### PR TITLE
Remove dependency bounds on `QuickCheck`

### DIFF
--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -46,7 +46,7 @@ library
         bytestring,
         cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib} >=1.7,
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
-        cardano-ledger-core:{cardano-ledger-core, testlib} >=1.11,
+        cardano-ledger-core:{cardano-ledger-core, testlib} >=1.15,
         cardano-ledger-allegra >=1.2,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.14,
         cardano-ledger-shelley-test >=1.4.1,

--- a/eras/shelley/test-suite/CHANGELOG.md
+++ b/eras/shelley/test-suite/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-shelley-test`
 
-## 1.4.1.0
+## 1.5.0.0
 
-*
+* Remove `myDiscard`
 
 ## 1.4.0.3
 

--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-shelley-test
-version:            1.4.1.0
+version:            1.5.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK
@@ -78,7 +78,7 @@ library
         cardano-data >=1.2,
         cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.3,
         cardano-ledger-byron,
-        cardano-ledger-core:{cardano-ledger-core, testlib} >=1.11 && <1.16,
+        cardano-ledger-core:{cardano-ledger-core, testlib} >=1.15,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.14,
         cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib} >=1.0.1,
         cardano-slotting:{cardano-slotting, testlib},

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 * Add `uniformSubMap` and `uniformSubMapElems`
 * Rename `uniformSubset` to `uniformSubSet`
+* Add `tracedDiscard`
 
 ## 1.14.0.0
 

--- a/libs/cardano-ledger-core/test/Test/Cardano/Ledger/AddressSpec.hs
+++ b/libs/cardano-ledger-core/test/Test/Cardano/Ledger/AddressSpec.hs
@@ -51,8 +51,8 @@ spec =
       sig <- arbitrary
       let addr = BootstrapAddress byronAddr
           (shelleyVKey, chainCode) = unpackByronVKey @StandardCrypto byronVKey
-          witness :: BootstrapWitness StandardCrypto
-          witness =
+          wit :: BootstrapWitness StandardCrypto
+          wit =
             BootstrapWitness
               { bwKey = shelleyVKey
               , bwChainCode = chainCode
@@ -61,7 +61,7 @@ spec =
               }
       pure $
         coerceKeyRole (bootstrapKeyHash @StandardCrypto addr)
-          === bootstrapWitKeyHash witness
+          === bootstrapWitKeyHash wit
 
 roundTripAddressSpec :: Spec
 roundTripAddressSpec = do

--- a/libs/constrained-generators/constrained-generators.cabal
+++ b/libs/constrained-generators/constrained-generators.cabal
@@ -56,7 +56,7 @@ library
         containers,
         mtl,
         prettyprinter,
-        QuickCheck ^>=2.14,
+        QuickCheck >=2.14,
         random,
         template-haskell
 


### PR DESCRIPTION
# Description

We have a dependency bound in `QuickCheck` in `cardano-ledger-shelley-test` and `constrained-generators`. We'd like to remove these constraints to enable the latest version of `QuickCheck` because it fixes a bug that's causing some of our other tests to fail occasionally.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
