### PR TITLE
Added `RewardUpdate` spec translation

### DIFF
--- a/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
+++ b/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
@@ -69,6 +69,7 @@ library
         cardano-ledger-binary:{cardano-ledger-binary, testlib},
         cardano-ledger-core,
         cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
+        cardano-ledger-shelley-test,
         cardano-ledger-alonzo,
         cardano-ledger-allegra,
         cardano-ledger-babbage,

--- a/libs/cardano-ledger-repl-environment/cardano-ledger-repl-environment.cabal
+++ b/libs/cardano-ledger-repl-environment/cardano-ledger-repl-environment.cabal
@@ -22,6 +22,7 @@ library
         cardano-ledger-conway:{cardano-ledger-conway, testlib},
         cardano-ledger-conformance,
         cardano-ledger-test,
+        constrained-generators,
         data-default,
         QuickCheck,
         microlens

--- a/libs/cardano-ledger-repl-environment/src/ReplEnvironment.hs
+++ b/libs/cardano-ledger-repl-environment/src/ReplEnvironment.hs
@@ -50,3 +50,5 @@ import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Core.Rational
 
 import Test.QuickCheck
+
+import Constrained


### PR DESCRIPTION
# Description

Adds the missing translation for `RewardUpdate` in the `NewEpochState`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
