### PR TITLE
Use `EpochNo` instead of `SlotNo` in `Pool`, `Cert` and `Certs` rules

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.18.0.0
 
+* Remove `SlotNo` from `CertEnv` and `CertsEnv`
 * Remove deprecated `translateTxOut` and `conwayWitsVKeyNeeded`
 * Add `DefaultVote` and `defaultStakePoolVote`
 * Add new event `GovRemovedVotes` for invalidated votes.

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
@@ -29,7 +29,6 @@ import Cardano.Ledger.BaseTypes (
   EpochNo (EpochNo),
   Globals (..),
   ShelleyBase,
-  SlotNo,
   StrictMaybe,
   binOpEpochNo,
  )
@@ -89,7 +88,6 @@ import NoThunks.Class (NoThunks (..))
 data CertsEnv era = CertsEnv
   { certsTx :: !(Tx era)
   , certsPParams :: !(PParams era)
-  , certsSlotNo :: !SlotNo
   , certsCurrentEpoch :: !EpochNo
   , certsCurrentCommittee :: StrictMaybe (Committee era)
   , certsCommitteeProposals :: Map.Map (GovPurposeId 'CommitteePurpose era) (GovActionState era)
@@ -97,13 +95,12 @@ data CertsEnv era = CertsEnv
   deriving (Generic)
 
 instance EraTx era => EncCBOR (CertsEnv era) where
-  encCBOR x@(CertsEnv _ _ _ _ _ _) =
+  encCBOR x@(CertsEnv _ _ _ _ _) =
     let CertsEnv {..} = x
      in encode $
           Rec CertsEnv
             !> To certsTx
             !> To certsPParams
-            !> To certsSlotNo
             !> To certsCurrentEpoch
             !> To certsCurrentCommittee
             !> To certsCommitteeProposals
@@ -217,7 +214,7 @@ conwayCertsTransition ::
   TransitionRule (ConwayCERTS era)
 conwayCertsTransition = do
   TRC
-    ( env@(CertsEnv tx pp slot currentEpoch committee committeeProposals)
+    ( env@(CertsEnv tx pp currentEpoch committee committeeProposals)
       , certState
       , certificates
       ) <-
@@ -271,7 +268,7 @@ conwayCertsTransition = do
       certState' <-
         trans @(ConwayCERTS era) $ TRC (env, certState, gamma)
       trans @(EraRule "CERT" era) $
-        TRC (CertEnv slot pp currentEpoch committee committeeProposals, certState', txCert)
+        TRC (CertEnv pp currentEpoch committee committeeProposals, certState', txCert)
 
 instance
   ( Era era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -446,7 +446,7 @@ ledgerTransition = do
         certStateAfterCERTS <-
           trans @(EraRule "CERTS" era) $
             TRC
-              ( CertsEnv tx pp slot currentEpoch committee committeeProposals
+              ( CertsEnv tx pp currentEpoch committee committeeProposals
               , certState
               , StrictSeq.fromStrict $ txBody ^. certsTxBodyL
               )

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.15.0.0
 
+* Change `PoolEnv` to take `EpochNo` instead of `SlotNo`
 * Added `Generic`, `Eq`, `Show`, `NFData`, `EncCBOR` instances for `ShelleyLedgersEnv`
 * Remove deprecated `witsVKeyNeededGov`, `witsVKeyNeededNoGov`, `shelleyWitsVKeyNeeded` and `propWits`
 * Remove deprecated `PPUPPredFailure`, `delPlAcnt`, `prAcnt`, `votedValue`

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -74,6 +74,7 @@ import Test.Cardano.Ledger.Shelley.Generator.Trace.Chain (mkGenesisChainState)
 import Test.Cardano.Ledger.Shelley.Rules.Chain (CHAIN, ChainState (..))
 import Test.Cardano.Ledger.Shelley.Utils (
   ChainProperty,
+  epochFromSlotNo,
   runShelleyBase,
   testGlobals,
  )
@@ -198,7 +199,7 @@ poolTraceFromBlock chainSt block =
     poolCerts = mapMaybe getPoolCertTxCert (certs txs)
     poolEnv =
       let (LedgerEnv s _ pp _ _) = ledgerEnv
-       in PoolEnv s pp
+       in PoolEnv (epochFromSlotNo s) pp
     poolSt0 =
       certPState (lsCertState ledgerSt0)
 

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/NetworkID.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/NetworkID.hs
@@ -16,13 +16,12 @@ import Cardano.Ledger.Shelley.API (
   ShelleyPOOL,
  )
 import Cardano.Ledger.Shelley.Core
-import Cardano.Ledger.Slot (SlotNo (..))
 import Control.State.Transition.Extended hiding (Assertion)
 import Data.Default (def)
 import Lens.Micro
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (C_Crypto)
 import qualified Test.Cardano.Ledger.Shelley.Examples.Cast as Cast
-import Test.Cardano.Ledger.Shelley.Utils (applySTSTest, runShelleyBase)
+import Test.Cardano.Ledger.Shelley.Utils (applySTSTest, epochFromSlotNo, runShelleyBase)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, assertBool, testCase)
 
@@ -47,7 +46,7 @@ testPoolNetworkID pv poolParams e = do
         runShelleyBase $
           applySTSTest @(ShelleyPOOL ShelleyTest)
             ( TRC
-                ( PoolEnv (SlotNo 0) $ emptyPParams & ppProtocolVersionL .~ pv
+                ( PoolEnv (epochFromSlotNo 0) $ emptyPParams & ppProtocolVersionL .~ pv
                 , def
                 , RegPool poolParams
                 )

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
@@ -52,7 +52,7 @@ certEnvSpec ::
   Specification fn (CertEnv era)
 certEnvSpec =
   constrained $ \ce ->
-    match ce $ \_slot pp _currEpoch _currCommittee _proposals ->
+    match ce $ \pp _currEpoch _currCommittee _proposals ->
       [ satisfies pp pparamsSpec
       ]
 
@@ -81,7 +81,7 @@ conwayTxCertSpec ::
   CertEnv (ConwayEra StandardCrypto) ->
   CertState (ConwayEra StandardCrypto) ->
   Specification fn (ConwayTxCert (ConwayEra StandardCrypto))
-conwayTxCertSpec (CertEnv slot pp ce cc cp) certState@CertState {..} =
+conwayTxCertSpec (CertEnv pp ce cc cp) certState@CertState {..} =
   constrained $ \txCert ->
     caseOn
       txCert
@@ -92,7 +92,7 @@ conwayTxCertSpec (CertEnv slot pp ce cc cp) certState@CertState {..} =
       (branchW 2 $ \govCert -> satisfies govCert $ govCertSpec govCertEnv certState)
   where
     delegEnv = ConwayDelegEnv pp (psStakePoolParams certPState)
-    poolEnv = PoolEnv slot pp
+    poolEnv = PoolEnv ce pp
     govCertEnv = ConwayGovCertEnv pp ce cc cp
 
 -- ==============================================================
@@ -143,7 +143,7 @@ shelleyTxCertSpec ::
   CertEnv era ->
   CertState era ->
   Specification fn (ShelleyTxCert era)
-shelleyTxCertSpec (CertEnv slot pp _ _ _) (CertState _vstate pstate dstate) =
+shelleyTxCertSpec (CertEnv pp e _ _) (CertState _vstate pstate dstate) =
   constrained $ \ [var|shelleyTxCert|] ->
     -- These weights try to make it equally likely that each of the many certs
     -- across the 3 categories are chosen at similar frequencies.
@@ -156,7 +156,7 @@ shelleyTxCertSpec (CertEnv slot pp _ _ _) (CertState _vstate pstate dstate) =
                 dstate
             )
       )
-      (branchW 3 $ \ [var|poolCert|] -> satisfies poolCert $ poolCertSpec (PoolEnv slot pp) pstate)
+      (branchW 3 $ \ [var|poolCert|] -> satisfies poolCert $ poolCertSpec (PoolEnv e pp) pstate)
       (branchW 1 $ \ [var|genesis|] -> satisfies genesis (genesisDelegCertSpec @fn @era dstate))
       (branchW 1 $ \ [var|_mir|] -> False) -- By design, we never generate a MIR cert
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
@@ -103,7 +103,7 @@ certsEnvSpec ::
   (EraSpecPParams era, HasSpec fn (Tx era), IsConwayUniv fn) =>
   Specification fn (CertsEnv era)
 certsEnvSpec = constrained $ \ce ->
-  match ce $ \tx pp _slot _currepoch _currcommittee commproposals ->
+  match ce $ \tx pp _currepoch _currcommittee commproposals ->
     [ satisfies pp pparamsSpec
     , assert $ tx ==. lit txZero
     , genHint 3 commproposals
@@ -114,7 +114,6 @@ projectEnv :: CertsEnv era -> CertEnv era
 projectEnv x =
   CertEnv
     { cePParams = certsPParams x
-    , ceSlotNo = certsSlotNo x
     , ceCurrentEpoch = certsCurrentEpoch x
     , ceCurrentCommittee = certsCurrentCommittee x
     , ceCommitteeProposals = certsCommitteeProposals x

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Pool.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Pool.hs
@@ -60,7 +60,7 @@ poolCertSpec ::
   PoolEnv era ->
   PState era ->
   Specification fn (PoolCert (EraCrypto era))
-poolCertSpec (PoolEnv s pp) ps =
+poolCertSpec (PoolEnv e pp) ps =
   constrained $ \pc ->
     (caseOn pc)
       -- RegPool !(PoolParams c)
@@ -76,7 +76,7 @@ poolCertSpec (PoolEnv s pp) ps =
       -- RetirePool !(KeyHash 'StakePool c) !EpochNo
       ( branchW 1 $ \keyHash epochNo ->
           [ epochNo <=. lit (maxEpochNo - 1)
-          , lit (currentEpoch s) <. epochNo
+          , lit e <. epochNo
           , elem_ keyHash $ lit rpools
           ]
       )

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -3572,7 +3572,7 @@ instance Reflect era => PrettyA (ConwayGovCertEnv era) where
   prettyA = pcConwayGovCertEnv
 
 pcPoolEnv :: Reflect era => PoolEnv era -> PDoc
-pcPoolEnv (PoolEnv sn pp) = ppSexp "PoolEnv" [pcSlotNo sn, pcPParams reify pp]
+pcPoolEnv (PoolEnv en pp) = ppSexp "PoolEnv" [ppEpochNo en, pcPParams reify pp]
 
 instance forall era. Reflect era => PrettyA (PoolEnv era) where
   prettyA = pcPoolEnv
@@ -3646,8 +3646,7 @@ instance Reflect era => PrettyA (CertEnv era) where
   prettyA CertEnv {..} =
     ppRecord
       "CertEnv"
-      [ ("slot no", prettyA ceSlotNo)
-      , ("pparams", prettyA cePParams)
+      [ ("pparams", prettyA cePParams)
       , ("currentEpoch", prettyA ceCurrentEpoch)
       ]
 
@@ -3664,12 +3663,11 @@ instance PrettyA x => PrettyA (Seq x) where
   prettyA x = prettyA (toList x)
 
 instance PrettyA (ConwayRules.CertsEnv era) where
-  prettyA (ConwayRules.CertsEnv _ _ slot epoch com prop) =
+  prettyA (ConwayRules.CertsEnv _ _ epoch com prop) =
     ppRecord
       "CertsEnv"
       [ ("Tx", ppString "Tx")
       , ("pparams", ppString "PParams")
-      , ("slot", pcSlotNo slot)
       , ("epoch", ppEpochNo epoch)
       , ("committee", ppStrictMaybe pcCommittee com)
       , ("proposals", ppMap pcGovPurposeId prettyA prop)


### PR DESCRIPTION
# Description

Slightly simplify rules by not passing slotNo around when not required.

Closes https://github.com/IntersectMBO/cardano-ledger/issues/4692

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
