### PR TITLE
Mempool rule

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledger.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledger.hs
@@ -125,7 +125,7 @@ ledgerTransition ::
   ) =>
   TransitionRule (someLEDGER era)
 ledgerTransition = do
-  TRC (LedgerEnv slot txIx pp account, LedgerState utxoSt certState, tx) <- judgmentContext
+  TRC (LedgerEnv slot txIx pp account _, LedgerState utxoSt certState, tx) <- judgmentContext
   let txBody = tx ^. bodyTxL
 
   certState' <-

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
@@ -73,6 +73,7 @@ instance
     LedgerEnv (SlotNo 0) minBound
       <$> genEraPParams @era geConstants
       <*> genAccountState geConstants
+      <*> pure False
 
   sigGen genenv env state = genTx genenv env state
 

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.17.0.0
 
+* Add `ConwayMempoolFailure` to `ConwayLedgerPredFailure`
 * Add `ZeroTreasuryWithdrawals` to `ConwayGovPredFailure`
 * Add `ProtVer` argument to `TxInfo` functions:
   * `transTxCert`

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.17.0.0
 
+* Add `ConwayMempoolEvent` type
+* Add `MempoolEvent` to `ConwayLedgerEvent`
 * Add `Mempool` module, `ConwayMEMPOOL` and `ConwayMempoolPredFailure`
 * Add `ConwayMempoolFailure` to `ConwayLedgerPredFailure`
 * Add `ZeroTreasuryWithdrawals` to `ConwayGovPredFailure`

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.17.0.0
 
+* Add `Mempool` module, `ConwayMEMPOOL` and `ConwayMempoolPredFailure`
 * Add `ConwayMempoolFailure` to `ConwayLedgerPredFailure`
 * Add `ZeroTreasuryWithdrawals` to `ConwayGovPredFailure`
 * Add `ProtVer` argument to `TxInfo` functions:

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -62,6 +62,7 @@ library
         Cardano.Ledger.Conway.Rules.Epoch
         Cardano.Ledger.Conway.Rules.Ledger
         Cardano.Ledger.Conway.Rules.Ledgers
+        Cardano.Ledger.Conway.Rules.Mempool
         Cardano.Ledger.Conway.Rules.NewEpoch
         Cardano.Ledger.Conway.Rules.Gov
         Cardano.Ledger.Conway.Rules.Pool

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
@@ -9,6 +9,7 @@ module Cardano.Ledger.Conway.Era (
   ConwayGOVCERT,
   ConwayCERTS,
   ConwayGOV,
+  ConwayMEMPOOL,
   ConwayNEWEPOCH,
   ConwayEPOCH,
   ConwayENACT,
@@ -134,6 +135,10 @@ type instance EraRule "UTXO" (ConwayEra c) = ConwayUTXO (ConwayEra c)
 data ConwayBBODY era
 
 type instance EraRule "BBODY" (ConwayEra c) = ConwayBBODY (ConwayEra c)
+
+data ConwayMEMPOOL era
+
+type instance EraRule "MEMPOOL" (ConwayEra c) = ConwayMEMPOOL (ConwayEra c)
 
 -- Rules inherited from Shelley
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules.hs
@@ -12,6 +12,7 @@ module Cardano.Ledger.Conway.Rules (
   module Cardano.Ledger.Conway.Rules.Enact,
   module Cardano.Ledger.Conway.Rules.Epoch,
   module Cardano.Ledger.Conway.Rules.Ledger,
+  module Cardano.Ledger.Conway.Rules.Mempool,
   module Cardano.Ledger.Conway.Rules.NewEpoch,
   module Cardano.Ledger.Conway.Rules.Tickf,
   module Cardano.Ledger.Conway.Rules.Ratify,
@@ -34,6 +35,7 @@ import Cardano.Ledger.Conway.Rules.Gov
 import Cardano.Ledger.Conway.Rules.GovCert
 import Cardano.Ledger.Conway.Rules.Ledger
 import Cardano.Ledger.Conway.Rules.Ledgers ()
+import Cardano.Ledger.Conway.Rules.Mempool
 import Cardano.Ledger.Conway.Rules.NewEpoch
 import Cardano.Ledger.Conway.Rules.Pool ()
 import Cardano.Ledger.Conway.Rules.Ratify

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -368,7 +368,8 @@ ledgerTransition ::
   ) =>
   TransitionRule (someLEDGER era)
 ledgerTransition = do
-  TRC (LedgerEnv slot _txIx pp account, LedgerState utxoState certState, tx) <- judgmentContext
+  TRC (LedgerEnv slot _txIx pp account _mempool, LedgerState utxoState certState, tx) <-
+    judgmentContext
 
   currentEpoch <- liftSTS $ do
     ei <- asks epochInfoPure

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -128,6 +128,7 @@ import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq)
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
+import Data.Text (Text)
 import GHC.Generics (Generic (..))
 import Lens.Micro as L
 import NoThunks.Class (NoThunks (..))
