### PR TITLE
`constrained-generators`: More tests for append and singleton

### DIFF
--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -152,6 +152,8 @@ tests nightly =
     testSpec "mapRestrictedValuesBool" mapRestrictedValuesBool
     testSpec "mapSetSmall" mapSetSmall
     testSpecNoShrink "powersetPickOne" powersetPickOne
+    testSpecNoShrink "appendSuffix" appendSuffix
+    testSpecNoShrink "appendForAll" appendForAll
     numberyTests
     sizeTests
     numNumSpecTree
@@ -203,15 +205,20 @@ negativeTests =
               (pure "You can't constrain the variable introduced by reify as its already decided")
               $ reify x id
               $ \y -> y ==. 10
-    prop "singletonErrorTooMany" $
-      expectFailure $
-        prop_complete singletonErrorTooMany
-    prop "singletonErrorTooLong" $
-      expectFailure $
-        prop_complete singletonErrorTooLong
-    prop "appendTooLong" $
-      expectFailure $
-        prop_complete appendTooLong
+    testSpecFail "singletonErrorTooMany" singletonErrorTooMany
+    testSpecFail "singletonErrorTooLong" singletonErrorTooLong
+    testSpecFail "appendTooLong" appendTooLong
+    testSpecFail "overconstrainedAppend" overconstrainedAppend
+    testSpecFail "overconstrainedPrefixes" overconstrainedPrefixes
+    testSpecFail "overconstrainedSuffixes" overconstrainedSuffixes
+    testSpecFail "appendForAllBad" appendForAllBad
+
+testSpecFail :: HasSpec fn a => String -> Specification fn a -> Spec
+testSpecFail s spec =
+  prop (s ++ " fails") $
+    expectFailure $
+      withMaxSuccess 1 $
+        prop_complete spec
 
 numberyTests :: Spec
 numberyTests =


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
