### PR TITLE
Avoid intermittent test failures in constrained-generators

### DIFF
--- a/libs/constrained-generators/src/Constrained/Properties.hs
+++ b/libs/constrained-generators/src/Constrained/Properties.hs
@@ -102,7 +102,7 @@ prop_univSound (TestableFn fn) =
             let sspec = simplifySpec (propagateSpecFun fn ctx spec)
              in QC.counterexample ("\n" ++ show ("propagateSpecFun fn ctx spec =" /> pretty sspec)) $
                   QC.counterexample ("\n" ++ show (prettyPlan sspec)) $
-                    QC.within 10_000_000 $
+                    QC.within 20_000_000 $
                       QC.forAllBlind (strictGen $ genFromSpecT @_ @_ sspec) $ \ge ->
                         fromGEDiscard $ do
                           a <- ge


### PR DESCRIPTION
# Description

~~Use `QC.discardAfter` instead of `QC.within` in `prop_univSound`. This treats a timeout as a discard rather than a failure. If the test consistently times out, the discard limit will be reached and the test will then fail.~~

Double the timeout in `prop_univSound`

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
