### PR TITLE
Various executable spec improvements

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -24,8 +24,8 @@ source-repository-package
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `MAlonzo-code` BEFORE MERGE!
   subdir: generated
-  tag: bc70df238ef53d30eb79a9de526c4e181b291c71
-  --sha256: sha256-NMcuS0hJFIkqonoIl5+jOSBjeaFWXOtB25xN5tUmUWc=
+  tag: 0909247e93410fca93180ca8a5d8e25ce4adb1e5
+  --sha256: sha256-iwFwUqI9qqGmMMwp9uu4CCsoVLbC235IcsxAl8XnBz0=
 -- NOTE: If you would like to update the above, look for the `MAlonzo-code`
 -- branch in the `formal-ledger-specifications` repo and copy the SHA of
 -- the commit you need. The `MAlonzo-code` branch functions like an alternative

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
@@ -18,6 +18,7 @@ import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway
 import Cardano.Ledger.Conway.TxCert (ConwayTxCert (..))
 import Cardano.Ledger.Crypto (StandardCrypto)
+import Constrained (lit)
 import Data.Bifunctor (first)
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
@@ -38,7 +39,7 @@ instance
   where
   type ExecContext fn "CERT" Conway = ConwayCertExecContext Conway
   environmentSpec _ = certEnvSpec
-  stateSpec _ _ = certStateSpec
+  stateSpec ctx _ = certStateSpec (lit $ ccecDelegatees ctx)
   signalSpec _ = txCertSpec
   runAgdaRule env st sig =
     first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
@@ -37,10 +37,10 @@ instance
   stateSpec context _ =
     constrained $ \x ->
       match x $ \vstate pstate dstate ->