@@ -147,6 +148,7 @@ data ConwayLedgerPredFailure era
       Int
       -- | Maximum allowed total reference script size
       Int
+  | ConwayMempoolFailure Text
   deriving (Generic)
 
 -- | In the next era this will become a proper protocol parameter. For now this is a hard
@@ -262,6 +264,7 @@ instance
       ConwayTreasuryValueMismatch actual submitted ->
         Sum (ConwayTreasuryValueMismatch @era) 5 !> To actual !> To submitted
       ConwayTxRefScriptsSizeTooBig x y -> Sum ConwayTxRefScriptsSizeTooBig 6 !> To x !> To y
+      ConwayMempoolFailure t -> Sum ConwayMempoolFailure 7 !> To t
 
 instance
   ( Era era
@@ -279,6 +282,7 @@ instance
       4 -> SumD ConwayWdrlNotDelegatedToDRep <! From
       5 -> SumD ConwayTreasuryValueMismatch <! From <! From
       6 -> SumD ConwayTxRefScriptsSizeTooBig <! From <! From
+      7 -> SumD ConwayMempoolFailure <! From
       n -> Invalid n
 
 data ConwayLedgerEvent era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Mempool.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Mempool.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE EmptyDataDeriving #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.Conway.Rules.Mempool (
+  ConwayMEMPOOL,
+  ConwayMempoolPredFailure (..),
+) where
+
+import Cardano.Ledger.BaseTypes (ShelleyBase)
+import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..), FromCBOR, ToCBOR)
+import Cardano.Ledger.Conway.Core
+import Cardano.Ledger.Conway.Era (ConwayEra, ConwayMEMPOOL)
+import Cardano.Ledger.Shelley.LedgerState
+import Cardano.Ledger.Shelley.Rules (LedgerEnv (..))
+import Control.DeepSeq (NFData)
+import Control.State.Transition (
+  BaseM,
+  Environment,
+  Event,
+  PredicateFailure,
+  STS (..),
+  Signal,
+  State,
+  TRC (TRC),
+  TransitionRule,
+  judgmentContext,
+  transitionRules,
+ )
+import Data.Text (Text)
+import Data.Void (Void)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
+
+newtype ConwayMempoolPredFailure era = ConwayMempoolPredFailure Text
+  deriving (Eq, Show, Generic)
+  deriving newtype (NoThunks, NFData, ToCBOR, FromCBOR, EncCBOR, DecCBOR)
+
+type instance EraRuleFailure "MEMPOOL" (ConwayEra c) = ConwayMempoolPredFailure (ConwayEra c)
+instance InjectRuleFailure "MEMPOOL" ConwayMempoolPredFailure (ConwayEra c)
+
+type instance EraRuleEvent "MEMPOOL" (ConwayEra c) = VoidEraRule "MEMPOOL" (ConwayEra c)
+
+instance
+  ( EraGov era
+  , State (EraRule "MEMPOOL" era) ~ LedgerState era
+  , Signal (EraRule "MEMPOOL" era) ~ Tx era
+  , Environment (EraRule "MEMPOOL" era) ~ LedgerEnv era
+  , EraRule "MEMPOOL" era ~ ConwayMEMPOOL era
+  ) =>
+  STS (ConwayMEMPOOL era)
+  where
+  type State (ConwayMEMPOOL era) = LedgerState era
+  type Signal (ConwayMEMPOOL era) = Tx era
+  type Environment (ConwayMEMPOOL era) = LedgerEnv era
+  type BaseM (ConwayMEMPOOL era) = ShelleyBase
+  type PredicateFailure (ConwayMEMPOOL era) = ConwayMempoolPredFailure era
+  type Event (ConwayMEMPOOL era) = Void
+
+  transitionRules = [mempoolTransition @era]
+
+mempoolTransition :: TransitionRule (ConwayMEMPOOL era)
+mempoolTransition = do
+  TRC (_ledgerEnv, _ledgerState, _tx) <-
+    judgmentContext
+  -- This rule only gets invoked on transactions within the mempool.
+  -- Add checks here that sanitize undesired transactions.
+  pure _ledgerState

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Mempool.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Mempool.hs
@@ -15,6 +15,7 @@
 
 module Cardano.Ledger.Conway.Rules.Mempool (
   ConwayMEMPOOL,
+  ConwayMempoolEvent (..),
   ConwayMempoolPredFailure (..),
 ) where
 
