### PR TITLE
Add TxInfo golden test for Conway

### DIFF
--- a/eras/alonzo/impl/test/Test/Cardano/Ledger/Alonzo/GoldenTranslation.hs
+++ b/eras/alonzo/impl/test/Test/Cardano/Ledger/Alonzo/GoldenTranslation.hs
@@ -12,11 +12,11 @@
 -- | Deserializes `TranslationInstance`s from golden/translations.cbor file.
 --
 -- Each instance represents arguments passed to `ExtendedUTxO.txInfo` along with the produced result.
--- This test checks that calling `alonzoTxInfo` with the arguments from this file, produces the same result as in the flie.
+-- This test checks that calling `alonzoTxInfo` with the arguments from this file, produces the same result as in the file.
 --
 -- To regenerate the golden file (for example, if the logic in the translation changes),
 -- run the following command from the root of the repository:
--- cabal run cardano-ledger-alonzotest:gen-golden"
+-- cabal run cardano-ledger-alonzo:gen-golden"
 module Test.Cardano.Ledger.Alonzo.GoldenTranslation (
   tests,
 )

--- a/eras/babbage/impl/test/Test/Cardano/Ledger/Babbage/GoldenTranslation.hs
+++ b/eras/babbage/impl/test/Test/Cardano/Ledger/Babbage/GoldenTranslation.hs
@@ -11,12 +11,9 @@
 
 -- | Deserializes `TranslationInstance`s from golden/translations.cbor file.
 --
--- Each instance represents arguments passed to `ExtendedUTxO.txInfo` along with the produced result.
--- This test checks that calling `alonzoTxInfo` with the arguments from this file, produces the same result as in the flie.
---
 -- To regenerate the golden file (for example, if the logic in the translation changes),
 -- run the following command from the root of the repository:
--- cabal run cardano-ledger-<era>-test:gen-golden"
+-- cabal run cardano-ledger-<era>:gen-golden"
 module Test.Cardano.Ledger.Babbage.GoldenTranslation (
   spec,
 )

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -21,6 +21,7 @@
   * `reCommitteeStateL`
 * Add a new field to `GovInfoEvent` and change "unclaimed" field from `Set` to a `Map`.
 * Changed return type of `proposalsShowDebug`
+* Added `gen-golden` executable needed for golden tests: #4629
 
 ### `testlib`
 

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -214,6 +214,7 @@ test-suite tests
         Test.Cardano.Ledger.Conway.GovActionReorderSpec
         Test.Cardano.Ledger.Conway.Plutus.PlutusSpec
         Test.Cardano.Ledger.Conway.TxInfoSpec
+        Test.Cardano.Ledger.Conway.GoldenTranslation
         Paths_cardano_ledger_conway
 
     default-language: Haskell2010
@@ -241,4 +242,5 @@ test-suite tests
         data-default-class,
         microlens,
         plutus-ledger-api,
-        testlib
+        testlib,
+        HUnit

--- a/eras/conway/impl/test/Main.hs
+++ b/eras/conway/impl/test/Main.hs
@@ -12,6 +12,7 @@ import qualified Test.Cardano.Ledger.Conway.BinarySpec as Binary
 import qualified Test.Cardano.Ledger.Conway.CommitteeRatifySpec as CommitteeRatify
 import qualified Test.Cardano.Ledger.Conway.DRepRatifySpec as DRepRatify
 import qualified Test.Cardano.Ledger.Conway.GenesisSpec as Genesis
+import qualified Test.Cardano.Ledger.Conway.GoldenTranslation as Golden
 import qualified Test.Cardano.Ledger.Conway.GovActionReorderSpec as GovActionReorder
 import qualified Test.Cardano.Ledger.Conway.Imp as Imp
 import Test.Cardano.Ledger.Conway.Plutus.PlutusSpec as PlutusSpec
@@ -24,6 +25,7 @@ main :: IO ()
 main =
   ledgerTestMain $
     describe "Conway" $ do
+      Golden.spec
       Spec.spec
       Proposals.spec
       Binary.spec

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/GoldenTranslation.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/GoldenTranslation.hs
@@ -11,12 +11,9 @@
 
 -- | Deserializes `TranslationInstance`s from golden/translations.cbor file.
 --
--- Each instance represents arguments passed to `ExtendedUTxO.txInfo` along with the produced result.
--- This test checks that calling `alonzoTxInfo` with the arguments from this file, produces the same result as in the flie.
---
 -- To regenerate the golden file (for example, if the logic in the translation changes),
 -- run the following command from the root of the repository:
--- cabal run cardano-ledger-<era>-test:gen-golden"
+-- cabal run cardano-ledger-<era>:gen-golden"
 module Test.Cardano.Ledger.Conway.GoldenTranslation (
   spec,
 )

--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/GoldenTranslation.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/GoldenTranslation.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Deserializes `TranslationInstance`s from golden/translations.cbor file.
+--
+-- Each instance represents arguments passed to `ExtendedUTxO.txInfo` along with the produced result.
+-- This test checks that calling `alonzoTxInfo` with the arguments from this file, produces the same result as in the flie.
+--
+-- To regenerate the golden file (for example, if the logic in the translation changes),
+-- run the following command from the root of the repository:
+-- cabal run cardano-ledger-<era>-test:gen-golden"
+module Test.Cardano.Ledger.Conway.GoldenTranslation (
+  spec,
+)
+where
+
+import Cardano.Ledger.Conway (Conway)
+import Paths_cardano_ledger_conway (getDataFileName)
+import Test.Cardano.Ledger.Alonzo.Translation.Golden (assertTranslationResultsMatchGolden)
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Conway.Translation.TranslatableGen ()
+import Test.HUnit (Assertion)
+
+spec :: Spec
+spec =
+  describe "Golden translation tests" $
+    it "golden/translation.cbor" $
+      check "golden/translations.cbor"
+
+check :: String -> Assertion
+check file = assertTranslationResultsMatchGolden @Conway (getDataFileName file)


### PR DESCRIPTION
# Description

Closes #3434.

NOTE: Merge after #4599 

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
