### PR TITLE
Mismatch type for predicate failures

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
@@ -29,6 +29,7 @@ import Cardano.Ledger.Allegra.Era (AllegraEra, AllegraUTXO)
 import Cardano.Ledger.Allegra.Rules.Ppup ()
 import Cardano.Ledger.Allegra.Scripts (inInterval)
 import Cardano.Ledger.BaseTypes (
+  Mismatch (..),
   Network,
   ProtVer (pvMajor),
   ShelleyBase,
@@ -471,9 +472,9 @@ shelleyToAllegraUtxoPredFailure = \case
   Shelley.BadInputsUTxO ins -> BadInputsUTxO ins
   Shelley.ExpiredUTxO ttl current ->
     OutsideValidityIntervalUTxO (ValidityInterval SNothing (SJust ttl)) current
-  Shelley.MaxTxSizeUTxO a m -> MaxTxSizeUTxO a m
+  Shelley.MaxTxSizeUTxO (Mismatch a m) -> MaxTxSizeUTxO a m
   Shelley.InputSetEmptyUTxO -> InputSetEmptyUTxO
-  Shelley.FeeTooSmallUTxO mf af -> FeeTooSmallUTxO mf af
+  Shelley.FeeTooSmallUTxO (Mismatch sf ef) -> FeeTooSmallUTxO ef sf
   Shelley.ValueNotConservedUTxO vc vp -> ValueNotConservedUTxO vc vp
   Shelley.WrongNetwork n as -> WrongNetwork n as
   Shelley.WrongNetworkWithdrawal n as -> WrongNetworkWithdrawal n as

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
@@ -33,7 +33,7 @@ import Cardano.Ledger.Alonzo.Tx (AlonzoTx, totExUnits)
 import Cardano.Ledger.Alonzo.TxSeq (AlonzoTxSeq, txSeqTxns)
 import Cardano.Ledger.Alonzo.TxWits (AlonzoEraTxWits (..))
 import Cardano.Ledger.BHeaderView (BHeaderView (..), isOverlaySlot)
-import Cardano.Ledger.BaseTypes (ShelleyBase, epochInfoPure)
+import Cardano.Ledger.BaseTypes (Mismatch (..), ShelleyBase, epochInfoPure)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.Block (Block (..))
@@ -209,14 +209,24 @@ alonzoBbodyTransition =
           == fromIntegral (bhviewBSize bh)
             ?! injectFailure
               ( ShelleyInAlonzoBbodyPredFailure
-                  (WrongBlockBodySizeBBODY actualBodySize (fromIntegral $ bhviewBSize bh))
+                  ( WrongBlockBodySizeBBODY $
+                      Mismatch
+                        { mismatchSupplied = actualBodySize
+                        , mismatchExpected = fromIntegral $ bhviewBSize bh
+                        }
+                  )
               )
 
         actualBodyHash
           == bhviewBHash bh
             ?! injectFailure
               ( ShelleyInAlonzoBbodyPredFailure
-                  (InvalidBodyHashBBODY @era actualBodyHash (bhviewBHash bh))
+                  ( InvalidBodyHashBBODY @era $
+                      Mismatch
+                        { mismatchSupplied = actualBodyHash
+                        , mismatchExpected = bhviewBHash bh
+                        }
+                  )
               )
 
         ls' <-

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
@@ -39,7 +39,7 @@ import Cardano.Ledger.Alonzo.TxWits (AlonzoEraTxWits (..))
 import Cardano.Ledger.BHeaderView (BHeaderView (..))
 import Cardano.Ledger.Babbage.Core (BabbageEraTxBody)
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure, BabbageUtxowPredFailure)
-import Cardano.Ledger.BaseTypes (ShelleyBase)
+import Cardano.Ledger.BaseTypes (Mismatch (..), ShelleyBase)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders (
   Decode (..),
@@ -237,8 +237,12 @@ shelleyToConwayBbodyPredFailure ::
   forall era.
   ShelleyBbodyPredFailure era ->
   ConwayBbodyPredFailure era
-shelleyToConwayBbodyPredFailure (Shelley.WrongBlockBodySizeBBODY x y) = WrongBlockBodySizeBBODY x y
-shelleyToConwayBbodyPredFailure (Shelley.InvalidBodyHashBBODY x y) = InvalidBodyHashBBODY x y
+shelleyToConwayBbodyPredFailure
+  (Shelley.WrongBlockBodySizeBBODY (Mismatch supplied expected)) =
+    WrongBlockBodySizeBBODY supplied expected
+shelleyToConwayBbodyPredFailure
+  (Shelley.InvalidBodyHashBBODY (Mismatch supplied expected)) =
+    InvalidBodyHashBBODY supplied expected
 shelleyToConwayBbodyPredFailure (Shelley.LedgersFailure x) = LedgersFailure x
 
 alonzoToConwayBbodyPredFailure ::

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
@@ -44,7 +44,7 @@ import Cardano.Ledger.Babbage.Rules (
   babbageUtxowTransition,
  )
 import qualified Cardano.Ledger.Babbage.Rules as Babbage (BabbageUtxowPredFailure (..))
-import Cardano.Ledger.BaseTypes (ShelleyBase)
+import Cardano.Ledger.BaseTypes (Mismatch (..), ShelleyBase)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders (
   Decode (..),
@@ -357,6 +357,7 @@ shelleyToConwayUtxowPredFailure = \case
     error "Impossible: MIR has been removed in Conway"
   Shelley.MissingTxBodyMetadataHash x -> MissingTxBodyMetadataHash x
   Shelley.MissingTxMetadata x -> MissingTxMetadata x
-  Shelley.ConflictingMetadataHash a b -> ConflictingMetadataHash a b
+  Shelley.ConflictingMetadataHash (Mismatch supplied expected) ->
+    ConflictingMetadataHash supplied expected
   Shelley.InvalidMetadata -> InvalidMetadata
   Shelley.ExtraneousScriptWitnessesUTXOW xs -> ExtraneousScriptWitnessesUTXOW xs

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## 1.14.0.0
 
+* Remove `ShelleyNewppPredFailure`. #4649
+* Change predicate-failures and their serialization to use the `Mismatch` type to report supplied and expected values. #4649
+  * `MaxTxSizeUTxO`
+  * `FeeTooSmallUTxO`
+  * `WrongBlockBodySizeBBODY`
+  * `InvalidBodyHashBBODY`
+  * `ConflictingMetadataHash`
+  * `StakePoolRetirementWrongEpochPOOL`
+  * `StakePoolCostTooLowPOOL`
+  * `WrongNetworkPOOL`
+  * `NonGenesisUpdatePPUP`
 * Deprecated `applyTxs` and `applyTxsTransition` in `Mempool`
 * Replaced `applyTx` in `ApplyTx` class with `applyTxOpts`
 * Added and exposed `applyTx` in `Mempool`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Newpp.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Newpp.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -13,12 +12,10 @@ module Cardano.Ledger.Shelley.Rules.Newpp (
   ShelleyNEWPP,
   ShelleyNewppState (..),
   NewppEnv (..),
-  ShelleyNewppPredFailure (..),
   PredicateFailure,
 ) where
 
 import Cardano.Ledger.BaseTypes (Globals (quorum), ShelleyBase)
-import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Era (ShelleyNEWPP)
 import Cardano.Ledger.Shelley.Governance
@@ -32,7 +29,6 @@ import Cardano.Ledger.Shelley.PParams (
   hasLegalProtVerUpdate,
  )
 import Cardano.Ledger.Shelley.Rules.Ppup (votedFuturePParams)
-import Control.DeepSeq (NFData)
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition (
   STS (..),
@@ -42,9 +38,8 @@ import Control.State.Transition (
   liftSTS,
  )
 import Data.Default.Class (Default, def)
+import Data.Void (Void)
 import Data.Word (Word64)
-import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks (..))
 
 data ShelleyNewppState era
   = NewppState (PParams era) (ShelleyGovState era)
@@ -53,16 +48,6 @@ data NewppEnv era = NewppEnv
   { neCertState :: !(CertState era)
   , neUTxOState :: !(UTxOState era)
   }
-
-data ShelleyNewppPredFailure era
-  = UnexpectedDepositPot
-      !Coin -- The total outstanding deposits
-      !Coin -- The deposit pot
-  deriving (Show, Eq, Generic)
-
-instance NoThunks (ShelleyNewppPredFailure era)
-
-instance NFData (ShelleyNewppPredFailure era)
 
 instance
   ( EraGov era
@@ -75,7 +60,7 @@ instance
   type Signal (ShelleyNEWPP era) = PParams era
   type Environment (ShelleyNEWPP era) = NewppEnv era
   type BaseM (ShelleyNEWPP era) = ShelleyBase
-  type PredicateFailure (ShelleyNEWPP era) = ShelleyNewppPredFailure era
+  type PredicateFailure (ShelleyNEWPP era) = Void
   transitionRules = [newPpTransition]
 
 instance EraPParams era => Default (ShelleyNewppState era) where

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Upec.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Upec.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
@@ -36,7 +35,6 @@ import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..))
 import Cardano.Ledger.Shelley.Rules.Newpp (
   NewppEnv (..),
   ShelleyNEWPP,
-  ShelleyNewppPredFailure,
   ShelleyNewppState (..),
  )
 import Cardano.Ledger.Shelley.Rules.Ppup (votedFuturePParams)
@@ -69,7 +67,7 @@ newtype ShelleyUpecPredFailure era
 
 instance NoThunks (ShelleyUpecPredFailure era)
 
-instance NFData (ShelleyNewppPredFailure era) => NFData (ShelleyUpecPredFailure era)
+instance NFData (ShelleyUpecPredFailure era)
 
 instance
   ( EraGov era

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/UtxowSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/UtxowSpec.hs
@@ -120,7 +120,8 @@ spec = describe "UTXOW" $ do
     submitFailingTx
       tx
       [ injectFailure $
-          ConflictingMetadataHash wrongAuxDataHash auxDataHash
+          ConflictingMetadataHash $
+            Mismatch {mismatchSupplied = wrongAuxDataHash, mismatchExpected = auxDataHash}
       ]
 
   it "ExtraneousScriptWitnessesUTXOW" $ do

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
@@ -476,7 +476,7 @@ testEmptyInputSet =
 testFeeTooSmall :: Assertion
 testFeeTooSmall =
   testInvalidTx
-    [UtxowFailure (UtxoFailure (FeeTooSmallUTxO (Coin 205) (Coin 1)))]
+    [UtxowFailure (UtxoFailure (FeeTooSmallUTxO $ Mismatch (Coin 1) (Coin 205)))]
     $ aliceGivesBobLovelace
       AliceToBob
         { input = TxIn genesisId minBound
@@ -637,7 +637,8 @@ testPoolCostTooSmall =
     [ DelegsFailure $
         DelplFailure $
           PoolFailure $
-            StakePoolCostTooLowPOOL (ppCost alicePoolParamsSmallCost) (pp @C ^. ppMinPoolCostL)
+            StakePoolCostTooLowPOOL $
+              Mismatch (ppCost alicePoolParamsSmallCost) (pp @C ^. ppMinPoolCostL)
     ]
     $ aliceGivesBobLovelace
     $ AliceToBob

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.15.0.0
 
+* Add `Mismatch` type to clarify predicate-failures reporting supplied and expected values. #4649
 * Added `drepDelegs` to `DRepState`
 * Add `member'` function to `UMap` module. #4639
 * Add `credKeyHash` to `Credential`

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -56,6 +56,7 @@ import Cardano.Ledger.BaseTypes (
   CertIx (..),
   DnsName,
   EpochInterval (..),
+  Mismatch (..),
   Network (..),
   NonNegativeInterval,
   Nonce (..),
@@ -807,10 +808,10 @@ instance Era era => Arbitrary (PState era) where
   arbitrary = PState <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
 instance Crypto c => Arbitrary (Anchor c) where
-  arbitrary =
-    Anchor
-      <$> arbitrary
-      <*> arbitrary
+  arbitrary = Anchor <$> arbitrary <*> arbitrary
+
+instance Arbitrary a => Arbitrary (Mismatch r a) where
+  arbitrary = Mismatch <$> arbitrary <*> arbitrary
 
 instance Crypto c => Arbitrary (CommitteeAuthorization c) where
   arbitrary =

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
@@ -149,6 +149,8 @@ instance ToExpr ProtVer
 
 instance ToExpr (Anchor c)
 
+instance ToExpr a => ToExpr (Mismatch r a)
+
 instance ToExpr EpochInterval
 
 -- AuxiliaryData


### PR DESCRIPTION
# Description

This is the first part of #4619. After this the priority is to first get Conway predicates to use the new `Mismatch` type, and then the rest of the remaining eras.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
