### PR TITLE
Enforce Cabal dependency in byron package

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -110,6 +110,10 @@ package cardano-ledger-mary
 package cardano-ledger-conway
   flags: +asserts
 
+package cardano-ledger-byron
+  -- Temporary fix, in order to add `Cabal >= 3.12`, to avoid errors when releasing the package
+  ghc-options: -fno-warn-unused-packages
+
 -- Always write GHC env files, because they are needed for repl and by the doctests.
 write-ghc-environment-files: always
 

--- a/eras/byron/ledger/impl/cardano-ledger-byron.cabal
+++ b/eras/byron/ledger/impl/cardano-ledger-byron.cabal
@@ -234,6 +234,7 @@ library
         bimap >=0.4 && <0.6,
         binary,
         bytestring,
+        Cabal >=3.12,
         canonical-json,
         cardano-crypto,
         cardano-crypto-wrapper,

--- a/flake.nix
+++ b/flake.nix
@@ -139,7 +139,7 @@
               packages.cardano-ledger-shelley-ma-test.configureFlags = ["--ghc-option=-Werror"];
               packages.small-steps.configureFlags = ["--ghc-option=-Werror"];
               packages.cardano-ledger-byron = {
-                configureFlags = ["--ghc-option=-Werror"];
+                configureFlags = ["--ghc-option=-Werror --ghc-option=-fno-warn-unused-packages"];
                 components = {
                   tests.cardano-ledger-byron-test = {
                     preCheck = ''


### PR DESCRIPTION
in order to avoid an error when releasing the package

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff


To prevent this error in the Chap build:

       > Configuring library for cabal-doctest-1.0.10..
       > Error:
       >     The following packages are broken because other packages they depend on are missing. These broken packages must be rebuilt before they can be used.
       > installed package Cabal-3.2.1.0 is broken due to missing package parsec-3.1.14.0, text-1.2.4.1
       >
       For full logs, run 'nix log /nix/store/r6jgcm89wc2czyqmwggjlycb56kdhk4k-cabal-doctest-lib-cabal-doctest-1.0.10.drv'.
error: 1 dependencies of derivation '/nix/store/672afr0iq9qnfxpv42pb1jv7a3ih5b12-pretty-simple-4.1.2.0-setup.drv' failed to build
building '/nix/store/hp9m0cfxc3h0fpa836k43nhkwjwmvzcl-call-stack-lib-call-stack-0.4.0.drv'...
error: 1 dependencies of derivation '/nix/store/s5hcv2p2bjmz9dndx13qz2ljg9mgj91x-pretty-simple-lib-pretty-simple-4.1.2.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/a9ys8di4hdv91z78x24313cihpn0vi5n-ouroboros-consensus-lib-unstable-consensus-testlib-0.20.1.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/qykliwqawv67lsck80pwzi2bg4wg0i1h-ouroboros-network-testing-lib-ouroboros-network-testing-0.7.0.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/d2bgl2kmiq84bj3yq8i8nnkkgy1d84bb-ouroboros-consensus-cardano-lib-unstable-byron-testlib-0.19.0.0.drv' failed to build