### PR TITLE
Upgrade to plutus-ledger-api 1.37.0.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -46,7 +46,7 @@ index-state:
   -- Bump this if you need newer packages from Hackage
   , hackage.haskell.org 2024-11-20T00:00:00Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2024-11-05T09:09:23Z
+  , cardano-haskell-packages 2024-11-27T20:49:28Z
 
 packages:
   eras/allegra/impl

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -90,7 +90,7 @@ library
         mtl,
         microlens,
         nothunks,
-        plutus-ledger-api >=1.33,
+        plutus-ledger-api >=1.37,
         set-algebra >=1.0,
         small-steps >=1.1,
         text,

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Translation/TranslationInstance.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Translation/TranslationInstance.hs
@@ -94,6 +94,7 @@ instance Cborg.Serialise PV3.GovernanceAction
 instance Cborg.Serialise PV3.GovernanceActionId
 instance Cborg.Serialise PV3.HotCommitteeCredential
 instance Cborg.Serialise PV3.Lovelace
+instance Cborg.Serialise PV3.MintValue
 instance Cborg.Serialise PV3.OutputDatum
 instance Cborg.Serialise PV3.POSIXTime
 instance Cborg.Serialise PV3.ProposalProcedure

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -101,7 +101,7 @@ library
         deepseq,
         microlens,
         nothunks,
-        plutus-ledger-api >=1.33,
+        plutus-ledger-api >=1.37,
         set-algebra,
         small-steps >=1.1,
         text,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
@@ -92,6 +92,7 @@ import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.DRep (DRep (..))
 import Cardano.Ledger.Keys (KeyRole (..), unVRFVerKeyHash)
 import Cardano.Ledger.Mary (MaryValue)
+import Cardano.Ledger.Mary.Value (MultiAsset)
 import Cardano.Ledger.Plutus.Data (Data)
 import Cardano.Ledger.Plutus.Language (Language (..), PlutusArgs (..))
 import Cardano.Ledger.Plutus.ToPlutusData (ToPlutusData (..))
@@ -127,6 +128,7 @@ import NoThunks.Class (NoThunks)
 import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusLedgerApi.V2 as PV2
 import qualified PlutusLedgerApi.V3 as PV3
+import qualified PlutusLedgerApi.V3.MintValue as PV3
 
 instance Crypto c => EraPlutusContext (ConwayEra c) where
   type ContextError (ConwayEra c) = ConwayContextError (ConwayEra c)
@@ -450,7 +452,7 @@ instance Crypto c => EraPlutusTxInfo 'PlutusV3 (ConwayEra c) where
         , PV3.txInfoOutputs = outputs
         , PV3.txInfoReferenceInputs = refInputs
         , PV3.txInfoFee = transCoinToLovelace (txBody ^. feeTxBodyL)
-        , PV3.txInfoMint = Alonzo.transMultiAsset (txBody ^. mintTxBodyL)
+        , PV3.txInfoMint = transMintValue (txBody ^. mintTxBodyL)
         , PV3.txInfoTxCerts = txCerts
         , PV3.txInfoWdrl = transTxBodyWithdrawals txBody
         , PV3.txInfoValidRange = timeRange
@@ -481,6 +483,9 @@ transTxBodyId txBody = PV3.TxId (transSafeHash (hashAnnotated txBody))
 
 transTxIn :: TxIn c -> PV3.TxOutRef
 transTxIn (TxIn txid txIx) = PV3.TxOutRef (transTxId txid) (toInteger (txIxToInt txIx))
+
+transMintValue :: MultiAsset c -> PV3.MintValue
+transMintValue = PV3.UnsafeMintValue . PV1.getValue . Alonzo.transMultiAsset
 
 -- | Translate all `Withdrawal`s from within a `TxBody`
 transTxBodyWithdrawals :: EraTxBody era => TxBody era -> PV3.Map PV3.Credential PV3.Lovelace

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1731401651,
-        "narHash": "sha256-tXaUck9+0Ob4h6GBlbhYMI4ekW5e8biVJU5jPT/rjus=",
+        "lastModified": 1732742574,
+        "narHash": "sha256-XUhDWQeChjNPcYluz8sCbs5vW+3jEYysxEhpKdFXbt0=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "82b295d6147a566c28dbcf038c54040f06f7e6b4",
+        "rev": "375a4694472aa362b7abba0e8b7f3de787e90c91",
         "type": "github"
       },
       "original": {

--- a/libs/plutus-preprocessor/plutus-preprocessor.cabal
+++ b/libs/plutus-preprocessor/plutus-preprocessor.cabal
@@ -40,7 +40,7 @@ library
         cardano-ledger-binary:testlib,
         plutus-tx,
         plutus-tx-plugin,
-        plutus-ledger-api,
+        plutus-ledger-api >=1.37,
         template-haskell
 
     if ((impl(ghc <9.6) || impl(ghc >=9.7)) || os(windows))

--- a/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor/Source/V3.hs
+++ b/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor/Source/V3.hs
@@ -127,7 +127,7 @@ purposeIsWellformedNoDatumQ =
           PV3.ScriptContext txInfo _redeemer scriptInfo ->
             case scriptInfo of
               PV3.MintingScript cs ->
-                PAM.member cs $ PV3.getValue $ PV3.txInfoMint txInfo
+                PAM.member cs $ PV3.getValue . PV3.mintValueMinted $ PV3.txInfoMint txInfo
               -- Expecting No Datum, therefore should fail when it is supplied
               PV3.SpendingScript txOutRef mDatum ->
                 case mDatum of


### PR DESCRIPTION
# Description

`plutus-ledger-api` `1.37.0.0` has been released to CHaP and contains a breaking change

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
