### PR TITLE
Run conformance on `passTick`

### DIFF
--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Test.Cardano.Ledger.Conway.Imp (spec) where
+module Test.Cardano.Ledger.Conway.Imp (spec, conwaySpec) where
 
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext (..))
 import Cardano.Ledger.Alonzo.Rules (
@@ -54,18 +54,23 @@ import qualified Test.Cardano.Ledger.Conway.Imp.LedgerSpec as Ledger
 import qualified Test.Cardano.Ledger.Conway.Imp.RatifySpec as Ratify
 import qualified Test.Cardano.Ledger.Conway.Imp.UtxoSpec as Utxo
 import qualified Test.Cardano.Ledger.Conway.Imp.UtxosSpec as Utxos
-import Test.Cardano.Ledger.Conway.ImpTest (ConwayEraImp, LedgerSpec, modifyImpInitProtVer)
+import Test.Cardano.Ledger.Conway.ImpTest (
+  ConwayEraImp,
+  LedgerSpec,
+  modifyImpInitProtVer,
+ )
 import Test.Cardano.Ledger.Imp.Common
+import Test.Cardano.Ledger.Shelley.ImpTest (ImpInit)
 
 spec ::
   forall era.
   ( Arbitrary (TxAuxData era)
   , ConwayEraImp era
   , EraSegWits era
-  , InjectRuleFailure "LEDGER" ConwayGovPredFailure era
-  , InjectRuleFailure "LEDGER" ConwayCertsPredFailure era
   , Inject (BabbageContextError era) (ContextError era)
   , Inject (ConwayContextError era) (ContextError era)
+  , InjectRuleFailure "LEDGER" ConwayGovPredFailure era
+  , InjectRuleFailure "LEDGER" ConwayCertsPredFailure era
   , InjectRuleFailure "LEDGER" BabbageUtxoPredFailure era
   , InjectRuleFailure "LEDGER" BabbageUtxowPredFailure era
   , InjectRuleFailure "LEDGER" AlonzoUtxoPredFailure era
@@ -77,38 +82,74 @@ spec ::
   , InjectRuleFailure "LEDGER" ConwayGovCertPredFailure era
   , InjectRuleFailure "LEDGER" ConwayLedgerPredFailure era
   , InjectRuleFailure "BBODY" ConwayBbodyPredFailure era
-  , NFData (Event (EraRule "ENACT" era))
-  , ToExpr (Event (EraRule "ENACT" era))
-  , Eq (Event (EraRule "ENACT" era))
-  , Typeable (Event (EraRule "ENACT" era))
   , InjectRuleEvent "TICK" ConwayEpochEvent era
   , Event (EraRule "EPOCH" era) ~ ConwayEpochEvent era
   , Event (EraRule "NEWEPOCH" era) ~ ConwayNewEpochEvent era
   , Event (EraRule "MEMPOOL" era) ~ ConwayMempoolEvent era
   , Event (EraRule "LEDGERS" era) ~ ShelleyLedgersEvent era
   , Event (EraRule "LEDGER" era) ~ ConwayLedgerEvent era
+  , Event (EraRule "HARDFORK" era) ~ ConwayHardForkEvent era
   , BaseM (EraRule "LEDGERS" era) ~ ShelleyBase
   , Environment (EraRule "LEDGERS" era) ~ ShelleyLedgersEnv era
   , Signal (EraRule "LEDGERS" era) ~ Seq (Tx era)
   , STS (EraRule "LEDGERS" era)
   , ApplyTx era
-  , Event (EraRule "HARDFORK" era) ~ ConwayHardForkEvent era
+  , NFData (Event (EraRule "ENACT" era))
+  , ToExpr (Event (EraRule "ENACT" era))
+  , Eq (Event (EraRule "ENACT" era))
+  , Typeable (Event (EraRule "ENACT" era))
   ) =>
   Spec
 spec = do
   BabbageImp.spec @era
-  withImpInit @(LedgerSpec era) $
-    forM_ (eraProtVersions @era) $ \protVer ->
-      describe ("ConwayImpSpec - " <> show protVer) $
-        modifyImpInitProtVer protVer $ do
-          describe "BBODY" Bbody.spec
-          describe "CERTS" Certs.spec
-          describe "DELEG" Deleg.spec
-          describe "ENACT" Enact.spec
-          describe "EPOCH" Epoch.spec
-          describe "GOV" Gov.spec
-          describe "GOVCERT" GovCert.spec
-          describe "LEDGER" Ledger.spec
-          describe "RATIFY" Ratify.spec
-          describe "UTXO" Utxo.spec
-          describe "UTXOS" Utxos.spec
+  withImpInit @(LedgerSpec era) $ conwaySpec @era
+
+conwaySpec ::
+  forall era.
+  ( ConwayEraImp era
+  , EraSegWits era
+  , Inject (BabbageContextError era) (ContextError era)
+  , Inject (ConwayContextError era) (ContextError era)
+  , InjectRuleFailure "LEDGER" ConwayGovPredFailure era
+  , InjectRuleFailure "LEDGER" ConwayCertsPredFailure era
+  , InjectRuleFailure "LEDGER" BabbageUtxoPredFailure era
+  , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
+  , InjectRuleFailure "LEDGER" AlonzoUtxowPredFailure era
+  , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
+  , InjectRuleFailure "LEDGER" ConwayDelegPredFailure era
+  , InjectRuleFailure "LEDGER" ConwayGovCertPredFailure era
+  , InjectRuleFailure "LEDGER" ConwayLedgerPredFailure era
+  , InjectRuleFailure "BBODY" ConwayBbodyPredFailure era
+  , InjectRuleEvent "TICK" ConwayEpochEvent era
+  , Event (EraRule "EPOCH" era) ~ ConwayEpochEvent era
+  , Event (EraRule "NEWEPOCH" era) ~ ConwayNewEpochEvent era
+  , Event (EraRule "MEMPOOL" era) ~ ConwayMempoolEvent era
+  , Event (EraRule "LEDGERS" era) ~ ShelleyLedgersEvent era
+  , Event (EraRule "LEDGER" era) ~ ConwayLedgerEvent era
+  , Event (EraRule "HARDFORK" era) ~ ConwayHardForkEvent era
+  , BaseM (EraRule "LEDGERS" era) ~ ShelleyBase
+  , Environment (EraRule "LEDGERS" era) ~ ShelleyLedgersEnv era
+  , Signal (EraRule "LEDGERS" era) ~ Seq (Tx era)
+  , STS (EraRule "LEDGERS" era)
+  , ApplyTx era
+  , NFData (Event (EraRule "ENACT" era))
+  , ToExpr (Event (EraRule "ENACT" era))
+  , Eq (Event (EraRule "ENACT" era))
+  , Typeable (Event (EraRule "ENACT" era))
+  ) =>
+  SpecWith (ImpInit (LedgerSpec era))
+conwaySpec = do
+  forM_ (eraProtVersions @era) $ \protVer ->
+    describe ("ConwayImpSpec - " <> show protVer) $
+      modifyImpInitProtVer protVer $ do
+        describe "BBODY" Bbody.spec
+        describe "CERTS" Certs.spec
+        describe "DELEG" Deleg.spec
+        describe "ENACT" Enact.spec
+        describe "EPOCH" Epoch.spec
+        describe "GOV" Gov.spec
+        describe "GOVCERT" GovCert.spec
+        describe "LEDGER" Ledger.spec
+        describe "RATIFY" Ratify.spec
+        describe "UTXO" Utxo.spec
+        describe "UTXOS" Utxos.spec

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -35,6 +35,10 @@
 
 ### `testlib`
 
+* Add `iteHook` to `ImpTesEnv` for additionally checking conformance with ImpTests. #4748
+  * Add lens `iteHookL`.
+  * Add `withHook` modifier for `ImpTestM era a`
+  * Add `modifyImpInitHook`.
 * Switch to using `ImpSpec` package
 * Remove: `runImpTestM`, `runImpTestM_`, `evalImpTestM`, `execImpTestM`, `runImpTestGenM`, `runImpTestGenM_`, `evalImpTestGenM`, `execImpTestGenM`, `withImpState` and `withImpStateModified`.
 * Add `LedgerSpec`, `modifyImpInitProtVer`.

--- a/libs/ImpSpec/ImpSpec.cabal
+++ b/libs/ImpSpec/ImpSpec.cabal
@@ -47,7 +47,8 @@ library
         prettyprinter-ansi-terminal,
         random,
         text,
-        unliftio
+        unliftio,
+        microlens
 
 test-suite tests
     type:             exitcode-stdio-1.0

--- a/libs/ImpSpec/src/Test/ImpSpec/Internal.hs
+++ b/libs/ImpSpec/src/Test/ImpSpec/Internal.hs
@@ -25,6 +25,7 @@ import Data.Proxy (Proxy (..))
 import Data.Text (Text)
 import qualified Data.Text.Lazy as TL
 import GHC.Stack (CallStack, HasCallStack, SrcLoc (..), getCallStack)
+import Lens.Micro
 import Prettyprinter (
   Doc,
   Pretty (..),
@@ -96,6 +97,12 @@ data ImpInit t = ImpInit
 deriving instance (Eq (ImpSpecEnv t), Eq (ImpSpecState t)) => Eq (ImpInit t)
 deriving instance (Ord (ImpSpecEnv t), Ord (ImpSpecState t)) => Ord (ImpInit t)
 deriving instance (Show (ImpSpecEnv t), Show (ImpSpecState t)) => Show (ImpInit t)
+
+impInitEnvL :: Lens' (ImpInit t) (ImpSpecEnv t)
+impInitEnvL = lens impInitEnv $ \x y -> x {impInitEnv = y}
+
+impInitStateL :: Lens' (ImpInit t) (ImpSpecState t)
+impInitStateL = lens impInitState $ \x y -> x {impInitState = y}
 
 -- | Stores extra information about the failure of the unit test
 data ImpException = ImpException

--- a/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
+++ b/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
@@ -22,13 +22,13 @@ library
     exposed-modules:
         Test.Cardano.Ledger.Conformance
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Core
+        Test.Cardano.Ledger.Conformance.SpecTranslate.Core
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway
 
     hs-source-dirs:   src
     other-modules:
-        Test.Cardano.Ledger.Conformance.SpecTranslate.Core
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool
@@ -106,6 +106,7 @@ test-suite tests
         Test.Cardano.Ledger.Conformance.Spec.Conway
         Test.Cardano.Ledger.Conformance.ExecSpecRule.MiniTrace
         Test.Cardano.Ledger.Conformance.Imp.Ratify
+        Test.Cardano.Ledger.Conformance.Imp
 
     default-language: Haskell2010
     ghc-options:
@@ -116,9 +117,11 @@ test-suite tests
     build-depends:
         base >=4.14 && <5,
         containers,
+        data-default,
         cardano-data,
         constrained-generators,
         small-steps,
+        cardano-ledger-binary,
         cardano-ledger-conformance,
         cardano-ledger-core:{cardano-ledger-core, testlib},
         cardano-strict-containers,
@@ -126,4 +129,6 @@ test-suite tests
         cardano-ledger-alonzo,
         cardano-ledger-conway:{cardano-ledger-conway, testlib},
         cardano-ledger-test,
-        microlens
+        microlens,
+        microlens-mtl,
+        unliftio

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway.hs
@@ -1,6 +1,7 @@
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway (
   module X,
   ConwayRatifyExecContext (..),
+  ConwayLedgerExecContext (..),
 ) where
 
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base as X (
@@ -16,7 +17,9 @@ import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Certs as X (nameCerts
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg as X (nameDelegCert)
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Gov as X ()
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.GovCert as X (nameGovCert)
-import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Ledger as X ()
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Ledger as X (
+  ConwayLedgerExecContext (..),
+ )
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Ledgers as X ()
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Pool as X (namePoolCert)
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Utxo as X ()

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
@@ -13,7 +13,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Ledger () where
+module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Ledger (ConwayLedgerExecContext (..)) where
 
 import Data.Bifunctor (Bifunctor (..))
 import Data.Functor.Identity (Identity)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
@@ -21,6 +21,8 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
   checkConformance,
   defaultTestConformance,
   translateWithContext,
+  ForAllExecSpecRep,
+  ForAllExecTypes,
 ) where
 
 import Cardano.Ledger.BaseTypes (Inject (..), ShelleyBase)

--- a/libs/cardano-ledger-conformance/test/Main.hs
+++ b/libs/cardano-ledger-conformance/test/Main.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Main (main) where
 

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Test.Cardano.Ledger.Conformance.Imp (spec) where
+
+import Cardano.Ledger.Alonzo.Tx (AlonzoTx)
+import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.Binary (EncCBOR)
+import Cardano.Ledger.Conway (Conway)
+import Cardano.Ledger.Conway.Rules
+import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley.Governance
+import Cardano.Ledger.Shelley.LedgerState
+import Cardano.Ledger.Shelley.Rules (UtxoEnv (..))
+import Control.State.Transition
+import Data.Bifunctor (bimap)
+import Data.Bitraversable (bimapM)
+import Data.Default (def)
+import Data.List.NonEmpty
+import Lens.Micro
+import Lens.Micro.Mtl (use)
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway (ConwayLedgerExecContext (..))
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
+import Test.Cardano.Ledger.Constrained.Conway
+import Test.Cardano.Ledger.Conway.Imp qualified as ConwayImp (conwaySpec)
+import Test.Cardano.Ledger.Conway.ImpTest
+import Test.Cardano.Ledger.Imp.Common hiding (Args)
+import UnliftIO (evaluateDeep)
+
+testImpConformance ::
+  forall era.
+  ( ConwayEraImp era
+  , ExecSpecRule ConwayFn "LEDGER" era
+  , ExecContext ConwayFn "LEDGER" era ~ ConwayLedgerExecContext era
+  , ExecSignal ConwayFn "LEDGER" era ~ AlonzoTx era
+  , ExecState ConwayFn "LEDGER" era ~ LedgerState era
+  , SpecTranslate (ExecContext ConwayFn "LEDGER" era) (ExecState ConwayFn "LEDGER" era)
+  , ForAllExecSpecRep NFData ConwayFn "LEDGER" era
+  , ForAllExecSpecRep ToExpr ConwayFn "LEDGER" era
+  , NFData (SpecRep (PredicateFailure (EraRule "LEDGER" era)))
+  , ToExpr (SpecRep (PredicateFailure (EraRule "LEDGER" era)))
+  , Eq (SpecRep (PredicateFailure (EraRule "LEDGER" era)))
+  , FixupSpecRep (SpecRep (PredicateFailure (EraRule "LEDGER" era)))
+  , EncCBOR (ExecContext ConwayFn "LEDGER" era)
+  , EncCBOR (Environment (EraRule "LEDGER" era))
+  , EncCBOR (State (EraRule "LEDGER" era))
+  , ToExpr (ExecContext ConwayFn "LEDGER" era)
+  , HasCallStack
+  ) =>
+  Either
+    (NonEmpty (PredicateFailure (EraRule "LEDGER" era)))
+    (State (EraRule "LEDGER" era), [Event (EraRule "LEDGER" era)]) ->
+  ExecEnvironment ConwayFn "LEDGER" era ->
+  ExecState ConwayFn "LEDGER" era ->
+  ExecSignal ConwayFn "LEDGER" era ->
+  ImpM (LedgerSpec era) ()
+testImpConformance impRuleResult env state signal = do
+  logDoc $
+    mconcat
+      [ "\n----- LedgerEnv:\n"
+      , ansiExpr env
+      , "\n----- LedgerState:\n"
+      , ansiExpr state
+      , "\n----- Transaction:\n"
+      , ansiExpr signal
+      ]
+  slot <- use impLastTickG
+  let ctx :: ConwayLedgerExecContext era =
+        ConwayLedgerExecContext
+          { clecPolicyHash = SNothing
+          , clecEnactState = def
+          , clecUtxoExecContext =
+              UtxoExecContext
+                { uecTx = signal
+                , uecUTxO = state ^. lsUTxOStateL . utxosUtxoL
+                , uecUtxoEnv =
+                    UtxoEnv
+                      { ueSlot = slot
+                      , uePParams = state ^. lsUTxOStateL . utxosGovStateL . curPParamsGovStateL
+                      , ueCertState = state ^. lsCertStateL
+                      }
+                }
+          }
+  logDoc $ "\n----- ConwayLedgerExecContext:\n" <> ansiExpr ctx
+
+  (specEnv, specState, specSignal) <-
+    impAnn "Translating the inputs" $
+      translateInputs @ConwayFn @"LEDGER" @era env state signal ctx
+  logDoc $
+    mconcat
+      [ "\n----- spec LedgerEnv:\n"
+      , ansiExpr specEnv
+      , "\n----- spec LedgerState:\n"
+      , ansiExpr specState
+      , "\n----- spec Transaction:\n"
+      , ansiExpr specSignal
+      ]
+
+  agdaResponse <-
+    fmap (bimap (fixup <$>) fixup) $
+      impAnn "Deep evaluating Agda output" $
+        evaluateDeep $
+          runAgdaRule @ConwayFn @"LEDGER" @era specEnv specState specSignal
+
+  impResponse <-
+    impAnn "Translating implementation values to SpecRep" $
+      expectRightExpr $
+        runSpecTransM ctx $
+          bimapM
+            (traverse toTestRep)
+            (toTestRep . inject @_ @(ExecState ConwayFn "LEDGER" era) . fst)
+            impRuleResult
+
+  checkConformance @"LEDGER" @era @ConwayFn
+    ctx
+    (inject env)
+    (inject state)
+    (inject signal)
+    impResponse
+    agdaResponse
+
+spec :: Spec
+spec =
+  withImpInit @(LedgerSpec Conway) $ do
+    xdescribe "Tx conformance"
+      . modifyImpInitProtVer @Conway (natVersion @10)
+      . modifyImpInitHook testImpConformance
+      $ do
+        it "Tx conformance" $ do
+          _ <- submitConstitution @Conway SNothing
+          passNEpochs 2
+    xdescribe "Test.Cardano.Ledger.Conway.Imp conformance" $
+      modifyImpInitHook testImpConformance $
+        ConwayImp.conwaySpec @Conway

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -7,8 +8,9 @@ module Test.Cardano.Ledger.Conformance.Spec.Conway (spec) where
 import Cardano.Ledger.Conway (Conway)
 import Test.Cardano.Ledger.Conformance (conformsToImpl, inputsGenerateWithin)
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway ()
-import qualified Test.Cardano.Ledger.Conformance.ExecSpecRule.MiniTrace as MiniTrace
-import qualified Test.Cardano.Ledger.Conformance.Imp.Ratify as RatifyImp
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.MiniTrace qualified as MiniTrace
+import Test.Cardano.Ledger.Conformance.Imp qualified as Imp (spec)
+import Test.Cardano.Ledger.Conformance.Imp.Ratify qualified as RatifyImp
 import Test.Cardano.Ledger.Constrained.Conway
 import Test.Cardano.Ledger.Conway.ImpTest ()
 import Test.Cardano.Ledger.Imp.Common
@@ -38,3 +40,4 @@ spec = do
       xprop "LEDGERS" $ conformsToImpl @"LEDGERS" @ConwayFn @Conway
     describe "ImpTests" $ do
       RatifyImp.spec
+      Imp.spec


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
