### PR TITLE
Implement some of the tests in Alonzo.Imp.UtxowSpec.Valid

### DIFF
--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -69,7 +69,7 @@ library
         cardano-crypto-class,
         cardano-ledger-binary >=1.4,
         cardano-ledger-core ^>=1.15,
-        cardano-ledger-shelley >=1.13 && <1.15,
+        cardano-ledger-shelley ^>=1.15,
         cardano-strict-containers,
         cardano-slotting,
         cborg,

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Version history for `cardano-ledger-alonzo`
 
-## 1.11.0.1
+## 1.12.0.0
 
 *
+
+### `testlib`
+
+* Rename `expectPhase2Invalid` to `submitPhase2Invalid_`
+* Add `submitPhase2Invalid`
+* Add `expectTxSuccess`
 
 ## 1.11.0.0
 

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -84,7 +84,7 @@ library
         cardano-ledger-binary ^>=1.4,
         cardano-ledger-core ^>=1.15,
         cardano-ledger-mary ^>=1.7,
-        cardano-ledger-shelley >=1.14 && <1.15,
+        cardano-ledger-shelley ^>=1.15,
         cardano-slotting,
         cardano-strict-containers,
         containers,

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-alonzo
-version:            1.11.0.0
+version:            1.12.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxosSpec.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxosSpec.hs
@@ -74,7 +74,7 @@ spec = describe "UTXOS" $
 
         it "Invalid transaction marked as valid" $ do
           txIn <- produceScript . hashPlutusScript $ alwaysFailsWithDatum slang
-          expectPhase2Invalid $ mkBasicTx mkBasicTxBody & bodyTxL . inputsTxBodyL .~ [txIn]
+          submitPhase2Invalid_ $ mkBasicTx mkBasicTxBody & bodyTxL . inputsTxBodyL .~ [txIn]
 
         it "Invalid plutus script fails in phase 2" $ do
           txIn0 <- produceScript redeemerSameAsDatumHash

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Invalid.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Invalid.hs
@@ -161,7 +161,7 @@ spec = describe "Invalid transactions" $ do
           -- PlutusV3 no longer requires a spending Datum, but it should still fail since the
           -- actual script expects it
           if lang >= PlutusV3
-            then expectPhase2Invalid tx
+            then submitPhase2Invalid_ tx
             else submitFailingTx tx [injectFailure $ UnspendableUTxONoDatumHash [txIn]]
 
         it "No ExtraRedeemers on same script certificates" $ do

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Valid.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Valid.hs
@@ -1,36 +1,86 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Cardano.Ledger.Alonzo.Imp.UtxowSpec.Valid (spec) where
 
-import Test.Cardano.Ledger.Alonzo.ImpTest (ImpTestState)
+import Cardano.Ledger.Alonzo.Core
+import Cardano.Ledger.Alonzo.Rules (
+  AlonzoUtxosPredFailure,
+ )
+import Cardano.Ledger.Alonzo.Scripts (eraLanguages)
+import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Ledger.Plutus (
+  hashPlutusScript,
+  withSLanguage,
+ )
+import Control.Monad ((<=<))
+import Lens.Micro ((&), (.~))
+import Test.Cardano.Ledger.Alonzo.ImpTest
 import Test.Cardano.Ledger.Imp.Common
+import Test.Cardano.Ledger.Plutus.Examples
 
 spec ::
   forall era.
+  ( AlonzoEraImp era
+  , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
+  ) =>
   SpecWith (ImpTestState era)
