### PR TITLE
Updated spec to fix a conformance failure

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -24,8 +24,8 @@ source-repository-package
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `MAlonzo-code` BEFORE MERGE!
   subdir: generated
-  tag: 511c5632eff71f4811b48fba71e7aaadfd69211a
-  --sha256: sha256-J6Sbrr9Klz3N72wT2ZF02z5G6iFHjpwfUH2pFVoJr3c=
+  tag: cc93692f5a57a9a66956b232662152676f659954
+  --sha256: sha256-s9ikqfXmz1wBrk4qEFR/iOloKvMOPGTB5IpHO34NSLE=
 -- NOTE: If you would like to update the above, look for the `MAlonzo-code`
 -- branch in the `formal-ledger-specifications` repo and copy the SHA of
 -- the commit you need. The `MAlonzo-code` branch functions like an alternative

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -227,6 +227,8 @@ newtype AlonzoUtxoEvent era
   = UtxosEvent (Event (EraRule "UTXOS" era))
   deriving (Generic)
 
+deriving instance Show (Event (EraRule "UTXOS" era)) => Show (AlonzoUtxoEvent era)
+
 deriving instance Eq (Event (EraRule "UTXOS" era)) => Eq (AlonzoUtxoEvent era)
 
 instance NFData (Event (EraRule "UTXOS" era)) => NFData (AlonzoUtxoEvent era)

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 ### `testlib`
 
+* Added `tryLookupReward`
 * Switch to using `ImpSpec` package
 * Remove: `runImpTestM`, `runImpTestM_`, `evalImpTestM`, `execImpTestM`, `runImpTestGenM`, `runImpTestGenM_`, `evalImpTestGenM`, `execImpTestGenM`, `withImpState` and `withImpStateModified`.
 * Add `LedgerSpec`, `modifyImpInitProtVer`.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -127,6 +127,14 @@ instance EraPParams era => EncCBOR (UtxoEnv era) where
             !> To uePParams
             !> To ueCertState
 
+instance EraPParams era => DecCBOR (UtxoEnv era) where
+  decCBOR =
+    decode $
+      RecD UtxoEnv
+        <! From
+        <! From
+        <! D decNoShareCBOR
+
 utxoEnvSlotL :: Lens' (UtxoEnv era) SlotNo
 utxoEnvSlotL = lens ueSlot $ \x y -> x {ueSlot = y}
 

--- a/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/DebugTools.hs
+++ b/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/DebugTools.hs
@@ -1,22 +1,45 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Cardano.Ledger.Api.DebugTools where
 
