### PR TITLE
Pass epochNo from BBODY instead of re-computing it  in downstream rules

### DIFF
--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
@@ -70,7 +70,7 @@ instance
   TQC.HasTrace (AlonzoLEDGER era) (GenEnv era)
   where
   envGen GenEnv {geConstants} =
-    LedgerEnv (SlotNo 0) minBound
+    LedgerEnv (SlotNo 0) Nothing minBound
       <$> genEraPParams @era geConstants
       <*> genAccountState geConstants
       <*> pure False

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.18.0.0
 
+* Remove `SlotNo` from `CertEnv` and `CertsEnv`
 * Remove deprecated `translateTxOut` and `conwayWitsVKeyNeeded`
 * Add `DefaultVote` and `defaultStakePoolVote`
 * Add new event `GovRemovedVotes` for invalidated votes.

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
@@ -29,7 +29,6 @@ import Cardano.Ledger.BaseTypes (
   EpochNo (EpochNo),
   Globals (..),
   ShelleyBase,
-  SlotNo,
   StrictMaybe,
   binOpEpochNo,
  )
@@ -89,7 +88,6 @@ import NoThunks.Class (NoThunks (..))
 data CertsEnv era = CertsEnv
   { certsTx :: !(Tx era)
   , certsPParams :: !(PParams era)
-  , certsSlotNo :: !SlotNo
   , certsCurrentEpoch :: !EpochNo
   , certsCurrentCommittee :: StrictMaybe (Committee era)
   , certsCommitteeProposals :: Map.Map (GovPurposeId 'CommitteePurpose era) (GovActionState era)
@@ -97,13 +95,12 @@ data CertsEnv era = CertsEnv
   deriving (Generic)
 
 instance EraTx era => EncCBOR (CertsEnv era) where
-  encCBOR x@(CertsEnv _ _ _ _ _ _) =
+  encCBOR x@(CertsEnv _ _ _ _ _) =
     let CertsEnv {..} = x
      in encode $
           Rec CertsEnv
             !> To certsTx
             !> To certsPParams
-            !> To certsSlotNo
             !> To certsCurrentEpoch
             !> To certsCurrentCommittee
             !> To certsCommitteeProposals
@@ -217,7 +214,7 @@ conwayCertsTransition ::
   TransitionRule (ConwayCERTS era)
 conwayCertsTransition = do
   TRC
-    ( env@(CertsEnv tx pp slot currentEpoch committee committeeProposals)
+    ( env@(CertsEnv tx pp currentEpoch committee committeeProposals)
       , certState
       , certificates
       ) <-
@@ -271,7 +268,7 @@ conwayCertsTransition = do
       certState' <-
         trans @(ConwayCERTS era) $ TRC (env, certState, gamma)
       trans @(EraRule "CERT" era) $
-        TRC (CertEnv slot pp currentEpoch committee committeeProposals, certState', txCert)
+        TRC (CertEnv pp currentEpoch committee committeeProposals, certState', txCert)
 
 instance
   ( Era era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
@@ -226,10 +226,11 @@ spec = do
       let ls = nes ^. nesEsL . esLStateL
           pp = nes ^. nesEsL . curPParamsEpochStateL
           account = nes ^. nesEsL . esAccountStateL
+          epochNo = nes ^. nesELL
       tx <- fixupTx $ mkBasicTx mkBasicTxBody
       Right (_, evs) <-
         tryRunImpRule @"LEDGERS"
-          (LedgersEnv slotNo pp account)
+          (LedgersEnv slotNo epochNo pp account)
           ls
           (Seq.singleton tx)
       let mempoolEvents = [ev | LedgerEvent ev@(MempoolEvent (ConwayMempoolEvent _)) <- evs]

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Allegra/ScriptTranslation.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Allegra/ScriptTranslation.hs
@@ -58,7 +58,14 @@ testScriptPostTranslation =
               Map.singleton
                 (S.TxIn bootstrapTxId minBound)
                 (S.ShelleyTxOut addr (Val.inject (S.Coin 1)))
-          env = S.LedgerEnv (SlotNo 0) minBound emptyPParams (S.AccountState (S.Coin 0) (S.Coin 0)) False
+          env =
+            S.LedgerEnv
+              (SlotNo 0)
+              Nothing
+              minBound
+              emptyPParams
+              (S.AccountState (S.Coin 0) (S.Coin 0))
+              False
           utxoStShelley = def {S.utxosUtxo = utxo}
           utxoStAllegra = fromRight . runExcept $ translateEra @Allegra NoGenesis utxoStShelley
           txb =

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
@@ -97,7 +97,7 @@ pp =
     & ppMinUTxOValueL .~ Coin 100
 
 ledgerEnv :: SlotNo -> LedgerEnv Mary
-ledgerEnv s = LedgerEnv s minBound pp (AccountState (Coin 0) (Coin 0)) False
+ledgerEnv s = LedgerEnv s Nothing minBound pp (AccountState (Coin 0) (Coin 0)) False
 
 feeEx :: Coin
 feeEx = Coin 3

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.15.0.0
 
+* Change `PoolEnv` to take `EpochNo` instead of `SlotNo`
+* Add `EpochNo` to `DelplEnv`
+* Add `Maybe EpochNo` to `LedgerEnv`
+* Add `EpochNo` to `LedgersEnv`
 * Added `Generic`, `Eq`, `Show`, `NFData`, `EncCBOR` instances for `ShelleyLedgersEnv`
 * Remove deprecated `witsVKeyNeededGov`, `witsVKeyNeededNoGov`, `shelleyWitsVKeyNeeded` and `propWits`
 * Remove deprecated `PPUPPredFailure`, `delPlAcnt`, `prAcnt`, `votedValue`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -193,6 +193,7 @@ mkMempoolEnv
   slot =
     Ledger.LedgerEnv
       { Ledger.ledgerSlotNo = slot
+      , Ledger.ledgerEpochNo = Nothing
       , Ledger.ledgerIx = minBound
       , Ledger.ledgerPp = nesEs ^. curPParamsEpochStateL
       , Ledger.ledgerAccount = LedgerState.esAccountState nesEs

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
@@ -29,6 +29,7 @@ module Cardano.Ledger.Shelley.Rules.Delegs (
 where
 
 import Cardano.Ledger.BaseTypes (
+  EpochNo,
   Network,
   ShelleyBase,
   TxIx,
@@ -100,6 +101,7 @@ import Validation (failureUnless)
 
 data DelegsEnv era = DelegsEnv
   { delegsSlotNo :: !SlotNo
+  , delegsEpochNo :: !EpochNo
   , delegsIx :: !TxIx
   , delegspp :: !(PParams era)
   , delegsTx :: !(Tx era)
@@ -235,7 +237,7 @@ delegsTransition ::
   ) =>
   TransitionRule (ShelleyDELEGS era)
 delegsTransition = do
-  TRC (env@(DelegsEnv slot txIx pp tx acnt), certState, certificates) <- judgmentContext
+  TRC (env@(DelegsEnv slot epochNo txIx pp tx acnt), certState, certificates) <- judgmentContext
   network <- liftSTS $ asks networkId
 
   case certificates of
@@ -257,7 +259,7 @@ delegsTransition = do
       -- transaction, therefore partial function is justified.
       let ptr = Ptr slot txIx (mkCertIxPartial $ toInteger $ length gamma)
       trans @(EraRule "DELPL" era) $
-        TRC (DelplEnv slot ptr pp acnt, certState', txCert)
+        TRC (DelplEnv slot epochNo ptr pp acnt, certState', txCert)
 
 validateStakePoolDelegateeRegistered ::
   PState era ->

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
@@ -23,7 +23,7 @@ module Cardano.Ledger.Shelley.Rules.Delpl (
 )
 where
 
-import Cardano.Ledger.BaseTypes (ShelleyBase, invalidKey)
+import Cardano.Ledger.BaseTypes (EpochNo, ShelleyBase, invalidKey)
 import Cardano.Ledger.Binary (
   DecCBOR (..),
   EncCBOR (..),
@@ -60,6 +60,7 @@ import NoThunks.Class (NoThunks (..))
 
 data DelplEnv era = DelplEnv
   { delplSlotNo :: SlotNo
+  , delpEpochNo :: EpochNo
   , delPlPtr :: Ptr
   , delPlPp :: PParams era
   , delPlAccount :: AccountState
@@ -199,22 +200,22 @@ delplTransition ::
   ) =>
   TransitionRule (ShelleyDELPL era)
 delplTransition = do
-  TRC (DelplEnv slot ptr pp acnt, d, c) <- judgmentContext
+  TRC (DelplEnv slot eNo ptr pp acnt, d, c) <- judgmentContext
   case c of
     ShelleyTxCertPool poolCert -> do
       ps <-
-        trans @(EraRule "POOL" era) $ TRC (PoolEnv slot pp, certPState d, poolCert)
+        trans @(EraRule "POOL" era) $ TRC (PoolEnv eNo pp, certPState d, poolCert)
       pure $ d {certPState = ps}
     ShelleyTxCertGenesisDeleg GenesisDelegCert {} -> do
       ds <-
-        trans @(EraRule "DELEG" era) $ TRC (DelegEnv slot ptr acnt pp, certDState d, c)
+        trans @(EraRule "DELEG" era) $ TRC (DelegEnv slot eNo ptr acnt pp, certDState d, c)
       pure $ d {certDState = ds}
     ShelleyTxCertDelegCert _ -> do
       ds <-
-        trans @(EraRule "DELEG" era) $ TRC (DelegEnv slot ptr acnt pp, certDState d, c)
+        trans @(EraRule "DELEG" era) $ TRC (DelegEnv slot eNo ptr acnt pp, certDState d, c)
       pure $ d {certDState = ds}
     ShelleyTxCertMir _ -> do
-      ds <- trans @(EraRule "DELEG" era) $ TRC (DelegEnv slot ptr acnt pp, certDState d, c)
+      ds <- trans @(EraRule "DELEG" era) $ TRC (DelegEnv slot eNo ptr acnt pp, certDState d, c)
       pure $ d {certDState = ds}
 
 instance

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -27,13 +27,13 @@ where
 import Cardano.Crypto.Hash.Class (sizeHash)
 import Cardano.Ledger.Address (raNetwork)
 import Cardano.Ledger.BaseTypes (
+  EpochNo,
   Globals (..),
   Mismatch (..),
   Network,
   Relation (..),
   ShelleyBase,
   addEpochInterval,
-  epochInfoPure,
   invalidKey,
   networkId,
  )
@@ -53,7 +53,6 @@ import Cardano.Ledger.Shelley.Era (ShelleyEra, ShelleyPOOL)
 import qualified Cardano.Ledger.Shelley.HardForks as HardForks
 import Cardano.Ledger.Shelley.LedgerState (PState (..), payPoolDeposit)
 import qualified Cardano.Ledger.Shelley.SoftForks as SoftForks
-import Cardano.Ledger.Slot (EpochNo (..), SlotNo, epochInfoEpoch)
 import Control.DeepSeq
 import Control.Monad (forM_, when)
 import Control.Monad.Trans.Reader (asks)
@@ -75,14 +74,14 @@ import Lens.Micro ((^.))
 import NoThunks.Class (NoThunks (..))
 
 data PoolEnv era
-  = PoolEnv !SlotNo !(PParams era)
+  = PoolEnv !EpochNo !(PParams era)
   deriving (Generic)
 
 instance EraPParams era => EncCBOR (PoolEnv era) where
-  encCBOR (PoolEnv s pp) =
+  encCBOR (PoolEnv e pp) =
     encode $
       Rec PoolEnv
-        !> To s
+        !> To e
         !> To pp
 
 deriving instance Show (PParams era) => Show (PoolEnv era)
@@ -199,7 +198,7 @@ poolDelegationTransition ::
   TransitionRule (ledger era)
 poolDelegationTransition = do
   TRC
-    ( PoolEnv slot pp
+    ( PoolEnv cEpoch pp
       , ps@PState {psStakePoolParams, psFutureStakePoolParams, psRetiring}
       , poolCert
       ) <-
@@ -260,16 +259,13 @@ poolDelegationTransition = do
               }
     RetirePool hk e -> do
       eval (hk ∈ dom psStakePoolParams) ?! StakePoolNotRegisteredOnKeyPOOL hk
-      cepoch <- liftSTS $ do
-        ei <- asks epochInfoPure
-        epochInfoEpoch ei slot
       let maxEpoch = pp ^. ppEMaxL
-          limitEpoch = addEpochInterval cepoch maxEpoch
-      (cepoch < e && e <= limitEpoch)
+          limitEpoch = addEpochInterval cEpoch maxEpoch
+      (cEpoch < e && e <= limitEpoch)
         ?! StakePoolRetirementWrongEpochPOOL
           Mismatch -- 'RelGT - The supplied value should be greater than the current epoch
             { mismatchSupplied = e
-            , mismatchExpected = cepoch
+            , mismatchExpected = cEpoch
             }
           Mismatch -- 'RelLTEQ - The supplied value should be less then or equal to ppEMax after the current epoch
             { mismatchSupplied = e

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -203,6 +203,7 @@ import Cardano.Ledger.Shelley.Rules (
   BbodyEnv (..),
   LedgerEnv (..),
   ShelleyBbodyState,
+  epochFromSlot,
  )
 import Cardano.Ledger.Shelley.Scripts (
   ShelleyEraScript,
@@ -633,9 +634,11 @@ modifyImpInitProtVer ver =
 impLedgerEnv :: EraGov era => NewEpochState era -> ImpTestM era (LedgerEnv era)
 impLedgerEnv nes = do
   slotNo <- gets impLastTick
+  epochNo <- runShelleyBase $ epochFromSlot slotNo
   pure
     LedgerEnv
       { ledgerSlotNo = slotNo
+      , ledgerEpochNo = Just epochNo
       , ledgerPp = nes ^. nesEsL . curPParamsEpochStateL
       , ledgerIx = TxIx 0
       , ledgerAccount = nes ^. nesEsL . esAccountStateL

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/BenchmarkFunctions.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/BenchmarkFunctions.hs
@@ -172,7 +172,7 @@ ppsBench =
     & ppTauL .~ unsafeBoundRational 0.2
 
 ledgerEnv :: (EraPParams era, ProtVerAtMost era 4, ProtVerAtMost era 6) => LedgerEnv era
-ledgerEnv = LedgerEnv (SlotNo 0) minBound ppsBench (AccountState (Coin 0) (Coin 0)) False
+ledgerEnv = LedgerEnv (SlotNo 0) Nothing minBound ppsBench (AccountState (Coin 0) (Coin 0)) False
 
 testLEDGER ::
   LedgerState B ->

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Block.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Block.hs
@@ -105,7 +105,7 @@ genBlock ge = genBlockWithTxGen genTxs ge
   where
     genTxs :: TxGen era
     genTxs pp reserves ls s = do
-      let ledgerEnv = LedgersEnv @era s pp reserves
+      let ledgerEnv = LedgersEnv @era s (epochFromSlotNo s) pp reserves
       block <- sigGen @(EraRule "LEDGERS" era) ge ledgerEnv ls
       genEraTweakBlock @era pp block
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/TxCert.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/TxCert.hs
@@ -70,7 +70,7 @@ import Test.Cardano.Ledger.Shelley.Generator.Core (GenEnv (..), KeySpace (..))
 import Test.Cardano.Ledger.Shelley.Generator.EraGen (EraGen (..))
 import Test.Cardano.Ledger.Shelley.Generator.ScriptClass (scriptKeyCombination)
 import Test.Cardano.Ledger.Shelley.Generator.TxCert (CertCred (..), genTxCert)
-import Test.Cardano.Ledger.Shelley.Utils (testGlobals)
+import Test.Cardano.Ledger.Shelley.Utils (epochFromSlotNo, testGlobals)
 import Test.Control.State.Transition.Trace (TraceOrder (OldestFirst), lastState, traceSignals)
 import qualified Test.Control.State.Transition.Trace.Generator.QuickCheck as QC
 import Test.QuickCheck (Gen)
@@ -133,9 +133,10 @@ certsTransition = do
   case c of
     Just (cert, _wits) -> do
       let ptr = Ptr slot txIx nextCertIx
+      let epoch = epochFromSlotNo slot
       dpState' <-
         trans @(Core.EraRule "DELPL" era) $
-          TRC (DelplEnv slot ptr pp acnt, dpState, cert)
+          TRC (DelplEnv slot epoch ptr pp acnt, dpState, cert)
 
       pure (dpState', succ nextCertIx)
     Nothing ->

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
@@ -156,7 +156,7 @@ genTx
         scriptspace
         constants
       )
-  (LedgerEnv slot txIx pparams reserves _)
+  (LedgerEnv slot _ txIx pparams reserves _)
   (LedgerState utxoSt@(UTxOState utxo _ _ _ _ _) dpState) =
     do
       -------------------------------------------------------------------------

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/MirTransfer.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/MirTransfer.hs
@@ -33,7 +33,13 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Lens.Micro
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (C_Crypto)
-import Test.Cardano.Ledger.Shelley.Utils (RawSeed (..), applySTSTest, mkKeyPair, runShelleyBase)
+import Test.Cardano.Ledger.Shelley.Utils (
+  RawSeed (..),
+  applySTSTest,
+  epochFromSlotNo,
+  mkKeyPair,
+  runShelleyBase,
+ )
 import Test.Control.State.Transition.Trace (checkTrace, (.-), (.->>))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, testCase, (@?=))
@@ -48,11 +54,14 @@ ignoreAllButIRWD = fmap dsIRewards
 env :: ProtVer -> AccountState -> DelegEnv ShelleyTest
 env pv acnt =
   DelegEnv
-    { slotNo = SlotNo 50
-    , ptr_ = Ptr (SlotNo 50) minBound minBound
+    { slotNo = slot
+    , curEpochNo = epochFromSlotNo slot
+    , ptr_ = Ptr slot minBound minBound
     , acnt_ = acnt
     , ppDE = emptyPParams & ppProtocolVersionL .~ pv
     }
+  where
+    slot = SlotNo 50
 
 shelleyPV :: ProtVer
 shelleyPV = ProtVer (natVersion @2) 0

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/NetworkID.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/NetworkID.hs
@@ -16,7 +16,7 @@ import Cardano.Ledger.Shelley.API (
   ShelleyPOOL,
  )
 import Cardano.Ledger.Shelley.Core
-import Cardano.Ledger.Slot (SlotNo (..))
+import Cardano.Ledger.Slot (EpochNo (..))
 import Control.State.Transition.Extended hiding (Assertion)
 import Data.Default (def)
 import Lens.Micro
@@ -47,7 +47,7 @@ testPoolNetworkID pv poolParams e = do
         runShelleyBase $
           applySTSTest @(ShelleyPOOL ShelleyTest)
             ( TRC
-                ( PoolEnv (SlotNo 0) $ emptyPParams & ppProtocolVersionL .~ pv
+                ( PoolEnv (EpochNo 0) $ emptyPParams & ppProtocolVersionL .~ pv
                 , def
                 , RegPool poolParams
                 )

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
@@ -345,7 +345,7 @@ addReward dp ra c = dp {certDState = ds {dsUnified = rewards'}}
 
 -- Any key deposit works in this test ^
 ledgerEnv :: LedgerEnv C
-ledgerEnv = LedgerEnv (SlotNo 0) minBound pp (AccountState (Coin 0) (Coin 0)) False
+ledgerEnv = LedgerEnv (SlotNo 0) Nothing minBound pp (AccountState (Coin 0) (Coin 0)) False
 
 testInvalidTx ::
   NonEmpty (PredicateFailure (ShelleyLEDGER C)) ->
@@ -506,7 +506,7 @@ testExpiredTx =
             , ttl = SlotNo 0
             , signers = [asWitness alicePay]
             }
-      ledgerEnv' = LedgerEnv (SlotNo 1) minBound pp (AccountState (Coin 0) (Coin 0)) False
+      ledgerEnv' = LedgerEnv (SlotNo 1) Nothing minBound pp (AccountState (Coin 0) (Coin 0)) False
    in testLEDGER ledgerState tx ledgerEnv' (Left errs)
 
 testInvalidWintess :: Assertion

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
@@ -130,7 +130,7 @@ instance
 
   environmentSpec ConwayLedgerExecContext {..} =
     let UtxoExecContext {..} = clecUtxoExecContext
-     in constrained' $ \slotNo _txIx pp _acntSt _mempool ->
+     in constrained' $ \slotNo _ _txIx pp _acntSt _mempool ->
           [ assert $ pp ==. lit (uePParams uecUtxoEnv)
           , assert $ slotNo ==. lit (ueSlot uecUtxoEnv)
           ]

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx/Gen.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx/Gen.hs
@@ -49,6 +49,7 @@ applyTxMempoolEnv :: PParams era -> MempoolEnv era
 applyTxMempoolEnv pp =
   LedgerEnv
     { ledgerSlotNo = SlotNo 0
+    , ledgerEpochNo = Nothing
     , ledgerIx = minBound
     , ledgerPp = pp
     , ledgerAccount = AccountState (Coin 45000000000) (Coin 45000000000)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
@@ -52,7 +52,7 @@ certEnvSpec ::
   Specification fn (CertEnv era)
 certEnvSpec =
   constrained $ \ce ->
-    match ce $ \_slot pp _currEpoch _currCommittee _proposals ->
+    match ce $ \pp _currEpoch _currCommittee _proposals ->
       [ satisfies pp pparamsSpec
       ]
 
@@ -81,7 +81,7 @@ conwayTxCertSpec ::
   CertEnv (ConwayEra StandardCrypto) ->
   CertState (ConwayEra StandardCrypto) ->
   Specification fn (ConwayTxCert (ConwayEra StandardCrypto))
-conwayTxCertSpec (CertEnv slot pp ce cc cp) certState@CertState {..} =
+conwayTxCertSpec (CertEnv pp ce cc cp) certState@CertState {..} =
   constrained $ \txCert ->
     caseOn
       txCert
@@ -92,7 +92,7 @@ conwayTxCertSpec (CertEnv slot pp ce cc cp) certState@CertState {..} =
       (branchW 2 $ \govCert -> satisfies govCert $ govCertSpec govCertEnv certState)
   where
     delegEnv = ConwayDelegEnv pp (psStakePoolParams certPState)
-    poolEnv = PoolEnv slot pp
+    poolEnv = PoolEnv ce pp
     govCertEnv = ConwayGovCertEnv pp ce cc cp
 
 -- ==============================================================
@@ -143,7 +143,7 @@ shelleyTxCertSpec ::
   CertEnv era ->
   CertState era ->
   Specification fn (ShelleyTxCert era)
-shelleyTxCertSpec (CertEnv slot pp _ _ _) (CertState _vstate pstate dstate) =
+shelleyTxCertSpec (CertEnv pp e _ _) (CertState _vstate pstate dstate) =
   constrained $ \ [var|shelleyTxCert|] ->
     -- These weights try to make it equally likely that each of the many certs
     -- across the 3 categories are chosen at similar frequencies.
@@ -156,7 +156,7 @@ shelleyTxCertSpec (CertEnv slot pp _ _ _) (CertState _vstate pstate dstate) =
                 dstate
             )
       )
-      (branchW 3 $ \ [var|poolCert|] -> satisfies poolCert $ poolCertSpec (PoolEnv slot pp) pstate)
+      (branchW 3 $ \ [var|poolCert|] -> satisfies poolCert $ poolCertSpec (PoolEnv e pp) pstate)
       (branchW 1 $ \ [var|genesis|] -> satisfies genesis (genesisDelegCertSpec @fn @era dstate))
       (branchW 1 $ \ [var|_mir|] -> False) -- By design, we never generate a MIR cert
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
@@ -103,7 +103,7 @@ certsEnvSpec ::
   (EraSpecPParams era, HasSpec fn (Tx era), IsConwayUniv fn) =>
   Specification fn (CertsEnv era)
 certsEnvSpec = constrained $ \ce ->
-  match ce $ \tx pp _slot _currepoch _currcommittee commproposals ->
+  match ce $ \tx pp _currepoch _currcommittee commproposals ->
     [ satisfies pp pparamsSpec
     , assert $ tx ==. lit txZero
     , genHint 3 commproposals
@@ -114,7 +114,6 @@ projectEnv :: CertsEnv era -> CertEnv era
 projectEnv x =
   CertEnv
     { cePParams = certsPParams x
-    , ceSlotNo = certsSlotNo x
     , ceCurrentEpoch = certsCurrentEpoch x
     , ceCurrentCommittee = certsCurrentCommittee x
     , ceCommitteeProposals = certsCommitteeProposals x

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Pool.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Pool.hs
@@ -60,7 +60,7 @@ poolCertSpec ::
   PoolEnv era ->
   PState era ->
   Specification fn (PoolCert (EraCrypto era))
-poolCertSpec (PoolEnv s pp) ps =
+poolCertSpec (PoolEnv e pp) ps =
   constrained $ \pc ->
     (caseOn pc)
       -- RegPool !(PoolParams c)
@@ -76,7 +76,7 @@ poolCertSpec (PoolEnv s pp) ps =
       -- RetirePool !(KeyHash 'StakePool c) !EpochNo
       ( branchW 1 $ \keyHash epochNo ->
           [ epochNo <=. lit (maxEpochNo - 1)
-          , lit (currentEpoch s) <. epochNo
+          , lit e <. epochNo
           , elem_ keyHash $ lit rpools
           ]
       )

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
@@ -907,7 +907,7 @@ gone = do
   (PParamsF _ pp) <- monadTyped (findVar (unVar (pparams proof)) env)
   accntState <- monadTyped (runTarget env accountStateT)
   utxo1 <- monadTyped (findVar (unVar (utxo proof)) env)
-  let lenv = LedgerEnv slot txIx pp accntState False
+  let lenv = LedgerEnv slot Nothing txIx pp accntState False
   -- putStrLn (show (pcTx Babbage tx))
   pure $ case applySTSByProof proof (TRC (lenv, ledgerstate, tx)) of
     Right _ledgerState' -> do
@@ -1016,7 +1016,7 @@ oneTest sizes proof = do
   (PParamsF _ pp) <- monadTyped (runTerm env2 (pparams proof))
   accntState <- monadTyped (runTarget env2 accountStateT)
   txIx <- arbitrary
-  let lenv = LedgerEnv slot txIx pp accntState False
+  let lenv = LedgerEnv slot Nothing txIx pp accntState False
   case applySTSByProof proof (TRC (lenv, ledgerstate, tx)) of
     Right ledgerState' -> pure (totalAda ledgerState' === totalAda ledgerstate)
     Left errs -> do

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/SimpleTx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/SimpleTx.hs
@@ -105,7 +105,7 @@ getSTSLedgerEnv proof txIx env = do
   slot <- runTerm env currentSlot
   (PParamsF _ pp) <- runTerm env (pparams proof)
   accntState <- runTarget env accountStateT
-  pure (LedgerEnv slot txIx pp accntState False, ledgerstate)
+  pure (LedgerEnv slot Nothing txIx pp accntState False, ledgerstate)
 
 -- ====================================================================
 -- Picking things that have no Plutus Scripts inside. To make very

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
@@ -350,7 +350,7 @@ runLEDGER ::
   Tx era ->
   Either (NonEmpty (PredicateFailure (EraRule "LEDGER" era))) (State (EraRule "LEDGER" era))
 runLEDGER wit@(LEDGER proof) state pparams tx =
-  let env = LedgerEnv (SlotNo 0) minBound pparams def False
+  let env = LedgerEnv (SlotNo 0) Nothing minBound pparams def False
    in case proof of
         Conway -> runSTS' wit (TRC (env, state, tx))
         Babbage -> runSTS' wit (TRC (env, state, tx))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
@@ -66,6 +66,7 @@ import Test.Cardano.Ledger.Generic.PrettyCore (
   ppTickPredicateFailure,
  )
 import Test.Cardano.Ledger.Generic.Proof (Proof (..), Reflect (reify))
+import Test.Cardano.Ledger.Shelley.Utils (epochFromSlotNo)
 
 -- ================================================
 
@@ -161,7 +162,8 @@ instance
         let newblocksmade = BlocksMade (Map.unionWith (+) current (Map.singleton issuer 1))
 
         newledgerState <-
-          trans @(EraRule "LEDGERS" era) $ TRC (LedgersEnv slot pparams account, ledgerState, fromStrict txs)
+          trans @(EraRule "LEDGERS" era) $
+            TRC (LedgersEnv slot (epochFromSlotNo slot) pparams account, ledgerState, fromStrict txs)
 
         let newEpochstate = epochState {esLState = newledgerState}
             newNewEpochState = nes' {nesEs = newEpochstate, nesBcur = newblocksmade}

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -3572,7 +3572,7 @@ instance Reflect era => PrettyA (ConwayGovCertEnv era) where
   prettyA = pcConwayGovCertEnv
 
 pcPoolEnv :: Reflect era => PoolEnv era -> PDoc
-pcPoolEnv (PoolEnv sn pp) = ppSexp "PoolEnv" [pcSlotNo sn, pcPParams reify pp]
+pcPoolEnv (PoolEnv en pp) = ppSexp "PoolEnv" [ppEpochNo en, pcPParams reify pp]
 
 instance forall era. Reflect era => PrettyA (PoolEnv era) where
   prettyA = pcPoolEnv
@@ -3646,7 +3646,7 @@ instance Reflect era => PrettyA (CertEnv era) where
   prettyA CertEnv {..} =
     ppRecord
       "CertEnv"
-      [ ("slot no", prettyA ceSlotNo)
+      [ ("slot no", prettyA ceCurrentEpoch)
       , ("pparams", prettyA cePParams)
       , ("currentEpoch", prettyA ceCurrentEpoch)
       ]
@@ -3664,12 +3664,11 @@ instance PrettyA x => PrettyA (Seq x) where
   prettyA x = prettyA (toList x)
 
 instance PrettyA (ConwayRules.CertsEnv era) where
-  prettyA (ConwayRules.CertsEnv _ _ slot epoch com prop) =
+  prettyA (ConwayRules.CertsEnv _ _ epoch com prop) =
     ppRecord
       "CertsEnv"
       [ ("Tx", ppString "Tx")
       , ("pparams", ppString "PParams")
-      , ("slot", pcSlotNo slot)
       , ("epoch", ppEpochNo epoch)
       , ("committee", ppStrictMaybe pcCommittee com)
       , ("proposals", ppMap pcGovPurposeId prettyA prop)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -88,27 +88,27 @@ import Test.Tasty (TestTree, defaultMain, testGroup)
 genTxAndUTXOState ::
   Reflect era => Proof era -> GenSize -> Gen (TRC (EraRule "UTXOW" era), GenState era)
 genTxAndUTXOState proof@Conway gsize = do
-  (Box _ (TRC (LedgerEnv slotNo _ pp _ _, ledgerState, vtx)) genState) <-
+  (Box _ (TRC (LedgerEnv slotNo _ _ pp _ _, ledgerState, vtx)) genState) <-
     genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 genTxAndUTXOState proof@Babbage gsize = do
-  (Box _ (TRC (LedgerEnv slotNo _ pp _ _, ledgerState, vtx)) genState) <-
+  (Box _ (TRC (LedgerEnv slotNo _ _ pp _ _, ledgerState, vtx)) genState) <-
     genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 genTxAndUTXOState proof@Alonzo gsize = do
-  (Box _ (TRC (LedgerEnv slotNo _ pp _ _, ledgerState, vtx)) genState) <-
+  (Box _ (TRC (LedgerEnv slotNo _ _ pp _ _, ledgerState, vtx)) genState) <-
     genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 genTxAndUTXOState proof@Mary gsize = do
-  (Box _ (TRC (LedgerEnv slotNo _ pp _ _, ledgerState, vtx)) genState) <-
+  (Box _ (TRC (LedgerEnv slotNo _ _ pp _ _, ledgerState, vtx)) genState) <-
     genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 genTxAndUTXOState proof@Allegra gsize = do
-  (Box _ (TRC (LedgerEnv slotNo _ pp _ _, ledgerState, vtx)) genState) <-
+  (Box _ (TRC (LedgerEnv slotNo _ _ pp _ _, ledgerState, vtx)) genState) <-
     genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 genTxAndUTXOState proof@Shelley gsize = do
-  (Box _ (TRC (LedgerEnv slotNo _ pp _ _, ledgerState, vtx)) genState) <-
+  (Box _ (TRC (LedgerEnv slotNo _ _ pp _ _, ledgerState, vtx)) genState) <-
     genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 
@@ -142,7 +142,7 @@ genTxAndLEDGERState proof sizes = do
         model <- gets gsModel
         pp <- gets (gePParams . gsGenEnv)
         let ledgerState = extract @(LedgerState era) model
-            ledgerEnv = LedgerEnv slotNo txIx pp (AccountState (Coin 0) (Coin 0)) False
+            ledgerEnv = LedgerEnv slotNo Nothing txIx pp (AccountState (Coin 0) (Coin 0)) False
         pure $ TRC (ledgerEnv, ledgerState, tx)
   (trc, genstate) <- runGenRS proof sizes (initStableFields >> genT)
   pure (Box proof trc genstate)


### PR DESCRIPTION
# Description

Closes https://github.com/IntersectMBO/cardano-ledger/issues/4692

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
