### PR TITLE
Better bootstrap-aware Imp tests

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### `testlib`
 
+* Add `mkConstitutionProposal`
+* Remove `submitConstitutionGovAction` and change signature of `submitConstitution`
 * Add `mkProposal` and `mkProposalWithRewardAccount`
 * Add `whenBootstrap`
 

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### `testlib`
 
+* Add `mkProposal` and `mkProposalWithRewardAccount`
 * Add `whenBootstrap`
 
 ## 1.17.2.0

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### `testlib`
 
+* Add `mkUpdateCommitteeProposal`
 * Add `SubmitFailureExpectation`, `FailBoth`, `submitBootstrapAwareFailingVote`, `submitBootstrapAwareFailingProposal`, `submitBootstrapAwareFailingProposal_`
 * Add `mkConstitutionProposal`
 * Remove `submitConstitutionGovAction` and change signature of `submitConstitution`

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### `testlib`
 
+* Add `SubmitFailureExpectation`, `FailBoth`, `submitBootstrapAwareFailingVote`, `submitBootstrapAwareFailingProposal`, `submitBootstrapAwareFailingProposal_`
 * Add `mkConstitutionProposal`
 * Remove `submitConstitutionGovAction` and change signature of `submitConstitution`
 * Add `mkProposal` and `mkProposalWithRewardAccount`

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -115,7 +115,7 @@ spec = do
       describe "CERTS" $ Certs.spec @era
       describe "DELEG" $ Deleg.spec @era
       describe "ENACT" $ Enact.spec @era
-      describe "EPOCH" $ Epoch.relevantDuringBootstrapSpec @era
+      describe "EPOCH" $ Epoch.spec @era
       describe "GOV" $ Gov.spec @era
       describe "GOVCERT" $ GovCert.spec @era
       describe "UTXO" $ Utxo.spec @era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -119,6 +119,6 @@ spec = do
       describe "GOV" $ Gov.spec @era
       describe "GOVCERT" $ GovCert.relevantDuringBootstrapSpec @era
       describe "UTXO" $ Utxo.spec @era
-      describe "UTXOS" $ Utxos.relevantDuringBootstrapSpec @era
+      describe "UTXOS" $ Utxos.spec @era
       describe "RATIFY" $ Ratify.relevantDuringBootstrapSpec @era
       describe "LEDGER" $ Ledger.spec @era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -16,7 +16,8 @@ import Cardano.Ledger.Alonzo.Rules (
  )
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure, BabbageUtxowPredFailure)
 import Cardano.Ledger.Babbage.TxInfo (BabbageContextError)
