### PR TITLE
Updated conformance to work with new MAlonzo types

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -24,8 +24,8 @@ source-repository-package
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `MAlonzo-code` BEFORE MERGE!
   subdir: generated
-  tag: 0b269ddbab4044a834554e94b3f9d1311a6ae06b
-  --sha256: sha256-M0ikZWKH8JCY+sSuujDILeFIsTzOsOfc9EilskHdWTU=
+  tag: 0b0b1f4eddb718b704824dcdc86abb8ce815deb2
+  --sha256: sha256-+bpsxn1hPGZqJ0rwZmUaPlOJuRj0RzLj1rulldUqk/E=
 -- NOTE: If you would like to update the above, look for the `MAlonzo-code`
 -- branch in the `formal-ledger-specifications` repo and copy the SHA of
 -- the commit you need. The `MAlonzo-code` branch functions like an alternative

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.17.0.0
 
+* Add `refScriptCostStride` and `refScriptCostMultiplier`
 * Added protocol version argument to `ppuWellFormed`
 * Add `ConwayMempoolEvent` type
 * Add `MempoolEvent` to `ConwayLedgerEvent`

--- a/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
+++ b/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
@@ -64,6 +64,7 @@ library
         cardano-ledger-core,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
         cardano-ledger-alonzo,
+        cardano-ledger-allegra,
         cardano-ledger-babbage,
         cardano-ledger-conway:{cardano-ledger-conway, testlib},
         cardano-ledger-executable-spec,

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
@@ -29,7 +29,7 @@ instance IsConwayUniv fn => ExecSpecRule fn "DELEG" Conway where
   runAgdaRule env st sig =
     first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
       . computationResultToEither
-      $ Agda.delegStep' env st sig
+      $ Agda.delegStep env st sig
 
   classOf = Just . nameDelegCert
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
@@ -15,17 +15,26 @@
 
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.GovCert (nameGovCert) where
 
+import Cardano.Ledger.BaseTypes (Inject)
+import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway
 import Cardano.Ledger.Conway.TxCert
+import Cardano.Ledger.Crypto (StandardCrypto)
 import Data.Bifunctor (Bifunctor (..))
 import qualified Data.List.NonEmpty as NE
+import Data.Map.Strict (Map)
 import qualified Data.Text as T
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base
 import Test.Cardano.Ledger.Constrained.Conway
 
-instance IsConwayUniv fn => ExecSpecRule fn "GOVCERT" Conway where
+instance
+  ( IsConwayUniv fn
+  , Inject (ConwayCertExecContext Conway) (Map (DepositPurpose StandardCrypto) Coin)
+  ) =>
+  ExecSpecRule fn "GOVCERT" Conway
+  where
   type ExecContext fn "GOVCERT" Conway = ConwayCertExecContext Conway
 
   environmentSpec _ctx = govCertEnvSpec
@@ -39,7 +48,7 @@ instance IsConwayUniv fn => ExecSpecRule fn "GOVCERT" Conway where
   runAgdaRule env st sig =
     first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
       . computationResultToEither
-      $ Agda.govCertStep' env st sig
+      $ Agda.govCertStep env st sig
 
 nameGovCert :: ConwayGovCert c -> String
 nameGovCert (ConwayRegDRep {}) = "ConwayRegDRep"

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -10,6 +10,7 @@ import Data.Bifunctor (Bifunctor (..))
 import Data.Default.Class (Default)
 import Data.List (nub, sortOn)
 import qualified Data.Set as Set
+import Data.Void (Void)
 import GHC.Generics (Generic)
 import Lib
 import Test.Cardano.Ledger.Common (NFData, ToExpr)
