### PR TITLE
Additional DELEG tests

### DIFF
--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Invalid.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Invalid.hs
@@ -166,7 +166,7 @@ spec = describe "Invalid transactions" $ do
 
         it "No ExtraRedeemers on same script certificates" $ do
           Positive n <- arbitrary
-          replicateM_ n registerPool
+          replicateM_ n $ freshKeyHash >>= registerPool
           pools <- getsNES $ nesEsL . epochStatePoolParamsL
           poolId <- elements $ Map.keys pools
           let scriptHash = alwaysSucceedsNoDatumHash
@@ -265,7 +265,7 @@ spec = describe "Invalid transactions" $ do
             it "Multiple equal plutus-locked certs" $ do
               let scriptHash = alwaysSucceedsWithDatumHash
               Positive n <- arbitrary
-              replicateM_ n registerPool
+              replicateM_ n $ freshKeyHash >>= registerPool
               pools <- getsNES $ nesEsL . epochStatePoolParamsL
               poolId <- elements $ Map.keys pools
               let cred = ScriptHashObj scriptHash

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -531,7 +531,8 @@ setupPoolWithStake ::
     , Credential 'Staking (EraCrypto era)
     )
 setupPoolWithStake delegCoin = do
-  khPool <- registerPool
+  khPool <- freshKeyHash
+  registerPool khPool
   credDelegatorPayment <- KeyHashObj <$> freshKeyHash
   credDelegatorStaking <- KeyHashObj <$> freshKeyHash
   void $
@@ -558,7 +559,8 @@ setupPoolWithoutStake ::
     , Credential 'Staking (EraCrypto era)
     )
 setupPoolWithoutStake = do
-  khPool <- registerPool
+  khPool <- freshKeyHash
+  registerPool khPool
   credDelegatorStaking <- KeyHashObj <$> freshKeyHash
   deposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppKeyDepositL
   submitTxAnn_ "Delegate to stake pool" $

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 ### `testlib`
 
+* Exposed `registerPoolWithRewardAccount`
+* Added `poolParams` to `ImpTest`
+* Changed signature of `registerPool`
 * Remove `minMajorPV` and `maxMajorPV` from `Constants`
 * Add `logDoc` that takes a `Doc AnsiStyle` instead of a `String`
 * Rename `logEntry` to `logString`


### PR DESCRIPTION
# Description

Some tests checking the status of pool delegations after pool has been retired and re-registered in various circumstances.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