-spec = do
-  describe "Valid transactions" $ do
-    it "Validating SPEND script" $ do
-      const $ pendingWith "not implemented yet"
-    it "Not validating SPEND script" $ do
-      const $ pendingWith "not implemented yet"
-    it "Validating CERT script" $ do
-      const $ pendingWith "not implemented yet"
-    it "Not validating CERT script" $ do
-      const $ pendingWith "not implemented yet"
-    it "Validating WITHDRAWAL script" $ do
-      const $ pendingWith "not implemented yet"
-    it "Not validating WITHDRAWAL script" $ do
-      const $ pendingWith "not implemented yet"
-    it "Validating MINT script" $ do
-      const $ pendingWith "not implemented yet"
-    it "Not validating MINT script" $ do
-      const $ pendingWith "not implemented yet"
-    it "Validating scripts everywhere" $ do
-      const $ pendingWith "not implemented yet"
-    it "Acceptable supplimentary datum" $ do
-      const $ pendingWith "not implemented yet"
-    it "Multiple identical certificates" $ do
-      const $ pendingWith "not implemented yet"
-    it "Non-script output with datum" $ do
-      const $ pendingWith "not implemented yet"
+spec = describe "Valid transactions" $ do
+  forM_ (eraLanguages @era) $ \lang ->
+    withSLanguage lang $ \slang ->
+      describe (show lang) $ do
+        let
+          alwaysSucceedsWithDatumHash = hashPlutusScript $ alwaysSucceedsWithDatum slang :: ScriptHash (EraCrypto era)
+          alwaysSucceedsNoDatumHash = hashPlutusScript $ alwaysSucceedsNoDatum slang :: ScriptHash (EraCrypto era)
+          alwaysFailsWithDatumHash = hashPlutusScript $ alwaysFailsWithDatum slang :: ScriptHash (EraCrypto era)
+
+        it "Validating SPEND script" $ do
+          txIn <- produceScript alwaysSucceedsWithDatumHash
+          expectTxSuccess <=< submitTx $
+            mkBasicTx $
+              mkBasicTxBody & inputsTxBodyL .~ [txIn]
+
+        it "Not validating SPEND script" $ do
+          txIn <- produceScript alwaysFailsWithDatumHash
+          expectTxSuccess <=< submitPhase2Invalid $
+            mkBasicTx $
+              mkBasicTxBody & inputsTxBodyL .~ [txIn]
+
+        it "Validating CERT script" $ do
+          txIn <- produceScript alwaysSucceedsWithDatumHash
+          let txCert = RegTxCert $ ScriptHashObj alwaysSucceedsNoDatumHash
+          expectTxSuccess <=< submitTx $
+            mkBasicTx $
+              mkBasicTxBody
+                & inputsTxBodyL .~ [txIn]
+                & certsTxBodyL .~ [txCert]
+
+        it "Not validating CERT script" $ do
+          txIn <- produceScript alwaysFailsWithDatumHash
+          let txCert = RegTxCert $ ScriptHashObj alwaysSucceedsNoDatumHash
+          expectTxSuccess <=< submitPhase2Invalid $
+            mkBasicTx $
+              mkBasicTxBody
+                & inputsTxBodyL .~ [txIn]
+                & certsTxBodyL .~ [txCert]
+
+  it "Validating WITHDRAWAL script" $ do
+    const $ pendingWith "not implemented yet"
+  it "Not validating WITHDRAWAL script" $ do
+    const $ pendingWith "not implemented yet"
+  it "Validating MINT script" $ do
+    const $ pendingWith "not implemented yet"
+  it "Not validating MINT script" $ do
+    const $ pendingWith "not implemented yet"
+  it "Validating scripts everywhere" $ do
+    const $ pendingWith "not implemented yet"
+  it "Acceptable supplimentary datum" $ do
+    const $ pendingWith "not implemented yet"
+  it "Multiple identical certificates" $ do
+    const $ pendingWith "not implemented yet"
+  it "Non-script output with datum" $ do
+    const $ pendingWith "not implemented yet"

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -79,7 +79,7 @@ library
         cardano-ledger-binary >=1.4,
         cardano-ledger-core ^>=1.15,
         cardano-ledger-mary ^>=1.7,