-        [ satisfies vstate vStateSpec
+        [ satisfies vstate (vStateSpec (lit $ ccecDelegatees context))
         , satisfies pstate pStateSpec
         , -- temporary workaround because Spec does some extra tests, that the implementation does not, in the bootstrap phase.
-          satisfies dstate (bootstrapDStateSpec (ccecWithdrawals context))
+          satisfies dstate (bootstrapDStateSpec (ccecDelegatees context) (ccecWithdrawals context))
         ]
 
   signalSpec _ = txCertsSpec

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -9,8 +10,13 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg (nameDelegCert)
 
 import Cardano.Ledger.Conway
 import Cardano.Ledger.Conway.TxCert (ConwayDelegCert (..))
+import Cardano.Ledger.Credential (Credential)
+import Cardano.Ledger.Crypto (StandardCrypto)
+import Cardano.Ledger.Keys (KeyRole (..))
+import Constrained (lit)
 import Data.Bifunctor (bimap)
 import qualified Data.List.NonEmpty as NE
+import Data.Set (Set)
 import qualified Data.Text as T
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
@@ -21,9 +27,11 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 import Test.Cardano.Ledger.Constrained.Conway
 
 instance IsConwayUniv fn => ExecSpecRule fn "DELEG" Conway where
+  type ExecContext fn "DELEG" Conway = Set (Credential 'DRepRole StandardCrypto)
+
   environmentSpec _ = delegEnvSpec
 
-  stateSpec _ _ = certStateSpec
+  stateSpec ctx _ = certStateSpec (lit ctx)
 
   signalSpec _ = conwayDelegCertSpec
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
@@ -20,6 +20,7 @@ import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway
 import Cardano.Ledger.Conway.TxCert
 import Cardano.Ledger.Crypto (StandardCrypto)
+import Constrained (lit)
 import Data.Bifunctor (Bifunctor (..))
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
@@ -39,7 +40,7 @@ instance
 
   environmentSpec _ctx = govCertEnvSpec
 
-  stateSpec _ctx _env = certStateSpec
+  stateSpec ctx _env = certStateSpec (lit $ ccecDelegatees ctx)
 
   signalSpec _ctx = govCertSpec
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxo.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxo.hs
@@ -32,6 +32,7 @@ import Test.Cardano.Ledger.Conformance (
   computationResultToEither,
   runSpecTransM,
  )
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base (externalFunctions)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Utxo ()
 import Test.Cardano.Ledger.Constrained.Conway (
@@ -97,7 +98,7 @@ instance
   runAgdaRule env st sig =
     first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
       . computationResultToEither
-      $ Agda.utxoStep env st sig
+      $ Agda.utxoStep externalFunctions env st sig
 
   extraInfo ctx env@UtxoEnv {..} st@UTxOState {..} sig =
     "Impl:\n"
@@ -105,7 +106,7 @@ instance
       <> "\n\nSpec:\n"
       <> PP.ppString
         ( either show T.unpack . runSpecTransM ctx $
-            Agda.utxoDebug
+            Agda.utxoDebug externalFunctions
               <$> toSpecRep env
               <*> toSpecRep st
               <*> toSpecRep sig

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxow.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxow.hs
@@ -12,16 +12,11 @@
 
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Utxow () where
 
-import Cardano.Crypto.DSIGN.Class (SignedDSIGN (..), verifySignedDSIGN)
-import Cardano.Crypto.Hash (ByteString, Hash)
 import Cardano.Ledger.Conway (Conway, ConwayEra)
 import Cardano.Ledger.Conway.TxCert (ConwayTxCert)
-import Cardano.Ledger.Crypto (Crypto (..), StandardCrypto)
-import Cardano.Ledger.Keys (VKey (..))
+import Cardano.Ledger.Crypto (StandardCrypto)
 import Data.Bifunctor (Bifunctor (..))
-import Data.Either (isRight)
 import qualified Data.List.NonEmpty as NE
-import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance (
@@ -29,13 +24,11 @@ import Test.Cardano.Ledger.Conformance (
   OpaqueErrorString (..),
   SpecTranslate,
   computationResultToEither,
-  integerToHash,
  )
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base (externalFunctions)
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Utxo (genUtxoExecContext)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (
   ConwayTxBodyTransContext,
-  signatureFromInteger,
-  vkeyFromInteger,
  )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Utxow ()
 import Test.Cardano.Ledger.Constrained.Conway (
@@ -45,33 +38,6 @@ import Test.Cardano.Ledger.Constrained.Conway (
   utxoStateSpec,
   utxoTxSpec,
  )
-
-externalFunctions :: Agda.ExternalFunctions
-externalFunctions = Agda.MkExternalFunctions {..}
-  where
-    extIsSigned vk ser sig =
-      isRight $
-        verifySignedDSIGN
-          @(DSIGN StandardCrypto)
-          @(Hash (HASH StandardCrypto) ByteString)
-          ()
-          vkey
-          hash
-          signature
-      where
-        vkey =
-          unVKey @_ @StandardCrypto
-            . fromMaybe (error "Failed to convert an Agda VKey to a Haskell VKey")
-            $ vkeyFromInteger vk
-        hash =
-          fromMaybe
-            (error $ "Failed to get hash from integer:\n" <> show ser)
-            $ integerToHash ser
-        signature =
-          SignedDSIGN
-            . fromMaybe
-              (error "Failed to decode the signature")
-            $ signatureFromInteger sig
 
 instance
   ( IsConwayUniv fn

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Gov.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Gov.hs
@@ -13,6 +13,7 @@
 module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Gov () where
 
 import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.CertState (CertState)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Conway.Rules
@@ -26,6 +27,8 @@ instance
   , Inject ctx (EnactState era)
   , EraPParams era
   , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
+  , SpecTranslate ctx (CertState era)
+  , SpecRep (CertState era) ~ Agda.CertState
   ) =>
   SpecTranslate ctx (GovEnv era)
   where
@@ -39,6 +42,7 @@ instance
       <*> toSpecRep gePParams
       <*> toSpecRep gePPolicy
       <*> toSpecRep enactState
+      <*> toSpecRep geCertState
 
 instance
   ( EraPParams era

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/GovCert.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/GovCert.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -11,19 +12,26 @@ module Test.Cardano.Ledger.Constrained.Conway.GovCert where
 
 import Cardano.Ledger.CertState
 import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway.Core (Era (..))
 import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Conway.PParams
 import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Conway.TxCert
+import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Crypto (StandardCrypto)
+import Cardano.Ledger.Keys (KeyRole (..))
 import Constrained
 import qualified Data.Map as Map
+import Data.Set (Set)
 import Lens.Micro
 import Test.Cardano.Ledger.Constrained.Conway.Instances.Ledger
 import Test.Cardano.Ledger.Constrained.Conway.PParams
 
-vStateSpec :: Specification fn (VState era)
-vStateSpec = TrueSpec
+vStateSpec ::
+  (IsConwayUniv fn, Era era) =>
+  Term fn (Set (Credential 'DRepRole (EraCrypto era))) ->
+  Specification fn (VState era)
+vStateSpec delegatees = constrained' $ \dreps _ _ -> dom_ dreps ==. delegatees
 
 {- There are no hard constraints on VState, but sometimes when something fails we want to
 -- limit how big some of the fields of VState are. In that case one might use something

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Tests.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Tests.hs
@@ -141,7 +141,9 @@ specSuite n = do
             )
     )
 
-  soundSpecWith @(CertState era) (5 * n) (certStateSpec !$! accountStateSpec !*! epochNoSpec)
+  soundSpecWith @(CertState era)
+    (5 * n)
+    $ certStateSpec !$! TrueSpec !*! accountStateSpec !*! epochNoSpec
   soundSpecWith @(UTxO era) (5 * n) (utxoSpec !$! delegationsSpec)
   soundSpecWith @(GovState era)
     (2 * n)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/WellFormed.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/WellFormed.hs
@@ -57,7 +57,7 @@ import Test.Cardano.Ledger.Constrained.Conway.LedgerTypes.Specs (
   vstateSpec,
  )
 import Test.Cardano.Ledger.Constrained.Conway.PParams (pparamsSpec)
-import Test.QuickCheck (Gen)
+import Test.QuickCheck (Arbitrary (..), Gen)
 
 -- ==============================================================
 -- Generators for all the types found in the Ledger State.
@@ -96,7 +96,8 @@ csX :: forall era. EraSpecLedger era ConwayFn => Gen (CertState era)
 csX = do
   acct <- genFromSpec @ConwayFn @AccountState accountStateSpec
   epoch <- genFromSpec @ConwayFn @EpochNo epochNoSpec
-  genFromSpec @ConwayFn @(CertState era) (certStateSpec (lit acct) (lit epoch))
+  delegatees <- arbitrary
+  genFromSpec @ConwayFn @(CertState era) (certStateSpec (lit delegatees) (lit acct) (lit epoch))
 
 utxoX :: forall era. EraSpecLedger era ConwayFn => Gen (UTxO era)
 utxoX = do

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/TxBodySpec.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/TxBodySpec.hs
@@ -40,7 +40,11 @@ import Lens.Micro
 
 -- , certStateSpec)
 
-import Test.Cardano.Ledger.Constrained.Conway.Cert (EraSpecCert (..), certStateSpec)
+import Test.Cardano.Ledger.Constrained.Conway.Cert (
+  EraSpecCert (..),
+  certStateSpec,
+  certStateSpecEx,
+ )
 import Test.Cardano.Ledger.Constrained.Conway.Certs (certsEnvSpec, projectEnv)
 import Test.Cardano.Ledger.Constrained.Conway.Instances
 import Test.Cardano.Ledger.Constrained.Conway.Instances.TxBody (fromShelleyBody)
@@ -256,7 +260,7 @@ go2 = do
   certState <-
     generate $
       genFromSpec @ConwayFn @(CertState era)
-        (certStateSpec @ConwayFn @era) -- (lit (AccountState (Coin 1000) (Coin 100))) (lit (EpochNo 100)))
+        (certStateSpecEx @ConwayFn @era) -- (lit (AccountState (Coin 1000) (Coin 100))) (lit (EpochNo 100)))
         -- error "STOP"
   certsEnv <- generate $ genFromSpec @ConwayFn @(CertsEnv era) certsEnvSpec
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -172,7 +172,7 @@ prop_CERT :: Property
 prop_CERT =
   stsPropertyV2 @"CERT" @ConwayFn
     certEnvSpec
-    (\_env -> certStateSpec)
+    (\_env -> certStateSpecEx)
     (\env st -> txCertSpec env st)
     -- TODO: we should probably check more things here
     $ \_env _st _sig _st' -> True
@@ -181,7 +181,7 @@ prop_DELEG :: Property
 prop_DELEG =
   stsPropertyV2 @"DELEG" @ConwayFn
     delegEnvSpec
-    (\_env -> certStateSpec)
+    (\_env -> certStateSpecEx)
     conwayDelegCertSpec
     $ \_env _st _sig _st' -> True
 
@@ -197,7 +197,7 @@ prop_GOVCERT :: Property
 prop_GOVCERT =
   stsPropertyV2 @"GOVCERT" @ConwayFn
     govCertEnvSpec
-    (\_env -> certStateSpec)
+    (\_env -> certStateSpecEx)
     (\env st -> govCertSpec env st)
     $ \_env _st _sig _st' -> True
 


### PR DESCRIPTION
# Description

This PR changes the Agda representation for `Network`, `Data` and `AuxiliaryData` so we can test more of the logic. 
Removed a filter in the constraints that limits SPO votes in the `RATIFY` rule to abstain votes.

There was also a conformance failure in the `ENACT` rule caused by a mismatch in the network field of withdrawal addresses. I modified the generators so that they only generate `Testnet` values in those places, because the network field is actually checked in the `GOV` rule so it's not supposed to show up in the `ENACT` rule.

closes [#4724](https://github.com/IntersectMBO/cardano-ledger/issues/4724)

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
