### PR TITLE
Disallow empty `TreasuryWithdrawals`

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.17.0.0
 
+* Add `ZeroTreasuryWithdrawals` to `ConwayGovPredFailure`
 * Add `ProtVer` argument to `TxInfo` functions:
   * `transTxCert`
   * `transScriptPurpose`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -118,6 +118,7 @@ library testlib
         Test.Cardano.Ledger.Conway.ImpTest
         Test.Cardano.Ledger.Conway.Imp
         Test.Cardano.Ledger.Conway.Imp.BbodySpec
+        Test.Cardano.Ledger.Conway.Imp.CertsSpec
         Test.Cardano.Ledger.Conway.Imp.DelegSpec
         Test.Cardano.Ledger.Conway.Imp.EpochSpec
         Test.Cardano.Ledger.Conway.Imp.EnactSpec

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -20,6 +20,7 @@ import Cardano.Ledger.BaseTypes (Inject, natVersion)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Rules (
   ConwayBbodyPredFailure,
+  ConwayCertsPredFailure,
   ConwayDelegPredFailure,
   ConwayEpochEvent,
   ConwayGovCertPredFailure,
@@ -33,6 +34,7 @@ import Data.Typeable (Typeable)
 import qualified Test.Cardano.Ledger.Babbage.Imp as BabbageImp
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Conway.Imp.BbodySpec as Bbody
+import qualified Test.Cardano.Ledger.Conway.Imp.CertsSpec as Certs
 import qualified Test.Cardano.Ledger.Conway.Imp.DelegSpec as Deleg
 import qualified Test.Cardano.Ledger.Conway.Imp.EnactSpec as Enact
 import qualified Test.Cardano.Ledger.Conway.Imp.EpochSpec as Epoch
@@ -50,6 +52,7 @@ spec ::
   , ConwayEraImp era
   , EraSegWits era
   , InjectRuleFailure "LEDGER" ConwayGovPredFailure era
+  , InjectRuleFailure "LEDGER" ConwayCertsPredFailure era
   , Inject (BabbageContextError era) (ContextError era)
   , Inject (ConwayContextError era) (ContextError era)
   , InjectRuleFailure "LEDGER" BabbageUtxoPredFailure era
@@ -89,6 +92,7 @@ spec = do
   describe "ConwayImpSpec - bootstrap phase (protocol version 9)" $
     withImpState @era $ do
       describe "BBODY" $ Bbody.spec @era
+      describe "CERTS" $ Certs.spec @era
       describe "DELEG" $ Deleg.spec @era
       describe "ENACT" $ Enact.relevantDuringBootstrapSpec @era
       describe "EPOCH" $ Epoch.relevantDuringBootstrapSpec @era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/CertsSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/CertsSpec.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Test.Cardano.Ledger.Conway.Imp.CertsSpec (spec) where
+
+import Cardano.Ledger.BaseTypes (EpochInterval (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway.Core
+import Cardano.Ledger.Conway.Rules (ConwayCertsPredFailure (..))
+import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Ledger.Val (Val (..))
+import Lens.Micro ((&), (.~))
+import Test.Cardano.Ledger.Conway.Arbitrary ()
+import Test.Cardano.Ledger.Conway.ImpTest
+import Test.Cardano.Ledger.Imp.Common
+
+spec ::
+  forall era.
+  ( ConwayEraImp era
+  , InjectRuleFailure "LEDGER" ConwayCertsPredFailure era
+  ) =>
+  SpecWith (ImpTestState era)
+spec = do
+  describe "Withdrawals" $ do
+    it "Withdrawing from an unregistered reward account" $ do
+      modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
+
+      rwdAccount <- KeyHashObj <$> freshKeyHash >>= getRewardAccountFor
+      submitFailingTx
+        ( mkBasicTx $
+            mkBasicTxBody
+              & withdrawalsTxBodyL
+                .~ Withdrawals
+                  [(rwdAccount, Coin 20)]
+        )
+        [injectFailure $ WithdrawalsNotInRewardsCERTS [(rwdAccount, Coin 20)]]
+
+      (registeredRwdAccount, reward) <- setupRewardAccount
+      submitFailingTx
+        ( mkBasicTx $
+            mkBasicTxBody
+              & withdrawalsTxBodyL
+                .~ Withdrawals
+                  [(rwdAccount, zero), (registeredRwdAccount, reward)]
+        )
+        [injectFailure $ WithdrawalsNotInRewardsCERTS [(rwdAccount, zero)]]
+
+    it "Withdrawing the wrong amount" $ do
+      modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
+
+      (rwdAccount1, reward1) <- setupRewardAccount
+      (rwdAccount2, reward2) <- setupRewardAccount
+      submitFailingTx
+        ( mkBasicTx $
+            mkBasicTxBody
+              & withdrawalsTxBodyL
+                .~ Withdrawals
+                  [ (rwdAccount1, reward1 <+> Coin 1)
+                  , (rwdAccount2, reward2)
+                  ]
+        )
+        [injectFailure $ WithdrawalsNotInRewardsCERTS [(rwdAccount1, reward1 <+> Coin 1)]]
+
+      submitFailingTx
+        ( mkBasicTx $
+            mkBasicTxBody
+              & withdrawalsTxBodyL
+                .~ Withdrawals
+                  [(rwdAccount1, zero)]
+        )
+        [injectFailure $ WithdrawalsNotInRewardsCERTS [(rwdAccount1, zero)]]
+  where
+    setupRewardAccount = do
+      cred <- KeyHashObj <$> freshKeyHash
+      ra <- registerStakeCredential cred
+      submitAndExpireProposalToMakeReward cred
+      rw <- lookupReward cred
+      pure (ra, rw)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
@@ -148,6 +148,7 @@ treasuryWithdrawalsSpec =
     it "Withdrawals exceeding treasury submitted in several proposals within the same epoch" $ do
       committeeCs <- registerInitialCommittee
       (drepC, _, _) <- setupSingleDRep 1_000_000
+      donateToTreasury $ Coin 5_000_000
       initialTreasury <- getTreasury
       numWithdrawals <- choose (1, 10)
       withdrawals <- genWithdrawalsExceeding initialTreasury numWithdrawals

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/RatifySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/RatifySpec.hs
@@ -807,6 +807,8 @@ votingSpec =
         it "AlwaysAbstain" $ do
           let getTreasury = getsNES (nesEsL . esAccountStateL . asTreasuryL)
 
+          donateToTreasury $ Coin 5_000_000
+
           (drep1, comMember, _) <- electBasicCommittee
           initialTreasury <- getTreasury
 

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -112,7 +112,6 @@ test-suite cardano-ledger-api-test
         bytestring,
         cardano-ledger-api,
         cardano-ledger-byron,
-        data-default,
         data-default-class,
         testlib,
         cardano-crypto-class,

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
@@ -32,7 +32,7 @@ import Cardano.Ledger.DRep
 import Cardano.Ledger.Keys (KeyRole (..))
 import qualified Cardano.Ledger.Shelley.HardForks as HF
 import Cardano.Ledger.Shelley.LedgerState
-import Data.Default (def)
+import Data.Default.Class (def)
 import Data.Foldable (Foldable (..))
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Gov.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Gov.hs
@@ -27,6 +27,7 @@ import Lens.Micro
 
 import Constrained
 
+import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Crypto (StandardCrypto)
@@ -344,6 +345,7 @@ wfGovAction GovEnv {gePPolicy, geEpoch, gePParams} ps govAction =
     ( branch $ \withdrawMap policy ->
         [ forAll (dom_ withdrawMap) $ \rewAcnt ->
             match rewAcnt $ \net _ -> net ==. lit Testnet
+        , assert $ sum_ (rng_ withdrawMap) >. lit (Coin 0)
         , assert $ policy ==. lit gePPolicy
         , assert $ not $ HardForks.bootstrapPhase (gePParams ^. ppProtocolVersionL)
         ]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1552,6 +1552,7 @@ ppConwayGovPredFailure x = case x of
     ppSexp "DisallowedProposalDuringBootstrap" [pcProposalProcedure p]
   DisallowedVotesDuringBootstrap m -> ppSexp "DisallowedVotesDuringBootstrap" [prettyA m]
   VotersDoNotExist m -> ppSexp "VotersDoNotExist" [prettyA m]
+  ZeroTreasuryWithdrawals ga -> ppSexp "ZeroTreasuryWithdrawals" [pcGovAction ga]
 
 instance PrettyA (ConwayGovPredFailure era) where
   prettyA = ppConwayGovPredFailure


### PR DESCRIPTION
# Description

* Disallow empty treasury withdrawals, closes: https://github.com/IntersectMBO/cardano-ledger/issues/4582
* Add some tests concerning withdrawals from accounts delegated to expired or unregistered Dreps 
* Add CERTS spec and some tests concerning withdrawals that are checked in Certs rule 

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
