### PR TITLE
Fix drep delegation invariant preservation

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 * Add `whenBootstrap`
 
+## 1.17.1.0
+
+* Add `processDelegation`
+
 ## 1.17.0.0
 
 * Added `reDelegatees` and `rePoolParams` to `RatifyEnv` for updated SPO vote calculation #4645


### PR DESCRIPTION
# Description

This PR fixes two bugs that where introduced in #4652:

1. Delegating to an SPO by a stake credential that was already delegated to a DRep violated the internal invariant leading to an inconsistency in which upon this DRep unregistration the delegation would not get cleaned up. Thus it would lead to a way to surpass the protection of delegation to a non-registered DRep
2. For testing and benchmarking we have ability to inject DReps and their delegations through the Genesis file. This injection was broken for DReps, since it did not maintain the internal invariant of DRep delegations

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
