### PR TITLE
HardFork rule

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.17.0.0
 
+* Add `HardForkEvent` constructor to `ConwayEpochEvent`
 * Add `HardFork` module, `ConwayHARDFORK` and `ConwayHardForkEvent`
 * Add predicate failures to guard against invalid reward accounts (return addresses) in proposals and treasury withdrawals. #4639
   * `ProposalReturnAddressDoesNotExist`, and 

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.17.0.0
 
+* Add `HardFork` module, `ConwayHARDFORK` and `ConwayHardForkEvent`
 * Add predicate failures to guard against invalid reward accounts (return addresses) in proposals and treasury withdrawals. #4639
   * `ProposalReturnAddressDoesNotExist`, and 
   * `TreasuryWithdrawalReturnAddressDoesNotExist`.

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -61,6 +61,7 @@ library
         Cardano.Ledger.Conway.Rules.Certs
         Cardano.Ledger.Conway.Rules.Enact
         Cardano.Ledger.Conway.Rules.Epoch
+        Cardano.Ledger.Conway.Rules.HardFork
         Cardano.Ledger.Conway.Rules.Ledger
         Cardano.Ledger.Conway.Rules.Ledgers
         Cardano.Ledger.Conway.Rules.Mempool

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
@@ -9,6 +9,7 @@ module Cardano.Ledger.Conway.Era (
   ConwayGOVCERT,
   ConwayCERTS,
   ConwayGOV,
+  ConwayHARDFORK,
   ConwayMEMPOOL,
   ConwayNEWEPOCH,
   ConwayEPOCH,
@@ -139,6 +140,10 @@ type instance EraRule "BBODY" (ConwayEra c) = ConwayBBODY (ConwayEra c)
 data ConwayMEMPOOL era
 
 type instance EraRule "MEMPOOL" (ConwayEra c) = ConwayMEMPOOL (ConwayEra c)
+
+data ConwayHARDFORK era
+
+type instance EraRule "HARDFORK" (ConwayEra c) = ConwayHARDFORK (ConwayEra c)
 
 -- Rules inherited from Shelley
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules.hs
@@ -11,6 +11,7 @@ module Cardano.Ledger.Conway.Rules (
   module Cardano.Ledger.Conway.Rules.Certs,
   module Cardano.Ledger.Conway.Rules.Enact,
   module Cardano.Ledger.Conway.Rules.Epoch,
+  module Cardano.Ledger.Conway.Rules.HardFork,
   module Cardano.Ledger.Conway.Rules.Ledger,
   module Cardano.Ledger.Conway.Rules.Mempool,
   module Cardano.Ledger.Conway.Rules.NewEpoch,
@@ -33,6 +34,7 @@ import Cardano.Ledger.Conway.Rules.Enact
 import Cardano.Ledger.Conway.Rules.Epoch
 import Cardano.Ledger.Conway.Rules.Gov
 import Cardano.Ledger.Conway.Rules.GovCert
+import Cardano.Ledger.Conway.Rules.HardFork
 import Cardano.Ledger.Conway.Rules.Ledger
 import Cardano.Ledger.Conway.Rules.Ledgers ()
 import Cardano.Ledger.Conway.Rules.Mempool

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
@@ -139,6 +139,7 @@ data ConwayEpochEvent era
       (Set (GovActionState era))
       -- | Map of removed governance action ids that had an unregistered reward account to their unclaimed deposits so they can be transferred to the treasury.
       (Map.Map (GovActionId (EraCrypto era)) Coin)
+  | HardForkEvent (Event (EraRule "HARDFORK" era))
   deriving (Generic)
 
 type instance EraRuleEvent "EPOCH" (ConwayEra c) = ConwayEpochEvent (ConwayEra c)
@@ -147,6 +148,7 @@ deriving instance
   ( EraPParams era
   , Eq (Event (EraRule "POOLREAP" era))
   , Eq (Event (EraRule "SNAP" era))
+  , Eq (Event (EraRule "HARDFORK" era))
   ) =>
   Eq (ConwayEpochEvent era)
 
@@ -154,6 +156,7 @@ instance
   ( EraPParams era
   , NFData (Event (EraRule "POOLREAP" era))
   , NFData (Event (EraRule "SNAP" era))
+  , NFData (Event (EraRule "HARDFORK" era))
   ) =>
   NFData (ConwayEpochEvent era)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/HardFork.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/HardFork.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE EmptyDataDeriving #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.Conway.Rules.HardFork (
+  ConwayHARDFORK,
+  ConwayHardForkEvent (..),
+) where
+
+import Cardano.Ledger.BaseTypes (ProtVer, ShelleyBase)
+import Cardano.Ledger.Conway.Core
+import Cardano.Ledger.Conway.Era (ConwayEra, ConwayHARDFORK)
+import Cardano.Ledger.Shelley.LedgerState
+import Control.DeepSeq (NFData)
+import Control.State.Transition (
+  BaseM,
+  Environment,
+  Event,
+  PredicateFailure,
+  STS (..),
+  Signal,
+  State,
+  TRC (TRC),
+  TransitionRule,
+  judgmentContext,
+  tellEvent,
+  transitionRules,
+ )
+import Data.Void (Void)
+import GHC.Generics (Generic)
+
+newtype ConwayHardForkEvent era = ConwayHardForkEvent ProtVer
+  deriving (Generic, Eq)
+  deriving newtype (NFData)
+
+type instance EraRuleEvent "HARDFORK" (ConwayEra c) = ConwayHardForkEvent (ConwayEra c)
+
+instance
+  EraGov era =>
+  STS (ConwayHARDFORK era)
+  where
+  type State (ConwayHARDFORK era) = EpochState era
+  type Signal (ConwayHARDFORK era) = ProtVer
+  type Environment (ConwayHARDFORK era) = ()
+  type BaseM (ConwayHARDFORK era) = ShelleyBase
+  type PredicateFailure (ConwayHARDFORK era) = Void
+  type Event (ConwayHARDFORK era) = ConwayHardForkEvent era
+
+  transitionRules = [hardforkTransition @era]
+
+hardforkTransition :: TransitionRule (ConwayHARDFORK era)
+hardforkTransition = do
+  TRC (_, st, pv) <-
+    judgmentContext
+  -- Add operations that modify the state meaningfully during intra-era hardforks.
+  tellEvent $ ConwayHardForkEvent pv
+  pure st

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Mempool.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Mempool.hs
@@ -58,13 +58,7 @@ newtype ConwayMempoolEvent era = ConwayMempoolEvent Text
 type instance EraRuleEvent "MEMPOOL" (ConwayEra c) = ConwayMempoolEvent (ConwayEra c)
 
 instance
-  ( EraTx era
-  , EraGov era
-  , State (EraRule "MEMPOOL" era) ~ LedgerState era
-  , Signal (EraRule "MEMPOOL" era) ~ Tx era
-  , Environment (EraRule "MEMPOOL" era) ~ LedgerEnv era
-  , EraRule "MEMPOOL" era ~ ConwayMEMPOOL era
-  ) =>
+  (EraTx era, EraGov era) =>
   STS (ConwayMEMPOOL era)
   where
   type State (ConwayMEMPOOL era) = LedgerState era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -25,6 +25,7 @@ import Cardano.Ledger.Conway.Rules (
   ConwayEpochEvent,
   ConwayGovCertPredFailure,
   ConwayGovPredFailure,
+  ConwayHardForkEvent,
   ConwayLedgerEvent,
   ConwayLedgerPredFailure,
   ConwayMempoolEvent,
@@ -91,6 +92,7 @@ spec ::
   , Signal (EraRule "LEDGERS" era) ~ Seq (Tx era)
   , STS (EraRule "LEDGERS" era)
   , ApplyTx era
+  , Event (EraRule "HARDFORK" era) ~ ConwayHardForkEvent era
   ) =>
   Spec
 spec = do

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
@@ -28,7 +28,6 @@ import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.Rules (Event, ShelleyTickEvent (..))
 import Cardano.Ledger.Val
 import Control.Monad.Writer (listen)
-import Data.Data (cast)
 import Data.Default.Class (Default (..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
@@ -36,6 +35,7 @@ import Data.Maybe.Strict (StrictMaybe (..))
 import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
 import Data.Tree
+import Data.Typeable (cast)
 import Lens.Micro
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Core.Rational (IsRatio (..), (%!))

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
@@ -191,12 +191,15 @@ instance
   ) =>
   ToExpr (ConwayNewEpochEvent era)
 
+instance ToExpr (ConwayHardForkEvent era)
+
 instance
   ( EraPParams era
   , ToExpr (PParams era)
   , ToExpr (PParamsHKD StrictMaybe era)
   , ToExpr (Event (EraRule "POOLREAP" era))
   , ToExpr (Event (EraRule "SNAP" era))
+  , ToExpr (Event (EraRule "HARDFORK" era))
   ) =>
   ToExpr (ConwayEpochEvent era)
 


### PR DESCRIPTION
# Description

Introduces a new rule that gets called from EPOCH whenever the protocol version changes. 

Closes https://github.com/IntersectMBO/cardano-ledger/issues/4621

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