@@ -36,10 +37,10 @@ import Control.State.Transition (
   TRC (TRC),
   TransitionRule,
   judgmentContext,
+  tellEvent,
   transitionRules,
  )
-import Data.Text (Text)
-import Data.Void (Void)
+import Data.Text (Text, pack)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 
@@ -50,10 +51,15 @@ newtype ConwayMempoolPredFailure era = ConwayMempoolPredFailure Text
 type instance EraRuleFailure "MEMPOOL" (ConwayEra c) = ConwayMempoolPredFailure (ConwayEra c)
 instance InjectRuleFailure "MEMPOOL" ConwayMempoolPredFailure (ConwayEra c)
 
-type instance EraRuleEvent "MEMPOOL" (ConwayEra c) = VoidEraRule "MEMPOOL" (ConwayEra c)
+newtype ConwayMempoolEvent era = ConwayMempoolEvent Text
+  deriving (Generic, Eq)
+  deriving newtype (NFData)
+
+type instance EraRuleEvent "MEMPOOL" (ConwayEra c) = ConwayMempoolEvent (ConwayEra c)
 
 instance
-  ( EraGov era
+  ( EraTx era
+  , EraGov era
   , State (EraRule "MEMPOOL" era) ~ LedgerState era
   , Signal (EraRule "MEMPOOL" era) ~ Tx era
   , Environment (EraRule "MEMPOOL" era) ~ LedgerEnv era
@@ -66,14 +72,15 @@ instance
   type Environment (ConwayMEMPOOL era) = LedgerEnv era
   type BaseM (ConwayMEMPOOL era) = ShelleyBase
   type PredicateFailure (ConwayMEMPOOL era) = ConwayMempoolPredFailure era
-  type Event (ConwayMEMPOOL era) = Void
+  type Event (ConwayMEMPOOL era) = ConwayMempoolEvent era
 
   transitionRules = [mempoolTransition @era]
 
-mempoolTransition :: TransitionRule (ConwayMEMPOOL era)
+mempoolTransition :: EraTx era => TransitionRule (ConwayMEMPOOL era)
 mempoolTransition = do
-  TRC (_ledgerEnv, _ledgerState, _tx) <-
+  TRC (_ledgerEnv, ledgerState, tx) <-
     judgmentContext
   -- This rule only gets invoked on transactions within the mempool.
   -- Add checks here that sanitize undesired transactions.
-  pure _ledgerState
+  tellEvent . ConwayMempoolEvent . ("Mempool rule for tx " <>) . pack . show . txIdTx $ tx
+  pure ledgerState

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -16,7 +16,7 @@ import Cardano.Ledger.Alonzo.Rules (
  )
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure, BabbageUtxowPredFailure)
 import Cardano.Ledger.Babbage.TxInfo (BabbageContextError)
-import Cardano.Ledger.BaseTypes (Inject, natVersion)
+import Cardano.Ledger.BaseTypes (Inject, ShelleyBase, natVersion)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Rules (
   ConwayBbodyPredFailure,
@@ -25,11 +25,20 @@ import Cardano.Ledger.Conway.Rules (
   ConwayEpochEvent,
   ConwayGovCertPredFailure,
   ConwayGovPredFailure,
+  ConwayLedgerEvent,
   ConwayLedgerPredFailure,
+  ConwayMempoolEvent,
   ConwayNewEpochEvent,
  )
 import Cardano.Ledger.Conway.TxInfo (ConwayContextError)
-import Cardano.Ledger.Shelley.Rules (Event, ShelleyUtxoPredFailure, ShelleyUtxowPredFailure)
+import Cardano.Ledger.Shelley.Rules (
+  ShelleyLedgersEnv,
+  ShelleyLedgersEvent,
+  ShelleyUtxoPredFailure,
+  ShelleyUtxowPredFailure,
+ )
+import Control.State.Transition.Extended
+import Data.Sequence (Seq)
 import Data.Typeable (Typeable)
 import qualified Test.Cardano.Ledger.Babbage.Imp as BabbageImp
 import Test.Cardano.Ledger.Common
@@ -73,6 +82,13 @@ spec ::
   , InjectRuleEvent "TICK" ConwayEpochEvent era
   , Event (EraRule "EPOCH" era) ~ ConwayEpochEvent era
   , Event (EraRule "NEWEPOCH" era) ~ ConwayNewEpochEvent era
+  , Event (EraRule "MEMPOOL" era) ~ ConwayMempoolEvent era
+  , Event (EraRule "LEDGERS" era) ~ ShelleyLedgersEvent era
+  , Event (EraRule "LEDGER" era) ~ ConwayLedgerEvent era
+  , BaseM (EraRule "LEDGERS" era) ~ ShelleyBase
+  , Environment (EraRule "LEDGERS" era) ~ ShelleyLedgersEnv era
+  , Signal (EraRule "LEDGERS" era) ~ Seq (Tx era)
+  , STS (EraRule "LEDGERS" era)
   ) =>
   Spec
 spec = do

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
@@ -4,21 +4,33 @@
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Test.Cardano.Ledger.Conway.Imp.LedgerSpec (spec) where
 
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Conway.Rules (ConwayLedgerPredFailure (..), maxRefScriptSizePerTx)
+import Cardano.Ledger.Conway.Rules (
+  ConwayLedgerEvent (..),
+  ConwayLedgerPredFailure (..),
+  ConwayMempoolEvent (..),
+  maxRefScriptSizePerTx,
+ )
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.DRep
 import Cardano.Ledger.Plutus (SLanguage (..), hashPlutusScript)
 import Cardano.Ledger.SafeHash (originalBytesSize)
 import qualified Cardano.Ledger.Shelley.HardForks as HF (bootstrapPhase)
+import Cardano.Ledger.Shelley.LedgerState
+import Cardano.Ledger.Shelley.Rules (ShelleyLedgersEnv (..), ShelleyLedgersEvent (..))
+import Control.State.Transition.Extended (STS (..))
 import Data.Default.Class (def)
+import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
-import Lens.Micro ((&), (.~))
+import Lens.Micro ((&), (.~), (^.))
+import Lens.Micro.Mtl (use)
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Imp.Common
 import Test.Cardano.Ledger.Plutus.Examples (
@@ -30,6 +42,13 @@ spec ::
   forall era.
   ( ConwayEraImp era
   , InjectRuleFailure "LEDGER" ConwayLedgerPredFailure era
+  , Event (EraRule "MEMPOOL" era) ~ ConwayMempoolEvent era
+  , BaseM (EraRule "LEDGERS" era) ~ ShelleyBase
+  , Environment (EraRule "LEDGERS" era) ~ ShelleyLedgersEnv era
+  , Signal (EraRule "LEDGERS" era) ~ Seq.Seq (Tx era)
+  , Event (EraRule "LEDGERS" era) ~ ShelleyLedgersEvent era
+  , Event (EraRule "LEDGER" era) ~ ConwayLedgerEvent era
+  , STS (EraRule "LEDGERS" era)
   ) =>
   SpecWith (ImpTestState era)
 spec = do
@@ -166,3 +185,19 @@ spec = do
     submitTx_ $
       mkBasicTx $
         mkBasicTxBody & withdrawalsTxBodyL .~ Withdrawals [(ra, mempty)]
+
+  describe "Mempool events" $ do
+    it "No Mempool events should be emitted via LEDGERS rules " $ do
+      nes <- use impNESL
+      slotNo <- use impLastTickG
+      let ls = nes ^. nesEsL . esLStateL
+          pp = nes ^. nesEsL . curPParamsEpochStateL
+          account = nes ^. nesEsL . esAccountStateL
+      tx <- fixupTx $ mkBasicTx mkBasicTxBody
+      Right (_, evs) <-
+        tryRunImpRule @"LEDGERS"
+          (LedgersEnv slotNo pp account)
+          ls
+          (Seq.singleton tx)
+      let mempoolEvents = [ev | LedgerEvent ev@(MempoolEvent (ConwayMempoolEvent _)) <- evs]
+      mempoolEvents `shouldBeExpr` []

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
@@ -204,6 +204,7 @@ instance
   ( ToExpr (Event (EraRule "CERTS" era))
   , ToExpr (Event (EraRule "UTXOW" era))
   , ToExpr (Event (EraRule "GOV" era))
+  , ToExpr (Event (EraRule "MEMPOOL" era))
   ) =>
   ToExpr (ConwayLedgerEvent era)
 
@@ -277,3 +278,5 @@ instance
   , ToExpr (Tx era)
   ) =>
   ToExpr (CertsEnv era)
+
+instance ToExpr (ConwayMempoolEvent era)

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Allegra/ScriptTranslation.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Allegra/ScriptTranslation.hs
@@ -58,7 +58,7 @@ testScriptPostTranslation =
               Map.singleton
                 (S.TxIn bootstrapTxId minBound)
                 (S.ShelleyTxOut addr (Val.inject (S.Coin 1)))
-          env = S.LedgerEnv (SlotNo 0) minBound emptyPParams (S.AccountState (S.Coin 0) (S.Coin 0))
+          env = S.LedgerEnv (SlotNo 0) minBound emptyPParams (S.AccountState (S.Coin 0) (S.Coin 0)) False
           utxoStShelley = def {S.utxosUtxo = utxo}
           utxoStAllegra = fromRight . runExcept $ translateEra @Allegra NoGenesis utxoStShelley
           txb =

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
@@ -97,7 +97,7 @@ pp =
     & ppMinUTxOValueL .~ Coin 100
 
 ledgerEnv :: SlotNo -> LedgerEnv Mary
-ledgerEnv s = LedgerEnv s minBound pp (AccountState (Coin 0) (Coin 0))
+ledgerEnv s = LedgerEnv s minBound pp (AccountState (Coin 0) (Coin 0)) False
 
 feeEx :: Coin
 feeEx = Coin 3

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.14.0.0
 
+* Added `mempool` to `LedgerEnv`
 * Added `registerStakeCredential` and `delegateStake` to `ImpTest`
 * Remove protocol version argument from `mkShelleyGlobals` (`maxMajorPV` was removed from `Globals`)
 * Added `EncCBOR` instances for:

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -208,6 +208,7 @@ mkMempoolEnv
       , Ledger.ledgerIx = minBound
       , Ledger.ledgerPp = nesEs ^. curPParamsEpochStateL
       , Ledger.ledgerAccount = LedgerState.esAccountState nesEs
+      , Ledger.ledgerMempool = True
       }
 
 -- | Construct a mempool state from the wider ledger state.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
