### PR TITLE
Prevent HSpec from messing with ImpSpec colors

### DIFF
--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add a function `tableDoc` that formats a table using `Prettyprinter`
 * Add a function `ansiDocToString` that converts a prettyprinted document to a string
   with embedded ANSI color sequences
+* Add `assertColorFailure`, `callStackToLocation` and `srcLocToLocation`
 
 ## 1.3.4.0
 

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Existing re-exported functions `diffExpr` and `diffExprCompact` have new return types
   per `cardano-ledger-binary-1.4.0.0`
 * Add a function `expectRawEqual`
+* Add `assertColorFailure`
 
 ## 1.14.0.0
 

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Common.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Common.hs
@@ -19,6 +19,7 @@ module Test.Cardano.Ledger.Common (
   -- * Expectations
   assertBool,
   assertFailure,
+  assertColorFailure,
 
   -- ** Non-standard expectations
   shouldBeExpr,
@@ -57,6 +58,7 @@ import Test.Cardano.Ledger.Binary.TreeDiff (
   ansiDocToString,
   ansiExpr,
   ansiExprString,
+  assertColorFailure,
   diffExpr,
   diffExprCompact,
   diffExprCompactString,

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary.hs
@@ -209,7 +209,7 @@ specUpgrade BinaryUpgradeOpts {isScriptUpgradeable, isTxUpgradeable} =
 expectRawEqual :: (EqRaw a, ToExpr a, HasCallStack) => Doc AnsiStyle -> a -> a -> Expectation
 expectRawEqual thing expected actual =
   unless (eqRaw expected actual) $
-    expectationFailure . ansiDocToString $
+    assertColorFailure . ansiDocToString $
       Pretty.vsep
         [ Pretty.hsep ["Expected raw representation of", thing, "to be equal:"]
         , Pretty.indent 2 $ diffExpr expected actual

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Imp/Common.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Imp/Common.hs
@@ -15,6 +15,7 @@ module Test.Cardano.Ledger.Imp.Common (
   -- ** Lifted expectations
   assertBool,
   assertFailure,
+  assertColorFailure,
   expectationFailure,
   shouldBe,
   shouldSatisfy,
@@ -80,6 +81,7 @@ import Test.Cardano.Ledger.Binary.TreeDiff (expectExprEqualWithMessage)
 import Test.Cardano.Ledger.Common as X hiding (
   arbitrary,
   assertBool,
+  assertColorFailure,
   assertFailure,
   choose,
   elements,
@@ -185,6 +187,9 @@ io = id
 -- version of `H.assertFailure`
 assertFailure :: (HasCallStack, MonadIO m) => String -> m a
 assertFailure = liftIO . H.assertFailure
+
+assertColorFailure :: HasCallStack => String -> IO a
+assertColorFailure = liftIO . H.assertColorFailure
 
 -- | Just like `expectationBool`, but does not force the return type to unit. Lifted
 -- version of `H.assertBool`


### PR DESCRIPTION
# Description

@neilmayhew This is the piece you are missing for the first point in your PR: #4497 

> hspec forces a red colour on every line when it outputs the text of a failure message.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
