### PR TITLE
UTXO conformance with Babbage transactions

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -24,8 +24,8 @@ source-repository-package
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `MAlonzo-code` BEFORE MERGE!
   subdir: generated
-  tag: b8fb4597d5dbae0fbfd6501342efc980d3ee07ee
-  --sha256: sha256-FNQ0r2QYKtMt+CJGW4wxMd9ReS+1L6Qegqp6xi8Ex1c=
+  tag: 8d97b3b77599d08452f0870615b9897e88d18e80
+  --sha256: sha256-+7cNT0ZiWF4JNn577mrdNaQdIZi1r7QGJGsNyhx2lcM=
 -- NOTE: If you would like to update the above, look for the `MAlonzo-code`
 -- branch in the `formal-ledger-specifications` repo and copy the SHA of
 -- the commit you need. The `MAlonzo-code` branch functions like an alternative

--- a/cabal.project
+++ b/cabal.project
@@ -24,8 +24,8 @@ source-repository-package
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `MAlonzo-code` BEFORE MERGE!
   subdir: generated
-  tag: 8d97b3b77599d08452f0870615b9897e88d18e80
-  --sha256: sha256-+7cNT0ZiWF4JNn577mrdNaQdIZi1r7QGJGsNyhx2lcM=
+  tag: 544ab20985e3374a1d672354e25d8ca0ca89e7e4
+  --sha256: sha256-bhh09OZkHazXCPjsiU/50Hrmfg52i+6UORTZ6/bAx6c=
 -- NOTE: If you would like to update the above, look for the `MAlonzo-code`
 -- branch in the `formal-ledger-specifications` repo and copy the SHA of
 -- the commit you need. The `MAlonzo-code` branch functions like an alternative

--- a/cabal.project
+++ b/cabal.project
@@ -24,8 +24,8 @@ source-repository-package
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `MAlonzo-code` BEFORE MERGE!
   subdir: generated
-  tag: d5c32e238236e6e2a3941551b4512e117e399271
-  --sha256: sha256-bi4+bXqi8n2BQM4+9uwwaDsm3nblg15Cj+9IvNGTkPI=
+  tag: b8fb4597d5dbae0fbfd6501342efc980d3ee07ee
+  --sha256: sha256-FNQ0r2QYKtMt+CJGW4wxMd9ReS+1L6Qegqp6xi8Ex1c=
 -- NOTE: If you would like to update the above, look for the `MAlonzo-code`
 -- branch in the `formal-ledger-specifications` repo and copy the SHA of
 -- the commit you need. The `MAlonzo-code` branch functions like an alternative

--- a/cabal.project
+++ b/cabal.project
@@ -24,8 +24,8 @@ source-repository-package
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `MAlonzo-code` BEFORE MERGE!
   subdir: generated
-  tag: 0b0b1f4eddb718b704824dcdc86abb8ce815deb2
-  --sha256: sha256-+bpsxn1hPGZqJ0rwZmUaPlOJuRj0RzLj1rulldUqk/E=
+  tag: d5c32e238236e6e2a3941551b4512e117e399271
+  --sha256: sha256-bi4+bXqi8n2BQM4+9uwwaDsm3nblg15Cj+9IvNGTkPI=
 -- NOTE: If you would like to update the above, look for the `MAlonzo-code`
 -- branch in the `formal-ledger-specifications` repo and copy the SHA of
 -- the commit you need. The `MAlonzo-code` branch functions like an alternative

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -1718,17 +1718,17 @@ showConwayTxBalance ::
   String
 showConwayTxBalance pp certState utxo tx = unlines
   [ "Consumed:   \t"
-  , "Inputs:     \t" <> show (coin inputs)
+  , "\tInputs:     \t" <> show (coin inputs)
   --, "Refunds:    \t" <> show refunds
-  , "Withdrawals \t" <> show withdrawals
-  , "Total:      \t" <> (show . coin $ consumed pp certState utxo txBody)
+  , "\tWithdrawals \t" <> show withdrawals
+  , "\tTotal:      \t" <> (show . coin $ consumed pp certState utxo txBody)
   , ""
   , "Produced:  \t"
-  , "Outputs:   \t" <> show (coin $ sumAllValue (txBody ^. outputsTxBodyL))
-  , "Donations: \t" <> show (txBody ^. treasuryDonationTxBodyL)
-  , "Deposits:  \t" <> show (getTotalDepositsTxBody pp isRegPoolId txBody)
-  , "Fees:      \t" <> show (txBody ^. feeTxBodyL)
-  , "Total:     \t" <> (show . coin $ produced pp certState txBody)
+  , "\tOutputs:   \t" <> show (coin $ sumAllValue (txBody ^. outputsTxBodyL))
+  , "\tDonations: \t" <> show (txBody ^. treasuryDonationTxBodyL)
+  , "\tDeposits:  \t" <> show (getTotalDepositsTxBody pp isRegPoolId txBody)
+  , "\tFees:      \t" <> show (txBody ^. feeTxBodyL)
+  , "\tTotal:     \t" <> (show . coin $ produced pp certState txBody)
   ]
   where
     --lookupStakingDeposit c = certState ^. certPStateL . psStakePoolParamsL

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -60,6 +60,8 @@ instance NFData BootstrapAddr
 
 instance NFData Timelock
 