@@ -167,7 +167,7 @@ ledgersTransition = do
   foldM
     ( \ !ls' (ix, tx) ->
         trans @(EraRule "LEDGER" era) $
-          TRC (LedgerEnv slot ix pp account, ls', tx)
+          TRC (LedgerEnv slot ix pp account False, ls', tx)
     )
     ls
     $ zip [minBound ..]

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -619,6 +619,7 @@ impLedgerEnv nes = do
       , ledgerPp = nes ^. nesEsL . curPParamsEpochStateL
       , ledgerIx = TxIx 0
       , ledgerAccount = nes ^. nesEsL . esAccountStateL
+      , ledgerMempool = False
       }
 
 -- | Modify the previous PParams in the current state with the given function. For current

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/BenchmarkFunctions.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/BenchmarkFunctions.hs
@@ -172,7 +172,7 @@ ppsBench =
     & ppTauL .~ unsafeBoundRational 0.2
 
 ledgerEnv :: (EraPParams era, ProtVerAtMost era 4, ProtVerAtMost era 6) => LedgerEnv era
-ledgerEnv = LedgerEnv (SlotNo 0) minBound ppsBench (AccountState (Coin 0) (Coin 0))
+ledgerEnv = LedgerEnv (SlotNo 0) minBound ppsBench (AccountState (Coin 0) (Coin 0)) False
 
 testLEDGER ::
   LedgerState B ->

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Ledger.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Ledger.hs
@@ -100,6 +100,7 @@ instance
     LedgerEnv (SlotNo 0) minBound
       <$> genEraPParams @era geConstants
       <*> genAccountState geConstants
+      <*> pure False
 
   sigGen genenv env state = genTx genenv env state
 
@@ -150,7 +151,7 @@ instance
           TxIx ->
           Gen (LedgerState era, [Tx era])
         genAndApplyTx (ls', txs) txIx = do
-          let ledgerEnv = LedgerEnv slotNo txIx pParams reserves
+          let ledgerEnv = LedgerEnv slotNo txIx pParams reserves False
           tx <- genTx ge ledgerEnv ls'
 
           let res =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
@@ -156,7 +156,7 @@ genTx
         scriptspace
         constants
       )
-  (LedgerEnv slot txIx pparams reserves)
+  (LedgerEnv slot txIx pparams reserves _)
   (LedgerState utxoSt@(UTxOState utxo _ _ _ _ _) dpState) =
     do
       -------------------------------------------------------------------------

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -197,7 +197,7 @@ poolTraceFromBlock chainSt block =
     certs = concatMap (toList . view certsTxBodyL . view bodyTxL)
     poolCerts = mapMaybe getPoolCertTxCert (certs txs)
     poolEnv =
-      let (LedgerEnv s _ pp _) = ledgerEnv
+      let (LedgerEnv s _ pp _ _) = ledgerEnv
        in PoolEnv s pp
     poolSt0 =
       certPState (lsCertState ledgerSt0)
@@ -222,7 +222,7 @@ delegTraceFromBlock chainSt block =
     certs = concatMap (reverse . toList . view certsTxBodyL . view bodyTxL)
     blockCerts = filter delegCert (certs txs)
     delegEnv =
-      let (LedgerEnv s txIx pp reserves) = ledgerEnv
+      let (LedgerEnv s txIx pp reserves _) = ledgerEnv
           dummyCertIx = minBound
           ptr = Ptr s txIx dummyCertIx
        in DelegEnv s ptr reserves pp
@@ -250,7 +250,7 @@ ledgerTraceBase ::
   (ChainState era, LedgerEnv era, LedgerState era, [Tx era])
 ledgerTraceBase chainSt block =
   ( tickedChainSt
-  , LedgerEnv slot minBound pp_ (esAccountState nes)
+  , LedgerEnv slot minBound pp_ (esAccountState nes) False
   , esLState nes
   , txs
   )

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
@@ -345,7 +345,7 @@ addReward dp ra c = dp {certDState = ds {dsUnified = rewards'}}
 
 -- Any key deposit works in this test ^
 ledgerEnv :: LedgerEnv C
-ledgerEnv = LedgerEnv (SlotNo 0) minBound pp (AccountState (Coin 0) (Coin 0))
+ledgerEnv = LedgerEnv (SlotNo 0) minBound pp (AccountState (Coin 0) (Coin 0)) False
 
 testInvalidTx ::
   NonEmpty (PredicateFailure (ShelleyLEDGER C)) ->
@@ -504,7 +504,7 @@ testExpiredTx =
             , ttl = SlotNo 0
             , signers = [asWitness alicePay]
             }
-      ledgerEnv' = LedgerEnv (SlotNo 1) minBound pp (AccountState (Coin 0) (Coin 0))
+      ledgerEnv' = LedgerEnv (SlotNo 1) minBound pp (AccountState (Coin 0) (Coin 0)) False
    in testLEDGER ledgerState tx ledgerEnv' (Left errs)
 
 testInvalidWintess :: Assertion

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx/Gen.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx/Gen.hs
@@ -52,6 +52,7 @@ applyTxMempoolEnv pp =
     , ledgerIx = minBound
     , ledgerPp = pp
     , ledgerAccount = AccountState (Coin 45000000000) (Coin 45000000000)
+    , ledgerMempool = False
     }
 
 data ApplyTxEnv era = ApplyTxEnv

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
@@ -907,7 +907,7 @@ gone = do
   (PParamsF _ pp) <- monadTyped (findVar (unVar (pparams proof)) env)
   accntState <- monadTyped (runTarget env accountStateT)
   utxo1 <- monadTyped (findVar (unVar (utxo proof)) env)
-  let lenv = LedgerEnv slot txIx pp accntState
+  let lenv = LedgerEnv slot txIx pp accntState False
   -- putStrLn (show (pcTx Babbage tx))
   pure $ case applySTSByProof proof (TRC (lenv, ledgerstate, tx)) of
     Right _ledgerState' -> do
@@ -1016,7 +1016,7 @@ oneTest sizes proof = do
   (PParamsF _ pp) <- monadTyped (runTerm env2 (pparams proof))
   accntState <- monadTyped (runTarget env2 accountStateT)
   txIx <- arbitrary
-  let lenv = LedgerEnv slot txIx pp accntState
+  let lenv = LedgerEnv slot txIx pp accntState False
   case applySTSByProof proof (TRC (lenv, ledgerstate, tx)) of
     Right ledgerState' -> pure (totalAda ledgerState' === totalAda ledgerstate)
     Left errs -> do

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/SimpleTx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/SimpleTx.hs
@@ -105,7 +105,7 @@ getSTSLedgerEnv proof txIx env = do
   slot <- runTerm env currentSlot
   (PParamsF _ pp) <- runTerm env (pparams proof)
   accntState <- runTarget env accountStateT
