### PR TITLE
Revert `Mismatch`-related changes of `ShelleyPoolPredFailure` serialization

### DIFF
--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-shelley`
 
-## 1.14.0.1
+## 1.14.1.0
 
-*
+* Revert changes to serialization of `ShelleyPoolPredFailure`
 
 ## 1.14.0.0
 

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-shelley
-version:            1.14.0.0
+version:            1.14.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -61,7 +61,7 @@ import Cardano.Ledger.Shelley.Rules (
   ShelleyDelplPredFailure,
   ShelleyLedgerPredFailure,
   ShelleyLedgersPredFailure,
-  ShelleyPoolPredFailure,
+  ShelleyPoolPredFailure (..),
   ShelleyPpupPredFailure,
   ShelleyUtxoPredFailure,
   ShelleyUtxowPredFailure,
@@ -659,7 +659,17 @@ instance Era era => Arbitrary (ShelleyPpupPredFailure era) where
   shrink = genericShrink
 
 instance Era era => Arbitrary (ShelleyPoolPredFailure era) where
-  arbitrary = genericArbitraryU
+  arbitrary =
+    oneof
+      [ StakePoolNotRegisteredOnKeyPOOL <$> arbitrary
+      , do
+          a <- arbitrary
+          b <- arbitrary
+          StakePoolRetirementWrongEpochPOOL (Mismatch a b) . Mismatch a <$> arbitrary
+      , StakePoolCostTooLowPOOL <$> arbitrary
+      , WrongNetworkPOOL <$> arbitrary <*> arbitrary
+      , PoolMedataHashTooBig <$> arbitrary <*> arbitrary
+      ]
   shrink = genericShrink
 
 instance

--- a/eras/shelley/test-suite/CHANGELOG.md
+++ b/eras/shelley/test-suite/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-shelley-test`
 
-## 1.5.0.1
+## 1.5.1.0
 
-*
+* Update `ShelleyPoolPredFailure` arbitrary instance
 
 ## 1.5.0.0
 

--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-shelley-test
-version:            1.5.0.0
+version:            1.5.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK


### PR DESCRIPTION
Since this predicate failure is reused in Conway, we need to keep the serialization unchanged.

# Description

In a previous PR #4649, we changed the definition of ShelleyPoolPredFailure, and along with it the (de)serialization. 
However, this predicate failure is reused in Conway, which means we should maintain the (de)serialization as it was, in order to not break clients.


<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