+instance NFData HashedTimelock
+
 instance NFData UTxOState
 
 instance NFData Vote
@@ -186,6 +188,8 @@ instance ToExpr BootstrapAddr
 
 instance ToExpr Timelock
 
+instance ToExpr HashedTimelock
+
 instance ToExpr TxBody
 
 instance ToExpr Tag
@@ -276,6 +280,8 @@ instance FixupSpecRep BaseAddr
 instance FixupSpecRep BootstrapAddr
 
 instance FixupSpecRep Timelock
+
+instance FixupSpecRep HashedTimelock
 
 instance FixupSpecRep UTxOState
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -124,7 +124,7 @@ import Test.Cardano.Ledger.Conformance (
   hashToInteger,
   withCtx,
  )
-import Test.Cardano.Ledger.Constrained.Conway (DepositPurpose (..), IsConwayUniv)
+import Test.Cardano.Ledger.Constrained.Conway (IsConwayUniv, DepositPurpose (..))
 import Test.Cardano.Ledger.Constrained.Conway.Epoch
 import Test.Cardano.Ledger.Conway.TreeDiff (ToExpr (..), showExpr)
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -124,7 +124,7 @@ import Test.Cardano.Ledger.Conformance (
   hashToInteger,
   withCtx,
  )
-import Test.Cardano.Ledger.Constrained.Conway (IsConwayUniv, DepositPurpose (..))
+import Test.Cardano.Ledger.Constrained.Conway (DepositPurpose (..), IsConwayUniv)
 import Test.Cardano.Ledger.Constrained.Conway.Epoch
 import Test.Cardano.Ledger.Conway.TreeDiff (ToExpr (..), showExpr)
 
@@ -308,8 +308,9 @@ instance
 
   toSpecRep UTxOState {..} = do
     let
-      gasDeposits = Map.fromList . fmap (bimap GovActionDeposit gasDeposit) $
-        OMap.assocList (utxosGovState ^. cgsProposalsL . pPropsL)
+      gasDeposits =
+        Map.fromList . fmap (bimap GovActionDeposit gasDeposit) $
+          OMap.assocList (utxosGovState ^. cgsProposalsL . pPropsL)
     Agda.MkUTxOState
       <$> toSpecRep utxosUtxo
       <*> toSpecRep utxosFees

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -217,23 +217,25 @@ instance
   ) =>
   SpecTranslate ctx (Timelock era)
   where
-  type SpecRep (Timelock era) = Agda.Timelock
+  type SpecRep (Timelock era) = Agda.HashedTimelock
 
