### PR TITLE
Implement ghc heap limiting and retrying in CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -96,6 +96,15 @@ jobs:
           flags: -external-libsodium-vrf
         EOF
 
+    - name: Configure to limit the heap size for ghc 8
+      if: startsWith(${{ matrix.ghc }}, 8)
+      run: |
+        cat >> cabal.project <<EOF
+        with-compiler: $PWD/scripts/ghc-limited
+        with-hc-pkg: ghc-pkg
+        EOF
+        echo "GHC_HEAP_LIMIT=12" >> $GITHUB_ENV
+
     - name: Cabal update
       run: cabal update
 

--- a/scripts/ghc-limited
+++ b/scripts/ghc-limited
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+if [ -z "$GHC_HEAP_LIMIT" ]; then
+  exec ghc "$@"
+fi
+
+# Set a heap limit in ghc's runtime options
+set -- "$@" +RTS "-M${GHC_HEAP_LIMIT}G" -RTS
+
+# Set an OS limit as well, as a backup
+ulimit -d $((("$GHC_HEAP_LIMIT" + 2) * 1024 * 1024)) # Allow for 2G additional data use
+ulimit -c 0 # Disable core dumping
+
+# Try the build multiple times if it fails with an out-of-memory error
+for TRIES_REMAINING in $(seq 4 -1 0); do
+  ghc "$@"
+  STATUS=$?
+
+  # Status 134 = 128 + 6 is a call to abort() which ghc calls when it can't allocate memory
+  if [ "$STATUS" -ne 134 ] || [ "$TRIES_REMAINING" -eq 0 ]; then
+    exit "$STATUS"
+  fi
+
+  echo "ghc aborted - retrying ($TRIES_REMAINING tries remaining)"
+done


### PR DESCRIPTION
# Description

Set a heap-size limit for ghc 8 only in CI

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