-import Cardano.Ledger.Binary (DecCBOR, EncCBOR, Version, decodeFull')
+import Cardano.Ledger.Binary (
+  Annotator,
+  DecCBOR (..),
+  DecShareCBOR,
+  EncCBOR,
+  Version,
+  decNoShareCBOR,
+  decodeFull',
+  decodeFullAnnotator,
+  decodeFullDecoder',
+ )
 import Cardano.Ledger.Binary.Encoding (serialize')
 import Cardano.Ledger.Core (Era, eraProtVerLow)
-import Control.Exception (throwIO)
+import Control.Exception (Exception, throwIO)
 import Control.Monad.IO.Class (MonadIO (..))
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
 
-readCBOR :: (DecCBOR a, MonadIO m) => Version -> FilePath -> m a
-readCBOR version path = liftIO $ do
+readCBORWith ::
+  (MonadIO m, Exception e) => (Version -> BS.ByteString -> Either e a) -> Version -> FilePath -> m a
+readCBORWith dec version path = liftIO $ do
   dat <- BS.readFile path
-  case decodeFull' version dat of
+  case dec version dat of
     Right x -> pure x
     Left err -> throwIO err
+
+readCBOR :: (DecCBOR a, MonadIO m) => Version -> FilePath -> m a
+readCBOR = readCBORWith decodeFull'
+
+readCBORNoShare :: (MonadIO m, DecShareCBOR a) => Version -> FilePath -> m a
+readCBORNoShare = readCBORWith (\v bs -> decodeFullDecoder' v "DecodeNoShare" decNoShareCBOR bs)
+
+readCBORAnnotated :: (MonadIO m, DecCBOR (Annotator a)) => Version -> FilePath -> m a
+readCBORAnnotated = readCBORWith (\v bs -> decodeFullAnnotator v "DecodeAnnotated" decCBOR (LBS.fromStrict bs))
 
 writeCBOR :: (EncCBOR a, MonadIO m) => Version -> FilePath -> a -> m ()
 writeCBOR version path = liftIO . BS.writeFile path . serialize' version

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
@@ -408,7 +408,7 @@ instance IsConwayUniv fn => ExecSpecRule fn "RATIFY" Conway where
       . computationResultToEither
       $ Agda.ratifyStep env st sig
 
-  extraInfo ctx env@RatifyEnv {..} st sig@(RatifySignal actions) =
+  extraInfo ctx env@RatifyEnv {..} st sig@(RatifySignal actions) _ =
     PP.vsep $ specExtraInfo : (actionAcceptedRatio <$> toList actions)
     where
       members = foldMap' (committeeMembers @Conway) $ ensCommittee (rsEnactState st)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
@@ -55,7 +55,7 @@ instance
     -- The results of runConformance are Agda types, the `ctx` is a Haskell type, we extract and translate the Withdrawal keys.
     specWithdrawalCredSet <-
       translateWithContext () (Map.keysSet (Map.mapKeys raCredential (ccecWithdrawals ctx)))
-    (implResTest, agdaResTest) <- runConformance @"CERTS" @fn @Conway ctx env st sig
+    (implResTest, agdaResTest, _) <- runConformance @"CERTS" @fn @Conway ctx env st sig
     case (implResTest, agdaResTest) of
       (Right haskell, Right spec) ->
         checkConformance @"CERTS" @Conway @fn

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
@@ -175,7 +175,7 @@ instance
         expectRightExpr $
           runSpecTransM ctx $
             bimapM (traverse toTestRep) (toTestRep . inject @_ @(ExecState fn "LEDGER" Conway) . fst) implRes
-    let extra = extraInfo @fn @"LEDGER" @Conway ctx (inject env) (inject st) (inject sig)
+    let extra = extraInfo @fn @"LEDGER" @Conway ctx (inject env) (inject st) (inject sig) implRes
     logDoc extra
     checkConformance @"LEDGER" @Conway @fn
       ctx

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Ratify.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Ratify.hs
@@ -133,7 +133,7 @@ spec = withImpInit @(LedgerSpec Conway) $ describe "RATIFY" $ modifyImpInitProtV
     let
       ratSt = getRatifyState govSt
       ratSig = RatifySignal (constitutionGAS SSeq.:<| mempty)
-    (implRes, agdaRes) <-
+    (implRes, agdaRes, implRes') <-
       runConformance @"RATIFY" @ConwayFn @Conway
         execCtx
         ratEnv
@@ -158,4 +158,5 @@ spec = withImpInit @(LedgerSpec Conway) $ describe "RATIFY" $ modifyImpInitProtV
         ratEnv
         ratSt
         ratSig
+        implRes'
     impAnn "Conformance failed" $ implRes `shouldBeExpr` agdaRes

--- a/libs/cardano-ledger-repl-environment/cardano-ledger-repl-environment.cabal
+++ b/libs/cardano-ledger-repl-environment/cardano-ledger-repl-environment.cabal
@@ -25,4 +25,5 @@ library
         constrained-generators,
         data-default,
         QuickCheck,
+        ImpSpec,
         microlens

--- a/libs/cardano-ledger-repl-environment/src/ReplEnvironment.hs
+++ b/libs/cardano-ledger-repl-environment/src/ReplEnvironment.hs
@@ -25,6 +25,7 @@ import Cardano.Ledger.Val
 import Test.Cardano.Ledger.Api.DebugTools
 
 import Control.Monad
+import Control.Monad.IO.Class
 
 import qualified Data.ByteString as BS
 import Data.Default
@@ -41,13 +42,14 @@ import Lens.Micro
 
 import System.IO
 
-import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway
-import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway (crecGovActionMapL)
 import Test.Cardano.Ledger.Constrained.Conway.Instances
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Core.Rational
+import Test.Cardano.Ledger.Imp.Common
+
+import Test.ImpSpec
 
 import Test.QuickCheck
 


### PR DESCRIPTION
# Description

This PR bumps the spec to a version that calculates refunds properly. I also modified the `extraInfo` method to give access to the final state when creating the debug message.

closes #4754

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