-import Cardano.Ledger.BaseTypes (Inject, ShelleyBase, natVersion)
+import Cardano.Ledger.BaseTypes (Inject, ShelleyBase)
+import Cardano.Ledger.Conway (Conway)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Rules (
   ConwayBbodyPredFailure,
@@ -55,7 +56,7 @@ import qualified Test.Cardano.Ledger.Conway.Imp.LedgerSpec as Ledger
 import qualified Test.Cardano.Ledger.Conway.Imp.RatifySpec as Ratify
 import qualified Test.Cardano.Ledger.Conway.Imp.UtxoSpec as Utxo
 import qualified Test.Cardano.Ledger.Conway.Imp.UtxosSpec as Utxos
-import Test.Cardano.Ledger.Conway.ImpTest (ConwayEraImp, withImpState, withImpStateWithProtVer)
+import Test.Cardano.Ledger.Conway.ImpTest (ConwayEraImp, withImpStateWithProtVer)
 
 spec ::
   forall era.
@@ -97,28 +98,20 @@ spec ::
   Spec
 spec = do
   BabbageImp.spec @era
-  describe "ConwayImpSpec - post bootstrap (protocol version 10)" $
-    withImpStateWithProtVer @era (natVersion @10) $ do
-      describe "BBODY" $ Bbody.spec @era
-      describe "DELEG" $ Deleg.spec @era
-      describe "ENACT" $ Enact.spec @era
-      describe "EPOCH" $ Epoch.spec @era
-      describe "GOV" $ Gov.spec @era
-      describe "GOVCERT" $ GovCert.spec @era
-      describe "UTXO" $ Utxo.spec @era
-      describe "UTXOS" $ Utxos.spec @era
-      describe "RATIFY" $ Ratify.spec @era
-      describe "LEDGER" $ Ledger.spec @era
-  describe "ConwayImpSpec - bootstrap phase (protocol version 9)" $
-    withImpState @era $ do
-      describe "BBODY" $ Bbody.spec @era
-      describe "CERTS" $ Certs.spec @era
-      describe "DELEG" $ Deleg.spec @era
-      describe "ENACT" $ Enact.spec @era
-      describe "EPOCH" $ Epoch.spec @era
-      describe "GOV" $ Gov.spec @era
-      describe "GOVCERT" $ GovCert.spec @era
-      describe "UTXO" $ Utxo.spec @era
-      describe "UTXOS" $ Utxos.spec @era
-      describe "RATIFY" $ Ratify.spec @era
-      describe "LEDGER" $ Ledger.spec @era
+  let
+    conwayImpSpec protVer =
+      describe ("ConwayImpSpec - " <> show protVer) $
+        withImpStateWithProtVer @era protVer $ do
+          describe "BBODY" $ Bbody.spec @era
+          describe "CERTS" $ Certs.spec @era
+          describe "DELEG" $ Deleg.spec @era
+          describe "ENACT" $ Enact.spec @era
+          describe "EPOCH" $ Epoch.spec @era
+          describe "GOV" $ Gov.spec @era
+          describe "GOVCERT" $ GovCert.spec @era
+          describe "LEDGER" $ Ledger.spec @era
+          describe "RATIFY" $ Ratify.spec @era
+          describe "UTXO" $ Utxo.spec @era
+          describe "UTXOS" $ Utxos.spec @era
+   in
+    forM_ [eraProtVerLow @Conway .. eraProtVerHigh @Conway] conwayImpSpec

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -114,7 +114,7 @@ spec = do
       describe "BBODY" $ Bbody.spec @era
       describe "CERTS" $ Certs.spec @era
       describe "DELEG" $ Deleg.spec @era
-      describe "ENACT" $ Enact.relevantDuringBootstrapSpec @era
+      describe "ENACT" $ Enact.spec @era
       describe "EPOCH" $ Epoch.relevantDuringBootstrapSpec @era
       describe "GOV" $ Gov.spec @era
       describe "GOVCERT" $ GovCert.spec @era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -117,7 +117,7 @@ spec = do
       describe "ENACT" $ Enact.relevantDuringBootstrapSpec @era
       describe "EPOCH" $ Epoch.relevantDuringBootstrapSpec @era
       describe "GOV" $ Gov.spec @era
-      describe "GOVCERT" $ GovCert.relevantDuringBootstrapSpec @era
+      describe "GOVCERT" $ GovCert.spec @era
       describe "UTXO" $ Utxo.spec @era
       describe "UTXOS" $ Utxos.spec @era
       describe "RATIFY" $ Ratify.relevantDuringBootstrapSpec @era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -116,7 +116,7 @@ spec = do
       describe "DELEG" $ Deleg.spec @era
       describe "ENACT" $ Enact.relevantDuringBootstrapSpec @era
       describe "EPOCH" $ Epoch.relevantDuringBootstrapSpec @era
-      describe "GOV" $ Gov.relevantDuringBootstrapSpec @era
+      describe "GOV" $ Gov.spec @era
       describe "GOVCERT" $ GovCert.relevantDuringBootstrapSpec @era
       describe "UTXO" $ Utxo.spec @era
       describe "UTXOS" $ Utxos.relevantDuringBootstrapSpec @era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -120,5 +120,5 @@ spec = do
       describe "GOVCERT" $ GovCert.spec @era
       describe "UTXO" $ Utxo.spec @era
       describe "UTXOS" $ Utxos.spec @era
-      describe "RATIFY" $ Ratify.relevantDuringBootstrapSpec @era
+      describe "RATIFY" $ Ratify.spec @era
       describe "LEDGER" $ Ledger.spec @era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
@@ -354,16 +354,7 @@ noConfidenceSpec =
     impAnn "Committee should be elected" $ do
       committee <- getCommittee
       committee `shouldBe` SJust (Committee committeeMap $ 1 %! 2)
-    pp <- getsNES $ nesEsL . curPParamsEpochStateL
-    returnAddr <- registerRewardAccount
-    gaidNoConf <-
-      submitProposal $
-        ProposalProcedure
-          { pProcReturnAddr = returnAddr
-          , pProcGovAction = NoConfidence (SJust prevGaidCommittee)
-          , pProcDeposit = pp ^. ppGovActionDepositL
-          , pProcAnchor = def
-          }
+    gaidNoConf <- mkProposal (NoConfidence (SJust prevGaidCommittee)) >>= submitProposal
     submitYesVote_ (StakePoolVoter khSPO) gaidNoConf
     submitYesVote_ (DRepVoter drep) gaidNoConf
     replicateM_ 4 passEpoch

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
@@ -365,7 +365,8 @@ constitutionSpec =
   it "Constitution" $ do
     (committeeMember1 :| [committeeMember2]) <- registerInitialCommittee
     (dRep, _, _) <- setupSingleDRep 1_000_000
-    (govActionId, constitution) <- submitConstitution SNothing
+    (proposal, constitution) <- mkConstitutionProposal SNothing
+    govActionId <- submitProposal proposal
     initialConstitution <- getConstitution
 
     proposalsBeforeVotes <- getsNES $ newEpochStateGovStateL . proposalsGovStateL

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
@@ -127,7 +127,7 @@ proposalsSpec =
       initialPulser <- getsNES $ newEpochStateGovStateL . drepPulsingStateGovStateL
       initialEnactState <- getEnactState
 
-      (govActionId, _) <- submitConstitution SNothing
+      govActionId <- submitConstitution SNothing
       curConstitution' <- getsNES $ newEpochStateGovStateL . constitutionGovStateL
       impAnn "Constitution has not been enacted yet" $
         curConstitution' `shouldBe` curConstitution

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovCertSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovCertSpec.hs
@@ -14,14 +14,12 @@ module Test.Cardano.Ledger.Conway.Imp.GovCertSpec (
 import Cardano.Ledger.BaseTypes (EpochInterval (..), Mismatch (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Conway.Governance (GovPurposeId (..), Voter (..))
 import Cardano.Ledger.Conway.Rules (ConwayGovCertPredFailure (..))
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Shelley.LedgerState (curPParamsEpochStateL, nesEsL)
 import Cardano.Ledger.Val (Val (..))
 import Data.Maybe.Strict (StrictMaybe (..))
 import qualified Data.Sequence.Strict as SSeq
-import qualified Data.Set as Set
 import Lens.Micro ((&), (.~))
 import Test.Cardano.Ledger.Conway.Arbitrary ()
 import Test.Cardano.Ledger.Conway.ImpTest
@@ -36,24 +34,6 @@ spec ::
   SpecWith (ImpTestState era)
 spec = do
   relevantDuringBootstrapSpec
-  it "Enact UpdateCommitee with lengthy lifetime" $ do
-    NonNegative n <- arbitrary
-    passNEpochs n
-    (drepCred, _, _) <- setupSingleDRep 1_000_000
-    (spoC, _, _) <- setupPoolWithStake $ Coin 42_000_000
-    cc <- KeyHashObj <$> freshKeyHash
-    EpochInterval committeeMaxTermLength <-
-      getsNES $ nesEsL . curPParamsEpochStateL . ppCommitteeMaxTermLengthL
-    secondAddCCGaid <-
-      submitUpdateCommittee Nothing mempty [(cc, EpochInterval (committeeMaxTermLength + 2))] (1 %! 2)
-    submitYesVote_ (DRepVoter drepCred) secondAddCCGaid
-    submitYesVote_ (StakePoolVoter spoC) secondAddCCGaid
-    passNEpochs 2
-    -- Due to longer than allowed lifetime we have to wait an extra epoch for this new action to be enacted
-    expectCommitteeMemberAbsence cc
-    passEpoch
-    expectCommitteeMemberPresence cc
-
   it "Resigning proposed CC key" $ do
     ccColdCred <- KeyHashObj <$> freshKeyHash
     _ <- submitUpdateCommittee Nothing mempty [(ccColdCred, EpochInterval 1234)] (1 %! 2)
@@ -62,51 +42,6 @@ spec = do
           & bodyTxL . certsTxBodyL
             .~ SSeq.singleton (ResignCommitteeColdTxCert ccColdCred SNothing)
       )
-  -- A CC that has resigned will need to be first voted out and then voted in to be considered active
-  it "CC re-election" $
-    do
-      (drepCred, _, _) <- setupSingleDRep 1_000_000
-      (spoC, _, _) <- setupPoolWithStake $ Coin 42_000_000
-      passNEpochs 2
-      -- Add a fresh CC
-      cc <- KeyHashObj <$> freshKeyHash
-      addCCGaid <- submitUpdateCommittee Nothing mempty [(cc, EpochInterval 10)] (1 %! 2)
-      submitYesVote_ (DRepVoter drepCred) addCCGaid
-      submitYesVote_ (StakePoolVoter spoC) addCCGaid
-      passNEpochs 2
-      -- Confirm that they are added
-      expectCommitteeMemberPresence cc
-      -- Confirm their hot key registration
-      _hotKey <- registerCommitteeHotKey cc
-      ccShouldNotBeResigned cc
-      -- Have them resign
-      _ <- resignCommitteeColdKey cc SNothing
-      ccShouldBeResigned cc
-      -- Re-add the same CC
-      reAddCCGaid <- submitUpdateCommittee Nothing mempty [(cc, EpochInterval 20)] (1 %! 2)
-      submitYesVote_ (DRepVoter drepCred) reAddCCGaid
-      submitYesVote_ (StakePoolVoter spoC) reAddCCGaid
-      passNEpochs 2
-      -- Confirm that they are still resigned
-      ccShouldBeResigned cc
-      -- Remove them
-      removeCCGaid <-
-        submitUpdateCommittee (Just (SJust $ GovPurposeId reAddCCGaid)) (Set.singleton cc) [] (1 %! 2)
-      submitYesVote_ (DRepVoter drepCred) removeCCGaid
-      submitYesVote_ (StakePoolVoter spoC) removeCCGaid
-      passNEpochs 2
-      -- Confirm that they have been removed
-      expectCommitteeMemberAbsence cc
-      secondAddCCGaid <-
-        submitUpdateCommittee Nothing mempty [(cc, EpochInterval 20)] (1 %! 2)
-      submitYesVote_ (DRepVoter drepCred) secondAddCCGaid
-      submitYesVote_ (StakePoolVoter spoC) secondAddCCGaid
-      passNEpochs 2
-      -- Confirm that they have been added
-      expectCommitteeMemberPresence cc
-      -- Confirm that after registering a hot key, they are active
-      _hotKey <- registerCommitteeHotKey cc
-      ccShouldNotBeResigned cc
 
 relevantDuringBootstrapSpec ::
   forall era.

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
@@ -1007,37 +1007,6 @@ constitutionSpec =
           invalidNoConfidenceProposal
           [ injectFailure $ InvalidPrevGovActionId invalidNoConfidenceProposal
           ]
-    it "submitted successfully with valid GovPurposeId" $ do
-      modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 1
-
-      curConstitution <- getsNES $ newEpochStateGovStateL . constitutionGovStateL
-      initialPulser <- getsNES $ newEpochStateGovStateL . drepPulsingStateGovStateL
-      initialEnactState <- getEnactState
-
-      (govActionId, _) <- submitConstitution SNothing
-      curConstitution' <- getsNES $ newEpochStateGovStateL . constitutionGovStateL
-      impAnn "Constitution has not been enacted yet" $
-        curConstitution' `shouldBe` curConstitution
-
-      govState <- getsNES newEpochStateGovStateL
-      let expectedProposals = govState ^. cgsProposalsL
-          expectedPulser = govState ^. cgsDRepPulsingStateL
-      expectedEnactState <- getEnactState
-
-      impAnn "EnactState reflects the submitted governance action" $ do
-        expectedEnactState `shouldBe` initialEnactState
-
-      impAnn "Proposals contain the submitted proposal" $
-        expectedProposals `shouldSatisfy` \props -> govActionId `elem` proposalsIds props
-
-      impAnn "Pulser has not changed" $
-        expectedPulser `shouldBe` initialPulser
-
-      passNEpochs 2
-      impAnn "Proposal gets removed after expiry" $ do
-        govStateFinal <- getsNES newEpochStateGovStateL
-        let ratifyState = extractDRepPulsingState (govStateFinal ^. cgsDRepPulsingStateL)
-        rsExpired ratifyState `shouldBe` Set.singleton govActionId
 
 policySpec ::
   forall era.

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
@@ -57,8 +57,6 @@ spec = do
   votingSpec
   policySpec
   predicateFailuresSpec
-  unknownCostModelsSpec
-
 relevantDuringBootstrapSpec ::
   forall era.
   ( ConwayEraImp era
@@ -66,6 +64,7 @@ relevantDuringBootstrapSpec ::
   ) =>
   SpecWith (ImpTestState era)
 relevantDuringBootstrapSpec = do
+  unknownCostModelsSpec
   constitutionSpec
   withdrawalsSpec
   hardForkSpec
@@ -89,7 +88,7 @@ unknownCostModelsSpec =
         submitParameterChange SNothing $
           emptyPParamsUpdate
             & ppuCostModelsL .~ SJust newCostModels
-      submitYesVote_ (DRepVoter drepC) gai
+      whenPostBootstrap $ submitYesVote_ (DRepVoter drepC) gai
       submitYesVoteCCs_ hotCommitteeCs gai
       passNEpochs 2
       getLastEnactedParameterChange `shouldReturn` SJust (GovPurposeId gai)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
@@ -10,10 +10,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Test.Cardano.Ledger.Conway.Imp.GovSpec (
-  spec,
-  relevantDuringBootstrapSpec,
-) where
+module Test.Cardano.Ledger.Conway.Imp.GovSpec (spec) where
 
 import Cardano.Ledger.Address (RewardAccount (..))
 import Cardano.Ledger.BaseTypes
@@ -51,20 +48,12 @@ spec ::
   ) =>
   SpecWith (ImpTestState era)
 spec = do
-  relevantDuringBootstrapSpec
-
-relevantDuringBootstrapSpec ::
-  forall era.
-  ( ConwayEraImp era
-  , InjectRuleFailure "LEDGER" ConwayGovPredFailure era
-  ) =>
-  SpecWith (ImpTestState era)
-relevantDuringBootstrapSpec = do
-  predicateFailuresSpec
-  policySpec
-  votingSpec
-  unknownCostModelsSpec
   constitutionSpec
+  proposalsSpec
+  votingSpec
+  policySpec
+  predicateFailuresSpec
+  unknownCostModelsSpec
   withdrawalsSpec
   hardForkSpec
   pparamUpdateSpec

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/RatifySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/RatifySpec.hs
@@ -5,10 +5,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Test.Cardano.Ledger.Conway.Imp.RatifySpec (
-  spec,
-  relevantDuringBootstrapSpec,
-) where
+module Test.Cardano.Ledger.Conway.Imp.RatifySpec (spec) where
 
 import Cardano.Ledger.Address
 import Cardano.Ledger.BaseTypes
@@ -42,19 +39,12 @@ spec ::
   ConwayEraImp era =>
   SpecWith (ImpTestState era)
 spec = do
-  relevantDuringBootstrapSpec
   votingSpec
   delayingActionsSpec
   committeeMinSizeAffectsInFlightProposalsSpec
   paramChangeAffectsProposalsSpec
   committeeExpiryResignationDiscountSpec
   committeeMaxTermLengthSpec
-
-relevantDuringBootstrapSpec ::
-  forall era.
-  ConwayEraImp era =>
-  SpecWith (ImpTestState era)
-relevantDuringBootstrapSpec = do
   spoVotesForHardForkInitiation
   initiateHardForkWithLessThanMinimalCommitteeSize
   spoAndCCVotingSpec
@@ -213,8 +203,9 @@ committeeExpiryResignationDiscountSpec ::
   ConwayEraImp era =>
   SpecWith (ImpTestState era)
 committeeExpiryResignationDiscountSpec =
+  -- Committee-update proposals are disallowed during bootstrap, so we can only run these tests post-bootstrap
   describe "Expired and resigned committee members are discounted from quorum" $ do
-    it "Expired" $ do
+    it "Expired" $ whenPostBootstrap $ do
       modifyPParams $ ppCommitteeMinSizeL .~ 2
       (drep, _, _) <- setupSingleDRep 1_000_000
       (spoC, _, _) <- setupPoolWithStake $ Coin 42_000_000
@@ -246,7 +237,7 @@ committeeExpiryResignationDiscountSpec =
       -- Check for CC acceptance should fail
       ccShouldBeExpired committeeColdC2
       isCommitteeAccepted gaiConstitution `shouldReturn` False
-    it "Resigned" $ do
+    it "Resigned" $ whenPostBootstrap $ do
       modifyPParams $ ppCommitteeMinSizeL .~ 2
       (drep, _, _) <- setupSingleDRep 1_000_000
       (spoC, _, _) <- setupPoolWithStake $ Coin 42_000_000
@@ -284,6 +275,8 @@ paramChangeAffectsProposalsSpec ::
   ConwayEraImp era =>
   SpecWith (ImpTestState era)
 paramChangeAffectsProposalsSpec =
+  -- These tests rely on submitting committee-update proposals and on drep votes, which are disallowed during bootstrap,
+  -- so we can only run them post-bootstrap
   describe "ParameterChange affects existing proposals" $ do
     let largerThreshold :: UnitInterval
         largerThreshold = 51 %! 100
@@ -327,7 +320,7 @@ paramChangeAffectsProposalsSpec =
             submitYesVote_ (DRepVoter drepC) pcGai
             submitYesVote_ (CommitteeVoter hotCommitteeC) pcGai
             passNEpochs 2
-      it "Increasing the threshold prevents a hitherto-ratifiable proposal from being ratified" $ do
+      it "Increasing the threshold prevents a hitherto-ratifiable proposal from being ratified" $ whenPostBootstrap $ do
         (drepC, hotCommitteeC, _) <- electBasicCommittee
         setThreshold smallerThreshold
         (drep, _, _) <- setupSingleDRep 1_000_000
@@ -335,7 +328,7 @@ paramChangeAffectsProposalsSpec =
         isDRepAccepted gaiChild `shouldReturn` True
         enactThreshold largerThreshold drepC hotCommitteeC
         isDRepAccepted gaiChild `shouldReturn` False
-      it "Decreasing the threshold ratifies a hitherto-unratifiable proposal" $ do
+      it "Decreasing the threshold ratifies a hitherto-unratifiable proposal" $ whenPostBootstrap $ do
         -- This sets up a stake pool with 1_000_000 Coin
         (drepC, hotCommitteeC, _) <- electBasicCommittee
         setThreshold largerThreshold
@@ -373,7 +366,7 @@ paramChangeAffectsProposalsSpec =
             submitYesVote_ (DRepVoter drepC) pcGai
             submitYesVote_ (CommitteeVoter hotCommitteeC) pcGai
             passNEpochs 2
-      it "Increasing the threshold prevents a hitherto-ratifiable proposal from being ratified" $ do
+      it "Increasing the threshold prevents a hitherto-ratifiable proposal from being ratified" $ whenPostBootstrap $ do
         -- This sets up a stake pool with 1_000_000 Coin
         (drepC, hotCommitteeC, _) <- electBasicCommittee
         setThreshold smallerThreshold
@@ -389,7 +382,7 @@ paramChangeAffectsProposalsSpec =
         isSpoAccepted gaiChild `shouldReturn` True
         enactThreshold largerThreshold drepC hotCommitteeC
         isSpoAccepted gaiChild `shouldReturn` False
-      it "Decreasing the threshold ratifies a hitherto-unratifiable proposal" $ do
+      it "Decreasing the threshold ratifies a hitherto-unratifiable proposal" $ whenPostBootstrap $ do
         -- This sets up a stake pool with 1_000_000 Coin
         (drepC, hotCommitteeC, _) <- electBasicCommittee
         setThreshold largerThreshold
@@ -413,7 +406,7 @@ paramChangeAffectsProposalsSpec =
         getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId gaiParent)
         passEpoch -- UpdateCommittee is a delaying action
         getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId gaiChild)