-  toSpecRep =
-    \case
-      RequireSignature kh ->
-        Agda.RequireSig <$> toSpecRep kh
-      RequireAllOf ss -> do
-        tls <- traverse toSpecRep ss
-        pure . Agda.RequireAllOf $ toList tls
-      RequireAnyOf ss -> do
-        tls <- traverse toSpecRep ss
-        pure . Agda.RequireAnyOf $ toList tls
-      RequireMOf m ss -> do
-        tls <- traverse toSpecRep ss
-        pure . Agda.RequireMOf (toInteger m) $ toList tls
-      RequireTimeExpire slot -> Agda.RequireTimeExpire <$> toSpecRep slot
-      RequireTimeStart slot -> Agda.RequireTimeStart <$> toSpecRep slot
+  toSpecRep tl = Agda.HashedTimelock <$> timelockToSpecRep tl <*> undefined
+    where
+      timelockToSpecRep x =
+        case x of
+          RequireSignature kh ->
+            Agda.RequireSig <$> toSpecRep kh
+          RequireAllOf ss -> do
+            tls <- traverse timelockToSpecRep ss
+            pure . Agda.RequireAllOf $ toList tls
+          RequireAnyOf ss -> do
+            tls <- traverse timelockToSpecRep ss
+            pure . Agda.RequireAnyOf $ toList tls
+          RequireMOf m ss -> do
+            tls <- traverse timelockToSpecRep ss
+            pure . Agda.RequireMOf (toInteger m) $ toList tls
+          RequireTimeExpire slot -> Agda.RequireTimeExpire <$> toSpecRep slot
+          RequireTimeStart slot -> Agda.RequireTimeStart <$> toSpecRep slot
 
 instance
   ( AlonzoEraScript era
@@ -261,7 +263,7 @@ instance
 instance
   ( EraTxOut era
   , SpecRep (Value era) ~ Agda.Coin
-  , SpecRep (Script era) ~ Either Agda.Timelock ()
+  , Script era ~ AlonzoScript era
   , SpecTranslate ctx (Value era)
   , SpecTranslate ctx (Script era)
   ) =>

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
@@ -33,8 +33,8 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.GovCert ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool ()
-import Test.Cardano.Ledger.Conway.TreeDiff
 import Test.Cardano.Ledger.Constrained.Conway.Utxo (depositsMap)
+import Test.Cardano.Ledger.Conway.TreeDiff
 
 instance
   ( SpecTranslate ctx (PParamsHKD Identity era)
@@ -101,7 +101,8 @@ instance
   , Inject ctx [GovActionState era]
   , ToExpr (PParamsHKD StrictMaybe era)
   , SpecRep (TxOut era) ~ Agda.TxOut
-  , SpecTranslate (Map (DepositPurpose (EraCrypto era)) Coin) (TxOut era), GovState era ~ ConwayGovState era
+  , SpecTranslate (Map (DepositPurpose (EraCrypto era)) Coin) (TxOut era)
+  , GovState era ~ ConwayGovState era
   ) =>
   SpecTranslate ctx (EpochState era)
   where

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
@@ -32,7 +32,6 @@ spec = do
       prop "CERT" $ conformsToImpl @"CERT" @ConwayFn @Conway
       prop "CERTS" $ conformsToImpl @"CERTS" @ConwayFn @Conway
       prop "GOV" $ conformsToImpl @"GOV" @ConwayFn @Conway
-
-      xprop "UTXO" $ conformsToImpl @"UTXO" @ConwayFn @Conway
+      prop "UTXO" $ conformsToImpl @"UTXO" @ConwayFn @Conway
     describe "ImpTests" $ do
       RatifyImp.spec

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Gov.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Gov.hs
@@ -48,6 +48,15 @@ govProposalsSpec ::
   GovEnv (ConwayEra StandardCrypto) ->
   Specification fn (Proposals (ConwayEra StandardCrypto))
 govProposalsSpec GovEnv {geEpoch, gePPolicy, geCertState} =
+  proposalsSpec (lit geEpoch) (lit gePPolicy) (lit geCertState)
+
+proposalsSpec ::
+  IsConwayUniv fn =>
+  Term fn EpochNo ->
+  Term fn (StrictMaybe (ScriptHash StandardCrypto)) ->
+  Term fn (CertState Conway) ->
+  Specification fn (Proposals Conway)
+proposalsSpec geEpoch gePPolicy geCertState =
   constrained $ \ [var|props|] ->
     -- Note each of ppupTree, hardForkTree, committeeTree, constitutionTree
     -- have the pair type ProposalTree = (StrictMaybe (GovActionId StandardCrypto), [Tree GAS])
@@ -64,7 +73,7 @@ govProposalsSpec GovEnv {geEpoch, gePPolicy, geCertState} =
                       \_ ppup policy ->
                         [ assert $ ppup /=. lit emptyPParamsUpdate
                         , satisfies ppup wfPParamsUpdateSpec
-                        , assert $ policy ==. lit gePPolicy
+                        , assert $ policy ==. gePPolicy
                         ]
                   ]
               )
@@ -117,7 +126,7 @@ govProposalsSpec GovEnv {geEpoch, gePPolicy, geCertState} =
                     -- UpdateCommittee - We are only interested in this case
                     ( branch $ \_ _ added _ ->
                         forAll (rng_ added) $ \epoch ->
-                          lit geEpoch <. epoch
+                          geEpoch <. epoch
                     )
                     (branch $ \_ _ -> False)
                     (branch $ \_ -> False)
