### PR TITLE
Alternative approach to `Annotator`

### DIFF
--- a/eras/byron/ledger/impl/src/Cardano/Chain/Byron/API/Common.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Byron/API/Common.hs
@@ -106,7 +106,7 @@ reAnnotateUsing ::
   f a ->
   f ByteString
 reAnnotateUsing encoder decoder =
-  (\bs -> splice bs $ CBOR.deserialiseFromBytes (toPlainDecoder byronProtVer decoder) bs)
+  (\bs -> splice bs $ CBOR.deserialiseFromBytes (toPlainDecoder (Just bs) byronProtVer decoder) bs)
     . CBOR.toLazyByteString
     . toPlainEncoding byronProtVer
     . encoder

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
@@ -58,7 +58,6 @@ import Cardano.Ledger.Binary (
   encodeListLen,
   encodeNullStrictMaybe,
   encodeWord8,
-  toPlainDecoder,
   toPlainEncoding,
  )
 import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
@@ -609,7 +608,7 @@ instance
   ) =>
   FromCBOR (ConwayTxCert era)
   where
-  fromCBOR = toPlainDecoder (eraProtVerLow @era) decCBOR
+  fromCBOR = fromEraCBOR @era
 
 instance
   ( ConwayEraTxCert era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
@@ -478,7 +478,7 @@ instance Crypto c => ToCBOR (ShelleyGenesis c) where
           <> encCBOR sgStaking
 
 instance Crypto c => FromCBOR (ShelleyGenesis c) where
-  fromCBOR = toPlainDecoder shelleyProtVer $ do
+  fromCBOR = toPlainDecoder Nothing shelleyProtVer $ do
     decodeRecordNamed "ShelleyGenesis" (const 15) $ do
       sgSystemStart <- decCBOR
       sgNetworkMagic <- decCBOR

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
@@ -41,7 +41,6 @@ import Cardano.Ledger.Binary (
   enforceDecoderVersion,
   ifDecoderVersionAtLeast,
   natVersion,
-  toPlainDecoder,
  )
 import Cardano.Ledger.Binary.Coders (Decode (From, RecD), Encode (..), decode, encode, (!>), (<!))
 import Cardano.Ledger.CertState (
@@ -362,7 +361,7 @@ instance (EraTxOut era, EraGov era) => ToCBOR (UTxOState era) where
   toCBOR = toEraCBOR @era
 
 instance (EraTxOut era, EraGov era) => FromCBOR (UTxOState era) where
-  fromCBOR = toPlainDecoder (eraProtVerLow @era) decNoShareCBOR
+  fromCBOR = fromEraShareCBOR @era
 
 instance (EraTxOut era, EraGov era) => ToJSON (UTxOState era) where
   toJSON = object . toUTxOStatePairs
@@ -556,7 +555,7 @@ instance (EraTxOut era, EraGov era) => ToCBOR (LedgerState era) where
   toCBOR = toEraCBOR @era
 
 instance (EraTxOut era, EraGov era) => FromCBOR (LedgerState era) where
-  fromCBOR = toPlainDecoder (eraProtVerLow @era) decNoShareCBOR
+  fromCBOR = fromEraShareCBOR @era
 
 instance (EraTxOut era, EraGov era) => ToJSON (LedgerState era) where
   toJSON = object . toLedgerStatePairs

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.5.0.0
 
+* Add `decodeAnnotated`
 * Add `getOriginalBytes`
 * `toPlainDecoder` now optionally expects one extra argument for the original `ByteString`
 * Extend `Coders` to accommodate `{Enc|Dec}CBORGroup`. #4666

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.5.0.0
 
+* Add `getOriginalBytes`
+* `toPlainDecoder` now optionally expects one extra argument for the original `ByteString`
 * Extend `Coders` to accommodate `{Enc|Dec}CBORGroup`. #4666
   * Add `ToGroup` to `Encode`
   * Add `FromGroup` to `Decode`

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding.hs
@@ -45,7 +45,7 @@ where
 
 import Cardano.Ledger.Binary.Decoding.Annotated
 import Cardano.Ledger.Binary.Decoding.DecCBOR
-import Cardano.Ledger.Binary.Decoding.Decoder
+import Cardano.Ledger.Binary.Decoding.Decoder hiding (getOriginalBytes)
 import Cardano.Ledger.Binary.Decoding.Drop
 import Cardano.Ledger.Binary.Decoding.Sharing
 import Cardano.Ledger.Binary.Decoding.Sized
@@ -143,8 +143,9 @@ deserialiseDecoder ::
   (forall s. Decoder s a) ->
   BSL.ByteString ->
   Either (Read.DeserialiseFailure, BS.ByteString) (a, BS.ByteString)
-deserialiseDecoder version decoder bs0 =
-  runST (supplyAllInput bs0 =<< Read.deserialiseIncremental (toPlainDecoder version decoder))
+deserialiseDecoder version decoder bsl =
+  runST $
+    supplyAllInput bsl =<< Read.deserialiseIncremental (toPlainDecoder (Just bsl) version decoder)
 {-# INLINE deserialiseDecoder #-}
 
 supplyAllInput ::

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Annotated.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Annotated.hs
@@ -12,6 +12,7 @@
 
 module Cardano.Ledger.Binary.Decoding.Annotated (
   Annotated (..),
+  decodeAnnotated,
   ByteSpan (..),
   Decoded (..),
   annotationBytes,
@@ -34,6 +35,7 @@ import Cardano.Ledger.Binary.Decoding.Decoder (
   decodeList,
   decodeWithByteSpan,
   fromPlainDecoder,
+  getOriginalBytes,
   setTag,
   whenDecoderVersionAtLeast,
  )
@@ -112,6 +114,12 @@ annotationBytes bytes = fmap (BSL.toStrict . slice bytes)
 -- | Reconstruct an annotation by re-serialising the payload to a ByteString.
 reAnnotate :: EncCBOR a => Version -> Annotated a b -> Annotated a BS.ByteString
 reAnnotate version (Annotated x _) = Annotated x (serialize' version x)
+
+decodeAnnotated :: Decoder s a -> Decoder s (Annotated a BSL.ByteString)
+decodeAnnotated decoder = do
+  bsl <- getOriginalBytes
+  fmap (slice bsl) <$> annotatedDecoder decoder
+{-# INLINE decodeAnnotated #-}
 
 class Decoded t where
   type BaseType t :: Type

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs
@@ -120,9 +120,9 @@ instance DecCBOR Version where
   {-# INLINE decCBOR #-}
 
 -- | Convert a versioned `DecCBOR` instance to a plain `Plain.Decoder` using Byron protocol
--- version.
+-- version and empty `BSL.ByteString`.
 fromByronCBOR :: DecCBOR a => Plain.Decoder s a
-fromByronCBOR = toPlainDecoder byronProtVer decCBOR
+fromByronCBOR = toPlainDecoder Nothing byronProtVer decCBOR
 {-# INLINE fromByronCBOR #-}
 
 --------------------------------------------------------------------------------

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/FlatTerm.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/FlatTerm.hs
@@ -17,4 +17,4 @@ toFlatTerm :: Version -> Encoding -> C.FlatTerm
 toFlatTerm version = C.toFlatTerm . toPlainEncoding version
 
 fromFlatTerm :: Version -> (forall s. Decoder s a) -> C.FlatTerm -> Either String a
-fromFlatTerm version decoder = C.fromFlatTerm (toPlainDecoder version decoder)
+fromFlatTerm version decoder = C.fromFlatTerm (toPlainDecoder mempty version decoder)

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/RoundTrip.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/RoundTrip.hs
@@ -522,7 +522,8 @@ embedTripLabelExtra lbl encVersion decVersion (Trip encoder decoder dropper) s =
         Right val
           | Nothing <- mDropperError ->
               let flatTerm = CBOR.toFlatTerm encoding
-               in case CBOR.fromFlatTerm (toPlainDecoder decVersion decoder) flatTerm of
+                  plainDecoder = toPlainDecoder (Just encodedBytes) decVersion decoder
+               in case CBOR.fromFlatTerm plainDecoder flatTerm of
                     Left _err ->
                       -- Until we switch to a release of cborg that includes a fix for this issue:
                       -- https://github.com/well-typed/cborg/issues/324

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.16.0.0
 
+* Remove requirement for `FromCBOR` instance for `TxOut` in `EraTxOut`
+* Add `decodeMemoized`
+* Add `DecCBOR` instance for `MemoBytes`
 * Add `VRFVerKeyHash` and `KeyRoleVRF`.
 * Switch `genDelegVrfHash`, `individualPoolStakeVrf` and `ppVrf` to using `VRFVerKeyHash`.
 * Add `{Enc|Dec}CBORGroup` instances for `Mismatch`. #4666

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -81,7 +81,6 @@ import Cardano.Ledger.Binary (
   DecShareCBOR (Share),
   EncCBOR,
   EncCBORGroup,
-  FromCBOR,
   Interns,
   Sized (sizedValue),
   ToCBOR,
@@ -276,7 +275,6 @@ class
   , DecCBOR (CompactForm (Value era))
   , EncCBOR (Value era)
   , ToCBOR (TxOut era)
-  , FromCBOR (TxOut era)
   , EncCBOR (TxOut era)
   , DecCBOR (TxOut era)
   , DecShareCBOR (TxOut era)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/Era.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/Era.hs
@@ -275,25 +275,34 @@ notSupportedInThisEraL :: HasCallStack => Lens' a b
 notSupportedInThisEraL = lens notSupportedInThisEra notSupportedInThisEra
 
 -- | Convert a type that implements `EncCBOR` to plain `Plain.Encoding` using the lowest
--- protocol version for the supplied @era@
+-- protocol version for the supplied @era@.
 toEraCBOR :: forall era t. (Era era, EncCBOR t) => t -> Plain.Encoding
 toEraCBOR = toPlainEncoding (eraProtVerLow @era) . encCBOR
 {-# INLINE toEraCBOR #-}
 
 -- | Convert a type that implements `DecCBOR` to plain `Plain.Decoder` using the lowest
 -- protocol version for the supplied @era@
+--
+-- This action should not be used for decoders that require access to original bytes, use
+-- `toPlainDecoder` instead.
 fromEraCBOR :: forall era t s. (Era era, DecCBOR t) => Plain.Decoder s t
 fromEraCBOR = eraDecoder @era decCBOR
 {-# INLINE fromEraCBOR #-}
 
 -- | Convert a type that implements `DecShareCBOR` to plain `Plain.Decoder` using the lowest
 -- protocol version for the supplied @era@
+--
+-- This action should not be used for decoders that require access to original bytes, use
+-- `toPlainDecoder` instead.
 fromEraShareCBOR :: forall era t s. (Era era, DecShareCBOR t) => Plain.Decoder s t
 fromEraShareCBOR = eraDecoder @era decNoShareCBOR
 {-# INLINE fromEraShareCBOR #-}
 
 -- | Convert a versioned `Decoder` to plain a `Plain.Decoder` using the lowest protocol
 -- version for the supplied @era@
+--
+-- This action should not be used for decoders that require access to original bytes, use
+-- `toPlainDecoder` instead.
 eraDecoder :: forall era t s. Era era => Decoder s t -> Plain.Decoder s t
-eraDecoder = toPlainDecoder (eraProtVerLow @era)
+eraDecoder = toPlainDecoder Nothing (eraProtVerLow @era)
 {-# INLINE eraDecoder #-}

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes.hs
@@ -21,6 +21,7 @@ module Cardano.Ledger.MemoBytes (
   -- * Memoized
   Memoized (RawType),
   mkMemoized,
+  decodeMemoized,
   getMemoSafeHash,
   getMemoRawType,
   zipMemoRawType,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
@@ -180,7 +180,7 @@ instance Crypto c => ToCBOR (PlutusWithContext c) where
 instance Crypto c => FromCBOR (PlutusWithContext c) where
   fromCBOR = Plain.decodeRecordNamed "PlutusWithContext" (const 6) $ do
     pwcProtocolVersion <- fromCBOR
-    toPlainDecoder pwcProtocolVersion $ decodeWithPlutus $ \plutus -> do
+    toPlainDecoder Nothing pwcProtocolVersion $ decodeWithPlutus $ \plutus -> do
       let lang = plutusLanguage plutus
           pwcScript = Left plutus
           scriptHash = hashPlutusScript plutus


### PR DESCRIPTION
# Description

Add `Maybe ByteString` to versioned `Decoder`. This approach allows us to get access to the original bytes inside of any decoder.

Fixes #4009 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