-    it "A parent ParameterChange proposal can prevent its child from being enacted" $ do
+    it "A parent ParameterChange proposal can prevent its child from being enacted" $ whenPostBootstrap $ do
       hotCommitteeCs <- registerInitialCommittee
       (drepC, _, _) <- setupSingleDRep 1_000_000
       -- Setup one other DRep with equal stake
@@ -455,12 +448,13 @@ committeeMinSizeAffectsInFlightProposalsSpec ::
   ConwayEraImp era =>
   SpecWith (ImpTestState era)
 committeeMinSizeAffectsInFlightProposalsSpec =
+  -- Treasury withdrawals are disallowed during bootstrap, so we can only run these tests post-bootstrap
   describe "CommitteeMinSize affects in-flight proposals" $ do
     let setCommitteeMinSize n = modifyPParams $ ppCommitteeMinSizeL .~ n
         submitTreasuryWithdrawal amount = do
           rewardAccount <- registerRewardAccount
           submitTreasuryWithdrawals [(rewardAccount, amount)]
-    it "TreasuryWithdrawal fails to ratify due to an increase in CommitteeMinSize" $ do
+    it "TreasuryWithdrawal fails to ratify due to an increase in CommitteeMinSize" $ whenPostBootstrap $ do
       disableTreasuryExpansion
       amount <- uniformRM (Coin 1, Coin 100_000_000)
       -- Ensure sufficient amount in the treasury