@@ -152,7 +161,7 @@ govProposalsSpec GovEnv {geEpoch, gePPolicy, geCertState} =
                           [ network ==. lit Testnet
                           , credential `member_` lit registeredCredentials
                           ]
-                    , assert $ policy ==. lit gePPolicy
+                    , assert $ policy ==. gePPolicy
                     ]
             )
             (branch $ \_ -> False) -- NoConfidence

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Gov.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Gov.hs
@@ -48,13 +48,13 @@ govProposalsSpec ::
   GovEnv (ConwayEra StandardCrypto) ->
   Specification fn (Proposals (ConwayEra StandardCrypto))
 govProposalsSpec GovEnv {geEpoch, gePPolicy, geCertState} =
-  proposalsSpec (lit geEpoch) (lit gePPolicy) (lit geCertState)
+  proposalsSpec (lit geEpoch) (lit gePPolicy) geCertState
 
 proposalsSpec ::
   IsConwayUniv fn =>
   Term fn EpochNo ->
   Term fn (StrictMaybe (ScriptHash StandardCrypto)) ->
-  Term fn (CertState Conway) ->
+  CertState Conway ->
   Specification fn (Proposals Conway)
 proposalsSpec geEpoch gePPolicy geCertState =
   constrained $ \ [var|props|] ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Ledger.hs
@@ -5,11 +5,9 @@
 
 module Test.Cardano.Ledger.Constrained.Conway.Ledger where
 
-import Cardano.Ledger.Shelley.API.Types
-
 import Constrained
 
-import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway (ConwayEra, Conway)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Crypto (StandardCrypto)
 import Test.Cardano.Ledger.Constrained.Conway.Instances
@@ -17,17 +15,6 @@ import Test.Cardano.Ledger.Constrained.Conway.Utxo
 
 ledgerTxSpec ::
   IsConwayUniv fn =>
-  LedgerEnv (ConwayEra StandardCrypto) ->
-  LedgerState (ConwayEra StandardCrypto) ->
+  UtxoExecContext Conway ->
   Specification fn (Tx (ConwayEra StandardCrypto))
-ledgerTxSpec env st =
-  constrained $ \tx ->
-    [ satisfies tx (utxoTxSpec utxoEnv (lsUTxOState st))
-    ]
-  where
-    utxoEnv =
-      UtxoEnv
-        { ueSlot = ledgerSlotNo env
-        , uePParams = ledgerPp env
-        , ueCertState = lsCertState st
-        }
+ledgerTxSpec = utxoTxSpec

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Ledger.hs
@@ -7,7 +7,7 @@ module Test.Cardano.Ledger.Constrained.Conway.Ledger where
 
 import Constrained
 
-import Cardano.Ledger.Conway (ConwayEra, Conway)
+import Cardano.Ledger.Conway (Conway, ConwayEra)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Crypto (StandardCrypto)
 import Test.Cardano.Ledger.Constrained.Conway.Instances

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE ImportQualifiedPost #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- | Specs necessary to generate, environment, state, and signal
 -- for the UTXO rule
@@ -17,159 +17,37 @@ module Test.Cardano.Ledger.Constrained.Conway.Utxo where
 
 import Cardano.Ledger.Babbage.TxOut
 import Cardano.Ledger.BaseTypes
-import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
-import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
-import Cardano.Ledger.Conway (ConwayEra)
-import Cardano.Ledger.Conway.Core (
-  EraPParams,
-  EraTx (..),
-  EraTxAuxData (..),
-  EraTxBody (..),
-  EraTxWits (..),
-  PParams,
-  ppMaxCollateralInputsL,
- )
-import Cardano.Ledger.Conway.Governance (GovActionId)
-import Cardano.Ledger.Conway.Tx (AlonzoTx)
-import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
-import Cardano.Ledger.Mary.Value
 import Cardano.Ledger.Shelley.API.Types
-import Cardano.Ledger.UTxO
-import Constrained
-import Control.DeepSeq (NFData)
-import Data.Foldable
-import Data.Map qualified as Map
-import Data.Maybe
-import Data.Set qualified as Set
 import Data.Word
