### PR TITLE
Drop pointers from UMap in Conway

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
@@ -200,7 +200,7 @@ instance Crypto c => TranslateEra (ConwayEra c) UTxOState where
         , API.utxosDeposited = API.utxosDeposited us
         , API.utxosFees = API.utxosFees us
         , API.utxosGovState = translateGovState ctxt $ API.utxosGovState us
-        , API.utxosStakeDistr = API.utxosStakeDistr us
+        , API.utxosStakeDistr = (API.utxosStakeDistr us) {API.ptrMap = mempty}
         , API.utxosDonation = API.utxosDonation us
         }
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
@@ -54,6 +54,7 @@ import qualified Cardano.Ledger.Shelley.API as API
 import Cardano.Ledger.Shelley.LedgerState (
   epochStateGovStateL,
  )
+import qualified Cardano.Ledger.UMap as UM
 import Data.Default.Class (Default (def))
 import qualified Data.Map.Strict as Map
 import Lens.Micro
@@ -138,7 +139,14 @@ instance Crypto c => TranslateEra (ConwayEra c) EpochState where
         }
 
 instance Crypto c => TranslateEra (ConwayEra c) DState where
-  translateEra _ DState {..} = pure DState {..}
+  translateEra _ DState {dsUnified = umap, ..} = pure DState {dsUnified = umap', ..}
+    where
+      umap' =
+        umap
+          { UM.umElems =
+              Map.map (\(UM.UMElem rd _ poolId drep) -> UM.UMElem rd mempty poolId drep) (UM.umElems umap)
+          , UM.umPtrs = mempty
+          }
 
 instance Crypto c => TranslateEra (ConwayEra c) CommitteeState where
   translateEra _ CommitteeState {..} = pure CommitteeState {..}

--- a/eras/conway/test-suite/CHANGELOG.md
+++ b/eras/conway/test-suite/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Version history for `cardano-ledger-conway-test`
 
-## 1.2.1.9
+## 1.3.0.0
 
 *
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/UMap.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/UMap.hs
@@ -218,7 +218,7 @@ data UMElem c
   | TFFEF {-# UNPACK #-} !RDPair !(Set Ptr) !(DRep c)
   | TFFFE {-# UNPACK #-} !RDPair !(Set Ptr) !(KeyHash 'StakePool c)
   | TFFFF {-# UNPACK #-} !RDPair !(Set Ptr) !(KeyHash 'StakePool c) !(DRep c)
-  deriving (Eq, Ord, Generic, NoThunks, NFData)
+  deriving (Eq, Ord, Show, Generic, NoThunks, NFData)
 
 instance Crypto c => ToJSON (UMElem c) where
   toJSON = object . toUMElemair
@@ -414,17 +414,6 @@ pattern UMElem i j k l <- (umElemAsTuple -> (i, j, k, l))
       (SJust r, p, SJust s, SJust d) -> TFFFF r p s d
 
 {-# COMPLETE UMElem #-}
-
-instance Show (UMElem c) where
-  show (UMElem a b c d) =
-    unlines
-      [ "(UMElem ("
-      , show a <> ", "
-      , show b <> ", "
-      , show c <> ", "
-      , show d
-      , "))"
-      ]
 
 -- | A unified map represents 4 Maps with domain @(Credential 'Staking c)@
 --


### PR DESCRIPTION
# Description

We no longer resolve pointers in Conway, nor do we add new pointers during registration in DELEG rule. This PR changes `UMap` and `UElem` deserializer to drop pointers in Conway. Also, in order for serialization tests to continue to roundtrip this PR prevent generations of pointers in `DState`s `Arbitrary` instance

Minor fix to `cardano-ledger-conway-test` version in changelog is also fixed

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