@@ -487,7 +481,7 @@ committeeMinSizeAffectsInFlightProposalsSpec =
       isCommitteeAccepted gaiTW `shouldReturn` False
       currentProposalsShouldContain gaiTW
       getsNES (nesEsL . esAccountStateL . asTreasuryL) `shouldReturn` treasury
-    it "TreasuryWithdrawal ratifies due to a decrease in CommitteeMinSize" $ do
+    it "TreasuryWithdrawal ratifies due to a decrease in CommitteeMinSize" $ whenPostBootstrap $ do
       disableTreasuryExpansion
       (drepC, hotCommitteeC, _) <- electBasicCommittee
       (spoC, _, _) <- setupPoolWithStake $ Coin 42_000_000
@@ -551,7 +545,9 @@ votingSpec ::
   SpecWith (ImpTestState era)
 votingSpec =
   describe "Voting" $ do
-    it "SPO needs to vote on security-relevant parameter changes" $ do
+    -- These tests involve DRep voting, which is not possible in bootstrap,
+    -- so we have to run them only post-bootstrap
+    it "SPO needs to vote on security-relevant parameter changes" $ whenPostBootstrap $ do
       ccCreds <- registerInitialCommittee
       (drep, _, _) <- setupSingleDRep 1_000_000
       (khPool, _, _) <- setupPoolWithStake $ Coin 42_000_000
