### PR TITLE
Fixed translation of  `StakeReference`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -24,8 +24,8 @@ source-repository-package
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `MAlonzo-code` BEFORE MERGE!
   subdir: generated
-  tag: 4c38bca875fc6ad1faf12a94508ac1645722a663
-  --sha256: sha256-0+2u8pG947XDLRFaT87DGHRlilGf94av0dg7a6MnfAM=
+  tag: 511c5632eff71f4811b48fba71e7aaadfd69211a
+  --sha256: sha256-J6Sbrr9Klz3N72wT2ZF02z5G6iFHjpwfUH2pFVoJr3c=
 -- NOTE: If you would like to update the above, look for the `MAlonzo-code`
 -- branch in the `formal-ledger-specifications` repo and copy the SHA of
 -- the commit you need. The `MAlonzo-code` branch functions like an alternative

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.15.0.0
 
+* Added `Generic`, `Eq`, `Show`, `NFData`, `EncCBOR` instances for `ShelleyLedgersEnv`
 * Remove deprecated `witsVKeyNeededGov`, `witsVKeyNeededNoGov`, `shelleyWitsVKeyNeeded` and `propWits`
 * Remove deprecated `PPUPPredFailure`, `delPlAcnt`, `prAcnt`, `votedValue`
 * Remove impossible predicate failure `StakeKeyInRewardsDELEG`
@@ -34,6 +35,7 @@
 
 ### `testlib`
 
+* Added `ToExpr` instance for `ShelleyLedgersEnv`
 * Changed type signature of `freshKeyHashVRF` to return `VRFVerKeyHash` instead of just a `Hash`
 * Added `expectUTxOContent`
 * Added `disableTreasuryExpansion`

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -151,11 +151,11 @@ instance SpecTranslate ctx (TxIn era) where
   toSpecRep (TxIn txId txIx) = toSpecRep (txId, txIx)
 
 instance SpecTranslate ctx (StakeReference era) where
-  type SpecRep (StakeReference era) = Agda.Credential
+  type SpecRep (StakeReference era) = Maybe Agda.Credential
 
-  toSpecRep (StakeRefBase c) = toSpecRep c
-  toSpecRep (StakeRefPtr _) = error "Cannot translate StakeRefPtr"
-  toSpecRep StakeRefNull = error "Cannot translate StakeRefNull"
+  toSpecRep (StakeRefBase c) = Just <$> toSpecRep c
+  toSpecRep (StakeRefPtr _) = pure Nothing
+  toSpecRep StakeRefNull = pure Nothing
 
 instance SpecTranslate ctx (BootstrapAddress era) where
   type SpecRep (BootstrapAddress era) = Agda.BootstrapAddr


### PR DESCRIPTION
# Description

related:
https://github.com/IntersectMBO/formal-ledger-specifications/issues/606
https://github.com/IntersectMBO/formal-ledger-specifications/pull/607

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
