### PR TITLE
Change `GovInfoEvent`'s "unclaimed" field from `Set` to a `Map`

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -14,7 +14,7 @@
   * `reDRepStateL`
   * `reCurrentEpochL`
   * `reCommitteeStateL`
-* Add a new field to `GovInfoEvent`
+* Add a new field to `GovInfoEvent` and change "unclaimed" field from `Set` to a `Map`.
 * Changed return type of `proposalsShowDebug`
 
 ### `testlib`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
@@ -137,9 +137,8 @@ data ConwayEpochEvent era
       (Set (GovActionState era))
       -- | Actions that were removed due to expiration together with their dependees
       (Set (GovActionState era))
-      -- | Ids of removed governance actions that had an unregistered reward account, thus
-      -- leading to unclaimed deposits being transfered to the treasury.
-      (Set (GovActionId (EraCrypto era)))
+      -- | Map of removed governance action ids that had an unregistered reward account to their unclaimed deposits so they can be transferred to the treasury.
+      (Map.Map (GovActionId (EraCrypto era)) Coin)
   deriving (Generic)
 
 type instance EraRuleEvent "EPOCH" (ConwayEra c) = ConwayEpochEvent (ConwayEra c)
@@ -354,7 +353,7 @@ epochTransition = do
       (Set.fromList $ Map.elems enactedActions)
       (Set.fromList $ Map.elems removedDueToEnactment)
       (Set.fromList $ Map.elems expiredActions)
-      (Map.keysSet unclaimed)
+      unclaimed
 
   let
     certState =

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
@@ -544,5 +544,5 @@ eventsSpec = describe "Events" $ do
                             (Set.singleton gasA)
                             (Set.singleton gasC)
                             (Set.singleton gasB)
-                            (Set.singleton proposalC)
+                            (Map.singleton proposalC propDeposit)
                        ]


### PR DESCRIPTION
# Description

@kderme, I this will be useful for db-sync to get access to the unclaimed amount right away, instead of forcing other to try and figure out unclaimed deposits from govActionId. Also the unclaimed amount is readily available in ledger anyways, so there is no point in discarding it.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