@@ -609,7 +605,7 @@ votingSpec =
       (pp ^. ppMinFeeAL) `shouldBe` newMinFeeA
     describe "Active voting stake" $ do
       describe "DRep" $ do
-        it "UTxOs contribute to active voting stake" $ do
+        it "UTxOs contribute to active voting stake" $ whenPostBootstrap $ do
           -- Setup DRep delegation #1
           (drep1, KeyHashObj stakingKH1, paymentKP1) <- setupSingleDRep 1_000_000_000
           -- Setup DRep delegation #2
@@ -632,7 +628,7 @@ votingSpec =
           passNEpochs 2
           -- The same vote should now successfully ratify the proposal
           getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)
-        it "Rewards contribute to active voting stake" $ do
+        it "Rewards contribute to active voting stake" $ whenPostBootstrap $ do
           -- Setup DRep delegation #1
           (drep1, staking1, _) <- setupSingleDRep 1_000_000_000
           -- Setup DRep delegation #2
@@ -659,7 +655,7 @@ votingSpec =
           passNEpochs 2
           -- The same vote should now successfully ratify the proposal
           getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)
-        it "Rewards contribute to active voting stake even in the absence of StakeDistr" $ do
+        it "Rewards contribute to active voting stake even in the absence of StakeDistr" $ whenPostBootstrap $ do
           let govActionLifetime = 5
               govActionDeposit = Coin 1_000_000
               poolDeposit = Coin 200_000
@@ -702,7 +698,7 @@ votingSpec =
           passEpoch
           getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)
         describe "Proposal deposits contribute to active voting stake" $ do
-          it "Directly" $ do
+          it "Directly" $ whenPostBootstrap $ do
             -- Only modify the applicable thresholds
             modifyPParams $ ppGovActionDepositL .~ Coin 600_000
             -- Setup DRep delegation without stake #1
@@ -741,7 +737,7 @@ votingSpec =
             passNEpochs 2
             -- The same vote should now successfully ratify the proposal
             getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)
-          it "After switching delegations" $ do
+          it "After switching delegations" $ whenPostBootstrap $ do
             -- Only modify the applicable thresholds
             modifyPParams $ ppGovActionDepositL .~ Coin 1_000_000
             -- Setup DRep delegation without stake #1
@@ -793,7 +789,7 @@ votingSpec =
             -- The same vote should now successfully ratify the proposal
             getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)
       describe "Predefined DReps" $ do
-        it "acceptedRatio with default DReps" $ do
+        it "acceptedRatio with default DReps" $ whenPostBootstrap $ do
           (drep1, _, committeeGovId) <- electBasicCommittee
           (_, drep2Staking, _) <- setupSingleDRep 1_000_000
 
@@ -821,7 +817,7 @@ votingSpec =
           -- AlwaysNoConfidence vote acts like 'Yes' for NoConfidence actions
           calculateDRepAcceptedRatio noConfidenceGovId `shouldReturn` 2 % 2
 
-        it "AlwaysNoConfidence" $ do
+        it "AlwaysNoConfidence" $ whenPostBootstrap $ do
           (drep1, _, committeeGovId) <- electBasicCommittee
           initialMembers <- getCommitteeMembers
 
@@ -854,7 +850,7 @@ votingSpec =
           isDRepAccepted noConfidenceGovId `shouldReturn` True
           passEpoch
           getCommitteeMembers `shouldReturn` mempty
-        it "AlwaysAbstain" $ do
+        it "AlwaysAbstain" $ whenPostBootstrap $ do
           let getTreasury = getsNES (nesEsL . esAccountStateL . asTreasuryL)
 
           disableTreasuryExpansion
@@ -885,7 +881,7 @@ votingSpec =
           passEpoch
           getTreasury `shouldReturn` zero
 
-        it "DRepAlwaysNoConfidence is sufficient to pass NoConfidence" $ do
+        it "DRepAlwaysNoConfidence is sufficient to pass NoConfidence" $ whenPostBootstrap $ do
           modifyPParams $ \pp ->
             pp
               & ppPoolVotingThresholdsL . pvtMotionNoConfidenceL .~ 0 %! 1
@@ -902,7 +898,7 @@ votingSpec =
           getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId noConfidence)
 
       describe "StakePool" $ do
-        it "UTxOs contribute to active voting stake" $ do
+        it "UTxOs contribute to active voting stake" $ whenPostBootstrap $ do
           -- Only modify the applicable thresholds
           modifyPParams $
             ppPoolVotingThresholdsL
@@ -936,7 +932,7 @@ votingSpec =
           passNEpochs 2
           -- The same vote should now successfully ratify the proposal
           getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)
-        it "Rewards contribute to active voting stake" $ do
+        it "Rewards contribute to active voting stake" $ whenPostBootstrap $ do
           -- Only modify the applicable thresholds
           modifyPParams $
             ppPoolVotingThresholdsL
@@ -972,62 +968,63 @@ votingSpec =
           passNEpochs 2
           -- The same vote should now successfully ratify the proposal
           getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)
-        it "Rewards contribute to active voting stake even in the absence of StakeDistr" $ do
-          let govActionLifetime = 5
-              govActionDeposit = Coin 1_000_000
-              poolDeposit = Coin 200_000
-          -- Only modify the applicable thresholds
-          modifyPParams $ \pp ->
-            pp
-              & ppPoolVotingThresholdsL
-                .~ def
-                  { pvtCommitteeNormal = 51 %! 100
-                  , pvtCommitteeNoConfidence = 51 %! 100
-                  }
-              & ppGovActionDepositL .~ govActionDeposit
-              & ppPoolDepositL .~ poolDeposit
-              & ppEMaxL .~ EpochInterval 5
-              & ppGovActionLifetimeL .~ EpochInterval govActionLifetime
-          whenPostBootstrap (modifyPParams $ ppDRepVotingThresholdsL .~ def)
+        it "Rewards contribute to active voting stake even in the absence of StakeDistr" $
+          whenPostBootstrap $ do
+            let govActionLifetime = 5
+                govActionDeposit = Coin 1_000_000
+                poolDeposit = Coin 200_000
+            -- Only modify the applicable thresholds
+            modifyPParams $ \pp ->
+              pp
+                & ppPoolVotingThresholdsL
+                  .~ def
+                    { pvtCommitteeNormal = 51 %! 100
+                    , pvtCommitteeNoConfidence = 51 %! 100
+                    }
+                & ppGovActionDepositL .~ govActionDeposit
+                & ppPoolDepositL .~ poolDeposit
+                & ppEMaxL .~ EpochInterval 5
+                & ppGovActionLifetimeL .~ EpochInterval govActionLifetime
+            whenPostBootstrap (modifyPParams $ ppDRepVotingThresholdsL .~ def)
 