-  pure $ (LedgerEnv slot txIx pp accntState, ledgerstate)
+  pure (LedgerEnv slot txIx pp accntState False, ledgerstate)
 
 -- ====================================================================
 -- Picking things that have no Plutus Scripts inside. To make very

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
@@ -350,7 +350,7 @@ runLEDGER ::
   Tx era ->
   Either (NonEmpty (PredicateFailure (EraRule "LEDGER" era))) (State (EraRule "LEDGER" era))
 runLEDGER wit@(LEDGER proof) state pparams tx =
-  let env = LedgerEnv (SlotNo 0) minBound pparams def
+  let env = LedgerEnv (SlotNo 0) minBound pparams def False
    in case proof of
         Conway -> runSTS' wit (TRC (env, state, tx))
         Babbage -> runSTS' wit (TRC (env, state, tx))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -3649,6 +3649,7 @@ instance Reflect era => PrettyA (LedgerEnv era) where
       , ("ix", prettyA (txIxToInt ledgerIx))
       , ("pparams", prettyA ledgerPp)
       , ("account", prettyA ledgerAccount)
+      , ("mempool", prettyA ledgerMempool)
       ]
 
 instance Reflect era => PrettyA (UtxoEnv era) where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1469,13 +1469,6 @@ ppConwayLedgerPredFailure proof x = case x of
       error
         ("Only the ConwayEra has a (PredicateFailure (EraRule \"GOV\" era)). This Era is " ++ show proof)
   ConwayUtxowFailure y -> ppUTXOW proof y
