### PR TITLE
Add `applyTxOpts` to `ApplyTx`

### DIFF
--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -31,6 +31,7 @@ import Cardano.Ledger.Conway.Rules (
   ConwayNewEpochEvent,
  )
 import Cardano.Ledger.Conway.TxInfo (ConwayContextError)
+import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
 import Cardano.Ledger.Shelley.Rules (
   ShelleyLedgersEnv,
   ShelleyLedgersEvent,
@@ -89,6 +90,7 @@ spec ::
   , Environment (EraRule "LEDGERS" era) ~ ShelleyLedgersEnv era
   , Signal (EraRule "LEDGERS" era) ~ Seq (Tx era)
   , STS (EraRule "LEDGERS" era)
+  , ApplyTx era
   ) =>
   Spec
 spec = do

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.14.0.0
 
+* Replaced `applyTx` in `ApplyTx` class with `applyTxOpts`
+* Added and exposed `applyTx` in `Mempool`
 * Added `mempool` to `LedgerEnv`
 * Added `registerStakeCredential` and `delegateStake` to `ImpTest`
 * Remove protocol version argument from `mkShelleyGlobals` (`maxMajorPV` was removed from `Globals`)

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.14.0.0
 
+* Deprecated `applyTxs` and `applyTxsTransition` in `Mempool`
 * Replaced `applyTx` in `ApplyTx` class with `applyTxOpts`
 * Added and exposed `applyTx` in `Mempool`
 * Added `mempool` to `LedgerEnv`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -280,6 +280,7 @@ applyTxs
     overNewEpochState (applyTxsTransition globals mempoolEnv txs) state
     where
       mempoolEnv = mkMempoolEnv state slot
+{-# DEPRECATED applyTxs "Use `applyTxOpts` and `mkMempoolEnv` instead" #-}
 
 applyTxsTransition ::
   forall era m.
@@ -296,6 +297,7 @@ applyTxsTransition globals env txs state =
     (\st tx -> fst <$> applyTx globals env st tx)
     state
     txs
+{-# DEPRECATED applyTxsTransition "Use `applyTxOpts` and `mkMempoolEnv` instead" #-}
 
 -- | Transform a function over mempool states to one over the full
 -- 'NewEpochState'.

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx.hs
@@ -27,14 +27,13 @@ import Cardano.Ledger.Shelley.API (
   Globals,
   LedgerEnv,
   LedgerState,
-  applyTxsTransition,
+  applyTx,
  )
 import Cardano.Ledger.Shelley.Core
 import Control.DeepSeq (NFData (..))
 import Control.State.Transition (Environment, Signal, State)
 import Criterion
 import Data.Proxy (Proxy (..))
-import qualified Data.Sequence as Seq
 import Data.Typeable (typeRep)
 import Test.Cardano.Ledger.Alonzo.AlonzoEraGen ()
 import Test.Cardano.Ledger.Alonzo.Trace ()
@@ -97,8 +96,11 @@ benchApplyTx px =
   benchWithGenState px pure $ \applyTxEnv ->
     let ApplyTxEnv {ateGlobals, ateMempoolEnv, ateState, ateTx} = applyTxEnv
      in nf
-          ( either (error . show) id
-              . applyTxsTransition ateGlobals ateMempoolEnv (Seq.singleton ateTx)
+          ( \st ->
+              either
+                (error . show)
+                fst
+                (applyTx ateGlobals ateMempoolEnv st ateTx)
           )
           ateState
 


### PR DESCRIPTION
# Description

Instead of `applyTx`, `ApplyTx` class is changed to  expose `applyTxOpts` , whereas `applyTx` is moved outside the class, still within Mempool rule. 
Also adding  a  that was pending this function. 

Fixes https://github.com/IntersectMBO/cardano-ledger/issues/4651

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