-          -- Setup Pool delegation #1
-          (poolKH1, delegatorCStaking1) <- setupPoolWithoutStake
-          -- Add rewards to delegation #1
-          submitAndExpireProposalToMakeReward delegatorCStaking1
-          lookupReward delegatorCStaking1 `shouldReturn` govActionDeposit
-          -- Setup Pool delegation #2
-          (poolKH2, delegatorCStaking2) <- setupPoolWithoutStake
-          -- Add rewards to delegation #2
-          submitAndExpireProposalToMakeReward delegatorCStaking2
-          lookupReward delegatorCStaking2 `shouldReturn` govActionDeposit
-          -- Submit a committee proposal
-          Positive extra <- arbitrary
-          cc <- KeyHashObj <$> freshKeyHash
-          addCCGaid <-
-            submitUpdateCommittee
-              Nothing
-              mempty
-              [(cc, EpochInterval (extra + 2 * govActionLifetime))]
-              (75 %! 100)
-          -- Submit the vote
-          submitVote_ VoteYes (StakePoolVoter poolKH1) addCCGaid
-          submitVote_ VoteNo (StakePoolVoter poolKH2) addCCGaid
-          passNEpochs 2
-          -- The vote should not result in a ratification
-          isSpoAccepted addCCGaid `shouldReturn` False
-          getLastEnactedCommittee `shouldReturn` SNothing
-          logRatificationChecks addCCGaid
-          -- Add to the rewards of the delegator to this SPO
-          -- to barely make the threshold (51 %! 100)
-          registerAndRetirePoolToMakeReward delegatorCStaking1
-          lookupReward delegatorCStaking1 `shouldReturn` poolDeposit <> govActionDeposit
-          -- The same vote should now successfully ratify the proposal
-          -- NOTE: It takes 2 epochs for SPO votes as opposed to 1 epoch
-          -- for DRep votes to ratify a proposal.
-          passNEpochs 2
-          getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)
+            -- Setup Pool delegation #1
+            (poolKH1, delegatorCStaking1) <- setupPoolWithoutStake
+            -- Add rewards to delegation #1
+            submitAndExpireProposalToMakeReward delegatorCStaking1
+            lookupReward delegatorCStaking1 `shouldReturn` govActionDeposit
+            -- Setup Pool delegation #2
+            (poolKH2, delegatorCStaking2) <- setupPoolWithoutStake
+            -- Add rewards to delegation #2
+            submitAndExpireProposalToMakeReward delegatorCStaking2
+            lookupReward delegatorCStaking2 `shouldReturn` govActionDeposit
+            -- Submit a committee proposal
+            Positive extra <- arbitrary
+            cc <- KeyHashObj <$> freshKeyHash
+            addCCGaid <-
+              submitUpdateCommittee
+                Nothing
+                mempty
+                [(cc, EpochInterval (extra + 2 * govActionLifetime))]
+                (75 %! 100)
+            -- Submit the vote
+            submitVote_ VoteYes (StakePoolVoter poolKH1) addCCGaid
+            submitVote_ VoteNo (StakePoolVoter poolKH2) addCCGaid
+            passNEpochs 2
+            -- The vote should not result in a ratification
+            isSpoAccepted addCCGaid `shouldReturn` False
+            getLastEnactedCommittee `shouldReturn` SNothing
+            logRatificationChecks addCCGaid
+            -- Add to the rewards of the delegator to this SPO
+            -- to barely make the threshold (51 %! 100)
+            registerAndRetirePoolToMakeReward delegatorCStaking1
+            lookupReward delegatorCStaking1 `shouldReturn` poolDeposit <> govActionDeposit
+            -- The same vote should now successfully ratify the proposal
+            -- NOTE: It takes 2 epochs for SPO votes as opposed to 1 epoch
+            -- for DRep votes to ratify a proposal.
+            passNEpochs 2
+            getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)
         describe "Proposal deposits contribute to active voting stake" $ do
-          it "Directly" $ do
+          it "Directly" $ whenPostBootstrap $ do
             -- Only modify the applicable thresholds
             modifyPParams $ \pp ->
               pp
@@ -1077,7 +1074,7 @@ votingSpec =
             passNEpochs 2
             -- The same vote should now successfully ratify the proposal
             getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)
-          it "After switching delegations" $ do
+          it "After switching delegations" $ whenPostBootstrap $ do
             -- Only modify the applicable thresholds
             modifyPParams $ \pp ->
               pp
@@ -1133,7 +1130,7 @@ votingSpec =
             -- The same vote should now successfully ratify the proposal
             getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)
     describe "Interaction between governing bodies" $ do
-      it "Motion of no-confidence" $ do
+      it "Motion of no-confidence" $ whenPostBootstrap $ do
         (drep, _, committeeGovId) <- electBasicCommittee
         (spoC, _, _) <- setupPoolWithStake $ Coin 1_000_000
         initialMembers <- getCommitteeMembers
@@ -1148,7 +1145,7 @@ votingSpec =
         -- SPOs voted no, so NoConfidence won't be ratified, thus committee remains the same
         isSpoAccepted noConfidenceGovId `shouldReturn` False
         getCommitteeMembers `shouldReturn` initialMembers
-      it "Update committee - normal state" $ do
+      it "Update committee - normal state" $ whenPostBootstrap $ do
         (drep, _, committeeGovId) <- electBasicCommittee
         (spoC, _, _) <- setupPoolWithStake $ Coin 1_000_000
         SJust initialCommittee <- getsNES $ newEpochStateGovStateL . committeeGovStateL
@@ -1166,7 +1163,7 @@ votingSpec =
         getLastEnactedCommittee `shouldReturn` SJust committeeGovId
         SJust currentCommittee <- getsNES $ newEpochStateGovStateL . committeeGovStateL
         currentCommittee ^. committeeThresholdL `shouldBe` initialThreshold
-      it "Hard-fork initiation" $ do
+      it "Hard-fork initiation" $ whenPostBootstrap $ do
         ccMembers <- registerInitialCommittee
         (drep, _, _) <- setupSingleDRep 1_000_000
         (spoC, _, _) <- setupPoolWithStake $ Coin 1_000_000
@@ -1187,6 +1184,7 @@ votingSpec =
         getProtVer `shouldReturn` nextProtVer
       it
         "A governance action is automatically ratified if threshold is set to 0 for all related governance bodies"
