### PR TITLE
`constrained-generators`: Better shrinking for SuspendedSpec

### DIFF
--- a/libs/constrained-generators/src/Constrained/GenT.hs
+++ b/libs/constrained-generators/src/Constrained/GenT.hs
@@ -137,6 +137,10 @@ headGE t
   | x : _ <- toList t = pure x
   | otherwise = fatalError (pure "head of empty structure")
 
+-- | Turn a `GE [a]` to `[a]`, `genError` goes to `[]` and `fatalError` to `error`.
+listFromGE :: GE [a] -> [a]
+listFromGE = fromGE (const []) . explain1 "listFromGE"
+
 ------------------------------------------------------------------------
 -- GenT
 ------------------------------------------------------------------------

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -61,16 +61,14 @@ tests nightly =
     testSpec "emptyListSpec" emptyListSpec
     testSpec "eitherSpec" eitherSpec
     testSpec "maybeSpec" maybeSpec
-    testSpec "eitherSetSpec" eitherSetSpec
+    testSpecNoShrink "eitherSetSpec" eitherSetSpec
     testSpec "fooSpec" fooSpec
-    -- TODO: this spec needs double shrinking to shrink properly
-    -- so we need to figure something out about double-shrinking
-    testSpecNoShrink "intSpec" intSpec
     testSpec "mapElemSpec" mapElemSpec
+    testSpec "mapElemKeySpec" mapElemKeySpec
     -- TODO: double shrinking
     testSpecNoShrink "mapIsJust" mapIsJust
-    testSpec "mapElemKeySpec" mapElemKeySpec
-    testSpec "mapPairSpec" mapPairSpec
+    testSpecNoShrink "intSpec" intSpec
+    testSpecNoShrink "mapPairSpec" mapPairSpec
     testSpecNoShrink "mapEmptyDomainSpec" mapEmptyDomainSpec
     -- TODO: this _can_ be shrunk, but it's incredibly expensive to do
     -- so and it's not obvious if there is a faster way without implementing
@@ -86,7 +84,7 @@ tests nightly =
     testSpec "eitherSimpleSetSpec" eitherSimpleSetSpec
     testSpecNoShrink "emptySetSpec" emptySetSpec
     testSpec "forAllAnySpec" forAllAnySpec
-    testSpec "notSubsetSpec" notSubsetSpec
+    testSpecNoShrink "notSubsetSpec" notSubsetSpec
     testSpec "maybeJustSetSpec" maybeJustSetSpec
     testSpec "weirdSetPairSpec" weirdSetPairSpec
     testSpec "knownDomainMap" knownDomainMap
@@ -146,7 +144,6 @@ tests nightly =
     testSpec "unionBounded" unionBounded
     testSpec "elemSpec" elemSpec
     testSpec "lookupSpecific" lookupSpecific
-    testSpec "specificElemConstraints" lookupSpecific
     testSpec "mapRestrictedValues" mapRestrictedValues
     testSpec "mapRestrictedValuesThree" mapRestrictedValuesThree
     testSpec "mapRestrictedValuesBool" mapRestrictedValuesBool
@@ -302,7 +299,7 @@ testSpec' withShrink n s = do
             prop_sound $ constrained $ \x -> explanation es $ x `satisfies` s
     when withShrink $
       prop "prop_shrink_sound" $
-        within 10_000_000 $
+        discardAfter 100_000 $
           checkCoverage' $
             prop_shrink_sound s
 


### PR DESCRIPTION
# Description

This PR is intended to help us deal with issues like what we encountered in a test failure in conformance a while back where the counterexample took up the better part of 10k lines.

This is not yet perfect, performance needs looking into but it's a start.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