@@ -17,75 +18,7 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Core (FixupSpecRep (..), Op
 import Test.Cardano.Ledger.Conformance.Utils
 import Test.Cardano.Ledger.Conway.TreeDiff (Expr (..), ToExpr (..))
 
-deriving instance Generic (HSSet a)
-
-deriving instance Generic GovActionState
-
-deriving instance Generic Vote
-
-deriving instance Generic GovProposal
-
-deriving instance Generic GovAction
-
-deriving instance Generic GovVote
-
-deriving instance Generic GovSignal
-
-deriving instance Generic GovEnv
-
-deriving instance Generic EnactState
-
-deriving instance Generic DepositPurpose
-
-deriving instance Generic CertEnv
-
-deriving instance Generic CertEnv'
-
-deriving instance Generic PState
-
-deriving instance Generic DState
-
-deriving instance Generic DState'
-
-deriving instance Generic GState
-
-deriving instance Generic GState'
-
-deriving instance Generic CertState
-
-deriving instance Generic CertState'
-
-deriving instance Generic RatifyEnv
-
-deriving instance Generic RatifyState
-
-deriving instance Generic StakeDistrs
-
-deriving instance Generic EnactEnv
-
-deriving instance Generic DelegEnv
-
-deriving instance Generic DelegEnv'
-
-deriving instance Generic PoolThresholds
-
-deriving instance Generic DrepThresholds
-
-deriving instance Generic NewEpochEnv
-
-deriving instance Generic EpochState
-
-deriving instance Generic Snapshots
-
-deriving instance Generic Snapshot
-
-deriving instance Generic LedgerState
-
-deriving instance Generic Acnt
-
-deriving instance Generic RewardUpdate
-
-deriving instance Generic NewEpochState
+deriving instance Generic HsRewardUpdate
 
 deriving instance Ord DepositPurpose
 
@@ -105,85 +38,11 @@ deriving instance Ord DrepThresholds
 
 deriving instance Ord PParamsUpdate
 
+deriving instance Ord RwdAddr
+
 deriving instance Ord GovAction
 
 deriving instance Ord GovActionState
-
-deriving instance Eq a => Eq (HSSet a)
-
-deriving instance Eq AgdaEmpty
-
-deriving instance Eq TxBody
-
-deriving instance Eq Tag
-
-deriving instance Eq TxWitnesses
-
-deriving instance Eq Tx
-
-deriving instance Eq PoolThresholds
-
-deriving instance Eq DrepThresholds
-
-deriving instance Eq PParams
-
-deriving instance Eq UTxOState
-
-deriving instance Eq PParamsUpdate
-
-deriving instance Eq GovAction
-
-deriving instance Eq GovVote
-
-deriving instance Eq GovSignal
-
-deriving instance Eq GovProposal
-
-deriving instance Eq Vote
-
-deriving instance Eq GovActionState
-
-deriving instance Eq GovEnv
-
-deriving instance Eq EnactState
-
-deriving instance Eq UTxOEnv
-
-deriving instance Eq DepositPurpose
-
-deriving instance Eq CertEnv
-
-deriving instance Eq CertEnv'
-
-deriving instance Eq DState
-
-deriving instance Eq DState'
-
-deriving instance Eq PState
-
-deriving instance Eq GState
-
-deriving instance Eq GState'
-
-deriving instance Eq CertState
-
-deriving instance Eq CertState'
-
-deriving instance Eq RatifyState
-
-deriving instance Eq EpochState
-
-deriving instance Eq Snapshots
-
-deriving instance Eq Snapshot
-
-deriving instance Eq Acnt
-
-deriving instance Eq LedgerState
-
-deriving instance Eq RewardUpdate
-
-deriving instance Eq NewEpochState
 
 instance (NFData k, NFData v) => NFData (HSMap k v)
 
@@ -191,9 +50,15 @@ instance NFData a => NFData (HSSet a)
 
 instance NFData PParamsUpdate
 
+instance NFData RwdAddr
+
 instance NFData GovAction
 
-instance NFData TxId
+instance NFData BaseAddr
+
+instance NFData BootstrapAddr
+
+instance NFData Timelock
 
 instance NFData UTxOState
 
@@ -205,13 +70,11 @@ instance NFData GovRole
 
 instance NFData GovActionState
 
-instance NFData AgdaEmpty
+instance NFData Anchor
 
 instance NFData GovVote
 
 instance NFData GovProposal
-
-instance NFData GovSignal
 
 instance NFData DrepThresholds
 
@@ -225,7 +88,9 @@ instance NFData GovEnv
 
 instance NFData VDeleg
 
-instance NFData TxCert
+instance NFData PoolParams
+
+instance NFData DCert
 
 instance NFData TxBody
 
@@ -241,21 +106,13 @@ instance NFData DepositPurpose
 
 instance NFData CertEnv
 
-instance NFData CertEnv'
-
 instance NFData PState
 
 instance NFData DState
 
-instance NFData DState'
-
 instance NFData GState
 
-instance NFData GState'
-
 instance NFData CertState
-
-instance NFData CertState'
 
 instance NFData StakeDistrs
 
@@ -267,10 +124,6 @@ instance NFData EnactEnv
 
 instance NFData DelegEnv
 
-instance NFData DelegEnv'
-
-instance NFData NewEpochEnv
-
 instance NFData EpochState
 
 instance NFData Snapshots
@@ -279,9 +132,9 @@ instance NFData Snapshot
 
 instance NFData Acnt
 
-instance NFData LedgerState
+instance NFData LState
 
-instance NFData RewardUpdate
+instance NFData HsRewardUpdate
 
 instance NFData NewEpochState
 
@@ -295,22 +148,21 @@ instance (ToExpr k, ToExpr v) => ToExpr (HSMap k v)
 
 instance ToExpr PParamsUpdate
 
+instance ToExpr RwdAddr
+
 instance ToExpr GovAction
 
 instance ToExpr GovRole
 
 instance ToExpr Vote
 
-instance ToExpr TxId where
-  toExpr (MkTxId x) = App "TxId" [agdaHashToExpr 32 x]
-
 instance ToExpr GovActionState
+
+instance ToExpr Anchor
 
 instance ToExpr GovProposal
 
 instance ToExpr GovVote
-
-instance ToExpr GovSignal
 
 instance ToExpr PoolThresholds
 
@@ -324,11 +176,17 @@ instance ToExpr EnactState
 
 instance ToExpr VDeleg
 
-instance ToExpr TxCert
+instance ToExpr PoolParams
+
+instance ToExpr DCert
+
+instance ToExpr BaseAddr
+
+instance ToExpr BootstrapAddr
+
+instance ToExpr Timelock
 
 instance ToExpr TxBody
-
-instance ToExpr AgdaEmpty
 
 instance ToExpr Tag
 
@@ -344,21 +202,13 @@ instance ToExpr DepositPurpose
 
 instance ToExpr CertEnv
 
-instance ToExpr CertEnv'
-
 instance ToExpr DState
-
-instance ToExpr DState'
 
 instance ToExpr PState
 
 instance ToExpr GState
 
-instance ToExpr GState'
-
 instance ToExpr CertState
-
-instance ToExpr CertState'
 
 instance ToExpr StakeDistrs
 
@@ -370,25 +220,23 @@ instance ToExpr EnactEnv
 
 instance ToExpr DelegEnv
 
-instance ToExpr DelegEnv'
-
-instance ToExpr NewEpochEnv
-
 instance ToExpr EpochState
 
 instance ToExpr Snapshots
 
 instance ToExpr Snapshot
 
-instance ToExpr LedgerState
+instance ToExpr LState
 
 instance ToExpr Acnt
 
-instance ToExpr RewardUpdate
+instance ToExpr HsRewardUpdate
 
 instance ToExpr NewEpochState
 
 instance Default (HSMap k v)
+
+instance FixupSpecRep Void
 
 instance FixupSpecRep OpaqueErrorString
 
@@ -416,14 +264,18 @@ instance FixupSpecRep a => FixupSpecRep (Maybe a)
 
 instance (FixupSpecRep a, FixupSpecRep b) => FixupSpecRep (Either a b)
 
-instance FixupSpecRep Integer where
-  fixup = id
-
 instance FixupSpecRep Bool
 
-instance FixupSpecRep TxId
+instance FixupSpecRep TxId where
+  fixup = id
 
 instance FixupSpecRep ()
+
+instance FixupSpecRep BaseAddr
+
+instance FixupSpecRep BootstrapAddr
+
+instance FixupSpecRep Timelock
 
 instance FixupSpecRep UTxOState
 
@@ -437,27 +289,26 @@ instance FixupSpecRep DepositPurpose
 
 instance FixupSpecRep DState
 
-instance FixupSpecRep DState'
+instance FixupSpecRep PoolParams
 
 instance FixupSpecRep PState
 
 instance FixupSpecRep GState
 
-instance FixupSpecRep GState'
-
 instance FixupSpecRep CertState
-
-instance FixupSpecRep CertState'
 
 instance FixupSpecRep Vote
 
+instance FixupSpecRep Lib.Rational where
+  fixup = id
+
 instance FixupSpecRep PParamsUpdate
+
+instance FixupSpecRep RwdAddr
 
 instance FixupSpecRep GovAction
 
 instance FixupSpecRep GovActionState
-
-instance FixupSpecRep AgdaEmpty
 
 instance FixupSpecRep StakeDistrs
 
@@ -481,8 +332,8 @@ instance FixupSpecRep Snapshot
 
 instance FixupSpecRep Acnt
 
-instance FixupSpecRep LedgerState
+instance FixupSpecRep LState
 
-instance FixupSpecRep RewardUpdate
+instance FixupSpecRep HsRewardUpdate
 
 instance FixupSpecRep NewEpochState

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -13,13 +12,12 @@
 
 module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Certs () where
 
+import Cardano.Ledger.Address (RewardAccount)
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Conway.Rules
-import Cardano.Ledger.Credential
-import Cardano.Ledger.Keys
 import Data.Functor.Identity (Identity)
 import Data.Map.Strict (Map)
 import qualified Lib as Agda
@@ -36,15 +34,15 @@ instance
   ( SpecTranslate ctx (PParamsHKD Identity era)
   , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
   , Inject ctx (VotingProcedures era)
-  , Inject ctx (Map (Network, Credential 'Staking (EraCrypto era)) Coin)
+  , Inject ctx (Map (RewardAccount (EraCrypto era)) Coin)
   ) =>
   SpecTranslate ctx (CertsEnv era)
   where
-  type SpecRep (CertsEnv era) = Agda.CertEnv'
+  type SpecRep (CertsEnv era) = Agda.CertEnv
   toSpecRep CertsEnv {..} = do
     votes <- askCtx @(VotingProcedures era)
-    withdrawals <- askCtx @(Map (Network, Credential 'Staking (EraCrypto era)) Coin)
-    Agda.MkCertEnv'
+    withdrawals <- askCtx @(Map (RewardAccount (EraCrypto era)) Coin)
+    Agda.MkCertEnv
       <$> toSpecRep certsCurrentEpoch
       <*> toSpecRep certsPParams
       <*> toSpecRep votes

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
@@ -39,15 +39,15 @@ instance
   ) =>
   SpecTranslate ctx (ConwayDelegEnv era)
   where
-  type SpecRep (ConwayDelegEnv era) = Agda.DelegEnv'
+  type SpecRep (ConwayDelegEnv era) = Agda.DelegEnv
 
   toSpecRep ConwayDelegEnv {..} =
-    Agda.MkDelegEnv'
+    Agda.MkDelegEnv
       <$> toSpecRep cdePParams
       <*> toSpecRep (Map.mapKeys (hashToInteger . unKeyHash) cdePools)
 
 instance SpecTranslate ctx (ConwayDelegCert c) where
-  type SpecRep (ConwayDelegCert c) = Agda.TxCert
+  type SpecRep (ConwayDelegCert c) = Agda.DCert
 
   toSpecRep (ConwayRegCert c d) =
     Agda.Delegate
@@ -78,10 +78,10 @@ instance SpecTranslate ctx (ConwayDelegPredFailure era) where
   toSpecRep e = pure . OpaqueErrorString . show $ toExpr e
 
 instance SpecTranslate ctx (DState era) where
-  type SpecRep (DState era) = Agda.DState'
+  type SpecRep (DState era) = Agda.DState
 
   toSpecRep DState {..} =
-    Agda.MkDState'
+    Agda.MkDState
       <$> toSpecRep (UMap.dRepMap dsUnified)
       <*> toSpecRep (UMap.sPoolMap dsUnified)
       <*> toSpecRep (UMap.rewardMap dsUnified)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Gov.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Gov.hs
@@ -47,13 +47,13 @@ instance
   ) =>
   SpecTranslate ctx (GovSignal era)
   where
-  type SpecRep (GovSignal era) = [Agda.GovSignal]
+  type SpecRep (GovSignal era) = [Either Agda.GovVote Agda.GovProposal]
 
   toSpecRep GovSignal {gsVotingProcedures, gsProposalProcedures} = do
     votingProcedures <- toSpecRep gsVotingProcedures
     proposalProcedures <- toSpecRep gsProposalProcedures
     pure $
       mconcat
-        [ Agda.GovSignalVote <$> votingProcedures
-        , Agda.GovSignalProposal <$> proposalProcedures
+        [ Left <$> votingProcedures
+        , Right <$> proposalProcedures
         ]

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
@@ -44,13 +44,13 @@ instance SpecTranslate ctx (PState era) where
       <*> toSpecRep (mapKeys (hashToInteger . unKeyHash) psRetiring)
 
 instance SpecTranslate ctx (PoolCert c) where
-  type SpecRep (PoolCert c) = Agda.TxCert
+  type SpecRep (PoolCert c) = Agda.DCert
 
   toSpecRep (RegPool p@PoolParams {ppId = KeyHash ppHash}) =
-    Agda.RegPool
+    Agda.Regpool
       <$> toSpecRep ppHash
       <*> toSpecRep p
   toSpecRep (RetirePool (KeyHash ppHash) e) =
-    Agda.RetirePool
+    Agda.Retirepool
       <$> toSpecRep ppHash
       <*> toSpecRep e

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
@@ -9,8 +9,8 @@
 -- for the CERTS rule
 module Test.Cardano.Ledger.Constrained.Conway.Certs where
 
+import Cardano.Ledger.Address (RewardAccount (..))
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), IsValid (..))
-import Cardano.Ledger.BaseTypes (Network (..))
 import Cardano.Ledger.CertState
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (Conway)
@@ -52,8 +52,8 @@ bootstrapDStateSpec ::
 bootstrapDStateSpec withdrawals =
   let isKey (ScriptHashObj _) = False
       isKey (KeyHashObj _) = True
-      withdrawalPairs = Map.toList (Map.mapKeys snd (Map.map coinToWord64 withdrawals))
-      withdrawalKeys = Map.keysSet (Map.mapKeys snd withdrawals)
+      withdrawalPairs = Map.toList (Map.mapKeys raCredential (Map.map coinToWord64 withdrawals))
+      withdrawalKeys = Map.keysSet (Map.mapKeys raCredential withdrawals)
    in constrained $ \ [var| dstate |] ->
         match dstate $ \ [var| rewardMap |] _futureGenDelegs _genDelegs _rewards ->
           [ assert $ sizeOf_ _futureGenDelegs ==. 0
@@ -86,7 +86,7 @@ bootstrapDStateSpec withdrawals =
 coinToWord64 :: Coin -> Word64
 coinToWord64 (Coin n) = fromIntegral n
 
-type CertsContext era = (Map (Network, Credential 'Staking (EraCrypto era)) Coin)
+type CertsContext era = Map (RewardAccount (EraCrypto era)) Coin
 
 txZero :: AlonzoTx Conway
 txZero = AlonzoTx mkBasicTxBody mempty (IsValid True) def


### PR DESCRIPTION
# Description

This PR brings the `SpecTranslate` instances up to date with the new MAlonzo types.

Spec PR: IntersectMBO/formal-ledger-specifications#580

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
