### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,10 @@
 # code owners are automatically assigned to review PRs
 
 # DevX
-*.nix       @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
-nix         @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
-flake.lock  @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
-.github     @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
+*.nix       @IntersectMBO/core-tech-devx
+nix         @IntersectMBO/core-tech-devx
+flake.lock  @IntersectMBO/core-tech-devx
+.github     @IntersectMBO/cardano-ledger-maintainers
+
+
+* @IntersectMBO/cardano-ledger-maintainers

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,1 +1,18 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report (suspected) security vulnerabilities to security@intersectmbo.org. You will receive a
+response from us within 48 hours. If the issue is confirmed, we will release a patch as soon
+as possible.
+
+Please provide a clear and concise description of the vulnerability, including:
+
+* the affected version(s) of OSC-documentation,
+* steps that can be followed to exercise the vulnerability,
+* any workarounds or mitigations
+
+If you have developed any code or utilities that can help demonstrate the suspected
+vulnerability, please mention them in your email but ***DO NOT*** attempt to include them as
+attachments as this may cause your Email to be blocked by spam filters.
 See the security file in the [Cardano engineering handbook](https://github.com/input-output-hk/cardano-engineering-handbook/blob/main/SECURITY.md).


### PR DESCRIPTION
# Description

Noticed that `CODEOWNERS` uses wrong teams. This PR fixes that
Also update `SECURITY.md` according to #4628 

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