-        cardano-ledger-shelley ^>=1.14,
+        cardano-ledger-shelley ^>=1.15,
         cardano-strict-containers,
         containers,
         deepseq,

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -75,7 +75,7 @@ library
         cardano-crypto-class,
         cardano-data >=1.2,
         cardano-ledger-allegra ^>=1.6,
-        cardano-ledger-alonzo >=1.11 && <1.12,
+        cardano-ledger-alonzo >=1.11,
         cardano-ledger-binary >=1.4,
         cardano-ledger-core ^>=1.15,
         cardano-ledger-mary ^>=1.7,

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -90,7 +90,7 @@ library
         cardano-data >=1.2.3,
         cardano-ledger-binary ^>=1.4,
         cardano-ledger-allegra ^>=1.6,
-        cardano-ledger-alonzo ^>=1.11,
+        cardano-ledger-alonzo ^>=1.12,
         cardano-ledger-babbage ^>=1.10,
         cardano-ledger-core ^>=1.15,
         cardano-ledger-mary ^>=1.7,

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -240,7 +240,7 @@ test-suite tests
         cardano-ledger-conway,
         cardano-ledger-core,
         cardano-ledger-binary:testlib,
-        cardano-ledger-shelley >=1.14,
+        cardano-ledger-shelley,
         cardano-slotting:testlib,
         cardano-strict-containers,
         containers,

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -94,7 +94,7 @@ library
         cardano-ledger-babbage ^>=1.10,
         cardano-ledger-core ^>=1.15,
         cardano-ledger-mary ^>=1.7,
-        cardano-ledger-shelley ^>=1.14,
+        cardano-ledger-shelley ^>=1.15,
         cardano-slotting,
         cardano-strict-containers,
         containers,

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
@@ -129,6 +129,7 @@ treasuryWithdrawalsSpec =
       ensTreasury enactState'' `shouldBe` Coin 1
 
     it "Withdrawals exceeding treasury submitted in a single proposal" $ do
+      disableTreasuryExpansion
       committeeCs <- registerInitialCommittee
       (drepC, _, _) <- setupSingleDRep 1_000_000
       initialTreasury <- getTreasury
@@ -150,6 +151,7 @@ treasuryWithdrawalsSpec =
       sumRewardAccounts withdrawals `shouldReturn` sumRequested
 
     it "Withdrawals exceeding maxBound Word64 submitted in a single proposal" $ do
+      disableTreasuryExpansion
       committeeCs <- registerInitialCommittee
       (drepC, _, _) <- setupSingleDRep 1_000_000
       initialTreasury <- getTreasury
@@ -159,6 +161,7 @@ treasuryWithdrawalsSpec =
       checkNoWithdrawal initialTreasury withdrawals
 
     it "Withdrawals exceeding treasury submitted in several proposals within the same epoch" $ do
+      disableTreasuryExpansion
       committeeCs <- registerInitialCommittee
       (drepC, _, _) <- setupSingleDRep 1_000_000
       donateToTreasury $ Coin 5_000_000

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
@@ -390,6 +390,7 @@ treasurySpec =
       treasuryWithdrawalExpectation []
 
     it "TreasuryWithdrawalExtra" $ do
+      disableTreasuryExpansion
       rewardAccount <- registerRewardAccount
       rewardAccountOther <- registerRewardAccount
       govPolicy <- getGovPolicy
@@ -408,6 +409,7 @@ treasuryWithdrawalExpectation ::
   [GovAction era] ->
   ImpTestM era ()
 treasuryWithdrawalExpectation extraWithdrawals = do
+  disableTreasuryExpansion
   withdrawalAmount <- uniformRM (Coin 1, Coin 1_000_000_000)
   -- Before making a withdrawal, we need to make sure there is enough money in the treasury:
   donateToTreasury withdrawalAmount
@@ -436,6 +438,7 @@ treasuryWithdrawalExpectation extraWithdrawals = do
 
 depositMovesToTreasuryWhenStakingAddressUnregisters :: ConwayEraImp era => ImpTestM era ()
 depositMovesToTreasuryWhenStakingAddressUnregisters = do
