### PR TITLE
Pass the signature checking function to Agda

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -24,8 +24,8 @@ source-repository-package
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `MAlonzo-code` BEFORE MERGE!
   subdir: generated
-  tag: 50a653f7a74791833268b648500c3677a84e7ea1
-  --sha256: sha256-jkFo6nIMXLbNcrqSfbhdoemnmGZMVZOt3YQ5Mag8YlM=
+  tag: bc70df238ef53d30eb79a9de526c4e181b291c71
+  --sha256: sha256-NMcuS0hJFIkqonoIl5+jOSBjeaFWXOtB25xN5tUmUWc=
 -- NOTE: If you would like to update the above, look for the `MAlonzo-code`
 -- branch in the `formal-ledger-specifications` repo and copy the SHA of
 -- the commit you need. The `MAlonzo-code` branch functions like an alternative

--- a/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
+++ b/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
@@ -24,11 +24,11 @@ library
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Core
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base
+        Test.Cardano.Ledger.Conformance.SpecTranslate.Conway
 
     hs-source-dirs:   src
     other-modules:
         Test.Cardano.Ledger.Conformance.SpecTranslate.Core
-        Test.Cardano.Ledger.Conformance.SpecTranslate.Conway
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxow.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxow.hs
@@ -3,18 +3,25 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Utxow () where
 
+import Cardano.Crypto.DSIGN.Class (SignedDSIGN (..), verifySignedDSIGN)
+import Cardano.Crypto.Hash (ByteString, Hash)
 import Cardano.Ledger.Conway (Conway, ConwayEra)
 import Cardano.Ledger.Conway.TxCert (ConwayTxCert)
-import Cardano.Ledger.Crypto (StandardCrypto)
+import Cardano.Ledger.Crypto (Crypto (..), StandardCrypto)
+import Cardano.Ledger.Keys (VKey (..))
 import Data.Bifunctor (Bifunctor (..))
+import Data.Either (isRight)
 import qualified Data.List.NonEmpty as NE