-  {- case proof of -- (PredicateFailure (EraRule "UTXOW" era))
-    Shelley -> ppShelleyUtxowPredFailure y
-    Allegra -> ppShelleyUtxowPredFailure y
-    Mary -> ppShelleyUtxowPredFailure y
-    Alonzo -> ppAlonzoUtxowPredFailure y
-    Babbage -> ppBabbageUtxowPredFailure proof y
-    Conway -> ppBabbageUtxowPredFailure proof y -}
   ConwayCertsFailure pf -> case proof of
     Conway -> ppConwayCertsPredFailure proof pf
     _ ->
@@ -1487,6 +1480,8 @@ ppConwayLedgerPredFailure proof x = case x of
       [ ("Computed sum of reference script size", ppInt s1)
       , ("Maximum allowed total reference script size", ppInt s2)
       ]
+  ConwayMempoolFailure t ->
+    ppSexp "ConwayMempoolFailure" [text t]
 
 instance Reflect era => PrettyA (ConwayLedgerPredFailure era) where
   prettyA = ppConwayLedgerPredFailure reify

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -88,27 +88,27 @@ import Test.Tasty (TestTree, defaultMain, testGroup)
 genTxAndUTXOState ::
   Reflect era => Proof era -> GenSize -> Gen (TRC (EraRule "UTXOW" era), GenState era)
 genTxAndUTXOState proof@Conway gsize = do
