### PR TITLE
Add changelog section for cardano-node-10.0 and 9.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,20 @@ the `CHANGELOG.md` for each individual package for any changes relevant for deve
 If you are looking for the Ledger Releasing and Versioning Process then you can find it in
 [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd).
 
-## 9.3
+## 10.0
 
+- Translation of `RegTxCert` and `UnRegTxCert` to `PlutusV3` scripts context will now be done correctly, which means deposit and refund respectively, will actually be translated: [#4627](https://github.com/IntersectMBO/cardano-ledger/pull/4627)
+- Treasury withdrawals that are empty or sum up to zero will no longer be allowed: [#4630](https://github.com/IntersectMBO/cardano-ledger/pull/4630)
+- Prevent non-registered return accounts for proposals' deposits and `TreasuryWithdrawals` [#4639](https://github.com/IntersectMBO/cardano-ledger/pull/4639)
+- Ensure `ppuCoinsPerUTxOBytes` cannot be zero: [#4650](https://github.com/IntersectMBO/cardano-ledger/pull/4650)
+- Ensure dreps exist prior to delegation: [#4652](https://github.com/IntersectMBO/cardano-ledger/pull/4652)
+- Change how SPO votes are counted: [#4659](https://github.com/IntersectMBO/cardano-ledger/pull/4659)
 - Disallow withdrawals to non-delegated keyhashes post-bootstrap [#4555](https://github.com/IntersectMBO/cardano-ledger/pull/4555)
 - Remove `maxMajorPV` from `Globals`, because it was unused: [#4218](https://github.com/IntersectMBO/cardano-ledger/pull/4218)
+
+## 9.2.1
+
+- Improve performance of certificate validation: [#4600](https://github.com/IntersectMBO/cardano-ledger/pull/4600) and [#4643](https://github.com/IntersectMBO/cardano-ledger/pull/4643)
 
 ## 9.2
 

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Imp/Common.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Imp/Common.hs
@@ -191,8 +191,7 @@ assertFailure = liftIO . H.assertFailure
 assertColorFailure :: HasCallStack => String -> IO a
 assertColorFailure = liftIO . H.assertColorFailure
 
--- | Just like `expectationBool`, but does not force the return type to unit. Lifted
--- version of `H.assertBool`
+-- | Lifted version of `H.assertBool`
 assertBool :: (HasCallStack, MonadIO m) => String -> Bool -> m ()
 assertBool msg = liftIO . H.assertBool msg
 


### PR DESCRIPTION
# Description

These changelogs will be necessary for the upcoming cardano-node-10.0 release.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
