### PR TITLE
Improve color output in Imp spec

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -37,6 +37,8 @@
 * Move `TxInfo` golden tests over from the older `-test` package. #4599
   * Also move the `gen-golden` executable over.
 * Added Test.Cardano.Ledger.Conway.CDDL with CDDL definitions in Conway.
+* Change `ImpException` to contain `Doc`
+* Add `impAnnDoc`
 
 ## 1.16.1.0
 


### PR DESCRIPTION
# Description

Output is formatted a bit prettier:
* Annotations now can use pretty printer
* Annotation get nice stair case formatting
* failures are reported Red

Here is an example with `impAnn "foo" $ impAnn "Bar" ...`:

![image](https://github.com/user-attachments/assets/34b45061-caea-400d-b3f3-fbeb7ed10e68)


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
