### PR TITLE
Ensure repo is buildable on Windows

### DIFF
--- a/libs/plutus-preprocessor/plutus-preprocessor.cabal
+++ b/libs/plutus-preprocessor/plutus-preprocessor.cabal
@@ -43,7 +43,7 @@ library
         plutus-ledger-api,
         template-haskell
 
-    if (impl(ghc <9.6) || impl(ghc >=9.7) || os(windows))
+    if ((impl(ghc <9.6) || impl(ghc >=9.7)) || os(windows))
         buildable: False
 
 executable plutus-preprocessor
@@ -60,5 +60,5 @@ executable plutus-preprocessor
         plutus-preprocessor,
         base >=4.14 && <5
 
-    if (impl(ghc <9.6) || impl(ghc >=9.7) || os(windows))
+    if ((impl(ghc <9.6) || impl(ghc >=9.7)) || os(windows))
         buildable: False

--- a/libs/plutus-preprocessor/plutus-preprocessor.cabal
+++ b/libs/plutus-preprocessor/plutus-preprocessor.cabal
@@ -43,7 +43,7 @@ library
         plutus-ledger-api,
         template-haskell
 
-    if (impl(ghc <9.6) || impl(ghc >=9.7))
+    if (impl(ghc <9.6) || impl(ghc >=9.7) || os(windows))
         buildable: False
 
 executable plutus-preprocessor
@@ -60,5 +60,5 @@ executable plutus-preprocessor
         plutus-preprocessor,
         base >=4.14 && <5
 
-    if (impl(ghc <9.6) || impl(ghc >=9.7))
+    if (impl(ghc <9.6) || impl(ghc >=9.7) || os(windows))
         buildable: False


### PR DESCRIPTION
# Description

Trying to build any package in the repository on Windows will fail with the following message:

```
➜ cabal build cardano-ledger-binary
Resolving dependencies...
Error: [Cabal-7107]
Could not resolve dependencies:
[__0] trying: cardano-ledger-alonzo-1.11.0.0 (user goal)
[__1] trying: plutus-ledger-api-1.34.1.0 (dependency of cardano-ledger-alonzo)
[__2] trying: plutus-core-1.34.1.0 (dependency of plutus-ledger-api)
[__3] trying: plutus-preprocessor-9.9.9.9 (user goal)
[__4] next goal: plutus-tx-plugin (dependency of plutus-preprocessor)
[__4] rejecting: plutus-tx-plugin; 1.34.1.0, 1.34.0.0, 1.33.1.0 (library is not buildable in the current environment, but it is required by plutus-preprocessor)
[__4] rejecting: plutus-tx-plugin-1.32.1.0 (conflict: plutus-core==1.34.1.0, plutus-tx-plugin => plutus-core^>=1.32)
[__4] skipping: plutus-tx-plugin; 1.32.0.0, 1.31.0.0, 1.30.0.0, 1.29.0.0, 1.28.0.0, 1.27.0.0, 1.26.0.0, 1.25.0.0, 1.24.0.0, 1.23.0.0, 1.22.1.0, 1.21.0.0, 1.20.0.0, 1.19.0.0, 1.18.0.0, 1.17.0.0, 1.16.0.0, 1.15.0.1, 1.15.0.0, 1.14.0.0, 1.13.0.0, 1.12.0.0, 1.11.0.0, 1.10.0.0, 1.9.1.0, 1.9.0.0, 1.8.0.0, 1.7.0.0, 1.6.0.0, 1.5.0.2, 1.5.0.0, 1.4.0.0, 1.3.0.0, 1.2.0.0, 1.1.1.0 (has the same characteristics that caused the previous version to fail: excludes 'plutus-core' version 1.34.1.0)
[__4] rejecting: plutus-tx-plugin-1.1.0.0 (library is not buildable in the current environment, but it is required by plutus-preprocessor)
[__4] rejecting: plutus-tx-plugin-1.0.0.0 (conflict: plutus-core==1.34.1.0, plutus-tx-plugin => plutus-core^>=1.0)
[__4] skipping: plutus-tx-plugin-1.22.0.0 (has the same characteristics that caused the previous version to fail: excludes 'plutus-core' version 1.34.1.0)
[__4] fail (backjumping, conflict set: plutus-core, plutus-preprocessor, plutus-tx-plugin)
After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: plutus-ledger-api, cardano-ledger-alonzo, plutus-core, plutus-tx-plugin, plutus-preprocessor
Try running with --minimize-conflict-set to improve the error message.
```

Because cabal will include `plutus-preprocessor` on the build plan and `plutus-tx-plugin` is not buildable on Windows, so it will fail to synthesize a build plan.

This PR marks `plutus-preprocessor` as unbuildable on Windows, which removes it from the build targets considered by cabal.


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
