### PR TITLE
`constrained-generators`: Fix test failure related to narrowing of fold specs

### DIFF
--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -182,6 +182,7 @@ tests nightly =
       prop "[(Set Int, Set Bool)]" $ prop_gen_sound @BaseFn @[(Set Int, Set Bool)]
       prop "Set (Set Bool)" $ prop_gen_sound @BaseFn @(Set (Set Bool))
     negativeTests
+    prop "prop_noNarrowLoop" $ withMaxSuccess 1000 prop_noNarrowLoop
 
 negativeTests :: Spec
 negativeTests =
@@ -369,3 +370,15 @@ hasSizeSet = hasSize (rangeSize 1 3)
 
 hasSizeMap :: Specification BaseFn (Map Int Int)
 hasSizeMap = hasSize (rangeSize 1 3)
+
+------------------------------------------------------------------------
+-- Tests for narrowing
+------------------------------------------------------------------------
+
+prop_noNarrowLoop :: Int -> Int -> Specification BaseFn Int -> Specification BaseFn Int -> Property
+prop_noNarrowLoop f s eSpec fSpec =
+  -- Make sure the fuel is non-negative
+  f >= 0 ==>
+    discardAfter 100_000 $
+      narrowByFuelAndSize f s (eSpec, fSpec) `seq`
+        property True


### PR DESCRIPTION
# Description

closes #4753

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
