### PR TITLE
Use non-zero costmodels in Imp tests

### DIFF
--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Invalid.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Invalid.hs
@@ -224,7 +224,7 @@ spec = describe "Invalid transactions" $ do
           let scriptHash = alwaysSucceedsWithDatumHash
           scriptInput <- produceScript scriptHash
           (collateralHash, collateralAddr) <- freshKeyAddr
-          collateralInput <- sendCoinTo collateralAddr $ Coin 1_000_000
+          collateralInput <- sendCoinTo collateralAddr $ Coin 3_000_000
           let
             tx =
               mkBasicTx mkBasicTxBody
@@ -275,7 +275,7 @@ spec = describe "Invalid transactions" $ do
                     , mkDelegStakeTxCert cred poolId -- 1: Needs a redeemer
                     , mkDelegStakeTxCert cred poolId -- 2: Duplicate, ignored, no redeemer needed
                     ]
-                  redeemer = (Data (P.I 32), ExUnits 5000 5000)
+                  redeemer = (Data (P.I 32), ExUnits 5000 1_000_000)
                   redeemers = Map.fromList [(mkCertifyingPurpose (AsIx i), redeemer) | i <- [1 .. 2]]
                   tx =
                     mkBasicTx mkBasicTxBody

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -432,8 +432,7 @@ instance
     pure
       AlonzoGenesis
         { agCoinsPerUTxOWord = CoinPerWord (Coin 34482)
-        , -- TODO: Replace with correct cost model.
-          agCostModels = testingCostModels [PlutusV1]
+        , agCostModels = testingCostModels [PlutusV1]
         , agPrices =
             Prices
               { prMem = 577 %! 10_000

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -132,7 +132,7 @@ class
 makeCollateralInput :: ShelleyEraImp era => ImpTestM era (TxIn (EraCrypto era))
 makeCollateralInput = do
   -- TODO: make more accurate
-  let collateral = Coin 10_000_000
+  let collateral = Coin 30_000_000
   addr <- freshKeyAddr_
   withFixup fixupTx $ sendCoinTo addr collateral
 

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/BbodySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/BbodySpec.hs
@@ -108,7 +108,7 @@ spec = describe "BBODY" $ do
     mkTxIn :: ImpTestM era (TxIn (EraCrypto era))
     mkTxIn = do
       addr <- freshKeyAddr_
-      sendCoinTo addr (Coin 7_000_000)
+      sendCoinTo addr (Coin 8_000_000)
 
     largeScript :: Maybe (Script era)
     largeScript = do

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -321,8 +321,7 @@ instance
               , ucppDRepDeposit = Coin 70_000_000
               , ucppDRepActivity = EpochInterval 100
               , ucppMinFeeRefScriptCostPerByte = 15 %! 1
-              , -- TODO: Replace with correct cost model.
-                ucppPlutusV3CostModel = testingCostModel PlutusV3
+              , ucppPlutusV3CostModel = testingCostModel PlutusV3
               }
         , cgConstitution = Constitution constitutionAnchor (SJust guardrailScriptHash)
         , cgCommittee = committee

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -147,7 +147,7 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Block (Block)
 import Cardano.Ledger.CertState (certDStateL, dsUnifiedL)
-import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Coin
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..), credToText)
 import Cardano.Ledger.Crypto (Crypto (..))
 import Cardano.Ledger.Genesis (EraGenesis (..), NoGenesis (..))
@@ -252,6 +252,7 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes, mapMaybe)
+import Data.Ratio ((%))
 import Data.Sequence.Strict (StrictSeq (..))
 import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
@@ -1010,9 +1011,10 @@ fixupFees txOriginal = impAnn "fixupFees" $ do
     txNoWits = tx & bodyTxL . outputsTxBodyL %~ (:|> changeBeforeFeeTxOut)
     outsBeforeFee = tx ^. bodyTxL . outputsTxBodyL
     suppliedFee = txOriginal ^. bodyTxL . feeTxBodyL
-    fee
+    fee0
       | suppliedFee == zero = calcMinFeeTxNativeScriptWits utxo pp txNoWits nativeScriptKeyWits
       | otherwise = suppliedFee
+    fee = rationalToCoinViaCeiling $ coinToRational fee0 * (11 % 10)
   logString "Validating change"
   change <- ensureNonNegativeCoin $ changeBeforeFeeTxOut ^. coinTxOutL <-> fee
   logToExpr change

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Plutus.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Plutus.hs
@@ -106,22 +106,13 @@ testingCostModel = \case
   PlutusV3 -> testingCostModelV3
 
 testingCostModelV1 :: HasCallStack => CostModel
-testingCostModelV1 =
-  if True
-    then zeroTestingCostModelV1
-    else mkCostModel' PlutusV1 $ snd <$> PV1.costModelParamsForTesting
+testingCostModelV1 = mkCostModel' PlutusV1 $ snd <$> PV1.costModelParamsForTesting
 
 testingCostModelV2 :: HasCallStack => CostModel
-testingCostModelV2 =
-  if True
-    then zeroTestingCostModelV2
-    else mkCostModel' PlutusV2 $ snd <$> PV2.costModelParamsForTesting
+testingCostModelV2 = mkCostModel' PlutusV2 $ snd <$> PV2.costModelParamsForTesting
 
 testingCostModelV3 :: HasCallStack => CostModel
-testingCostModelV3 =
-  if True
-    then zeroTestingCostModelV3
-    else mkCostModel' PlutusV3 $ snd <$> PV3.costModelParamsForTesting
+testingCostModelV3 = mkCostModel' PlutusV3 $ snd <$> PV3.costModelParamsForTesting
 
 testingEvaluationContext :: Language -> PV1.EvaluationContext
 testingEvaluationContext = getCostModelEvaluationContext . testingCostModel


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

At the moment, Imp tests are using zeroCostModels with Plutus scripts, which, in essence means that the way we are setting the budget in the redeemers has no impact on script execution.

In this PR, I have switched to using the cost models provided by Plutus for testing. 
Making the switch revealed that we weren't computing the budget correctly, but because of the zero cost models, the problem hasn't manifested. 
Specifically, the budget (set in the redeemers) depends on the value of the fee, which in turn depends on the value of the redeemers (I think via the size of the transaction). 

In master, the order of the fixup is:  fixupRedeemers >=> fixupFees ...  With non-zero cost models, tests are failing because of unsufficient budget (that doesn't take the fee into account). 
In this PR, I'm first computing the fee, maximizing it with respect to the budget (so assuming the maximum budget), then computing the real budget, with a previously computed more realistic fee. 
I also added 10% to the fee as a margin, because in some cases it would still go over.

Any suggestions for a more elegant solution are welcome! 

Closes  https://github.com/IntersectMBO/cardano-ledger/issues/4404

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
