### PR TITLE
Fix looping issue in constrained-generators

### DIFF
--- a/libs/constrained-generators/src/Constrained/Examples/Basic.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Basic.hs
@@ -312,3 +312,14 @@ whenTrueExists = constrained $ \x ->
       [ not_ [var| b |]
       , not_ (not_ b)
       ]
+
+wtfSpec :: Specification BaseFn ([Int], Maybe ((), [Int]))
+wtfSpec = constrained' $ \ [var| options |] [var| mpair |] ->
+  caseOn
+    mpair
+    (branch $ \_ -> False)
+    ( branch $ \pair -> match pair $ \unit ints ->
+        [ forAll ints $ \int -> reify options id $ \xs -> int `elem_` xs
+        , assert $ unit ==. lit ()
+        ]
+    )

--- a/libs/constrained-generators/src/Constrained/GenT.hs
+++ b/libs/constrained-generators/src/Constrained/GenT.hs
@@ -82,9 +82,10 @@ instance Monad GE where
 instance MonadGenError GE where
   genError neStr = GenError [] neStr
   fatalError neStr = FatalError [] neStr
-  explain nes (GenError es' err) = GenError (nes : es') err
-  explain nes (FatalError es' err) = FatalError (nes : es') err
-  explain nes (Result es' a) = Result (nes : es') a
+  explain nes ge = case ge of
+    GenError es' err -> GenError (nes : es') err
+    FatalError es' err -> FatalError (nes : es') err
+    Result es' a -> Result (nes : es') a
 
 instance MonadGenError m => MonadGenError (GenT m) where
   genError es = GenT $ \_ -> pure $ genError es

--- a/libs/constrained-generators/src/Constrained/Properties.hs
+++ b/libs/constrained-generators/src/Constrained/Properties.hs
@@ -61,6 +61,11 @@ prop_sound spec =
 prop_constrained_satisfies_sound :: HasSpec fn a => Specification fn a -> QC.Property
 prop_constrained_satisfies_sound spec = prop_sound (constrained $ \a -> satisfies a spec)
 
+prop_constrained_explained :: HasSpec fn a => Specification fn a -> QC.Property
+prop_constrained_explained spec =
+  QC.forAll QC.arbitrary $ \es ->
+    prop_sound $ constrained $ \x -> explanation es $ x `satisfies` spec
+
 -- | `prop_complete ps` assumes that `ps` is satisfiable
 prop_complete :: HasSpec fn a => Specification fn a -> QC.Property
 prop_complete s =

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -25,7 +25,6 @@ import GHC.Natural
 import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck hiding (Args, Fun, forAll)
-import Test.QuickCheck qualified as QC
 
 import Constrained.Examples
 import Constrained.Internals
@@ -151,6 +150,7 @@ tests nightly =
     testSpecNoShrink "powersetPickOne" powersetPickOne
     testSpecNoShrink "appendSuffix" appendSuffix
     testSpecNoShrink "appendForAll" appendForAll
+    testSpec "wtfSpec" wtfSpec
     numberyTests
     sizeTests
     numNumSpecTree
@@ -295,8 +295,7 @@ testSpec' withShrink n s = do
     prop "prop_constrained_explained" $
       within 10_000_0000 $
         checkCoverage' $
-          QC.forAll arbitrary $ \es ->
-            prop_sound $ constrained $ \x -> explanation es $ x `satisfies` s
+          prop_constrained_explained s
     when withShrink $
       prop "prop_shrink_sound" $
         discardAfter 100_000 $


### PR DESCRIPTION
# Description

@TimSheard I don't get what the intent of this change was, it's always going to cause a stack overflow.

This needs to be merged ASAP as it's causing a block on #4669 
# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
