### PR TITLE
Simplify working with current epoch number

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
@@ -232,17 +232,16 @@ alonzoBbodyTransition =
         -- we make an assumption that 'incrBlocks' must enforce, better for it
         -- to be done in 'incrBlocks' where we can see that the assumption is
         -- enforced.
-        let hkAsStakePool = coerceKeyRole . bhviewID $ bh
+        let hkAsStakePool = coerceKeyRole $ bhviewID bh
             slot = bhviewSlot bh
-        (firstSlotNo, currEpoch) <- liftSTS $ do
+        (firstSlotNo, curEpochNo) <- liftSTS $ do
           ei <- asks epochInfoPure
-          e <- epochInfoEpoch ei slot
-          firstSlot <- epochInfoFirst ei e
-          pure (firstSlot, e)
+          let curEpochNo = epochInfoEpoch ei slot
+          pure (epochInfoFirst ei curEpochNo, curEpochNo)
 
         ls' <-
           trans @(EraRule "LEDGERS" era) $
-            TRC (LedgersEnv (bhviewSlot bh) currEpoch pp account, ls, StrictSeq.fromStrict txs)
+            TRC (LedgersEnv (bhviewSlot bh) curEpochNo pp account, ls, StrictSeq.fromStrict txs)
 
         {- ∑(tx ∈ txs)(totExunits tx) ≤ maxBlockExUnits pp  -}
         let txTotal, ppMax :: ExUnits

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
@@ -77,7 +77,8 @@ import NoThunks.Class (NoThunks)
 
 data CertEnv era = CertEnv
   { cePParams :: !(PParams era)
-  , ceCurrentEpoch :: !EpochNo
+  , ceCurrentEpoch :: EpochNo
+  -- ^ Lazy on purpose, because not all certificates need to know the current EpochNo
   , ceCurrentCommittee :: StrictMaybe (Committee era)
   , ceCommitteeProposals :: Map.Map (GovPurposeId 'CommitteePurpose era) (GovActionState era)
   }

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
@@ -88,7 +88,8 @@ import NoThunks.Class (NoThunks (..))
 data CertsEnv era = CertsEnv
   { certsTx :: !(Tx era)
   , certsPParams :: !(PParams era)
-  , certsCurrentEpoch :: !EpochNo
+  , certsCurrentEpoch :: EpochNo
+  -- ^ Lazy on purpose, because not all certificates need to know the current EpochNo
   , certsCurrentCommittee :: StrictMaybe (Committee era)
   , certsCommitteeProposals :: Map.Map (GovPurposeId 'CommitteePurpose era) (GovActionState era)
   }

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
@@ -91,7 +91,8 @@ import NoThunks.Class (NoThunks (..))
 
 data ConwayGovCertEnv era = ConwayGovCertEnv
   { cgcePParams :: !(PParams era)
-  , cgceCurrentEpoch :: !EpochNo
+  , cgceCurrentEpoch :: EpochNo
+  -- ^ Lazy on purpose, because not all certificates need to know the current EpochNo
   , cgceCurrentCommittee :: StrictMaybe (Committee era)
   , cgceCommitteeProposals :: Map.Map (GovPurposeId 'CommitteePurpose era) (GovActionState era)
   -- ^ All of the `UpdateCommittee` proposals

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -41,7 +41,6 @@ where
 
 import Cardano.Ledger.Address (Addr (..), compactAddr)
 import Cardano.Ledger.BaseTypes (
-  BlocksMade,
   Globals (..),
   NonNegativeInterval,
   UnitInterval,
@@ -404,21 +403,19 @@ getRewardProvenance ::
   Globals ->
   NewEpochState era ->
   (RewardUpdate (EraCrypto era), RewardProvenance (EraCrypto era))
-getRewardProvenance globals newepochstate =
+getRewardProvenance globals newEpochState =
   ( runReader
-      (createRUpd slotsPerEpoch blocksmade epochstate maxsupply asc secparam)
+      (createRUpd slotsPerEpoch blocksMade epochState maxSupply asc secparam)
       globals
   , def
   )
   where
-    epochstate = nesEs newepochstate
-    maxsupply :: Coin
-    maxsupply = Coin (fromIntegral (maxLovelaceSupply globals))
-    blocksmade :: BlocksMade (EraCrypto era)
-    blocksmade = nesBprev newepochstate
-    epochnumber = nesEL newepochstate
+    epochState = nesEs newEpochState
+    maxSupply = Coin (fromIntegral (maxLovelaceSupply globals))
+    blocksMade = nesBprev newEpochState
+    epochNo = nesEL newEpochState
     slotsPerEpoch :: EpochSize
-    slotsPerEpoch = runReader (epochInfoSize (epochInfoPure globals) epochnumber) globals
+    slotsPerEpoch = epochInfoSize (epochInfoPure globals) epochNo
     asc = activeSlotCoeff globals
     secparam = securityParameter globals
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Bbody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Bbody.hs
@@ -209,15 +209,14 @@ bbodyTransition =
         -- easier than differentiating here.
         let hkAsStakePool = coerceKeyRole $ bhviewID bhview
             slot = bhviewSlot bhview
-        (firstSlotNo, currEpoch) <- liftSTS $ do
+        (firstSlotNo, curEpochNo) <- liftSTS $ do
           ei <- asks epochInfoPure
-          e <- epochInfoEpoch ei slot
-          firstSlot <- epochInfoFirst ei e
-          pure (firstSlot, e)
+          let curEpochNo = epochInfoEpoch ei slot
+          pure (epochInfoFirst ei curEpochNo, curEpochNo)
 
         ls' <-
           trans @(EraRule "LEDGERS" era) $
-            TRC (LedgersEnv (bhviewSlot bhview) currEpoch pp account, ls, StrictSeq.fromStrict txs)
+            TRC (LedgersEnv (bhviewSlot bhview) curEpochNo pp account, ls, StrictSeq.fromStrict txs)
 
         let isOverlay = isOverlaySlot firstSlotNo (pp ^. ppDG) slot
         pure $ BbodyState ls' (incrBlocks isOverlay hkAsStakePool b)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
@@ -101,7 +101,8 @@ import Validation (failureUnless)
 
 data DelegsEnv era = DelegsEnv
   { delegsSlotNo :: !SlotNo
-  , delegsEpochNo :: !EpochNo
+  , delegsEpochNo :: EpochNo
+  -- ^ Lazy on purpose, because not all certificates need to know the current EpochNo
   , delegsIx :: !TxIx
   , delegspp :: !(PParams era)
   , delegsTx :: !(Tx era)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
@@ -60,7 +60,7 @@ import NoThunks.Class (NoThunks (..))
 
 data DelplEnv era = DelplEnv
   { delplSlotNo :: SlotNo
-  , delpEpochNo :: EpochNo
+  , delplEpochNo :: EpochNo
   , delPlPtr :: Ptr
   , delPlPp :: PParams era
   , delPlAccount :: AccountState

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Rupd.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Rupd.hs
@@ -69,7 +69,6 @@ import Control.State.Transition (
   liftSTS,
   tellEvent,
  )
-import Data.Functor ((<&>))
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import GHC.Generics (Generic)
@@ -129,9 +128,9 @@ rupdTransition = do
   (slotsPerEpoch, slot, slotForce, maxLL, asc, k, e) <- liftSTS $ do
     ei <- asks epochInfoPure
     sr <- asks randomnessStabilisationWindow
-    e <- epochInfoEpoch ei s
-    slotsPerEpoch <- epochInfoSize ei e
-    slot <- epochInfoFirst ei e <&> (+* Duration sr)
+    let e = epochInfoEpoch ei s
+        slotsPerEpoch = epochInfoSize ei e
+        slot = epochInfoFirst ei e +* Duration sr
     maxLL <- asks maxLovelaceSupply
     asc <- asks activeSlotCoeff
     k <- asks securityParameter -- Maximum number of blocks we are allowed to roll back

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -599,7 +599,7 @@ defaultInitImpTestState nes = do
           (mkSlotLength . fromNominalDiffTimeMicro $ sgSlotLength shelleyGenesis)
       globals = mkShelleyGlobals shelleyGenesis epochInfoE
       epochNo = nesWithRoot ^. nesELL
-      slotNo = runIdentity $ runReaderT (epochInfoFirst (epochInfoPure globals) epochNo) globals
+      slotNo = epochInfoFirst (epochInfoPure globals) epochNo
   pure $
     ImpTestState
       { impNES = nesWithRoot

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Core.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Core.hs
@@ -503,7 +503,7 @@ getKESPeriodRenewalNo keys (KESPeriod kp) =
 tooLateInEpoch :: SlotNo -> Bool
 tooLateInEpoch s = runShelleyBase $ do
   ei <- asks epochInfoPure
-  firstSlotNo <- epochInfoFirst ei (epochFromSlotNo s + 1)
+  let firstSlotNo = epochInfoFirst ei (epochFromSlotNo s + 1)
   stabilityWindow <- asks stabilityWindow
 
   return (s >= firstSlotNo *- Duration (2 * stabilityWindow))

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rewards.hs
@@ -635,9 +635,9 @@ oldEqualsNew pv newepochstate =
     maxsupply = Coin (fromIntegral (maxLovelaceSupply globals))
     blocksmade :: BlocksMade (EraCrypto era)
     blocksmade = nesBprev newepochstate
-    epochnumber = nesEL newepochstate
+    epochNumber = nesEL newepochstate
     slotsPerEpoch :: EpochSize
-    slotsPerEpoch = runReader (epochInfoSize (epochInfoPure globals) epochnumber) globals
+    slotsPerEpoch = epochInfoSize (epochInfoPure globals) epochNumber
     unAggregated =
       runReader (createRUpd slotsPerEpoch blocksmade epochstate maxsupply asc k) globals
     old = rsOld $ runReader (createRUpdOld slotsPerEpoch blocksmade epochstate maxsupply) globals
@@ -660,9 +660,9 @@ oldEqualsNewOn pv newepochstate = old === new
     maxsupply = Coin (fromIntegral (maxLovelaceSupply globals))
     blocksmade :: BlocksMade (EraCrypto era)
     blocksmade = nesBprev newepochstate
-    epochnumber = nesEL newepochstate
+    epochNumber = nesEL newepochstate
     slotsPerEpoch :: EpochSize
-    slotsPerEpoch = runReader (epochInfoSize (epochInfoPure globals) epochnumber) globals
+    slotsPerEpoch = epochInfoSize (epochInfoPure globals) epochNumber
     unAggregated =
       runReader (createRUpd slotsPerEpoch blocksmade epochstate maxsupply asc k) globals
     old :: Map (Credential 'Staking (EraCrypto era)) Coin

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
@@ -409,7 +409,9 @@ epochsInTrace bs'
       let
         fromEpoch = atEpoch . blockSlot $ NE.head bs
         toEpoch = atEpoch . blockSlot $ NE.last bs
-        EpochSize slotsPerEpoch = runShelleyBase $ (epochInfoSize . epochInfoPure) testGlobals undefined
+        EpochSize slotsPerEpoch =
+          epochInfoSize (epochInfoPure testGlobals) $
+            error "Impossible: Fixed epoch size does not care about current epoch number"
         blockSlot = bheaderSlotNo . bhbody . bheader
         atEpoch (SlotNo s) = s `div` slotsPerEpoch
        in

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/MirTransfer.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/MirTransfer.hs
@@ -55,7 +55,7 @@ env :: ProtVer -> AccountState -> DelegEnv ShelleyTest
 env pv acnt =
   DelegEnv
     { slotNo = slot
-    , curEpochNo = epochFromSlotNo slot
+    , deCurEpochNo = epochFromSlotNo slot
     , ptr_ = Ptr slot minBound minBound
     , acnt_ = acnt
     , ppDE = emptyPParams & ppProtocolVersionL .~ pv

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.16.0.0
 
+* Add `epochFromSlot`
+* Remove usage of a `Reader` monad in `epochInfoEpoch`, `epochInfoFirst` and `epochInfoSize`.
 * Add `eraProtVersions`
 * Remove deprecated `_unTxId` and `adaOnly`
 * Remove deprecated module `Cardano.Ledger.Serialization`

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Overlay.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Overlay.hs
@@ -266,8 +266,7 @@ overlayTransition =
         asc <- liftSTS $ asks activeSlotCoeff
         firstSlotNo <- liftSTS $ do
           ei <- asks epochInfoPure
-          e <- epochInfoEpoch ei slot
-          epochInfoFirst ei e
+          pure $ epochInfoFirst ei $ epochInfoEpoch ei slot
 
         case (lookupInOverlaySchedule firstSlotNo gkeys dval asc slot :: Maybe (OBftSlot c)) of
           Nothing ->

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Updn.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Updn.hs
@@ -63,10 +63,10 @@ updTransition = do
   TRC (UpdnEnv eta, UpdnState eta_v eta_c, s) <- judgmentContext
   ei <- liftSTS $ asks epochInfoPure
   sp <- liftSTS $ asks stabilityWindow
-  EpochNo e <- liftSTS $ epochInfoEpoch ei s
-  let newEpochNo = EpochNo (e + 1)
-  firstSlotNextEpoch <- liftSTS $ epochInfoFirst ei newEpochNo
-  tellEvent $ NewEpoch newEpochNo
+  let curEpochNo = epochInfoEpoch ei s
+      nextEpochNo = addEpochInterval curEpochNo (EpochInterval 1)
+      firstSlotNextEpoch = epochInfoFirst ei nextEpochNo
+  tellEvent $ NewEpoch nextEpochNo
   pure $
     UpdnState
       (eta_v ⭒ eta)


### PR DESCRIPTION

# Description

Placement of `epochInfoEpoch`, `epochInfoFirst` and `epochInfoSize` in a reader monad was superfluous.

Another improvement is making current epoch number lazy in the environment, because that information is not necessary for all types of transactions


<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