+import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance (
@@ -22,9 +29,14 @@ import Test.Cardano.Ledger.Conformance (
   OpaqueErrorString (..),
   SpecTranslate,
   computationResultToEither,
+  integerToHash,
  )
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Utxo (genUtxoExecContext)
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (ConwayTxBodyTransContext)
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (
+  ConwayTxBodyTransContext,
+  signatureFromInteger,
+  vkeyFromInteger,
+ )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Utxow ()
 import Test.Cardano.Ledger.Constrained.Conway (
   IsConwayUniv,
@@ -33,6 +45,33 @@ import Test.Cardano.Ledger.Constrained.Conway (
   utxoStateSpec,
   utxoTxSpec,
  )
+
+externalFunctions :: Agda.ExternalFunctions
+externalFunctions = Agda.MkExternalFunctions {..}
+  where
+    extIsSigned vk ser sig =
+      isRight $
+        verifySignedDSIGN
+          @(DSIGN StandardCrypto)
+          @(Hash (HASH StandardCrypto) ByteString)
+          ()
+          vkey
+          hash
+          signature
+      where
+        vkey =
+          unVKey @_ @StandardCrypto
+            . fromMaybe (error "Failed to convert an Agda VKey to a Haskell VKey")
+            $ vkeyFromInteger vk
+        hash =
+          fromMaybe
+            (error $ "Failed to get hash from integer:\n" <> show ser)
+            $ integerToHash ser
+        signature =
+          SignedDSIGN
+            . fromMaybe
+              (error "Failed to decode the signature")
+            $ signatureFromInteger sig
 
 instance
   ( IsConwayUniv fn
@@ -49,4 +88,4 @@ instance
   runAgdaRule env st sig =
     first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
       . computationResultToEither
-      $ Agda.utxowStep env st sig
+      $ Agda.utxowStep externalFunctions env st sig

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -145,8 +145,8 @@ instance NFData LEnv
 instance ToExpr a => ToExpr (HSSet a)
 
 instance ToExpr Credential where
-  toExpr (KeyHashObj h) = App "KeyHashObj" [agdaHashToExpr 28 h]
-  toExpr (ScriptObj h) = App "ScriptObj" [agdaHashToExpr 28 h]
+  toExpr (KeyHashObj h) = App "KeyHashObj" [agdaHashToExpr standardHashSize h]
+  toExpr (ScriptObj h) = App "ScriptObj" [agdaHashToExpr standardHashSize h]
 
 instance (ToExpr k, ToExpr v) => ToExpr (HSMap k v)
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway.hs
@@ -1,6 +1,6 @@
-module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway () where
+module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway (vkeyFromInteger, vkeyToInteger) where
 
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (vkeyFromInteger, vkeyToInteger)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Certs ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Utils.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Utils.hs
@@ -1,19 +1,31 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
 module Test.Cardano.Ledger.Conformance.Utils where
 
-import Cardano.Crypto.Hash (ByteString, Hash, hashToBytes)
+import Cardano.Crypto.Hash (ByteString, Hash, HashAlgorithm, hashFromBytes, hashToBytes, sizeHash)
 import Cardano.Crypto.Util (bytesToNatural, naturalToBytes)
+import Cardano.Ledger.Crypto (Crypto (..), StandardCrypto)
 import qualified Data.ByteString.Base16 as B16
+import Data.Data (Proxy (..))
 import qualified Lib as Agda
 import Test.Cardano.Ledger.TreeDiff (Expr, ToExpr (..))
 
+standardHashSize :: Int
+standardHashSize = fromIntegral . sizeHash $ Proxy @(HASH StandardCrypto)
+
 agdaHashToBytes :: Int -> Integer -> ByteString
-agdaHashToBytes hashSize = B16.encode . naturalToBytes hashSize . fromInteger
+agdaHashToBytes hs = B16.encode . naturalToBytes hs . fromInteger
 
 agdaHashToExpr :: Int -> Integer -> Expr
-agdaHashToExpr hashSize = toExpr . agdaHashToBytes hashSize
+agdaHashToExpr hs = toExpr . agdaHashToBytes hs
 
 hashToInteger :: Hash a b -> Integer
 hashToInteger = toInteger . bytesToNatural . hashToBytes
+
+integerToHash :: forall h a. HashAlgorithm h => Integer -> Maybe (Hash h a)
+integerToHash = hashFromBytes . naturalToBytes (fromIntegral . sizeHash $ Proxy @h) . fromInteger
 
 computationResultToEither :: Agda.ComputationResult e a -> Either e a
 computationResultToEither (Agda.Success x) = Right x

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/ConformanceSpec.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/ConformanceSpec.hs
@@ -7,13 +7,21 @@
 
 module Test.Cardano.Ledger.Conformance.ConformanceSpec (spec) where
 
-import Cardano.Ledger.Crypto (StandardCrypto)
+import Cardano.Ledger.Crypto (Crypto (..), StandardCrypto)
 import Cardano.Ledger.TxIn (TxId)
 import Data.List (isInfixOf)
 import Data.Typeable (Proxy (..), Typeable, typeRep)
 import Test.Cardano.Ledger.Common
-import Test.Cardano.Ledger.Conformance (FixupSpecRep, SpecTranslate (..), runSpecTransM, toTestRep)
+import Test.Cardano.Ledger.Conformance (
+  FixupSpecRep,
+  SpecTranslate (..),
+  hashToInteger,
+  integerToHash,
+  runSpecTransM,
+  toTestRep,
+ )
 import Test.Cardano.Ledger.Conformance.Spec.Conway ()
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway (vkeyFromInteger, vkeyToInteger)
 
 hashDisplayProp ::
   forall a.
@@ -44,3 +52,8 @@ spec =
   describe "Translation" $ do
     describe "Hashes are displayed in the same way in the implementation and in the spec" $ do
       hashDisplayProp @(TxId StandardCrypto)
+    describe "Utility properties" $ do
+      prop "vkeyToInteger and vkeyFromInteger are inverses" $
+        \vk -> vkeyFromInteger (vkeyToInteger @StandardCrypto vk) === Just vk
+      prop "hashToInteger and integerToHash are inverses" $
+        \h -> integerToHash (hashToInteger @(ADDRHASH StandardCrypto) h) === Just h


### PR DESCRIPTION
# Description

This PR passes the signing function to Agda via the new `ExternalFunctions` structure. I also updated `RatifyEnv` translation by adding translations for new fields.

related: https://github.com/IntersectMBO/formal-ledger-specifications/issues/593

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