+        $ whenPostBootstrap
         $ do
           modifyPParams $ \pp ->
             pp
@@ -1214,33 +1212,39 @@ delayingActionsSpec ::
   ConwayEraImp era =>
   SpecWith (ImpTestState era)
 delayingActionsSpec =
+  -- All tests below are relying on submitting constitution of committe-update proposals, which are disallowed during bootstrap,
+  -- so we can only run them post-bootstrap.
   describe "Delaying actions" $ do
-    it "A delaying action delays its child even when both ere proposed and ratified in the same epoch" $ do
-      committeeMembers' <- registerInitialCommittee
-      (dRep, _, _) <- setupSingleDRep 1_000_000
-      gai0 <- submitConstitution SNothing
-      gai1 <- submitConstitution $ SJust (GovPurposeId gai0)
-      gai2 <- submitConstitution $ SJust (GovPurposeId gai1)
-      gai3 <- submitConstitution $ SJust (GovPurposeId gai2)
-      submitYesVote_ (DRepVoter dRep) gai0
-      submitYesVoteCCs_ committeeMembers' gai0
-      submitYesVote_ (DRepVoter dRep) gai1
-      submitYesVoteCCs_ committeeMembers' gai1
-      submitYesVote_ (DRepVoter dRep) gai2
-      submitYesVoteCCs_ committeeMembers' gai2
-      submitYesVote_ (DRepVoter dRep) gai3
-      submitYesVoteCCs_ committeeMembers' gai3
-      passNEpochs 2
-      getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai0)
-      passEpoch
-      getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai1)
-      passEpoch
-      getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai2)
-      passEpoch
-      getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai3)
-      getConstitutionProposals `shouldReturn` Map.empty
+    it
+      "A delaying action delays its child even when both ere proposed and ratified in the same epoch"
+      $ whenPostBootstrap
+      $ do
+        committeeMembers' <- registerInitialCommittee
+        (dRep, _, _) <- setupSingleDRep 1_000_000
+        gai0 <- submitConstitution SNothing
+        gai1 <- submitConstitution $ SJust (GovPurposeId gai0)
+        gai2 <- submitConstitution $ SJust (GovPurposeId gai1)
+        gai3 <- submitConstitution $ SJust (GovPurposeId gai2)
+        submitYesVote_ (DRepVoter dRep) gai0
+        submitYesVoteCCs_ committeeMembers' gai0
+        submitYesVote_ (DRepVoter dRep) gai1
+        submitYesVoteCCs_ committeeMembers' gai1
+        submitYesVote_ (DRepVoter dRep) gai2
+        submitYesVoteCCs_ committeeMembers' gai2
+        submitYesVote_ (DRepVoter dRep) gai3
+        submitYesVoteCCs_ committeeMembers' gai3
+        passNEpochs 2
+        getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai0)
+        passEpoch
+        getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai1)
+        passEpoch
+        getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai2)
+        passEpoch
+        getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai3)
+        getConstitutionProposals `shouldReturn` Map.empty
     it
       "A delaying action delays all other actions even when all of them may be ratified in the same epoch"
+      $ whenPostBootstrap
       $ do
         committeeMembers' <- registerInitialCommittee
         (dRep, _, _) <- setupSingleDRep 1_000_000
@@ -1284,7 +1288,7 @@ delayingActionsSpec =
         getLastEnactedParameterChange `shouldReturn` SJust (GovPurposeId pGai2)
         getParameterChangeProposals `shouldReturn` Map.empty
     describe "An action expires when delayed enough even after being ratified" $ do
-      it "Same lineage" $ do
+      it "Same lineage" $ whenPostBootstrap $ do
         committeeMembers' <- registerInitialCommittee
         (dRep, _, _) <- setupSingleDRep 1_000_000
         modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
@@ -1309,7 +1313,7 @@ delayingActionsSpec =
         getConstitutionProposals `shouldReturn` Map.empty
         passEpoch
         getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai2)
-      it "Other lineage" $ do
+      it "Other lineage" $ whenPostBootstrap $ do
         committeeMembers' <- registerInitialCommittee
         (dRep, _, _) <- setupSingleDRep 1_000_000
         modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
@@ -1355,7 +1359,7 @@ delayingActionsSpec =
         -- and nothing gets enacted
         getLastEnactedParameterChange `shouldReturn` SNothing
         getParameterChangeProposals `shouldReturn` Map.empty
-      it "proposals to update the committee get delayed if the expiration exceeds the max term" $ do
+      it "proposals to update the committee get delayed if the expiration exceeds the max term" $ whenPostBootstrap $ do
         (drep, _, _) <- setupSingleDRep 1_000_000
         (spoC, _, _) <- setupPoolWithStake $ Coin 42_000_000
         maxTermLength <- getsNES $ nesEsL . curPParamsEpochStateL . ppCommitteeMaxTermLengthL
@@ -1425,6 +1429,7 @@ committeeMaxTermLengthSpec ::
   ConwayEraImp era =>
   SpecWith (ImpTestState era)
 committeeMaxTermLengthSpec =
+  -- Committee-update proposals are disallowed during bootstrap, so we can only run these tests post-bootstrap
   describe "Committee members can serve full `CommitteeMaxTermLength`" $ do
     let
       electMembersWithMaxTermLength ::
@@ -1448,7 +1453,7 @@ committeeMaxTermLengthSpec =
             members
         submitYesVote_ (StakePoolVoter spoC) gaid
         pure [m1, m2]
-    it "maxTermLength = 0" $ do
+    it "maxTermLength = 0" $ whenPostBootstrap $ do
       -- ======== EPOCH e ========
 
       let termLength = EpochInterval 0
@@ -1509,7 +1514,7 @@ committeeMaxTermLengthSpec =
       getLastEnactedHardForkInitiation `shouldReturn` SNothing
       getProtVer `shouldReturn` curProtVer
       isCommitteeAccepted gid `shouldReturn` False
-    it "maxTermLength = 1" $ do
+    it "maxTermLength = 1" $ whenPostBootstrap $ do
       -- ======== EPOCH e ========
 
       let termLength = EpochInterval 1

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxosSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxosSpec.hs
@@ -8,10 +8,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Test.Cardano.Ledger.Conway.Imp.UtxosSpec (
-  spec,
-  relevantDuringBootstrapSpec,
-) where
+module Test.Cardano.Ledger.Conway.Imp.UtxosSpec (spec) where
 
 import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Allegra.Scripts (
@@ -71,21 +68,8 @@ spec ::
   ) =>
   SpecWith (ImpTestState era)
 spec = do
-  relevantDuringBootstrapSpec
   govPolicySpec
   costModelsSpec