-import GHC.Generics (Generic)
-import Lens.Micro
-import Test.Cardano.Ledger.Common (Arbitrary (..), oneof)
+
+import Constrained
+
+import Cardano.Ledger.Conway (ConwayEra, Conway)
+import Cardano.Ledger.Conway.Core
+  ( EraTxWits (..)
+  , EraTxAuxData (..)
+  , EraTx
+  , EraTxBody (..)
+  , PParams
+  , EraPParams
+  )
+import Test.Cardano.Ledger.Babbage.Arbitrary ()
+import Test.Cardano.Ledger.Conway.TreeDiff ()
+import Cardano.Ledger.Crypto (StandardCrypto, Crypto)
 import Test.Cardano.Ledger.Constrained.Conway.Instances
-import Test.Cardano.Ledger.Constrained.Conway.PParams
-import Test.Cardano.Ledger.Constrained.Conway.SimplePParams (maxTxSize_, protocolVersion_)
+import Test.Cardano.Ledger.Constrained.Conway.Gov (proposalsSpec)
+import Cardano.Ledger.Shelley.Rules (epochFromSlot)
+import Control.Monad.Reader (runReader)
+import Test.Cardano.Ledger.Core.Utils (testGlobals)
+import Control.DeepSeq (NFData)
+import GHC.Generics (Generic)
+import Test.Cardano.Ledger.Common (ToExpr, Arbitrary (..), oneof)
+import Cardano.Ledger.Binary (EncCBOR (..), DecCBOR (..))
+import Cardano.Ledger.Binary.Coders (Encode(..), encode, (!>), decode, Decode (..), (<!))
+import Cardano.Ledger.Conway.Tx (AlonzoTx)
+import Cardano.Ledger.Conway.Governance (GovActionId)
 import Test.Cardano.Ledger.Conway.Arbitrary ()