-  (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <-
+  (Box _ (TRC (LedgerEnv slotNo _ pp _ _, ledgerState, vtx)) genState) <-
     genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 genTxAndUTXOState proof@Babbage gsize = do
-  (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <-
+  (Box _ (TRC (LedgerEnv slotNo _ pp _ _, ledgerState, vtx)) genState) <-
     genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 genTxAndUTXOState proof@Alonzo gsize = do
-  (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <-
+  (Box _ (TRC (LedgerEnv slotNo _ pp _ _, ledgerState, vtx)) genState) <-
     genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 genTxAndUTXOState proof@Mary gsize = do
-  (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <-
+  (Box _ (TRC (LedgerEnv slotNo _ pp _ _, ledgerState, vtx)) genState) <-
     genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 genTxAndUTXOState proof@Allegra gsize = do
-  (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <-
+  (Box _ (TRC (LedgerEnv slotNo _ pp _ _, ledgerState, vtx)) genState) <-
     genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 genTxAndUTXOState proof@Shelley gsize = do
-  (Box _ (TRC (LedgerEnv slotNo _ pp _, ledgerState, vtx)) genState) <-
+  (Box _ (TRC (LedgerEnv slotNo _ pp _ _, ledgerState, vtx)) genState) <-
     genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 
@@ -142,7 +142,7 @@ genTxAndLEDGERState proof sizes = do
         model <- gets gsModel
         pp <- gets (gePParams . gsGenEnv)
         let ledgerState = extract @(LedgerState era) model
-            ledgerEnv = LedgerEnv slotNo txIx pp (AccountState (Coin 0) (Coin 0))
+            ledgerEnv = LedgerEnv slotNo txIx pp (AccountState (Coin 0) (Coin 0)) False
         pure $ TRC (ledgerEnv, ledgerState, tx)
   (trc, genstate) <- runGenRS proof sizes (initStableFields >> genT)
   pure (Box proof trc genstate)


### PR DESCRIPTION
# Description

Introduces Mempool rule and calls it from Ledger rule for transactions in the mempool. 

The first commit adds the predicate failure to ConwayLedgerPredFailure, which breaks node-to-client protocol. 
If the rest of the PR requires much rework, which would detract too much from [Issues discovered in Conway and fixed during the bootstrap phase](https://github.com/IntersectMBO/cardano-ledger/issues/4572), then we can just merge the first commit and put the rest on hold for after the intra-era HF. 

Closes https://github.com/IntersectMBO/cardano-ledger/issues/4622

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