+  disableTreasuryExpansion
   initialTreasury <- getsNES $ nesEsL . esAccountStateL . asTreasuryL
   modifyPParams $ \pp ->
     pp

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/RatifySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/RatifySpec.hs
@@ -462,6 +462,7 @@ committeeMinSizeAffectsInFlightProposalsSpec =
           rewardAccount <- registerRewardAccount
           submitTreasuryWithdrawals [(rewardAccount, amount)]
     it "TreasuryWithdrawal fails to ratify due to an increase in CommitteeMinSize" $ do
+      disableTreasuryExpansion
       amount <- uniformRM (Coin 1, Coin 100_000_000)
       -- Ensure sufficient amount in the treasury
       submitTx_ $ mkBasicTx (mkBasicTxBody & treasuryDonationTxBodyL .~ amount)
@@ -488,6 +489,7 @@ committeeMinSizeAffectsInFlightProposalsSpec =
       currentProposalsShouldContain gaiTW
       getsNES (nesEsL . esAccountStateL . asTreasuryL) `shouldReturn` treasury
     it "TreasuryWithdrawal ratifies due to a decrease in CommitteeMinSize" $ do
+      disableTreasuryExpansion
       (drepC, hotCommitteeC, _) <- electBasicCommittee
       (spoC, _, _) <- setupPoolWithStake $ Coin 42_000_000
       amount <- uniformRM (Coin 1, Coin 100_000_000)
@@ -927,6 +929,7 @@ votingSpec =
         it "AlwaysAbstain" $ do
           let getTreasury = getsNES (nesEsL . esAccountStateL . asTreasuryL)
 
+          disableTreasuryExpansion
           donateToTreasury $ Coin 5_000_000
 
           (drep1, comMember, _) <- electBasicCommittee

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxosSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxosSpec.hs
@@ -570,7 +570,7 @@ govPolicySpec = do
                 , pProcAnchor = anchor
                 }
         let tx = mkBasicTx mkBasicTxBody & bodyTxL . proposalProceduresTxBodyL .~ [proposal]
-        expectPhase2Invalid tx
+        submitPhase2Invalid_ tx
 
       impAnn "TreasuryWithdrawals" $ do
         let withdrawals = Map.fromList [(rewardAccount, Coin 1000)]
@@ -583,7 +583,7 @@ govPolicySpec = do
                 , pProcAnchor = anchor
                 }
         let tx = mkBasicTx mkBasicTxBody & bodyTxL . proposalProceduresTxBodyL .~ [proposal]
-        expectPhase2Invalid tx
+        submitPhase2Invalid_ tx
 
 costModelsSpec ::
   forall era.
@@ -628,7 +628,7 @@ costModelsSpec =
                 , pProcAnchor = anchor
                 }
         let tx = mkBasicTx mkBasicTxBody & bodyTxL . proposalProceduresTxBodyL .~ [proposal]
-        expectPhase2Invalid tx
+        submitPhase2Invalid_ tx
 
     it "Updating CostModels with alwaysSucceeds govPolicy but no PlutusV3 CostModels fails" $ do
       modifyPParams $ ppCostModelsL .~ testingCostModels [PlutusV1 .. PlutusV2]

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -78,7 +78,7 @@ library
         cardano-ledger-allegra ^>=1.6,
         cardano-ledger-binary >=1.4,
         cardano-ledger-core ^>=1.15,
-        cardano-ledger-shelley >=1.13 && <1.15,
+        cardano-ledger-shelley ^>=1.15,
         containers,
         deepseq,
         groups,

--- a/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
+++ b/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
@@ -49,7 +49,7 @@ library
         containers,
         hashable,
         cardano-ledger-shelley-test >=1.1,