-import Test.Cardano.Ledger.Conway.TreeDiff (ToExpr)
-
-utxoEnvSpec :: IsConwayUniv fn => Specification fn (UtxoEnv (ConwayEra StandardCrypto))
-utxoEnvSpec =
-  constrained $ \utxoEnv ->
-    match utxoEnv $
-      \_ueSlot
-       uePParams
-       _ueCertState ->
-          [ satisfies uePParams pparamsSpec
-          , match uePParams $ \spp ->
-              -- NOTE cpp has type (Term fn (SimplePParams era))
-              -- NOTE: this is for testing only! We should figure out a nicer way
-              -- of splitting generation and checking constraints here!
-              [ assert $ protocolVersion_ spp ==. lit (ProtVer (natVersion @10) 0)
-              , assert $ lit 3000 ==. maxTxSize_ spp
-              ]
-          ]
-
-utxoStateSpec ::
-  IsConwayUniv fn =>
-  UtxoEnv (ConwayEra StandardCrypto) ->
-  Specification fn (UTxOState (ConwayEra StandardCrypto))
-utxoStateSpec _env =
-  constrained $ \utxoState ->
-    match utxoState $
-      \utxosUtxo
-       _utxosDeposited
-       _utxosFees
-       _utxosGovState
-       _utxosStakeDistr
-       _utxosDonation ->
-          [ assert $ utxosUtxo /=. lit mempty
-          , match utxosUtxo $ \utxoMap ->
-              forAll (rng_ utxoMap) correctAddrAndWFCoin
-          ]
-
-utxoTxSpec ::
-  IsConwayUniv fn =>
-  UtxoEnv (ConwayEra StandardCrypto) ->
-  UTxOState (ConwayEra StandardCrypto) ->
-  Specification fn (Tx (ConwayEra StandardCrypto))
-utxoTxSpec env st =
-  constrained $ \tx ->
-    match tx $ \bdy _wits isValid _auxData ->
-      [ match isValid assert
-      , match bdy $
-          \ctbSpendInputs
-           ctbCollateralInputs
-           _ctbReferenceInputs
-           ctbOutputs
-           ctbCollateralReturn
-           _ctbTotalCollateral
-           _ctbCerts
-           ctbWithdrawals
-           ctbTxfee
-           ctbVldt
-           _ctbReqSignerHashes
-           _ctbMint
-           _ctbScriptIntegrityHash
-           _ctbAdHash
-           ctbTxNetworkId
-           _ctbVotingProcedures
-           ctbProposalProcedures
-           _ctbCurrentTreasuryValue
-           ctbTreasuryDonation ->
-              [ assert $ ctbSpendInputs /=. lit mempty
-              , assert $ ctbSpendInputs `subset_` lit (Map.keysSet $ unUTxO $ utxosUtxo st)
-              , match ctbWithdrawals $ \withdrawalMap ->
-                  forAll' (dom_ withdrawalMap) $ \net _ ->
-                    net ==. lit Testnet
-              , -- TODO: we need to do this for collateral as well?
-                match ctbProposalProcedures $ \proposalsList ->
-                  match ctbOutputs $ \outputList ->
-                    [ (reify ctbSpendInputs)
-                        ( \actualInputs ->
-                            fold
-                              [ c
-                              | i <- Set.toList actualInputs
-                              , BabbageTxOut _ (MaryValue c _) _ _ <- maybeToList . txinLookup i . utxosUtxo $ st
-                              ]
-                        )
-                        $ \totalValueConsumed ->
-                          [ let outputSum =
-                                  foldMap_
-                                    (maryValueCoin_ . txOutVal_ . sizedValue_)
-                                    outputList
-                                depositSum =
-                                  foldMap_
-                                    pProcDeposit_
-                                    proposalsList
-                             in outputSum + depositSum + ctbTxfee + ctbTreasuryDonation ==. totalValueConsumed
-                          ]
-                    , forAll outputList (flip onSized correctAddrAndWFCoin)
-                    ]
-              , match ctbVldt $ \before after ->
-                  [ onJust' before (<=. lit (ueSlot env))
-                  , onJust' after (lit (ueSlot env) <.)
-                  ]
-              , onJust' ctbTxNetworkId (==. lit Testnet)
-              , onJust' ctbCollateralReturn $ flip onSized correctAddrAndWFCoin
-              , assert $ size_ ctbCollateralInputs <=. lit (fromIntegral $ uePParams env ^. ppMaxCollateralInputsL)
-              ]
-      ]
-
-correctAddrAndWFCoin ::
-  IsConwayUniv fn =>
-  Term fn (TxOut (ConwayEra StandardCrypto)) ->
-  Pred fn
-correctAddrAndWFCoin txOut =
-  match txOut $ \addr v _ _ ->
-    [ match v $ \c -> [0 <. c, c <=. fromIntegral (maxBound :: Word64)]
-    , (caseOn addr)
-        (branch $ \n _ _ -> n ==. lit Testnet)
-        ( branch $ \bootstrapAddr ->
-            match bootstrapAddr $ \_ nm _ ->
-              (caseOn nm)
-                (branch $ \_ -> False)
-                (branch $ \_ -> True)
-        )
-    ]
+import qualified Data.Map.Strict as Map
 
 data DepositPurpose c
   = CredentialDeposit !(Credential 'Staking c)
@@ -208,6 +86,42 @@ instance Crypto c => EncCBOR (DepositPurpose c) where
 instance Crypto c => NFData (DepositPurpose c)
 
 instance ToExpr (DepositPurpose c)
+
+utxoEnvSpec ::
+  IsConwayUniv fn =>
+  UtxoExecContext Conway ->
+  Specification fn (UtxoEnv (ConwayEra StandardCrypto))
+utxoEnvSpec UtxoExecContext {..} =
+  constrained $ \utxoEnv ->
+    match utxoEnv $
+      \ueSlot
+       uePParams
+       _ueCertState ->
+          [ assert $ uePParams ==. lit uecPParams
+          , assert $ ueSlot ==. lit uecSlotNo
+          ]
+
+utxoStateSpec ::
+  IsConwayUniv fn =>
+  UtxoExecContext (ConwayEra StandardCrypto) ->
+  UtxoEnv (ConwayEra StandardCrypto) ->
+  Specification fn (UTxOState (ConwayEra StandardCrypto))
+utxoStateSpec UtxoExecContext {uecUTxO} UtxoEnv {ueSlot} =
+  constrained $ \utxoState ->
+    match utxoState $
+      \utxosUtxo
+       _utxosDeposited
+       _utxosFees
+       utxosGovState
+       _utxosStakeDistr
+       _utxosDonation ->
+          [ assert $ utxosUtxo ==. lit uecUTxO
+          , match utxosGovState $ \props _ constitution _ _ _ _ ->
+              match constitution $ \_ policy ->
+                satisfies props $ proposalsSpec (lit curEpoch) policy
+          ]
+  where
+    curEpoch = runReader (epochFromSlot ueSlot) testGlobals
 
 data UtxoExecContext era = UtxoExecContext
   { uecTx :: !(AlonzoTx era)
@@ -248,10 +162,36 @@ instance
   EncCBOR (UtxoExecContext era)
   where
   encCBOR x@(UtxoExecContext _ _ _ _ _) =
-    let UtxoExecContext {..} = x
-     in encode $
-          Rec UtxoExecContext
-            !> To uecTx
-            !> To uecUTxO
-            !> To uecSlotNo
-            !> To uecPParams
+    let  UtxoExecContext {..} = x
+     in encode $ Rec UtxoExecContext
+      !> To uecTx
+      !> To uecUTxO
+      !> To uecSlotNo
+      !> To uecPParams
+      !> To uecDeposits
+
+utxoTxSpec ::
+  ( IsConwayUniv fn
+  , HasSpec fn (AlonzoTx era)
+  ) =>
+  UtxoExecContext era ->
+  Specification fn (AlonzoTx era)
+utxoTxSpec UtxoExecContext {uecTx} =
+  constrained $ \tx -> tx ==. lit uecTx
+
+correctAddrAndWFCoin ::
+  IsConwayUniv fn =>
+  Term fn (TxOut (ConwayEra StandardCrypto)) ->
+  Pred fn
+correctAddrAndWFCoin txOut =
+  match txOut $ \addr v _ _ ->
+    [ match v $ \c -> [0 <. c, c <=. fromIntegral (maxBound :: Word64)]
+    , (caseOn addr)
+        (branch $ \n _ _ -> n ==. lit Testnet)
+        ( branch $ \bootstrapAddr ->
+            match bootstrapAddr $ \_ nm _ ->
+              (caseOn nm)
+                (branch $ \_ -> False)
+                (branch $ \_ -> True)
+        )
+    ]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
@@ -104,7 +104,7 @@ utxoStateSpec ::
   UtxoExecContext (ConwayEra StandardCrypto) ->
   UtxoEnv (ConwayEra StandardCrypto) ->
   Specification fn (UTxOState (ConwayEra StandardCrypto))
-utxoStateSpec UtxoExecContext {uecUTxO} UtxoEnv {ueSlot} =
+utxoStateSpec UtxoExecContext {uecUTxO} UtxoEnv {ueSlot, ueCertState} =
   constrained $ \utxoState ->
     match utxoState $
       \utxosUtxo
@@ -116,7 +116,7 @@ utxoStateSpec UtxoExecContext {uecUTxO} UtxoEnv {ueSlot} =
           [ assert $ utxosUtxo ==. lit uecUTxO
           , match utxosGovState $ \props _ constitution _ _ _ _ ->
               match constitution $ \_ policy ->
-                satisfies props $ proposalsSpec (lit curEpoch) policy
+                satisfies props $ proposalsSpec (lit curEpoch) policy ueCertState
           ]
   where
     curEpoch = runReader (epochFromSlot ueSlot) testGlobals

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
@@ -210,6 +210,7 @@ data GenSize = GenSize
   , withdrawalMax :: !Int
   , oldUtxoPercent :: !Int -- between 0-100, 10 means pick an old UTxO 10% of the time
   , maxStablePools :: !Int
+  , invalidScriptFreq :: !Int -- percentage
   }
   deriving (Show)
 
@@ -283,6 +284,7 @@ instance Default GenSize where
       , certificateMax = 10
       , withdrawalMax = 10
       , maxStablePools = 5
+      , invalidScriptFreq = 5
       }
 
 small :: GenSize
