### PR TITLE
Continue implementing the tests in `Alonzo.Imp.UtxowSpec.Valid`

### DIFF
--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Valid.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Valid.hs
@@ -37,6 +37,7 @@ spec = describe "Valid transactions" $ do
           alwaysSucceedsWithDatumHash = hashPlutusScript $ alwaysSucceedsWithDatum slang :: ScriptHash (EraCrypto era)
           alwaysSucceedsNoDatumHash = hashPlutusScript $ alwaysSucceedsNoDatum slang :: ScriptHash (EraCrypto era)
           alwaysFailsWithDatumHash = hashPlutusScript $ alwaysFailsWithDatum slang :: ScriptHash (EraCrypto era)
+          alwaysFailsNoDatumHash = hashPlutusScript $ alwaysFailsNoDatum slang :: ScriptHash (EraCrypto era)
 
         it "Validating SPEND script" $ do
           txIn <- produceScript alwaysSucceedsWithDatumHash
@@ -68,10 +69,18 @@ spec = describe "Valid transactions" $ do
                 & inputsTxBodyL .~ [txIn]
                 & certsTxBodyL .~ [txCert]
 
-  it "Validating WITHDRAWAL script" $ do
-    const $ pendingWith "not implemented yet"
-  it "Not validating WITHDRAWAL script" $ do
-    const $ pendingWith "not implemented yet"
+        it "Validating WITHDRAWAL script" $ do
+          account <- registerStakeCredential @era $ ScriptHashObj alwaysSucceedsNoDatumHash
+          expectTxSuccess <=< submitTx $
+            mkBasicTx $
+              mkBasicTxBody & withdrawalsTxBodyL .~ Withdrawals [(account, mempty)]
+
+        it "Not validating WITHDRAWAL script" $ do
+          account <- registerStakeCredential @era $ ScriptHashObj alwaysFailsNoDatumHash
+          expectTxSuccess <=< submitPhase2Invalid $
+            mkBasicTx $
+              mkBasicTxBody & withdrawalsTxBodyL .~ Withdrawals [(account, mempty)]
+
   it "Validating MINT script" $ do
     const $ pendingWith "not implemented yet"
   it "Not validating MINT script" $ do

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Valid.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Valid.hs
@@ -19,6 +19,7 @@ import Cardano.Ledger.Plutus (
  )
 import Control.Monad ((<=<))
 import Lens.Micro ((&), (.~))
+import Test.Cardano.Ledger.Alonzo.Arbitrary ()
 import Test.Cardano.Ledger.Alonzo.ImpTest
 import Test.Cardano.Ledger.Imp.Common
 import Test.Cardano.Ledger.Plutus.Examples
@@ -81,10 +82,12 @@ spec = describe "Valid transactions" $ do
             mkBasicTx $
               mkBasicTxBody & withdrawalsTxBodyL .~ Withdrawals [(account, mempty)]
 
-  it "Validating MINT script" $ do
-    const $ pendingWith "not implemented yet"
-  it "Not validating MINT script" $ do
-    const $ pendingWith "not implemented yet"
+        it "Validating MINT script" $ do
+          expectTxSuccess <=< submitTx <=< mkTokenMintingTx $ alwaysSucceedsNoDatumHash
+
+        it "Not validating MINT script" $ do
+          expectTxSuccess <=< submitPhase2Invalid <=< mkTokenMintingTx $ alwaysFailsNoDatumHash
+
   it "Validating scripts everywhere" $ do
     const $ pendingWith "not implemented yet"
   it "Acceptable supplimentary datum" $ do

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### `testlib`
 
+* Remove `mintingTokenTx` (which is replaced by `mkTokenMintingTx` in Mary)
 * Add `minFeeUpdateGovAction`
 * Add `mkTreasuryWithdrawalsGovAction` and `mkParameterChangeGovAction`
 * Switch to using `ImpSpec` package

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -163,7 +163,6 @@ library testlib
         cardano-ledger-babbage:{cardano-ledger-babbage, testlib},
         cardano-ledger-conway,
         cardano-ledger-core:{cardano-ledger-core, testlib},
-        cardano-ledger-mary,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
         cardano-strict-containers,
         containers,

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### `testlib`
 
+* Add `mkTokenMintingTx`
 * Switch to using `ImpSpec` package
 
 ## 1.7.0.1


### PR DESCRIPTION
# Description

Implement the remainder of the tests in `Alonzo.Imp.UtxowSpec.Valid` and remove the ones they replace in `Examples.AlonzoValidTxUTXOW`.

Addresses more of #4180

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
