### PR TITLE
Create specialized newtype `VRFVerKeyHash`

### DIFF
--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -68,7 +68,7 @@ library
         bytestring,
         cardano-crypto-class,
         cardano-ledger-binary >=1.4,
-        cardano-ledger-core ^>=1.15,
+        cardano-ledger-core >=1.15 && <1.17,
         cardano-ledger-shelley ^>=1.15,
         cardano-strict-containers,
         cardano-slotting,

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -82,7 +82,7 @@ library
         cardano-ledger-allegra ^>=1.6.1,
         cardano-crypto-class,
         cardano-ledger-binary ^>=1.5,
-        cardano-ledger-core ^>=1.15,
+        cardano-ledger-core ^>=1.16,
         cardano-ledger-mary ^>=1.7,
         cardano-ledger-shelley ^>=1.15,
         cardano-slotting,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
@@ -67,6 +67,7 @@ import Cardano.Ledger.Binary.Coders (
  )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Crypto (Crypto)
+import Cardano.Ledger.Keys (unVRFVerKeyHash)
 import Cardano.Ledger.Mary.Value (
   AssetName (..),
   MaryValue (..),
@@ -343,7 +344,9 @@ transTxCertCommon = \case
     Just $ PV1.DCertDelegDelegate (PV1.StakingHash (transCred stakeCred)) (transKeyHash keyHash)
   RegPoolTxCert (PoolParams {ppId, ppVrf}) ->
     Just $
-      PV1.DCertPoolRegister (transKeyHash ppId) (PV1.PubKeyHash (PV1.toBuiltin (hashToBytes ppVrf)))
+      PV1.DCertPoolRegister
+        (transKeyHash ppId)
+        (PV1.PubKeyHash (PV1.toBuiltin (hashToBytes (unVRFVerKeyHash ppVrf))))
   RetirePoolTxCert poolId retireEpochNo ->
     Just $ PV1.DCertPoolRetire (transKeyHash poolId) (transEpochNo retireEpochNo)
   _ -> Nothing

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -77,7 +77,7 @@ library
         cardano-ledger-allegra ^>=1.6.1,
         cardano-ledger-alonzo >=1.12,
         cardano-ledger-binary >=1.4,
-        cardano-ledger-core ^>=1.15,
+        cardano-ledger-core >=1.15 && <1.17,
         cardano-ledger-mary ^>=1.7,
         cardano-ledger-shelley ^>=1.15,
         cardano-strict-containers,

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -92,7 +92,7 @@ library
         cardano-ledger-allegra ^>=1.6.1,
         cardano-ledger-alonzo ^>=1.12,
         cardano-ledger-babbage ^>=1.10.1,
-        cardano-ledger-core ^>=1.15.1,
+        cardano-ledger-core ^>=1.16,
         cardano-ledger-mary ^>=1.7,
         cardano-ledger-shelley ^>=1.15,
         cardano-slotting,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
@@ -90,7 +90,7 @@ import Cardano.Ledger.Conway.UTxO ()
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.DRep (DRep (..))
-import Cardano.Ledger.Keys (KeyRole (..))
+import Cardano.Ledger.Keys (KeyRole (..), unVRFVerKeyHash)
 import Cardano.Ledger.Mary (MaryValue)
 import Cardano.Ledger.Plutus.Data (Data)
 import Cardano.Ledger.Plutus.Language (Language (..), PlutusArgs (..))
@@ -494,7 +494,9 @@ transTxBodyWithdrawals txBody =
 transTxCert :: ConwayEraTxCert era => ProtVer -> TxCert era -> PV3.TxCert
 transTxCert pv = \case
   RegPoolTxCert PoolParams {ppId, ppVrf} ->
-    PV3.TxCertPoolRegister (transKeyHash ppId) (PV3.PubKeyHash (PV3.toBuiltin (hashToBytes ppVrf)))
+    PV3.TxCertPoolRegister
+      (transKeyHash ppId)
+      (PV3.PubKeyHash (PV3.toBuiltin (hashToBytes (unVRFVerKeyHash ppVrf))))
   RetirePoolTxCert poolId retireEpochNo ->
     PV3.TxCertPoolRetire (transKeyHash poolId) (transEpochNo retireEpochNo)
   RegTxCert stakeCred ->

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -77,7 +77,7 @@ library
         cardano-data ^>=1.2,
         cardano-ledger-allegra ^>=1.6.1,
         cardano-ledger-binary >=1.4,
-        cardano-ledger-core ^>=1.15,
+        cardano-ledger-core >=1.15 && <1.17,
         cardano-ledger-shelley ^>=1.15,
         containers,
         deepseq,

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.15.0.0
 
+* Change type of VRF key hash in `GenesisDelegCert`, `GenesisDelegTxCert` and `DuplicateGenesisVRFDELEG` to `VRFVerKeyHash`
 * Added `EncCBOR` instance for `LedgerEnv`
 * Use `Mismatch` to clarify _some more_ predicate failures. #4711
   * `Shelley/InsufficientForInstantaneousRewardsDELEG`
@@ -9,10 +10,10 @@
   * `Shelley/InsufficientForTransferDELEG`
   * `Shelley/ExpiredUTxO`
   * `Shelley/ValueNotConservedUTxO`
-  
 
 ### `testlib`
 
+* Changed type signature of `freshKeyHashVRF` to return `VRFVerKeyHash` instead of just a `Hash`
 * Added `expectUTxOContent`
 * Added `disableTreasuryExpansion`
 * Added a `MonadFail` constraint to two methods of `ShelleyEraImp`:

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -105,7 +105,7 @@ library
         cardano-data ^>=1.2.2,
         cardano-ledger-binary ^>=1.5,
         cardano-ledger-byron,
-        cardano-ledger-core ^>=1.15,
+        cardano-ledger-core ^>=1.16,
         cardano-slotting,
         vector-map ^>=1.1,
         containers,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
@@ -39,10 +39,10 @@ import Cardano.Ledger.Credential (Credential, Ptr)
 import Cardano.Ledger.Keys (
   GenDelegPair (..),
   GenDelegs (..),
-  Hash,
   KeyHash,
   KeyRole (..),
-  VerKeyVRF,
+  KeyRoleVRF (..),
+  VRFVerKeyHash,
  )
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.Era (ShelleyDELEG, ShelleyEra)
@@ -125,7 +125,7 @@ data ShelleyDelegPredFailure era
   | MIRCertificateTooLateinEpochDELEG
       !(Mismatch 'RelLT SlotNo)
   | DuplicateGenesisVRFDELEG
-      !(Hash (EraCrypto era) (VerKeyVRF (EraCrypto era))) -- VRF KeyHash which is already delegated to
+      !(VRFVerKeyHash 'GenDelegVRF (EraCrypto era)) -- VRF KeyHash which is already delegated to
   | MIRTransferNotCurrentlyAllowed
   | MIRNegativesNotCurrentlyAllowed
   | InsufficientForTransferDELEG

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
@@ -111,7 +111,13 @@ import Cardano.Ledger.Credential (
   credScriptHash,
  )
 import Cardano.Ledger.Crypto
-import Cardano.Ledger.Keys (Hash, KeyHash (..), KeyRole (..), VerKeyVRF, asWitness)
+import Cardano.Ledger.Keys (
+  KeyHash (..),
+  KeyRole (..),
+  KeyRoleVRF (..),
+  VRFVerKeyHash,
+  asWitness,
+ )
 import Cardano.Ledger.PoolParams (PoolParams (..))
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.PParams ()
@@ -238,13 +244,13 @@ pattern GenesisDelegTxCert ::
   (ShelleyEraTxCert era, ProtVerAtMost era 8) =>
   KeyHash 'Genesis (EraCrypto era) ->
   KeyHash 'GenesisDelegate (EraCrypto era) ->
-  Hash (EraCrypto era) (VerKeyVRF (EraCrypto era)) ->
+  VRFVerKeyHash 'GenDelegVRF (EraCrypto era) ->
   TxCert era
-pattern GenesisDelegTxCert genKey genDelegKey vrf <-
-  (getGenesisDelegTxCert -> Just (GenesisDelegCert genKey genDelegKey vrf))
+pattern GenesisDelegTxCert genKey genDelegKey vrfKeyHash <-
+  (getGenesisDelegTxCert -> Just (GenesisDelegCert genKey genDelegKey vrfKeyHash))
   where
-    GenesisDelegTxCert genKey genDelegKey vrf =
-      mkGenesisDelegTxCert $ GenesisDelegCert genKey genDelegKey vrf
+    GenesisDelegTxCert genKey genDelegKey vrfKeyHash =
+      mkGenesisDelegTxCert $ GenesisDelegCert genKey genDelegKey vrfKeyHash
 
 {-# COMPLETE
   RegPoolTxCert
@@ -261,7 +267,7 @@ data GenesisDelegCert c
   = GenesisDelegCert
       !(KeyHash 'Genesis c)
       !(KeyHash 'GenesisDelegate c)
-      !(Hash c (VerKeyVRF c))
+      !(VRFVerKeyHash 'GenDelegVRF c)
   deriving (Show, Generic, Eq, Ord)
 
 instance NoThunks (GenesisDelegCert c)

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -161,7 +161,8 @@ import Cardano.Ledger.Keys (
   Hash,
   KeyHash,
   KeyRole (..),
-  VerKeyVRF,
+  KeyRoleVRF (..),
+  VRFVerKeyHash,
   asWitness,
   bootstrapWitKeyHash,
   hashKey,
@@ -1550,7 +1551,7 @@ freshSafeHash = arbitrary
 
 freshKeyHashVRF ::
   Era era =>
-  ImpTestM era (Hash (EraCrypto era) (VerKeyVRF (EraCrypto era)))
+  ImpTestM era (VRFVerKeyHash (r :: KeyRoleVRF) (EraCrypto era))
 freshKeyHashVRF = arbitrary
 
 -- | Adds a key pair to the keyhash lookup map

--- a/eras/shelley/test-suite/bench/Cardano/Ledger/Shelley/Bench/Rewards.hs
+++ b/eras/shelley/test-suite/bench/Cardano/Ledger/Shelley/Bench/Rewards.hs
@@ -12,11 +12,7 @@ module Cardano.Ledger.Shelley.Bench.Rewards (
 )
 where
 
-import Cardano.Crypto.VRF (hashVerKeyVRF)
-import Cardano.Ledger.Address (
-  Addr (..),
-  RewardAccount (..),
- )
+import Cardano.Ledger.Address (Addr (..), RewardAccount (..))
 import Cardano.Ledger.BaseTypes (
   Globals (activeSlotCoeff, securityParameter),
   Network (Testnet),
@@ -25,7 +21,7 @@ import Cardano.Ledger.BaseTypes (
  )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
-import Cardano.Ledger.Keys (KeyHash, KeyRole (Staking))
+import Cardano.Ledger.Keys (KeyHash, KeyRole (Staking), hashVerKeyVRF)
 import Cardano.Ledger.PoolParams (PoolParams (..))
 import Cardano.Ledger.Shelley.Genesis (ShelleyGenesisStaking (..))
 import qualified Cardano.Ledger.Shelley.LedgerState as LS

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/BenchmarkFunctions.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/BenchmarkFunctions.hs
@@ -41,10 +41,10 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Crypto (Crypto (..))
 import Cardano.Ledger.Keys (
-  Hash,
   KeyHash,
   KeyRole (..),
-  VerKeyVRF,
+  KeyRoleVRF (StakePoolVRF),
+  VRFVerKeyHash,
   asWitness,
   hashKey,
   hashVerKeyVRF,
@@ -397,7 +397,7 @@ mkPoolKeyHash = hashKey . vKey
 firstStakePoolKeyHash :: KeyHash 'StakePool B_Crypto
 firstStakePoolKeyHash = mkPoolKeyHash firstStakePool
 
-vrfKeyHash :: Hash B_Crypto (VerKeyVRF B_Crypto)
+vrfKeyHash :: VRFVerKeyHash 'StakePoolVRF B_Crypto
 vrfKeyHash = hashVerKeyVRF . vrfVerKey . mkVRFKeyPair @B_Crypto $ RawSeed 0 0 0 0 0
 
 mkPoolParameters :: KeyPair 'StakePool B_Crypto -> PoolParams B_Crypto

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Cast.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Cast.hs
@@ -53,9 +53,9 @@ import Cardano.Ledger.Credential (
  )
 import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Keys (
-  Hash,
   KeyRole (..),
-  VerKeyVRF,
+  KeyRoleVRF (StakePoolVRF),
+  VRFVerKeyHash,
   hashKey,
   hashVerKeyVRF,
  )
@@ -146,7 +146,7 @@ alicePoolParams =
 aliceVRFKeyHash ::
   forall c.
   Crypto c =>
-  Hash c (VerKeyVRF c)
+  VRFVerKeyHash 'StakePoolVRF c
 aliceVRFKeyHash = hashVerKeyVRF (vrfVerKey $ aikVrf (alicePoolKeys @c))
 
 -- | Bob's payment key pair
@@ -199,7 +199,7 @@ bobPoolParams =
 bobVRFKeyHash ::
   forall c.
   Crypto c =>
-  Hash c (VerKeyVRF c)
+  VRFVerKeyHash 'StakePoolVRF c
 bobVRFKeyHash = hashVerKeyVRF (vrfVerKey $ aikVrf (bobPoolKeys @c))
 
 -- Carl's payment key pair

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
@@ -15,7 +15,7 @@ module Test.Cardano.Ledger.Shelley.Examples.Consensus where
 import Cardano.Crypto.DSIGN as DSIGN
 import Cardano.Crypto.Hash as Hash
 import Cardano.Crypto.Seed as Seed
-import Cardano.Crypto.VRF as VRF
+import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Ledger.AuxiliaryData
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rewards.hs
@@ -63,6 +63,7 @@ import Cardano.Ledger.Keys (
   KeyRole (..),
   VKey (..),
   hashKey,
+  hashVerKeyVRF,
  )
 import Cardano.Ledger.Shelley.API (NonMyopic, SnapShot (..), SnapShots (..))
 import Cardano.Ledger.Shelley.API.Types (PoolParams (..))
@@ -279,7 +280,7 @@ genPoolInfo PoolSetUpArgs {poolPledge, poolCost, poolMargin, poolMembers} = do
       params =
         PoolParams
           { ppId = hashKey . vKey $ coldKey
-          , ppVrf = Crypto.hashVerKeyVRF . snd $ vrfKey
+          , ppVrf = hashVerKeyVRF $ snd vrfKey
           , ppPledge = pledge
           , ppCost = cost
           , ppMargin = margin

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/GenesisDelegation.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/GenesisDelegation.hs
@@ -24,9 +24,9 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Keys (
   GenDelegPair (..),
-  Hash,
   KeyRole (..),
-  VerKeyVRF,
+  KeyRoleVRF (..),
+  VRFVerKeyHash,
   asWitness,
   hashKey,
   hashVerKeyVRF,
@@ -118,7 +118,7 @@ newGenDelegate = KeyPair vkCold skCold
   where
     (skCold, vkCold) = mkKeyPair (RawSeed 108 0 0 0 1)
 
-newGenesisVrfKH :: forall c. Crypto c => Hash c (VerKeyVRF c)
+newGenesisVrfKH :: forall c. Crypto c => VRFVerKeyHash 'GenDelegVRF c
 newGenesisVrfKH = hashVerKeyVRF (vrfVerKey (mkVRFKeyPair @c (RawSeed 9 8 7 6 5)))
 
 feeTx1 :: Coin

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Genesis.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Genesis.hs
@@ -14,13 +14,12 @@ module Test.Cardano.Ledger.Shelley.Serialisation.Golden.Genesis (
 )
 where
 
-import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Ledger.BaseTypes (textToDns, textToUrl)
 import Cardano.Ledger.Binary (Tokens (..))
 import qualified Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Core (emptyPParams, ppDL, ppMaxBBSizeL, ppMaxBHSizeL)
-import Cardano.Ledger.Crypto (Crypto (HASH), StandardCrypto)
-import Cardano.Ledger.Keys (hashKey, hashVerKeyVRF)
+import Cardano.Ledger.Crypto (Crypto, StandardCrypto)
+import Cardano.Ledger.Keys (KeyRoleVRF (..), VRFVerKeyHash (..), hashKey, hashVerKeyVRF)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import qualified Cardano.Ledger.Shelley.API as L
 import Cardano.Ledger.Shelley.Genesis
@@ -223,8 +222,8 @@ exampleShelleyGenesis =
     genDelegPair = L.GenDelegPair delegVerKeyHash delegVrfKeyHash
     delegVerKeyHash :: L.KeyHash 'L.GenesisDelegate c
     delegVerKeyHash = L.KeyHash "e6960dd671ee8d73de1a83d1345b661165dcddeba99623beef2f157a"
-    delegVrfKeyHash :: Hash.Hash (HASH c) (L.VerKeyVRF c)
-    delegVrfKeyHash = "fce31c6f3187531ee4a39aa743c24d22275f415a8895e9cd22c30c8a25cdef0d"
+    delegVrfKeyHash :: VRFVerKeyHash 'GenDelegVRF c
+    delegVrfKeyHash = VRFVerKeyHash "fce31c6f3187531ee4a39aa743c24d22275f415a8895e9cd22c30c8a25cdef0d"
     initialFundedAddress :: L.Addr c
     initialFundedAddress =
       L.Addr

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -59,7 +59,7 @@ library
         cardano-ledger-babbage >=1.10.1 && <=1.11,
         cardano-ledger-binary >=1.4,
         cardano-ledger-conway >=1.13 && <1.19,
-        cardano-ledger-core ^>=1.15,
+        cardano-ledger-core >=1.15 && <1.17,
         cardano-ledger-mary ^>=1.7,
         cardano-ledger-shelley ^>=1.15,
         cardano-strict-containers,

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Version history for `cardano-ledger-core`
 
-## 1.15.1.0
+## 1.16.0.0
 
+* Add `VRFVerKeyHash` and `KeyRoleVRF`.
+* Switch `genDelegVrfHash`, `individualPoolStakeVrf` and `ppVrf` to using `VRFVerKeyHash`.
 * Add `{Enc|Dec}CBORGroup` instances for `Mismatch`. #4666
   * Add `(un)swapMismatch` to swap `Mismatch` values to preserve serialisation when necessary.
 * Add `drepDelegsL`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### `testlib`
 
 * Generalize the return type of `assertColorFailure` to `MonadIO`
+* Moved `Test.Cardano.Ledger.Core.Tools` into the test suite.
 
 ## 1.15.0.0
 

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -153,7 +153,6 @@ library testlib
         Test.Cardano.Ledger.Core.KeyPair
         Test.Cardano.Ledger.Core.Utils
         Test.Cardano.Ledger.Core.Rational
-        Test.Cardano.Ledger.Core.Tools
         Test.Cardano.Ledger.Imp.Common
         Test.Cardano.Ledger.Plutus
         Test.Cardano.Ledger.Plutus.Examples
@@ -208,8 +207,7 @@ library testlib
         time,
         cardano-slotting,
         unliftio,
-        small-steps >=1.1,
-        quickcheck-instances
+        small-steps >=1.1
 
     if !impl(ghc >=9.2)
         ghc-options: -Wno-name-shadowing
@@ -238,6 +236,7 @@ test-suite tests
         Test.Cardano.Ledger.JsonSpec
         Test.Cardano.Ledger.PlutusSpec
         Test.Cardano.Ledger.UMapSpec
+        Test.Cardano.Ledger.ToolsSpec
 
     default-language: Haskell2010
     ghc-options:
@@ -260,6 +259,7 @@ test-suite tests
         testlib,
         genvalidity,
         genvalidity-scientific,
+        quickcheck-instances,
         scientific
 
 benchmark umap

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               cardano-ledger-core
-version:            1.15.1.0
+version:            1.16.0.0
 license:            Apache-2.0
 maintainer:         operations@iohk.io
 author:             IOHK

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/Era.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/Era.hs
@@ -156,7 +156,7 @@ instance (KnownSymbol rule, Era era) => DecCBOR (VoidEraRule (rule :: Symbol) er
 absurdEraRule :: VoidEraRule rule era -> a
 absurdEraRule a = case a of {}
 
--- Rules that should never have a predicate failures
+-- Rules that must never have a predicate failures
 type instance EraRuleFailure "EPOCH" era = VoidEraRule "EPOCH" era
 type instance EraRuleFailure "NEWEPOCH" era = VoidEraRule "NEWEPOCH" era
 type instance EraRuleFailure "MIR" era = VoidEraRule "MIR" era

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/PoolDistr.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/PoolDistr.hs
@@ -29,7 +29,7 @@ import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..), decodeRecordNamed, enc
 import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Crypto
-import Cardano.Ledger.Keys (Hash, KeyHash, KeyRole (..), VerKeyVRF)
+import Cardano.Ledger.Keys (KeyHash, KeyRole (..), KeyRoleVRF (StakePoolVRF), VRFVerKeyHash)
 import Control.DeepSeq (NFData)
 import Data.Aeson (KeyValue, ToJSON (..), object, pairs, (.=))
 import Data.Map.Strict (Map)
@@ -57,7 +57,7 @@ data IndividualPoolStake c = IndividualPoolStake
   -- ^ Total stake delegated to this pool. In addition to all the stake  that
   -- is part of `individualPoolStake` we also add proposal-deposits to this
   -- field.
-  , individualPoolStakeVrf :: !(Hash c (VerKeyVRF c))
+  , individualPoolStakeVrf :: !(VRFVerKeyHash 'StakePoolVRF c)
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (NFData, NoThunks)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/PoolParams.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/PoolParams.hs
@@ -47,12 +47,7 @@ import Cardano.Ledger.Binary (
  )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Crypto
-import Cardano.Ledger.Keys (
-  Hash,
-  KeyHash (..),
-  KeyRole (..),
-  VerKeyVRF,
- )
+import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..), KeyRoleVRF (StakePoolVRF), VRFVerKeyHash)
 import Cardano.Ledger.Orphans ()
 import Control.DeepSeq (NFData ())
 import Data.Aeson (FromJSON (..), ToJSON (..), Value, (.!=), (.:), (.:?), (.=))
@@ -203,7 +198,7 @@ instance DecCBOR StakePoolRelay where
 -- | A stake pool.
 data PoolParams c = PoolParams
   { ppId :: !(KeyHash 'StakePool c)
-  , ppVrf :: !(Hash c (VerKeyVRF c))
+  , ppVrf :: !(VRFVerKeyHash 'StakePoolVRF c)
   , ppPledge :: !Coin
   , ppCost :: !Coin
   , ppMargin :: !UnitInterval

--- a/libs/cardano-ledger-core/test/Main.hs
+++ b/libs/cardano-ledger-core/test/Main.hs
@@ -4,9 +4,9 @@ import qualified Test.Cardano.Ledger.AddressSpec as AddressSpec
 import qualified Test.Cardano.Ledger.BaseTypesSpec as BaseTypesSpec
 import qualified Test.Cardano.Ledger.BinarySpec as BinarySpec
 import Test.Cardano.Ledger.Common
-import qualified Test.Cardano.Ledger.Core.Tools as ToolsSpec
 import qualified Test.Cardano.Ledger.JsonSpec as JsonSpec
 import qualified Test.Cardano.Ledger.PlutusSpec as PlutusSpec
+import qualified Test.Cardano.Ledger.ToolsSpec as ToolsSpec
 import qualified Test.Cardano.Ledger.UMapSpec as UMapSpec
 
 main :: IO ()

--- a/libs/cardano-ledger-core/test/Test/Cardano/Ledger/ToolsSpec.hs
+++ b/libs/cardano-ledger-core/test/Test/Cardano/Ledger/ToolsSpec.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Test.Cardano.Ledger.Core.Tools (spec) where
+module Test.Cardano.Ledger.ToolsSpec (spec) where
 
 import Cardano.Ledger.Tools
 import qualified Data.ByteString as BS

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -103,6 +103,7 @@ import Cardano.Ledger.Keys (
   KeyHash (..),
   KeyRole (StakePool, Staking),
   VKey (..),
+  VRFVerKeyHash (..),
  )
 import Cardano.Ledger.Keys.Bootstrap (BootstrapWitness (..), ChainCode (..))
 import Cardano.Ledger.Keys.WitVKey (WitVKey (..))
@@ -372,8 +373,11 @@ instance Crypto c => Arbitrary (AuxiliaryDataHash c) where
 -- Cardano.Ledger.Keys -------------------------------------------------------------------
 ------------------------------------------------------------------------------------------
 
-instance Crypto c => Arbitrary (KeyHash a c) where
+instance Crypto c => Arbitrary (KeyHash r c) where
   arbitrary = KeyHash <$> genHash
+
+instance Crypto c => Arbitrary (VRFVerKeyHash r c) where
+  arbitrary = VRFVerKeyHash <$> genHash
 
 instance DSIGNAlgorithm (DSIGN c) => Arbitrary (VKey kd c) where
   arbitrary = VKey <$> arbitrary

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
@@ -69,6 +69,9 @@ instance ToExpr (GenDelegPair c)
 instance ToExpr (KeyHash keyrole c) where
   toExpr (KeyHash x) = App "KeyHash" [toExpr x]
 
+instance ToExpr (VRFVerKeyHash keyrole c) where
+  toExpr (VRFVerKeyHash x) = App "VRFVerKeyHash" [toExpr x]
+
 -- PoolDist
 instance ToExpr (PoolDistr c)
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
@@ -30,6 +30,7 @@ import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Conway.TxCert
 import Cardano.Ledger.Core
 import Cardano.Ledger.Crypto (StandardCrypto)
+import Cardano.Ledger.Keys (KeyRoleVRF (GenDelegVRF), VRFVerKeyHash)
 import Cardano.Ledger.Mary (Mary)
 import Cardano.Ledger.Shelley (Shelley)
 import Cardano.Ledger.Shelley.API.Types
@@ -108,7 +109,7 @@ genesisDelegCertSpec ds =
 --   This mimics what happens in the Cardano.Ledger.Shelley.Rules.Deleg module
 computeSets ::
   DState era ->
-  ( KeyHash 'Genesis (EraCrypto era) -> Set (Hash (EraCrypto era) (VerKeyVRF (EraCrypto era)))
+  ( KeyHash 'Genesis (EraCrypto era) -> Set (VRFVerKeyHash 'GenDelegVRF (EraCrypto era))
   , KeyHash 'Genesis (EraCrypto era) -> Set (KeyHash 'GenesisDelegate (EraCrypto era))
   )
 computeSets ds =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Certs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Certs.hs
@@ -13,8 +13,6 @@ module Test.Cardano.Ledger.Constrained.Preds.Certs where
 import Cardano.Ledger.Shelley.HardForks as HardForks (allowMIRTransfer)
 import Test.Cardano.Ledger.Generic.Functions (protocolVersion)
 
-import Cardano.Crypto.Hash.Class (Hash)
-import Cardano.Crypto.VRF.Class (VerKeyVRF)
 import Cardano.Ledger.Address (RewardAccount (..))
 import Cardano.Ledger.BaseTypes (EpochNo (..), maybeToStrictMaybe)
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
@@ -26,7 +24,6 @@ import Cardano.Ledger.Conway.TxCert (
   pattern RegDepositDelegTxCert,
  )
 import Cardano.Ledger.Credential (Credential (..), StakeCredential)
-import Cardano.Ledger.Crypto (HASH, VRF)
 import Cardano.Ledger.DRep (DRep (..))
 import Cardano.Ledger.Era (Era (EraCrypto))
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
@@ -34,7 +31,6 @@ import Cardano.Ledger.PoolParams (PoolMetadata, PoolParams (..))
 import Cardano.Ledger.Shelley.LedgerState (AccountState, InstantaneousRewards, availableAfterMIR)
 import Cardano.Ledger.Shelley.TxCert (
   EraTxCert (..),
-  GenesisDelegCert (..),
   MIRCert (..),
   MIRPot (..),
   MIRTarget (..),
@@ -111,16 +107,6 @@ sMirShift =
     "sMirShift"
     (typeRep @(ShelleyTxCert era))
     (\_avail x c -> ShelleyTxCertMir (MIRCert x (SendToOppositePotMIR c)))
-
-sGovern ::
-  Target
-    era
-    ( KeyHash 'Genesis (EraCrypto era) ->
-      KeyHash 'GenesisDelegate (EraCrypto era) ->
-      Hash (HASH (EraCrypto era)) (VerKeyVRF (VRF (EraCrypto era))) ->
-      ShelleyTxCert era
-    )
-sGovern = Constr "sGovern" (\a b c -> ShelleyTxCertGenesisDeleg (GenesisDelegCert a b c))
 
 -- ==========================================
 -- Conway Cert Targets

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -168,6 +168,7 @@ import Cardano.Ledger.Keys (
   KeyHash (..),
   KeyRole (..),
   VKey (..),
+  VRFVerKeyHash (..),
   WitVKey (..),
   hashKey,
  )
@@ -708,6 +709,9 @@ instance PrettyA EpochInterval where
 
 ppHash :: Hash.Hash a b -> PDoc
 ppHash x = text "#" <> reAnnotate (Width 5 :) (viaShow x)
+
+ppVRFHash :: VRFVerKeyHash r c -> PDoc
+ppVRFHash = ppHash . unVRFVerKeyHash
 
 ppUnitInterval :: UnitInterval -> PDoc
 ppUnitInterval = viaShow
@@ -1914,7 +1918,7 @@ ppShelleyDelegPredFailure x = case x of
       [ppString (show pot), pcCoin mismatchSupplied, pcCoin mismatchExpected]
   MIRCertificateTooLateinEpochDELEG Mismatch {..} ->
     ppSexp "MIRCertificateTooLateinEpochDELEG" [pcSlotNo mismatchSupplied, pcSlotNo mismatchExpected]
-  DuplicateGenesisVRFDELEG hash -> ppSexp "DuplicateGenesisVRFDELEG" [ppHash hash]
+  DuplicateGenesisVRFDELEG hash -> ppSexp "DuplicateGenesisVRFDELEG" [ppVRFHash hash]
   MIRTransferNotCurrentlyAllowed -> ppString "MIRTransferNotCurrentlyAllowed"
   MIRNegativesNotCurrentlyAllowed -> ppString " MIRNegativesNotCurrentlyAllowed"
   InsufficientForTransferDELEG pot Mismatch {..} ->
@@ -2696,7 +2700,7 @@ pcGenesisDelegCert (GenesisDelegCert a b c) =
     "GenesisDelegCert"
     [ ("Genesis", pcKeyHash a)
     , ("GenesisDelegate", pcKeyHash b)
-    , ("VerKeyVRF", trim (ppHash c))
+    , ("VerKeyVRF", trim (ppVRFHash c))
     ]
 
 instance PrettyA (GenesisDelegCert c) where
@@ -3220,7 +3224,7 @@ pcIndividualPoolStake x =
   ppRecord
     "IPS"
     [ ("ratio", ppRational (individualPoolStake x))
-    , ("vrf", trim (ppHash (individualPoolStakeVrf x)))
+    , ("vrf", trim (ppVRFHash (individualPoolStakeVrf x)))
     ]
 
 instance PrettyA (IndividualPoolStake c) where prettyA = pcIndividualPoolStake
@@ -3412,7 +3416,7 @@ pcGenDelegPair x =
   ppRecord
     "GDPair"
     [ ("keyhash", pcKeyHash (genDelegKeyHash x))
-    , ("vrfhash", trim (ppHash (genDelegVrfHash x)))
+    , ("vrfhash", trim (ppVRFHash (genDelegVrfHash x)))
     ]
 
 pcIRewards :: InstantaneousRewards c -> PDoc

--- a/libs/cardano-protocol-tpraos/CHANGELOG.md
+++ b/libs/cardano-protocol-tpraos/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-protocol-tpraos`
 
-## 1.2.0.2
+## 1.3.0.0
 
-*
+* Change the type of hashes that are contained in `WrongGenesisVRFKeyOVERLAY` and `VRFKeyWrongVRFKey` predicate failures
 
 ## 1.2.0.1
 

--- a/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
+++ b/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          cardano-protocol-tpraos
-version:       1.2.0.1
+version:       1.3.0.0
 license:       Apache-2.0
 maintainer:    operations@iohk.io
 author:        IOHK
@@ -39,7 +39,7 @@ library
         cardano-ledger-babbage >=1.1,
         cardano-ledger-binary >=1.0,
         cardano-ledger-conway >=1.1,
-        cardano-ledger-core >=1.13,
+        cardano-ledger-core >=1.16,
         cardano-ledger-mary >=1.1,
         cardano-ledger-shelley >=1.9,
         cardano-slotting,


### PR DESCRIPTION
# Description

VRF algorithm should not appear in the hash, since that prevents us from changing the VRF algorithm. There is a potential we will do that in the future and switch to Batch VRF.

That being said, the biggest motivation behind this change is that we want to extract VRF and KES out of `Crypto` type class and having type signature like this
```haskell
Crypto c => Hash (HASH c) (VerKeyVRF (VRF c))
```
prevents us from doing that.

Moreover, with addition of specialized role `KeyRoleVRF` to be used in `VRFVerKeyHash (r :: KeyRoleVRF) c` we gain type safety that prevents us mising up genesis and pool VRF key hashes.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
