### PR TITLE
Adjust semantics of `ConwayWdrlNotDelegatedToDRep`

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 * Add `whenBootstrap`
 
+## 1.17.2.0
+
+* Change the state used for `ConwayWdrlNotDelegatedToDRep` predicate failure checking
+
 ## 1.17.1.0
 
 * Add `processDelegation`

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -685,7 +685,7 @@ instance
                 & ppMaxBBSizeL .~ 65536
                 & ppMaxTxSizeL .~ 16384
                 & ppKeyDepositL .~ Coin 2_000_000
-                & ppKeyDepositL .~ Coin 500_000_000
+                & ppPoolDepositL .~ Coin 500_000_000
                 & ppEMaxL .~ EpochInterval 18
                 & ppNOptL .~ 150
                 & ppA0L .~ (3 %! 10)


### PR DESCRIPTION

# Description

Previous semantics did not allow to withdraw rewards and deregister in the same transaction, because deregistration would effectively clear out delegation to a DRep, thus preventing withdrawals.


<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