-
-relevantDuringBootstrapSpec ::
-  forall era.
-  ( ConwayEraImp era
-  , Inject (BabbageContextError era) (ContextError era)
-  , Inject (ConwayContextError era) (ContextError era)
-  , InjectRuleFailure "LEDGER" BabbageUtxoPredFailure era
-  , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
-  , InjectRuleFailure "LEDGER" AlonzoUtxowPredFailure era
-  ) =>
-  SpecWith (ImpTestState era)
-relevantDuringBootstrapSpec = do
   datumAndReferenceInputsSpec
   conwayFeaturesPlutusV1V2FailureSpec
   describe "Spending script without a Datum" $ do
@@ -469,7 +453,9 @@ govPolicySpec ::
   SpecWith (ImpTestState era)
 govPolicySpec = do
   describe "Gov policy scripts" $ do
-    it "failing native script govPolicy" $ do
+    -- These tests rely on the script in the constitution, but we can only change the constitution after bootstrap.
+    -- So we cannot run these tests during bootstrap
+    it "failing native script govPolicy" $ whenPostBootstrap $ do
       committeeMembers' <- registerInitialCommittee
       (dRep, _, _) <- setupSingleDRep 1_000_000
       scriptHash <- impAddNativeScript $ RequireTimeStart (SlotNo 1)
@@ -497,7 +483,7 @@ govPolicySpec = do
                 & bodyTxL . vldtTxBodyL .~ ValidityInterval SNothing SNothing
         submitFailingTx tx [injectFailure $ ScriptWitnessNotValidatingUTXOW [scriptHash]]
 
-    it "alwaysSucceeds Plutus govPolicy validates" $ do
+    it "alwaysSucceeds Plutus govPolicy validates" $ whenPostBootstrap $ do
       let alwaysSucceedsSh = hashPlutusScript (alwaysSucceedsNoDatum SPlutusV3)
       committeeMembers' <- registerInitialCommittee
       (dRep, _, _) <- setupSingleDRep 1_000_000
@@ -519,7 +505,7 @@ govPolicySpec = do
         let govAction = TreasuryWithdrawals withdrawals (SJust alwaysSucceedsSh)
         mkProposal govAction >>= submitProposal_
 
-    it "alwaysFails Plutus govPolicy does not validate" $ do
+    it "alwaysFails Plutus govPolicy does not validate" $ whenPostBootstrap $ do
       let alwaysFailsSh = hashPlutusScript (alwaysFailsNoDatum SPlutusV3)
       committeeMembers' <- registerInitialCommittee
       (dRep, _, _) <- setupSingleDRep 1_000_000
@@ -550,8 +536,10 @@ costModelsSpec ::
   ) =>
   SpecWith (ImpTestState era)
 costModelsSpec =
+  -- These tests rely on the script in the constitution, but we can only change the constitution after bootstrap.
+  -- So we cannot run these tests during bootstrap
   describe "PlutusV3 Initialization" $ do
-    it "Updating CostModels with alwaysFails govPolicy does not validate" $ do
+    it "Updating CostModels with alwaysFails govPolicy does not validate" $ whenPostBootstrap $ do
       -- no initial PlutusV3 CostModels
       modifyPParams $ ppCostModelsL .~ testingCostModels [PlutusV1 .. PlutusV2]
 
@@ -579,26 +567,27 @@ costModelsSpec =
         let tx = mkBasicTx mkBasicTxBody & bodyTxL . proposalProceduresTxBodyL .~ [proposal]
         submitPhase2Invalid_ tx
 
-    it "Updating CostModels with alwaysSucceeds govPolicy but no PlutusV3 CostModels fails" $ do
-      modifyPParams $ ppCostModelsL .~ testingCostModels [PlutusV1 .. PlutusV2]
+    it "Updating CostModels with alwaysSucceeds govPolicy but no PlutusV3 CostModels fails" $
+      whenPostBootstrap $ do
+        modifyPParams $ ppCostModelsL .~ testingCostModels [PlutusV1 .. PlutusV2]
 
-      committeeMembers' <- registerInitialCommittee
-      (dRep, _, _) <- setupSingleDRep 1_000_000
-      anchor <- arbitrary
-      let alwaysSucceedsSh = hashPlutusScript (alwaysSucceedsNoDatum SPlutusV3)
-      void $
-        enactConstitution
-          SNothing
-          (Constitution anchor (SJust alwaysSucceedsSh))
-          dRep
-          committeeMembers'
+        committeeMembers' <- registerInitialCommittee
+        (dRep, _, _) <- setupSingleDRep 1_000_000
+        anchor <- arbitrary
+        let alwaysSucceedsSh = hashPlutusScript (alwaysSucceedsNoDatum SPlutusV3)
+        void $
+          enactConstitution
+            SNothing
+            (Constitution anchor (SJust alwaysSucceedsSh))
+            dRep
+            committeeMembers'
 
-      let pparamsUpdate = def & ppuCostModelsL .~ SJust (testingCostModels [PlutusV3])
-      let govAction = ParameterChange SNothing pparamsUpdate (SJust alwaysSucceedsSh)
+        let pparamsUpdate = def & ppuCostModelsL .~ SJust (testingCostModels [PlutusV3])
+        let govAction = ParameterChange SNothing pparamsUpdate (SJust alwaysSucceedsSh)
 
-      submitFailingGovAction govAction [injectFailure $ CollectErrors [NoCostModel PlutusV3]]
+        submitFailingGovAction govAction [injectFailure $ CollectErrors [NoCostModel PlutusV3]]
 
-    it "Updating CostModels and setting the govPolicy afterwards succeeds" $ do
+    it "Updating CostModels and setting the govPolicy afterwards succeeds" $ whenPostBootstrap $ do
       modifyPParams $ ppCostModelsL .~ testingCostModels [PlutusV1 .. PlutusV2]
 
       committeeMembers' <- registerInitialCommittee


### PR DESCRIPTION
This PR is enabling conway Imp tests  to run with both protocol version 9 and 10.

Instead of having tests grouped in functions with respect to whether they should be run for both versions, each test is individually specifying whether it should run only for version 10 , in case there are operations involved that are disallowed in version 9. 

Where I felt it made sense, i have ran them for both versions, checking that the expected `DisallowedProposalDuringBootstrap` / `DisallowedVotesDuringBootstrap` predicate failure is returned - I chose to this where i thought that the test is more about submission of proposals, rather than the logic involving disallowed proposals. 


The PR contains a few other improvements - extracting some commonly used logic to functions, moving a few tests  where it seems like they would make more sense, removing some that didn't make sense to me. 


Because of this moving around of code, I preferred to keep the commits like this for the moment -  in order to make reviewing easier.  To avoid all this noise in master,  it would be better to squash at least all the commits that are enabling ImpTests for both versions - there is no point to have one commit per file in the end. 

Closes  https://github.com/IntersectMBO/cardano-ledger/issues/4703

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
