### PR TITLE
Add Conformance.Imp: imptests with conformance

### DIFF
--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 1.15.0.0
 
+* Add lenses for `LedgerEnv`. #4748
+  * `ledgerSlotNoL`
+  * `ledgerEpochNoL`
+  * `ledgerIxL`
+  * `ledgerPpL`
+  * `ledgerAccountL`
+  * `ledgerMempoolL`
 * Change `PoolEnv` to take `EpochNo` instead of `SlotNo`
 * Add `EpochNo` to `DelplEnv`
 * Add `Maybe EpochNo` to `LedgerEnv`
@@ -39,6 +46,9 @@
 
 ### `testlib`
 
+* Add `iteExpectLedgerRuleConformance` to `ImpTestEnv` for additionally checking conformance with ImpTests. #4748
+  * Add lens `iteExpectLedgerRuleConformanceL`.
+  * Add `modifyImpInitExpectLedgerRuleConformance`.
 * Added `tryLookupReward`
 * Switch to using `ImpSpec` package
 * Remove: `runImpTestM`, `runImpTestM_`, `evalImpTestM`, `execImpTestM`, `runImpTestGenM`, `runImpTestGenM_`, `evalImpTestGenM`, `execImpTestGenM`, `withImpState` and `withImpStateModified`.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
