### PR TITLE
Don't return `ZeroTreasuryWithdrawals` failure during bootstrap

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -103,6 +103,7 @@ import qualified Cardano.Ledger.Shelley.HardForks as HF (bootstrapPhase)
 import Cardano.Ledger.Shelley.PParams (pvCanFollow)
 import Cardano.Ledger.TxIn (TxId (..))
 import Control.DeepSeq (NFData)
+import Control.Monad (unless)
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition.Extended (
   STS (..),
@@ -467,8 +468,9 @@ govTransition = do
                   -- Policy check
                   runTest $ checkPolicy @era constitutionPolicy proposalPolicy
 
-                  -- The sum of all withdrawals must be positive
-                  F.fold wdrls /= mempty ?! ZeroTreasuryWithdrawals pProcGovAction
+                  unless (HF.bootstrapPhase (pp ^. ppProtocolVersionL)) $
+                    -- The sum of all withdrawals must be positive
+                    F.fold wdrls /= mempty ?! ZeroTreasuryWithdrawals pProcGovAction
           UpdateCommittee _mPrevGovActionId membersToRemove membersToAdd _qrm -> do
             checkConflictingUpdate
             checkExpirationEpoch


### PR DESCRIPTION
and run withdrawal tests for both bootstrap and post-bootstrap


While reviewing Aniket's PR, I realized that in my previous PR, i have changed the behavior of empty withdrawals happening during bootstrap, by returning an extra predicate failure, which breaks node-to-client protocol. 

This PR is changing that, ensuring that during bootstrap the new predicate failure is omitted, and also makes sure that withdrawal tests are executing for both protocol versions of Conway, to make sure that the predicate failures during bootstrap are kept unchanged.  

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
