### PR TITLE
Add `nix develop` to main `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,9 @@ The directory structure of this repository is as follows:
 
 # Building
 
-It is recommended to use [`nix`](https://nixos.org/nix/download.html) for building everything in this repository.
-Haskell files can be built with [`cabal`](https://www.haskell.org/cabal/) inside of a nix shell, which can be
-entered by invoking the command `nix develop` from the root directory.
+It is recommended to use [`nix`](https://nixos.org/nix/download.html) for building everything in this repository. Make sure you have a recent version of `nix` by following this [guide](https://nixos.org/manual/nix/stable/installation/upgrading.html).
 
-Make sure you have a recent version of `nix` by following this [guide](https://nixos.org/manual/nix/stable/installation/upgrading.html)
+Haskell files can be built with [`cabal`](https://www.haskell.org/cabal/) inside of a nix shell, which can be entered by invoking `nix develop` from the root directory.
 
 ## Nix Cache
 
@@ -165,8 +163,7 @@ nix develop --command make watch
 
 # Testing
 
-From the root directory invoke `nix develop` to enter a nix shell, then run `cabal test all` 
-to run all tests or `cabal test <package>` to run the tests for a specific package.
+From the root directory invoke `nix develop` to enter a nix shell, then run `cabal test all` to run all tests or `cabal test <package>` to run the tests for a specific package.
 
 Note: The `CARDANO_MAINNET_MIRROR` environment variable can be overridden in `flake.nix` if one desires to run
 the Byron tests with a different version of the [mainnet epochs](https://github.com/input-output-hk/cardano-mainnet-mirror/tree/master/epochs).

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ The directory structure of this repository is as follows:
 # Building
 
 It is recommended to use [`nix`](https://nixos.org/nix/download.html) for building everything in this repository.
-Haskell files can be built with [`cabal`](https://www.haskell.org/cabal/) inside of a nix shell.
+Haskell files can be built with [`cabal`](https://www.haskell.org/cabal/) inside of a nix shell, which can be
+entered by invoking the command `nix develop` from the root directory.
 
 Make sure you have a recent version of `nix` by following this [guide](https://nixos.org/manual/nix/stable/installation/upgrading.html)
 
@@ -164,7 +165,8 @@ nix develop --command make watch
 
 # Testing
 
-Run `cabal test all` to run all tests or `cabal test <package>` to run the tests for a specific package.
+From the root directory invoke `nix develop` to enter a nix shell, then run `cabal test all` 
+to run all tests or `cabal test <package>` to run the tests for a specific package.
 
 Note: The `CARDANO_MAINNET_MIRROR` environment variable can be overridden in `flake.nix` if one desires to run
 the Byron tests with a different version of the [mainnet epochs](https://github.com/input-output-hk/cardano-mainnet-mirror/tree/master/epochs).


### PR DESCRIPTION
This closes issue #4687.

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] ~New tests are added if needed and existing tests are updated~ N/A
- [ ] ~All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.~
      ~**_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))~ N/A
- [ ] ~When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the~ 
      ~[versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).~ N/A
- [ ] ~The version bounds in `.cabal` files for all affected packages are updated.~
      ~**_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))~ N/A
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
