### PR TITLE
Added additional operators single_ and append_ to operations on Lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ specs/**/.ghc.environment.x86_64-linux-*
 
 ## Misc
 .pre-commit-config.yaml
+/.gitmessage

--- a/libs/constrained-generators/constrained-generators.cabal
+++ b/libs/constrained-generators/constrained-generators.cabal
@@ -41,8 +41,10 @@ library
         Constrained.Examples.Tree
         Constrained.Examples.Either
         Constrained.Examples.CheatSheet
+        Constrained.Examples.Append
         Constrained.Properties
         Constrained.Syntax
+        Constrained.ListSplit
 
     hs-source-dirs:   src
     default-language: Haskell2010

--- a/libs/constrained-generators/src/Constrained.hs
+++ b/libs/constrained-generators/src/Constrained.hs
@@ -98,6 +98,8 @@ module Constrained (
   elem_,
   not_,
   foldMap_,
+  single_,
+  append_,
   sum_,
   size_,
   rng_,

--- a/libs/constrained-generators/src/Constrained/Examples.hs
+++ b/libs/constrained-generators/src/Constrained/Examples.hs
@@ -1,5 +1,6 @@
 module Constrained.Examples (module X) where
 
+import Constrained.Examples.Append as X
 import Constrained.Examples.Basic as X
 import Constrained.Examples.Either as X
 import Constrained.Examples.List as X

--- a/libs/constrained-generators/src/Constrained/Examples/Append.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Append.hs
@@ -26,10 +26,10 @@ even :: Specification BaseFn Int
 even = MemberSpec [0, 2, 4, 6, 8, 10]
 
 endsWith :: [Int] -> Specification BaseFn [Int]
-endsWith suffix = TypeSpec (ListSpec Nothing [] TrueSpec TrueSpec NoFold (Split Nothing (Just suffix))) []
+endsWith suffix = TypeSpec (ListSpec Nothing [] TrueSpec TrueSpec NoFold (Split [] suffix)) []
 
 beginsWith :: [Int] -> Specification BaseFn [Int]
-beginsWith prefix = TypeSpec (ListSpec Nothing [] TrueSpec TrueSpec NoFold (Split (Just prefix) Nothing)) []
+beginsWith prefix = TypeSpec (ListSpec Nothing [] TrueSpec TrueSpec NoFold (Split prefix [])) []
 
 -- | Run an example
 go :: forall a. HasSpec BaseFn a => Specification BaseFn a -> IO a
@@ -171,7 +171,7 @@ appPrefix10 = constrained $
   \ [var|y|] ->
     [ satisfies
         y
-        (TypeSpec (ListSpec Nothing [] (MemberSpec [5]) TrueSpec NoFold (Split Nothing (Just [1, 2]))) [])
+        (TypeSpec (ListSpec Nothing [] (MemberSpec [5]) TrueSpec NoFold (Split [] [1, 2])) [])
     ]
 
 -- | test that prefix and size interact to constrain the size of the suffix in the HOLE.
@@ -180,5 +180,5 @@ appSuffix11 = constrained $
   \ [var|y|] ->
     [ satisfies
         y
-        (TypeSpec (ListSpec Nothing [] (MemberSpec [5]) TrueSpec NoFold (Split (Just [1, 2]) Nothing)) [])
+        (TypeSpec (ListSpec Nothing [] (MemberSpec [5]) TrueSpec NoFold (Split [1, 2] [])) [])
     ]

--- a/libs/constrained-generators/src/Constrained/Examples/Append.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Append.hs
@@ -1,0 +1,184 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Constrained.Examples.Append where
+
+import Constrained
+import Constrained.Base
+import Constrained.ListSplit
+import Test.QuickCheck (Gen, Property, counterexample, generate, property)
+import Prelude hiding (even)
+
+-- =========================================================
+-- Useful specs to use in Examples
+
+even :: Specification BaseFn Int
+even = MemberSpec [0, 2, 4, 6, 8, 10]
+
+endsWith :: [Int] -> Specification BaseFn [Int]
+endsWith suffix = TypeSpec (ListSpec Nothing [] TrueSpec TrueSpec NoFold (Split Nothing (Just suffix))) []
+
+beginsWith :: [Int] -> Specification BaseFn [Int]
+beginsWith prefix = TypeSpec (ListSpec Nothing [] TrueSpec TrueSpec NoFold (Split (Just prefix) Nothing)) []
+
+-- | Run an example
+go :: forall a. HasSpec BaseFn a => Specification BaseFn a -> IO a
+go spec = do
+  !ans <- generate $ genFromSpec spec
+  pure ans
+
+-- | The spec actually generates something.
+succeeds :: forall a. HasSpec BaseFn a => Specification BaseFn a -> Gen Property
+succeeds spec = do
+  !ans <- genFromSpec @BaseFn @a spec
+  pure (property (conformsToSpec ans spec))
+
+-- | The spec fails to generate something
+fails :: forall a. HasSpec BaseFn a => Specification BaseFn a -> Gen Property
+fails spec = do
+  ans <- catchGen (genFromSpecT spec)
+  case ans of
+    Left _ -> pure (property True)
+    Right _ ->
+      pure (counterexample ("\nFAILING test does not fail as expected.\n" ++ show spec) (property False))
+
+-- =============================================
+-- The examples
+
+-- | Completely constrained by Split
+app1 :: Specification BaseFn [Int]
+app1 = constrained $
+  \x -> assert $ x ==. append_ (lit [1, 2, 3]) (lit [4, 5, 6])
+
+-- | Fails because the cant set is over constrained
+app2 :: Specification BaseFn ([Int], [Int])
+app2 = constrained' $
+  \ [var|x|] [var|y|] ->
+    [ dependsOn y x
+    , assert $ x ==. append_ (lit [1, 2, 3]) y
+    , assert $ y ==. lit [4, 5, 6]
+    , assert $ x /=. lit [1, 2, 3, 4, 5, 6]
+    ]
+
+-- | x and y only constrained by suffix
+appSuffix2 :: Specification BaseFn ([Int], [Int])
+appSuffix2 = constrained' $
+  \ [var|x|] [var|y|] -> assert $ x ==. append_ y (lit [4, 5, 6])
+
+-- | test that the Split is constrained by even
+appSuffix3 :: Specification BaseFn ([Int], [Int])
+appSuffix3 = constrained' $
+  \ [var|x|] [var|y|] ->
+    [ forAll x $ \i -> satisfies i even
+    , assert $ x ==. append_ y (lit [4, 6])
+    ]
+
+-- | test that the Split fails because suffix has element not even
+appSuffix4 :: Specification BaseFn ([Int], [Int])
+appSuffix4 = constrained' $
+  \ [var|x|] [var|y|] ->
+    [ forAll x $ \i -> satisfies i even
+    , assert $ x ==. append_ y (lit [4, 5, 6]) -- 5 fails even
+    ]
+
+-- | test that the suffix makes the length too long for the size constraint
+appSuffix5 :: Specification BaseFn ([Int], [Int])
+appSuffix5 = constrained' $
+  \ [var|x|] [var|y|] ->
+    [ assert $ sizeOf_ x <=. 4
+    , assert $ x ==. append_ y (lit [1, 2, 3, 4, 5])
+    ]
+
+-- | test that 'x' is overconstrained in the suffix.
+appSuffix6 :: Specification BaseFn ([Int])
+appSuffix6 = constrained $
+  \ [var|x|] -> [satisfies x (endsWith [1, 2]), satisfies x (endsWith [3, 4])]
+
+-- | test that 'x' has conflicting suffix requirements
+appSuffix7 :: Specification BaseFn ([Int], [Int])
+appSuffix7 = constrained' $
+  \ [var|x|] [var|y|] -> [assert $ x ==. append_ (lit [1, 2, 3]) (lit [4, 5, 6]), assert $ x ==. append_ y (lit [1, 2])]
+
+-- | another test that 'x' has conflicting suffix requirements
+appSuffix8 :: Specification BaseFn ([Int], [Int])
+appSuffix8 = constrained' $
+  \ [var|x|] [var|y|] -> [satisfies x (endsWith [3, 4]), assert $ x ==. append_ y (lit [1, 2])]
+
+-- | x and y only constrained by prefix
+appPrefix2 :: Specification BaseFn ([Int], [Int])
+appPrefix2 = constrained' $
+  \ [var|x|] [var|y|] -> assert $ x ==. append_ (lit [4, 5, 6]) y
+
+-- | test that the Split is constrained by even
+appPrefix3 :: Specification BaseFn ([Int], [Int])
+appPrefix3 = constrained' $
+  \ [var|x|] [var|y|] ->
+    [ forAll x $ \i -> satisfies i even
+    , assert $ x ==. append_ (lit [4, 6]) y
+    ]
+
+-- | test that the Split fails because prefix has element not even
+appPrefix4 :: Specification BaseFn ([Int], [Int])
+appPrefix4 = constrained' $
+  \ [var|x|] [var|y|] ->
+    [ forAll x $ \i -> satisfies i even
+    , assert $ x ==. append_ (lit [4, 5, 6]) y -- 5 fails even
+    ]
+
+-- | test that the prefix makes the length too long for the size constraint
+appPrefix5 :: Specification BaseFn ([Int], [Int])
+appPrefix5 = constrained' $
+  \ [var|x|] [var|y|] ->
+    [ assert $ sizeOf_ x <=. 4
+    , assert $ x ==. append_ (lit [1, 2, 3, 4, 5]) y
+    ]
+
+-- | test that 'x' is overconstrained in the prefix.
+appPrefix6 :: Specification BaseFn ([Int])
+appPrefix6 = constrained $
+  \ [var|x|] -> [satisfies x (beginsWith [1, 2]), satisfies x (beginsWith [3, 4])]
+
+-- | test that 'y' fills out what is missing from 'x'
+appPrefix7 :: Specification BaseFn ([Int], [Int])
+appPrefix7 = constrained' $
+  \ [var|x|] [var|y|] -> [assert $ x ==. append_ (lit [1, 2, 3]) (lit [4, 5, 6]), assert $ x ==. append_ (lit [1, 2]) y]
+
+-- | test that prefix is ambiguous
+appPrefix8 :: Specification BaseFn ([Int], [Int])
+appPrefix8 = constrained' $
+  \ [var|x|] [var|y|] -> [satisfies x (beginsWith [3, 4]), assert $ x ==. append_ (lit [1, 2]) y]
+
+-- | test that suffix and size interact correctly constrain the prefix in the HOLE.
+appPrefix9 :: Specification BaseFn ([Int])
+appPrefix9 = constrained $
+  \ [var|y|] ->
+    [ satisfies y (endsWith [3, 4] <> (hasSize $ NumSpecInterval (Just 2) (Just 2)))
+    ]
+
+-- | test that suffix and size interact to constrain the size of the prefix in the HOLE.
+appPrefix10 :: Specification BaseFn ([Int])
+appPrefix10 = constrained $
+  \ [var|y|] ->
+    [ satisfies
+        y
+        (TypeSpec (ListSpec Nothing [] (MemberSpec [5]) TrueSpec NoFold (Split Nothing (Just [1, 2]))) [])
+    ]
+
+-- | test that prefix and size interact to constrain the size of the suffix in the HOLE.
+appSuffix11 :: Specification BaseFn ([Int])
+appSuffix11 = constrained $
+  \ [var|y|] ->
+    [ satisfies
+        y
+        (TypeSpec (ListSpec Nothing [] (MemberSpec [5]) TrueSpec NoFold (Split (Just [1, 2]) Nothing)) [])
+    ]

--- a/libs/constrained-generators/src/Constrained/ListSplit.hs
+++ b/libs/constrained-generators/src/Constrained/ListSplit.hs
@@ -1,0 +1,164 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Constrained.ListSplit where
+
+import Data.List (elemIndices, isPrefixOf, isSuffixOf)
+import Data.List.NonEmpty qualified as NE
+import Data.Maybe (mapMaybe)
+import Prettyprinter
+import Test.QuickCheck
+
+data ListSplit a = Split (Maybe [a]) (Maybe [a]) deriving (Eq, Show)
+
+instance Show a => Pretty (ListSplit a) where
+  pretty (Split Nothing Nothing) = "noSplit"
+  pretty (Split Nothing (Just xs)) = parens $ sep ["Split", "...", "++", viaShow xs]
+  pretty (Split (Just ys) (Just xs)) = parens $ sep ["Split", viaShow ys, "++", viaShow xs]
+  pretty (Split (Just ys) Nothing) = parens $ sep ["Split", viaShow ys, "++", "..."]
+
+noSplit :: ListSplit a
+noSplit = Split Nothing Nothing
+
+splitContents :: ListSplit a -> [a]
+splitContents (Split Nothing Nothing) = []
+splitContents (Split (Just xs) (Just ys)) = xs ++ ys
+splitContents (Split Nothing (Just ys)) = ys
+splitContents (Split (Just xs) Nothing) = xs
+
+genFromListSplit :: Arbitrary a => ListSplit a -> Gen [a]
+genFromListSplit (Split Nothing Nothing) = vectorOf 4 arbitrary
+genFromListSplit (Split (Just xs) (Just ys)) = pure (xs ++ ys)
+genFromListSplit (Split Nothing (Just ys)) = (++ ys) <$> arbitrary
+genFromListSplit (Split (Just ys) Nothing) = (ys ++) <$> arbitrary
+
+conformSplit :: Eq a => [a] -> ListSplit a -> Bool
+conformSplit _ (Split Nothing Nothing) = True
+conformSplit xs (Split (Just ys) Nothing) = isPrefixOf ys xs
+conformSplit xs (Split Nothing (Just ys)) = isSuffixOf ys xs
+conformSplit xs (Split (Just ps) (Just ss)) = xs == (ps ++ ss)
+
+soundListSplit :: ListSplit Int -> Gen Property
+soundListSplit pf = do
+  x <- genFromListSplit pf
+  pure $ property (conformSplit x pf)
+
+soundMerge :: Gen Property
+soundMerge = do
+  pf1 <- arbitrary :: Gen (ListSplit Int)
+  pf2 <- arbitrary :: Gen (ListSplit Int)
+  case merge pf1 pf2 of
+    Left _ -> pure $ classify True "MergeFails" $ property True
+    Right pf3 -> do
+      x <- genFromListSplit pf3
+      pure $
+        counterexample (unlines [show pf1, show pf2, show pf3, show x]) $
+          withMaxSuccess 10000 $
+            classify
+              True
+              "MergeSucceeds"
+              (property $ conformSplit x pf1 && conformSplit x pf2 && conformSplit x pf3)
+
+genSmall :: Arbitrary a => Gen (Maybe [a])
+genSmall =
+  frequency
+    [
+      ( 2
+      , Just <$> do
+          n <- choose (1, 5)
+          vectorOf n (arbitrary)
+      )
+    , (1, pure Nothing)
+    ]
+
+instance Arbitrary a => Arbitrary (ListSplit a) where
+  arbitrary = Split <$> genSmall <*> genSmall
+
+-- | if (merge x y) == Right z, then anything that conforms to z, should also conform to both x and y
+merge :: (Eq a, Show a) => ListSplit a -> ListSplit a -> Either (NE.NonEmpty String) (ListSplit a)
+merge (Split Nothing Nothing) x = Right x
+merge x (Split Nothing Nothing) = Right x
+merge (Split (Just ps) Nothing) (Split (Just xs) Nothing)
+  | isPrefixOf ps xs = Right (Split (Just xs) Nothing)
+  | isPrefixOf xs ps = Right (Split (Just ps) Nothing)
+  | True = Left $ NE.fromList ["Non matching prefixes in merge" ++ show ps ++ " " ++ show xs]
+merge (Split (Just ps) Nothing) (Split Nothing (Just ys)) = Right (mergeOverlap ps ys)
+merge p@(Split (Just ps) Nothing) q@(Split (Just xs) (Just ys))
+  | isPrefixOf ps (xs ++ ys) = Right q
+  | True = Left $ NE.fromList ["Non matching ListSplit in merge", "  " ++ show p, " " ++ show q]
+merge (Split Nothing (Just ss)) (Split (Just xs) Nothing) = Right (mergeOverlap xs ss)
+merge (Split Nothing (Just ss)) (Split Nothing (Just ys))
+  | isSuffixOf ss ys = Right (Split Nothing (Just ys))
+  | isSuffixOf ys ss = Right (Split Nothing (Just ss))
+  | True = Left $ NE.fromList ["Non matching suffixes in merge" ++ show ss ++ " " ++ show ys]
+merge p@(Split Nothing (Just ss)) q@(Split (Just xs) (Just ys))
+  | isSuffixOf ss (xs ++ ys) = Right q
+  | True = Left $ NE.fromList ["Non matching ListSplit in merge", "  " ++ show p, " " ++ show q]
+merge p@(Split (Just ps) (Just ss)) (Split q@(Just xs) Nothing)
+  | isPrefixOf xs (ps ++ ss) = Right p
+  | True = Left $ NE.fromList ["Non ListSplit in merge", "  " ++ show p, " " ++ show q]
+merge p@(Split (Just ps) (Just ss)) q@(Split Nothing (Just ys))
+  | isSuffixOf ys (ps ++ ss) = Right p
+  | True = Left $ NE.fromList ["Non ListSplit in merge", "  " ++ show p, " " ++ show q]
+merge p@(Split (Just ps) (Just ss)) q@(Split (Just xs) (Just ys)) =
+  if (ps ++ ss) == (xs ++ ys)
+    then Right p
+    else Left $ NE.fromList ["Two rigid ListSplits are inconsistent.", "  " ++ show p, "  " ++ show q]
+
+-- | "abcde" "defghi" have an over lap of "de", so return ("abc","de","fgi")
+--   "abc" "xyz" do Not have an overlap so return ("abc","","xyz")
+overlap :: Eq a => [a] -> [a] -> ([a], [a], [a])
+overlap xs [] = (xs, [], [])
+overlap xs (y : ys) = first (reverse (elemIndices y xs)) xs (y : ys)
+  where
+    first [] prefix suffix = (prefix, [], suffix)
+    first (n : ns) prefix suffix =
+      let (before, after) = splitAt n prefix
+       in if isPrefixOf after suffix
+            then (before, after, drop (length after) suffix)
+            else first ns prefix suffix
+
+mergeOverlap :: Eq a => [a] -> [a] -> ListSplit a
+mergeOverlap xs ys = Split (Just (before ++ lap)) (Just after)
+  where
+    (before, lap, after) = overlap xs ys
+
+stripPrefix :: Eq a => [a] -> [a] -> Maybe [a]
+stripPrefix [] ys = Just ys
+stripPrefix (x : xs) (y : ys)
+  | x == y = stripPrefix xs ys
+stripPrefix _ _ = Nothing
+
+stripSuffix :: Eq a => [a] -> [a] -> Maybe [a]
+stripSuffix suffix whole =
+  case stripPrefix (reverse suffix) (reverse whole) of
+    Nothing -> Nothing
+    Just x -> Just (reverse x)
+
+dropSuffix :: Eq a => [a] -> [[a]] -> [[a]]
+dropSuffix xs xss = mapMaybe (stripSuffix xs) xss
+
+dropPrefix :: Eq a => [a] -> [[a]] -> [[a]]
+dropPrefix xs xss = mapMaybe (stripPrefix xs) xss

--- a/libs/constrained-generators/src/Constrained/Properties.hs
+++ b/libs/constrained-generators/src/Constrained/Properties.hs
@@ -215,6 +215,8 @@ instance fn ~ BaseFn => QC.Arbitrary (TestableFn fn) where
       , TestableFn $ singletonFn @fn @Int
       , TestableFn $ unionFn @fn @Int
       , TestableFn $ foldMapFn @fn @Int idFn
+      , TestableFn $ singleFn @fn @Int
+      , TestableFn $ appendFn @fn @Int
       , TestableFn $ rngFn @fn @Int @Int
       , TestableFn $ domFn @fn @Int @Int
       , TestableFn $ fromListFn @fn @Int

--- a/libs/constrained-generators/src/Constrained/Spec/Map.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Map.hs
@@ -317,7 +317,7 @@ instance BaseUniverse fn => Functions (MapFn fn) fn where
           | NilCtx HOLE <- ctx
           , Evidence <- prerequisites @fn @(Map k v) ->
               case spec of
-                TypeSpec (ListSpec listHint must size elemspec foldspec (Split Nothing Nothing)) [] ->
+                TypeSpec (ListSpec listHint must size elemspec foldspec (Split [] [])) [] ->
                   typeSpec $
                     MapSpec
                       listHint

--- a/libs/constrained-generators/src/Constrained/Spec/Tree.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Tree.hs
@@ -24,6 +24,7 @@ import Constrained.Base
 import Constrained.Core
 import Constrained.GenT
 import Constrained.List
+import Constrained.ListSplit
 import Constrained.Spec.Generics
 import Constrained.Spec.Pairs
 import Constrained.Univ
@@ -166,6 +167,7 @@ instance (HasSpec fn a, Member (TreeFn fn) fn) => HasSpec fn (Tree a) where
               TrueSpec
               (typeSpec $ TreeSpec mal (Just sz') TrueSpec s)
               NoFold
+              noSplit
         innerSpec = s <> typeSpec (Cartesian rs childrenSpec)
     fmap (uncurry Node) $
       genFromSpecT @fn @(a, [Tree a]) innerSpec

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -29,7 +29,7 @@ import Test.QuickCheck qualified as QC
 
 import Constrained.Examples
 import Constrained.Internals
-import Constrained.ListSplit (soundListSplit, soundMerge)
+import Constrained.ListSplit (prop_genFromListSplit_sound, prop_merge_sound)
 import Constrained.Properties
 
 ------------------------------------------------------------------------
@@ -184,8 +184,8 @@ tests nightly =
     negativeTests
     appendSpec
     describe "ListSplit soundness tests" $ do
-      prop "ListSplit specifications are sound" soundListSplit
-      prop "Merging ListSplit specifications are sound" soundMerge
+      prop "ListSplit specifications are sound" prop_genFromListSplit_sound
+      prop "Merging ListSplit specifications are sound" prop_merge_sound
 
 negativeTests :: Spec
 negativeTests =


### PR DESCRIPTION
Added file ListSplit.hs which introduces data ListSplit and combine functions 
Added a ListSplit component to ListSpec
Added cases to propagateSpec, toPreds, conformsTo, genFromTypeSpec
Added a bunch of tests and examplea

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