@@ -301,6 +303,7 @@ small =
     , certificateMax = 2
     , withdrawalMax = 2
     , maxStablePools = 4
+    , invalidScriptFreq = 5
     }
 
 data PlutusPurposeTag
@@ -969,7 +972,8 @@ genPlutusScript ::
   PlutusPurposeTag ->
   GenRS era (ScriptHash (EraCrypto era))
 genPlutusScript proof tag = do
-  isValid <- lift $ frequency [(5, pure False), (95, pure True)]
+  falseFreq <- asks $ invalidScriptFreq . geSize
+  isValid <- lift $ frequency [(falseFreq, pure False), (100 - falseFreq, pure True)]
   -- Plutus scripts alwaysSucceeds needs at least numArgs, while
   -- alwaysFails needs exactly numArgs to have the desired affect.
   -- For reasons unknown, this number differs from Alonzo to Babbage

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -26,9 +26,7 @@ import Test.Cardano.Ledger.Constrained.Conway.Deleg
 import Test.Cardano.Ledger.Constrained.Conway.Gov
 import Test.Cardano.Ledger.Constrained.Conway.GovCert
 import Test.Cardano.Ledger.Constrained.Conway.Instances
-import Test.Cardano.Ledger.Constrained.Conway.Ledger
 import Test.Cardano.Ledger.Constrained.Conway.Pool