@@ -19,6 +19,12 @@
 module Cardano.Ledger.Shelley.Rules.Ledger (
   ShelleyLEDGER,
   LedgerEnv (..),
+  ledgerSlotNoL,
+  ledgerEpochNoL,
+  ledgerIxL,
+  ledgerPpL,
+  ledgerAccountL,
+  ledgerMempoolL,
   ShelleyLedgerPredFailure (..),
   ShelleyLedgerEvent (..),
   Event,
@@ -118,6 +124,24 @@ data ShelleyLedgerPredFailure era
   = UtxowFailure (PredicateFailure (EraRule "UTXOW" era)) -- Subtransition Failures
   | DelegsFailure (PredicateFailure (EraRule "DELEGS" era)) -- Subtransition Failures
   deriving (Generic)
+
+ledgerSlotNoL :: Lens' (LedgerEnv era) SlotNo
+ledgerSlotNoL = lens ledgerSlotNo $ \x y -> x {ledgerSlotNo = y}
+
+ledgerEpochNoL :: Lens' (LedgerEnv era) (Maybe EpochNo)
+ledgerEpochNoL = lens ledgerEpochNo $ \x y -> x {ledgerEpochNo = y}
+
+ledgerIxL :: Lens' (LedgerEnv era) TxIx
+ledgerIxL = lens ledgerIx $ \x y -> x {ledgerIx = y}
+
+ledgerPpL :: Lens' (LedgerEnv era) (PParams era)
+ledgerPpL = lens ledgerPp $ \x y -> x {ledgerPp = y}
+
+ledgerAccountL :: Lens' (LedgerEnv era) AccountState
+ledgerAccountL = lens ledgerAccount $ \x y -> x {ledgerAccount = y}
+
+ledgerMempoolL :: Lens' (LedgerEnv era) Bool
+ledgerMempoolL = lens ledgerMempool $ \x y -> x {ledgerMempool = y}
 
 type instance EraRuleFailure "LEDGER" (ShelleyEra c) = ShelleyLedgerPredFailure (ShelleyEra c)
 

--- a/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
+++ b/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
@@ -22,13 +22,13 @@ library
     exposed-modules:
         Test.Cardano.Ledger.Conformance
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Core
+        Test.Cardano.Ledger.Conformance.SpecTranslate.Core
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway
 
     hs-source-dirs:   src
     other-modules:
-        Test.Cardano.Ledger.Conformance.SpecTranslate.Core
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool
@@ -106,6 +106,7 @@ test-suite tests
         Test.Cardano.Ledger.Conformance.Spec.Conway
         Test.Cardano.Ledger.Conformance.ExecSpecRule.MiniTrace
         Test.Cardano.Ledger.Conformance.Imp.Ratify
+        Test.Cardano.Ledger.Conformance.Imp
 
     default-language: Haskell2010
     ghc-options:
@@ -126,4 +127,7 @@ test-suite tests
         cardano-ledger-alonzo,
         cardano-ledger-conway:{cardano-ledger-conway, testlib},
         cardano-ledger-test,
-        microlens
+        cardano-ledger-executable-spec,
+        microlens,
+        unliftio,
+        text

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway.hs
@@ -1,6 +1,7 @@
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway (
   module X,
   ConwayRatifyExecContext (..),
+  ConwayLedgerExecContext (..),
 ) where
 
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base as X (
@@ -16,7 +17,9 @@ import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Certs as X (nameCerts
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg as X (nameDelegCert)
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Gov as X ()
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.GovCert as X (nameGovCert)
-import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Ledger as X ()
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Ledger as X (
+  ConwayLedgerExecContext (..),
+ )
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Ledgers as X ()
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Pool as X (namePoolCert)
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Utxo as X ()

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
@@ -13,7 +13,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Ledger () where
+module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Ledger (ConwayLedgerExecContext (..)) where
 
 import Data.Bifunctor (Bifunctor (..))
 import Data.Functor.Identity (Identity)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
@@ -21,6 +21,8 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
   checkConformance,
   defaultTestConformance,
   translateWithContext,
+  ForAllExecSpecRep,
+  ForAllExecTypes,
 ) where
 
 import Cardano.Ledger.BaseTypes (Inject (..), ShelleyBase)
@@ -279,7 +281,7 @@ checkConformance ctx env st sig implResTest agdaResTest = do
         dumpCbor path env "conformance_dump_env"
         dumpCbor path st "conformance_dump_st"
         dumpCbor path sig "conformance_dump_sig"
-        logDoc $ "Dumped a CBOR files to " <> ansiExpr path
+        logDoc $ "Dumped the CBOR files to " <> ansiExpr path
       Nothing ->
         logDoc $
           "Run the test again with "

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway.hs
@@ -1,6 +1,14 @@
-module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway (vkeyFromInteger, vkeyToInteger) where
+module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway (
+  vkeyFromInteger,
+  vkeyToInteger,
+  ConwayTxBodyTransContext,
+) where
 
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (vkeyFromInteger, vkeyToInteger)
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (
+  ConwayTxBodyTransContext,
+  vkeyFromInteger,
+  vkeyToInteger,
+ )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Certs ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
@@ -38,7 +38,7 @@ import Test.Cardano.Ledger.TreeDiff (Expr (..), ToExpr (..))
 -- | OpaqueErrorString behaves like unit in comparisons, but contains an
 -- error string that can be displayed.
 newtype OpaqueErrorString = OpaqueErrorString String
-  deriving (Generic)
+  deriving (Generic, Show)
 
 instance Eq OpaqueErrorString where
   _ == _ = True

--- a/libs/cardano-ledger-conformance/test/Main.hs
+++ b/libs/cardano-ledger-conformance/test/Main.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Main (main) where
 

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Test.Cardano.Ledger.Conformance.Imp (spec) where
+
+import Cardano.Ledger.Alonzo.Tx (AlonzoTx)
+import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.Conway (Conway)
+import Cardano.Ledger.Conway.Governance
+import Cardano.Ledger.Conway.Rules
+import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley.LedgerState
+import Cardano.Ledger.Shelley.Rules (LedgerEnv, UtxoEnv (..), ledgerSlotNoL)
+import Control.State.Transition
+import Data.Bifunctor (bimap)
+import Data.Bitraversable (bimapM)
+import Data.List.NonEmpty
+import Data.Text (unpack)
+import Lens.Micro
+import Lib qualified as Agda
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway (ConwayLedgerExecContext (..))
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway (ConwayTxBodyTransContext)
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
+import Test.Cardano.Ledger.Constrained.Conway
+import Test.Cardano.Ledger.Conway.Imp qualified as ConwayImp (conwaySpec)
+import Test.Cardano.Ledger.Conway.ImpTest
+import Test.Cardano.Ledger.Imp.Common hiding (Args)
+import UnliftIO (evaluateDeep)
+
+testImpConformance ::
+  forall era.
+  ( ConwayEraImp era
+  , ExecSpecRule ConwayFn "LEDGER" era
+  , ExecContext ConwayFn "LEDGER" era ~ ConwayLedgerExecContext era
+  , ExecSignal ConwayFn "LEDGER" era ~ AlonzoTx era
+  , ExecState ConwayFn "LEDGER" era ~ LedgerState era
+  , SpecTranslate (ExecContext ConwayFn "LEDGER" era) (ExecState ConwayFn "LEDGER" era)
+  , SpecTranslate (ExecContext ConwayFn "LEDGER" era) (ExecEnvironment ConwayFn "LEDGER" era)
+  , SpecTranslate (ExecContext ConwayFn "LEDGER" era) (TxWits era)
+  , NFData (SpecRep (PredicateFailure (EraRule "LEDGER" era)))
+  , Show (SpecRep (PredicateFailure (EraRule "LEDGER" era)))
+  , Eq (SpecRep (PredicateFailure (EraRule "LEDGER" era)))
+  , FixupSpecRep (SpecRep (PredicateFailure (EraRule "LEDGER" era)))
+  , HasCallStack
+  , SpecRep (TxWits era) ~ Agda.TxWitnesses
+  , SpecRep (TxBody era) ~ Agda.TxBody
+  , ExecEnvironment ConwayFn "LEDGER" era ~ LedgerEnv era
+  , Tx era ~ AlonzoTx era
+  , SpecTranslate (ConwayTxBodyTransContext (EraCrypto era)) (TxBody era)
+  ) =>
+  Either
+    (NonEmpty (PredicateFailure (EraRule "LEDGER" era)))
+    (State (EraRule "LEDGER" era), [Event (EraRule "LEDGER" era)]) ->
+  ExecEnvironment ConwayFn "LEDGER" era ->
+  ExecState ConwayFn "LEDGER" era ->
+  ExecSignal ConwayFn "LEDGER" era ->
+  Expectation
+testImpConformance impRuleResult env state signal = do
+  let ctx =
+        ConwayLedgerExecContext
+          { clecPolicyHash =
+              state ^. lsUTxOStateL . utxosGovStateL . constitutionGovStateL . constitutionScriptL
+          , clecEnactState = mkEnactState $ state ^. lsUTxOStateL . utxosGovStateL
+          , clecUtxoExecContext =
+              UtxoExecContext
+                { uecTx = signal
+                , uecUTxO = state ^. lsUTxOStateL . utxosUtxoL
+                , uecUtxoEnv =
+                    UtxoEnv
+                      { ueSlot = env ^. ledgerSlotNoL
+                      , uePParams = state ^. lsUTxOStateL . utxosGovStateL . curPParamsGovStateL
+                      , ueCertState = state ^. lsCertStateL
+                      }
+                }
+          }
+  -- translate inputs
+  let failOnLeft = either (assertFailure . unpack) pure
+  (specEnv, specState, specSignal) <-
+    (,,)
+      <$> failOnLeft (runSpecTransM ctx $ toSpecRep env)
+      <*> failOnLeft (runSpecTransM ctx $ toSpecRep state)
+      <*> failOnLeft (runSpecTransM ctx $ toSpecRep signal)
+  -- get agda response
+  agdaResponse <-
+    fmap (bimap (fixup <$>) fixup) $
+      evaluateDeep $
+        runAgdaRule @ConwayFn @"LEDGER" @era specEnv specState specSignal
+  -- translate imp response
+  impResponse <-
+    expectRightExpr $
+      runSpecTransM ctx $
+        bimapM
+          (traverse toTestRep)
+          (toTestRep . inject @_ @(ExecState ConwayFn "LEDGER" era) . fst)
+          impRuleResult
+
+  impResponse `shouldBe` agdaResponse
+
+spec :: Spec
+spec =
+  withImpInit @(LedgerSpec Conway) $
+    modifyImpInitProtVer @Conway (natVersion @10) $
+      modifyImpInitExpectLedgerRuleConformance testImpConformance $ do
+        xdescribe "Tx conformance" $ it "Tx conformance" $ do
+          _ <- submitConstitution @Conway SNothing
+          passNEpochs 2
+        xdescribe "Test.Cardano.Ledger.Conway.Imp conformance" $ ConwayImp.conwaySpec @Conway

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -7,8 +8,9 @@ module Test.Cardano.Ledger.Conformance.Spec.Conway (spec) where
 import Cardano.Ledger.Conway (Conway)
 import Test.Cardano.Ledger.Conformance (conformsToImpl, inputsGenerateWithin)
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway ()
-import qualified Test.Cardano.Ledger.Conformance.ExecSpecRule.MiniTrace as MiniTrace
-import qualified Test.Cardano.Ledger.Conformance.Imp.Ratify as RatifyImp
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.MiniTrace qualified as MiniTrace
+import Test.Cardano.Ledger.Conformance.Imp qualified as Imp (spec)
+import Test.Cardano.Ledger.Conformance.Imp.Ratify qualified as RatifyImp
 import Test.Cardano.Ledger.Constrained.Conway
 import Test.Cardano.Ledger.Conway.ImpTest ()
 import Test.Cardano.Ledger.Imp.Common
@@ -38,3 +40,4 @@ spec = do
       xprop "LEDGERS" $ conformsToImpl @"LEDGERS" @ConwayFn @Conway
     describe "ImpTests" $ do
       RatifyImp.spec
+      Imp.spec


### PR DESCRIPTION
# Description

With a new `iteExpectLedgerRuleConformance` field added to `ImpTestEnv`,
we get an overridable function that can be executed within `trySubmitTx`
for every submitted transaction. To override this hook we have
`modifyImpInitExpectLedgerRuleConformance` the function. We add a new
`Conformance.Imp` module to `cardano-ledger-conformance` package, to
import `Conway.Imp` and run those tests with a modified "hook" that
runs the `LEDGER` rule from Agda on the Tx and `checkConformance` on
the results.

Additions:
- `iteExpectLedgerRuleConformance` field to `ImpTestEnv`.
- `modifyImpInitExpectLedgerRuleConformance` function to override the
hook.
- Add lenses for all fields of `LedgerEnv`.

Changes:
- Change `trySubmitTx` to run the `iteExpectLedgerRuleConformance` for
every submitted Tx.

### The Problem

We get a failure from the Agda side, telling us that the `witsVKeyNeeded utxo txb` is not a subset of `witsKeyHashes` as it should be. We have isolated the issue to be with the translation of `spendableInputs`, since it is most likely that those aren't being handled in a manner that fits into the problem we are trying to solve with this conformance.

This PR can be merged as it is, since @Soupstraw and I want to work in parallel on related issues.

Closes #4725 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