-        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.12 && <1.15,
+        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.12,
         cardano-strict-containers,
         microlens,
         mtl,

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Version history for `cardano-ledger-shelley`
 
-## 1.14.2.0
+## 1.15.0.0
 
 * Added `EncCBOR` instance for `LedgerEnv`
 
 ### `testlib`
 
+* Added a `MonadFail` constraint to two methods of `ShelleyEraImp`:
+  - `initGenesis`
+  - `initNewEpochState`
+* Added a `MonadFail` constraint to:
+  - `defaultInitNewEpochState`
+  - `defaultInitImpTestState`
 * Added `logText`
 * Added `ToExpr` instance for `LedgerEnv`
 * Added `tryRunImpRuleNoAssertions` to `ImpTest`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### `testlib`
 
+* Added `logText`
 * Added `ToExpr` instance for `LedgerEnv`
 * Added `tryRunImpRuleNoAssertions` to `ImpTest`
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### `testlib`
 
+* Added `expectUTxOContent`
 * Added `disableTreasuryExpansion`
 * Added a `MonadFail` constraint to two methods of `ShelleyEraImp`:
   - `initGenesis`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### `testlib`
 
+* Added `disableTreasuryExpansion`
 * Added a `MonadFail` constraint to two methods of `ShelleyEraImp`:
   - `initGenesis`
   - `initNewEpochState`

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-shelley
-version:            1.14.2.0
+version:            1.15.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -135,7 +135,7 @@ module Test.Cardano.Ledger.Shelley.ImpTest (
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Chain.UTxO as Byron (empty)
 import Cardano.Crypto.DSIGN (DSIGNAlgorithm (..), Ed25519DSIGN)
-import Cardano.Crypto.Hash (Hash, HashAlgorithm)
+import Cardano.Crypto.Hash (HashAlgorithm)
 import Cardano.Crypto.Hash.Blake2b (Blake2b_224)
 import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Ledger.Address (
@@ -156,6 +156,7 @@ import Cardano.Ledger.Crypto (Crypto (..))
 import Cardano.Ledger.Genesis (EraGenesis (..), NoGenesis (..))
 import Cardano.Ledger.Keys (
   HasKeyRole (..),
+  Hash,
   KeyHash,
   KeyRole (..),
   VerKeyVRF,
@@ -470,7 +471,7 @@ class
   , VRF.VRFAlgorithm (VRF (EraCrypto era))
   , HashAlgorithm (HASH (EraCrypto era))
   , DSIGNAlgorithm (DSIGN (EraCrypto era))
-  , Signable (DSIGN (EraCrypto era)) (Hash (HASH (EraCrypto era)) EraIndependentTxBody)
+  , Signable (DSIGN (EraCrypto era)) (Hash (EraCrypto era) EraIndependentTxBody)
   , ADDRHASH (EraCrypto era) ~ Blake2b_224
   ) =>
   ShelleyEraImp era
@@ -649,7 +650,7 @@ instance
   , NFData (VerKeyDSIGN (DSIGN c))
   , ADDRHASH c ~ Blake2b_224
   , DSIGN c ~ Ed25519DSIGN
-  , Signable (DSIGN c) (Hash (HASH c) EraIndependentTxBody)
+  , Signable (DSIGN c) (Hash c EraIndependentTxBody)
   , ShelleyEraScript (ShelleyEra c)
   ) =>
   ShelleyEraImp (ShelleyEra c)
@@ -1537,7 +1538,7 @@ freshSafeHash = arbitrary
 
 freshKeyHashVRF ::
   Era era =>
-  ImpTestM era (Hash (HASH (EraCrypto era)) (VerKeyVRF (EraCrypto era)))
+  ImpTestM era (Hash (EraCrypto era) (VerKeyVRF (EraCrypto era)))
 freshKeyHashVRF = arbitrary
 
 -- | Adds a key pair to the keyhash lookup map

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -93,6 +93,7 @@ module Test.Cardano.Ledger.Shelley.ImpTest (
   expectRegisteredRewardAddress,
   expectNotRegisteredRewardAddress,
   expectTreasury,
+  disableTreasuryExpansion,
   updateAddrTxWits,
   addNativeScriptTxWits,
   addRootTxIn,
@@ -1857,6 +1858,10 @@ expectTreasury c =
   impAnn "Checking treasury amount" $ do
     treasuryAmt <- getsNES $ nesEsL . esAccountStateL . asTreasuryL
     c `shouldBe` treasuryAmt
+
+-- Ensure no fees reach the treasury since that complicates withdrawal checks
+disableTreasuryExpansion :: ShelleyEraImp era => ImpTestM era ()
+disableTreasuryExpansion = modifyPParams $ ppTauL .~ (0 %! 1)
 
 impGetNativeScript :: ScriptHash (EraCrypto era) -> ImpTestM era (Maybe (NativeScript era))
 impGetNativeScript sh = Map.lookup sh <$> gets impNativeScripts

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -55,7 +55,7 @@ library
         aeson >=2.2,
         bytestring,
         cardano-ledger-allegra ^>=1.6,
-        cardano-ledger-alonzo >=1.9 && <1.12,
+        cardano-ledger-alonzo >=1.9,
         cardano-ledger-babbage >=1.10 && <=1.11,
         cardano-ledger-binary >=1.4,
         cardano-ledger-conway >=1.13 && <1.19,

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -61,7 +61,7 @@ library
         cardano-ledger-conway >=1.13 && <1.19,
         cardano-ledger-core ^>=1.15,
         cardano-ledger-mary ^>=1.7,
-        cardano-ledger-shelley >=1.13 && <1.15,
+        cardano-ledger-shelley ^>=1.15,
         cardano-strict-containers,
         containers,
         FailT,

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Version history for `cardano-ledger-core`
 
-## 1.15.0.1
+## 1.15.1.0
 
 *
+
+### `testlib`
+
+* Generalize the return type of `assertColorFailure` to `MonadIO`
 
 ## 1.15.0.0
 

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-core
-version:            1.15.0.0
+version:            1.15.1.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/Internal.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/Internal.hs
@@ -35,7 +35,6 @@ module Cardano.Ledger.Keys.Internal (
   -- * Genesis delegations
   GenDelegPair (..),
   GenDelegs (..),
-  GKeys (..),
 
   -- * KES
   KESignable,
@@ -95,7 +94,6 @@ import Data.Coerce (Coercible, coerce)
 import Data.Default.Class (Default (..))
 import Data.Kind (Type)
 import Data.Map.Strict (Map)
-import Data.Set (Set)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
@@ -336,10 +334,6 @@ newtype GenDelegs c = GenDelegs
   deriving (Show) via Quiet (GenDelegs c)
 
 deriving instance Crypto c => ToJSON (GenDelegs c)
-
-newtype GKeys c = GKeys {unGKeys :: Set (VKey 'Genesis c)}
-  deriving (Eq, NoThunks, Generic)
-  deriving (Show) via Quiet (GKeys c)
 
 --------------------------------------------------------------------------------
 -- crypto-parametrised types

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Imp/Common.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Imp/Common.hs
@@ -188,7 +188,7 @@ io = id
 assertFailure :: (HasCallStack, MonadIO m) => String -> m a
 assertFailure = liftIO . H.assertFailure
 
-assertColorFailure :: HasCallStack => String -> IO a
+assertColorFailure :: (HasCallStack, MonadIO m) => String -> m a
 assertColorFailure = liftIO . H.assertColorFailure
 
 -- | Lifted version of `H.assertBool`


### PR DESCRIPTION
# Description

* Implement some of the tests in `Alonzo.Imp.UtxowSpec.Valid`
* Shorten the stability window used in ImpTests and fix resulting test breakages
* Add some quality-of-life improvements to testing
* Tidy up a few other things in passing

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