-import Test.Cardano.Ledger.Constrained.Conway.Utxo
 
 import Test.Cardano.Ledger.Generic.PrettyCore
 import Test.Cardano.Ledger.Shelley.Utils
@@ -134,15 +132,15 @@ prop_UTXOS =
     (\_env _st -> TrueSpec)
     $ \_env _st _sig _st' -> True
 
-prop_LEDGER :: Property
-prop_LEDGER =
-  stsPropertyV2 @"LEDGER" @ConwayFn
-    TrueSpec
-    (\_env -> TrueSpec)
-    -- TODO: the `GenDelegs` don't appear to be used (?!) so we just give an
-    -- empty map here. One could consider generating them instead
-    ledgerTxSpec
-    $ \_env _st _sig _st' -> True
+--prop_LEDGER :: Property
+--prop_LEDGER = property $ do
+--  pure $ stsPropertyV2 @"LEDGER" @ConwayFn
+--    TrueSpec
+--    (\_env -> TrueSpec)
+--    -- TODO: the `GenDelegs` don't appear to be used (?!) so we just give an
+--    -- empty map here. One could consider generating them instead
+--    ledgerTxSpec
+--    $ \_env _st _sig _st' -> True
 
 -- prop_TICKF :: Property
 -- prop_TICKF =
@@ -211,13 +209,14 @@ prop_UTXOW =
     (\_env _st -> TrueSpec)
     $ \_env _st _sig _st' -> True
 
-prop_UTXO :: Property
-prop_UTXO =
-  stsPropertyV2 @"UTXO" @ConwayFn
-    utxoEnvSpec
-    utxoStateSpec
-    utxoTxSpec
-    $ \_env _st _sig _st' -> True
+--prop_UTXO :: Property
+--prop_UTXO = property $ do
+--  ctx <- arbitrary
+--  pure $ stsPropertyV2 @"UTXO" @ConwayFn
+--    utxoEnvSpec
+--    utxoStateSpec
+--    (utxoTxSpec ctx)
+--    $ \_env _st _sig _st' -> True
 
 -- prop_BBODY :: Property
 -- prop_BBODY =
@@ -293,8 +292,8 @@ utxoTests :: TestTree
 utxoTests =
   testGroup
     "UTXO* rules"
-    [ testProperty "prop_UTXO" prop_UTXO
-    , testProperty "prop_UTXOW" prop_UTXOW
+    [ {-testProperty "prop_UTXO" prop_UTXO
+    ,-} testProperty "prop_UTXOW" prop_UTXOW
     , testProperty "prop_UTXOS" prop_UTXOS
     ]
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -132,8 +132,8 @@ prop_UTXOS =
     (\_env _st -> TrueSpec)
     $ \_env _st _sig _st' -> True
 
---prop_LEDGER :: Property
---prop_LEDGER = property $ do
+-- prop_LEDGER :: Property
+-- prop_LEDGER = property $ do
 --  pure $ stsPropertyV2 @"LEDGER" @ConwayFn
 --    TrueSpec
 --    (\_env -> TrueSpec)
@@ -209,8 +209,8 @@ prop_UTXOW =
     (\_env _st -> TrueSpec)
     $ \_env _st _sig _st' -> True
 
---prop_UTXO :: Property
---prop_UTXO = property $ do
+-- prop_UTXO :: Property
+-- prop_UTXO = property $ do
 --  ctx <- arbitrary
 --  pure $ stsPropertyV2 @"UTXO" @ConwayFn
 --    utxoEnvSpec
@@ -293,7 +293,7 @@ utxoTests =
   testGroup
     "UTXO* rules"
     [ {-testProperty "prop_UTXO" prop_UTXO
-    ,-} testProperty "prop_UTXOW" prop_UTXOW
+      ,-} testProperty "prop_UTXOW" prop_UTXOW
     , testProperty "prop_UTXOS" prop_UTXOS
     ]
 


### PR DESCRIPTION
# Description

This PR adds conformance testing for the UTXO rule using the old generic generators from Babbage.

related to IntersectMBO/formal-ledger-specifications#584

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
