### PR TITLE
Change type of `nOpt` pparam to Word16

### DIFF
--- a/eras/alonzo/impl/cddl-files/alonzo.cddl
+++ b/eras/alonzo/impl/cddl-files/alonzo.cddl
@@ -248,7 +248,7 @@ protocol_param_update =
   , ? 5:  coin                ; key deposit
   , ? 6:  coin                ; pool deposit
   , ? 7: epoch                ; maximum epoch
-  , ? 8: uint                 ; n_opt: desired number of stake pools
+  , ? 8: uint .size 2         ; n_opt: desired number of stake pools
   , ? 9: nonnegative_interval ; pool pledge influence
   , ? 10: unit_interval       ; expansion rate
   , ? 11: unit_interval       ; treasury growth rate

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
@@ -268,7 +268,7 @@ data AlonzoPParams f era = AlonzoPParams
   , appEMax :: !(HKD f EpochInterval)
   -- ^ Maximum number of epochs in the future a pool retirement is allowed to
   -- be scheduled for.
-  , appNOpt :: !(HKD f Natural)
+  , appNOpt :: !(HKD f Word16)
   -- ^ Desired number of pools
   , appA0 :: !(HKD f NonNegativeInterval)
   -- ^ Pool influence

--- a/eras/babbage/impl/cddl-files/babbage.cddl
+++ b/eras/babbage/impl/cddl-files/babbage.cddl
@@ -276,7 +276,7 @@ protocol_param_update =
   , ? 5:  coin                ; key deposit
   , ? 6:  coin                ; pool deposit
   , ? 7: epoch                ; maximum epoch
-  , ? 8: uint                 ; n_opt: desired number of stake pools
+  , ? 8: uint .size 2         ; n_opt: desired number of stake pools
   , ? 9: nonnegative_interval ; pool pledge influence
   , ? 10: unit_interval       ; expansion rate
   , ? 11: unit_interval       ; treasury growth rate

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
@@ -152,7 +152,7 @@ data BabbagePParams f era = BabbagePParams
   , bppEMax :: !(HKD f EpochInterval)
   -- ^ Maximum number of epochs in the future a pool retirement is allowed to
   -- be scheduled for.
-  , bppNOpt :: !(HKD f Natural)
+  , bppNOpt :: !(HKD f Word16)
   -- ^ Desired number of pools
   , bppA0 :: !(HKD f NonNegativeInterval)
   -- ^ Pool influence

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -700,10 +700,7 @@ instance Crypto c => EraPParams (ConwayEra c) where
   hkdKeyDepositL = lens (unTHKD . cppKeyDeposit) $ \pp x -> pp {cppKeyDeposit = THKD x}
   hkdPoolDepositL = lens (unTHKD . cppPoolDeposit) $ \pp x -> pp {cppPoolDeposit = THKD x}
   hkdEMaxL = lens (unTHKD . cppEMax) $ \pp x -> pp {cppEMax = THKD x}
-  hkdNOptL :: forall f. HKDFunctor f => Lens' (PParamsHKD f (ConwayEra c)) (HKD f Natural)
-  hkdNOptL =
-    lens (asNaturalHKD @f @Word16 . (unTHKD . cppNOpt)) $
-      \pp x -> pp {cppNOpt = THKD (asBoundedIntegralHKD @f @Natural @Word16 x)}
+  hkdNOptL = lens (unTHKD . cppNOpt) $ \pp x -> pp {cppNOpt = THKD x}
   hkdA0L = lens (unTHKD . cppA0) $ \pp x -> pp {cppA0 = THKD x}
   hkdRhoL = lens (unTHKD . cppRho) $ \pp x -> pp {cppRho = THKD x}
   hkdTauL = lens (unTHKD . cppTau) $ \pp x -> pp {cppTau = THKD x}
@@ -1213,7 +1210,7 @@ upgradeConwayPParams UpgradeConwayPParams {..} BabbagePParams {..} =
     , cppKeyDeposit = THKD bppKeyDeposit
     , cppPoolDeposit = THKD bppPoolDeposit
     , cppEMax = THKD bppEMax
-    , cppNOpt = THKD (asBoundedIntegralHKD @f @Natural @Word16 bppNOpt)
+    , cppNOpt = THKD bppNOpt
     , cppA0 = THKD bppA0
     , cppRho = THKD bppRho
     , cppTau = THKD bppTau
@@ -1267,7 +1264,7 @@ downgradeConwayPParams ConwayPParams {..} =
     , bppKeyDeposit = unTHKD cppKeyDeposit
     , bppPoolDeposit = unTHKD cppPoolDeposit
     , bppEMax = unTHKD cppEMax
-    , bppNOpt = asNaturalHKD @f @Word16 (unTHKD cppNOpt)
+    , bppNOpt = unTHKD cppNOpt
     , bppA0 = unTHKD cppA0
     , bppRho = unTHKD cppRho
     , bppTau = unTHKD cppTau

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.15.0.0
 
+* Change param of `PoolRank.desirability` to `Word16`
+* Change type of `nOpt` in `RewardParams` to `Word16`
 * Add lenses for `LedgerEnv`. #4748
   * `ledgerSlotNoL`
   * `ledgerEpochNoL`

--- a/eras/shelley/impl/cddl-files/shelley.cddl
+++ b/eras/shelley/impl/cddl-files/shelley.cddl
@@ -141,7 +141,7 @@ protocol_param_update = {? 0 : uint
                         , ? 5 : coin
                         , ? 6 : coin
                         , ? 7 : epoch
-                        , ? 8 : uint
+                        , ? 8 : uint .size 2
                         , ? 9 : nonnegative_interval
                         , ? 10 : unit_interval
                         , ? 11 : unit_interval

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -115,10 +115,10 @@ import Data.Ratio ((%))
 import Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.VMap as VMap
+import Data.Word (Word16)
 import GHC.Generics (Generic)
 import Lens.Micro
 import NoThunks.Class (NoThunks (..))
-import Numeric.Natural (Natural)
 
 --------------------------------------------------------------------------------
 -- UTxOs
@@ -320,7 +320,7 @@ deriving instance ToJSON RewardInfoPool
 
 -- | Global information that influences stake pool rewards
 data RewardParams = RewardParams
-  { nOpt :: Natural
+  { nOpt :: Word16
   -- ^ Desired number of stake pools
   , a0 :: NonNegativeInterval
   -- ^ Influence of the pool owner's pledge on rewards

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/PParams.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/PParams.hs
@@ -98,7 +98,6 @@ import Data.Word (Word16, Word32)
 import GHC.Generics (Generic)
 import Lens.Micro (lens, (^.))
 import NoThunks.Class (NoThunks (..))
-import Numeric.Natural (Natural)
 
 -- ====================================================================
 
@@ -120,7 +119,7 @@ data ShelleyPParams f era = ShelleyPParams
   -- ^ The amount of a pool registration deposit
   , sppEMax :: !(HKD f EpochInterval)
   -- ^ epoch bound on pool retirement
-  , sppNOpt :: !(HKD f Natural)
+  , sppNOpt :: !(HKD f Word16)
   -- ^ Desired number of pools
   , sppA0 :: !(HKD f NonNegativeInterval)
   -- ^ Pool influence
@@ -496,7 +495,7 @@ shelleyCommonPParamsHKDPairs px pp =
   , ("stakeAddressDeposit", hkdMap px (toJSON @Coin) (pp ^. hkdKeyDepositL @era @f))
   , ("stakePoolDeposit", hkdMap px (toJSON @Coin) (pp ^. hkdPoolDepositL @era @f))
   , ("poolRetireMaxEpoch", hkdMap px (toJSON @EpochInterval) (pp ^. hkdEMaxL @era @f))
-  , ("stakePoolTargetNum", hkdMap px (toJSON @Natural) (pp ^. hkdNOptL @era @f))
+  , ("stakePoolTargetNum", hkdMap px (toJSON @Word16) (pp ^. hkdNOptL @era @f))
   , ("poolPledgeInfluence", hkdMap px (toJSON @NonNegativeInterval) (pp ^. hkdA0L @era @f))
   , ("monetaryExpansion", hkdMap px (toJSON @UnitInterval) (pp ^. hkdRhoL @era @f))
   , ("treasuryCut", hkdMap px (toJSON @UnitInterval) (pp ^. hkdTauL @era @f))

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/PoolRank.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/PoolRank.hs
@@ -71,6 +71,7 @@ import qualified Data.Sequence.Strict as StrictSeq
 import Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.VMap as VMap
+import Data.Word (Word16)
 import GHC.Generics (Generic)
 import Lens.Micro ((^.), _1)
 import NoThunks.Class (NoThunks (..))
@@ -266,7 +267,7 @@ toNonMyopicPair nm@(NonMyopic _ _) =
 -- corresponding to f^~ in section 5.6.1 of
 -- "Design Specification for Delegation and Incentives in Cardano"
 desirability ::
-  (NonNegativeInterval, Natural) ->
+  (NonNegativeInterval, Word16) ->
   Coin ->
   PoolParams c ->
   PerformanceEstimate ->

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/CDDL.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/CDDL.hs
@@ -264,7 +264,7 @@ protocol_param_update =
       , opt (idx 5 ==> coin) -- key deposit
       , opt (idx 6 ==> coin) -- pool deposit
       , opt (idx 7 ==> epoch) -- maximum epoch
-      , opt (idx 8 ==> VUInt) -- n_opt: desired number of stake pools
+      , opt (idx 8 ==> VUInt `sized` (2 :: Word64)) -- n_opt: desired number of stake pools
       , opt (idx 9 ==> nonnegative_interval) -- pool pledge influence
       , opt (idx 10 ==> unit_interval) -- expansion rate
       , opt (idx 11 ==> unit_interval) -- treasury growth rate

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Update.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Update.hs
@@ -180,8 +180,8 @@ genEMax Constants {frequencyLowMaxEpoch} =
   EpochInterval . fromIntegral <$> genWord64 frequencyLowMaxEpoch 500
 
 -- | nOpt
-genNOpt :: HasCallStack => Gen Natural
-genNOpt = genNatural 1 100
+genNOpt :: HasCallStack => Gen Word16
+genNOpt = fromIntegral <$> genNatural 1 100
 
 -- | genKeyDeposit
 -- NOTE: we need to keep these deposits small, otherwise

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Change lens type of `hkdNOptL`, `ppNOptL`, and `ppuNOptL` to `Word16`
 * Add `epochFromSlot`
 * Remove usage of a `Reader` monad in `epochInfoEpoch`, `epochInfoFirst` and `epochInfoSize`.
 * Add `eraProtVersions`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/PParams.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/PParams.hs
@@ -102,7 +102,6 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Word (Word16, Word32)
 import GHC.Generics (Generic (..), K1 (..), M1 (..), U1, V1, type (:*:) (..))
-import GHC.Natural (Natural)
 import Lens.Micro (Lens', SimpleGetter, lens)
 import NoThunks.Class (NoThunks)
 
@@ -322,7 +321,7 @@ class
   hkdEMaxL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f EpochInterval)
 
   -- | Desired number of pools
-  hkdNOptL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Natural)
+  hkdNOptL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Word16)
 
   -- | Pool influence
   hkdA0L :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f NonNegativeInterval)
@@ -409,7 +408,7 @@ ppEMaxL :: forall era. EraPParams era => Lens' (PParams era) EpochInterval
 ppEMaxL = ppLens . hkdEMaxL @era @Identity
 
 -- | Desired number of pools
-ppNOptL :: forall era. EraPParams era => Lens' (PParams era) Natural
+ppNOptL :: forall era. EraPParams era => Lens' (PParams era) Word16
 ppNOptL = ppLens . hkdNOptL @era @Identity
 
 -- | Pool influence
@@ -475,7 +474,7 @@ ppuEMaxL :: forall era. EraPParams era => Lens' (PParamsUpdate era) (StrictMaybe
 ppuEMaxL = ppuLens . hkdEMaxL @era @StrictMaybe
 
 -- | Desired number of pools
-ppuNOptL :: forall era. EraPParams era => Lens' (PParamsUpdate era) (StrictMaybe Natural)
+ppuNOptL :: forall era. EraPParams era => Lens' (PParamsUpdate era) (StrictMaybe Word16)
 ppuNOptL = ppuLens . hkdNOptL @era @StrictMaybe
 
 -- | Pool influence

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/EpochBoundary.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/EpochBoundary.hs
@@ -81,11 +81,11 @@ import qualified Data.Map.Strict as Map
 import Data.Ratio ((%))
 import Data.Typeable
 import Data.VMap as VMap
+import Data.Word (Word16)
 import GHC.Generics (Generic)
 import GHC.Word (Word64)
 import Lens.Micro (Lens', lens, (^.), _1, _2)
 import NoThunks.Class (AllowThunksIn (..), NoThunks (..))
-import Numeric.Natural (Natural)
 
 -- | Type of stake as map from hash key to coins associated.
 newtype Stake c = Stake
@@ -135,7 +135,7 @@ sumStakePerPool delegs (Stake stake) = VMap.foldlWithKey accum Map.empty stake
 -- | Calculate maximal pool reward
 maxPool' ::
   NonNegativeInterval ->
-  Natural ->
+  Word16 ->
   Coin ->
   Rational ->
   Rational ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Basic.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Basic.hs
@@ -239,7 +239,7 @@ data SimplePParams era = SimplePParams
   , keyDeposit :: Coin
   , poolDeposit :: Coin
   , eMax :: EpochInterval
-  , nOpt :: Natural
+  , nOpt :: Word16
   , a0 :: NonNegativeInterval
   , rho :: UnitInterval
   , tau :: UnitInterval
@@ -289,7 +289,7 @@ data SimplePPUpdate = SimplePPUpdate
   , ukeyDeposit :: StrictMaybe Coin
   , upoolDeposit :: StrictMaybe Coin
   , ueMax :: StrictMaybe EpochInterval
-  , unOpt :: StrictMaybe Natural
+  , unOpt :: StrictMaybe Word16
   , ua0 :: StrictMaybe NonNegativeInterval
   , urho :: StrictMaybe UnitInterval
   , utau :: StrictMaybe UnitInterval

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/PParams.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/PParams.hs
@@ -439,7 +439,7 @@ eMax_ ::
   (EraSpecPParams era, BaseUniverse fn) => Term fn (SimplePParams era) -> Term fn EpochInterval
 eMax_ simplepp = sel @7 simplepp
 
-nOpt_ :: (EraSpecPParams era, BaseUniverse fn) => Term fn (SimplePParams era) -> Term fn Natural
+nOpt_ :: (EraSpecPParams era, BaseUniverse fn) => Term fn (SimplePParams era) -> Term fn Word16
 nOpt_ simplepp = sel @8 simplepp
 
 a0_ ::

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
@@ -211,7 +211,7 @@ data PParamsField era
   | -- | epoch bound on pool retirement
     EMax EpochInterval
   | -- | Desired number of pools
-    NOpt Natural
+    NOpt Word16
   | -- | Pool influence
     A0 NonNegativeInterval
   | -- | Monetary expansion

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -1130,7 +1130,7 @@ pcPParamsField x = case x of
   KeyDeposit coin -> [("keydeposit", pcCoin coin)]
   PoolDeposit coin -> [("pooldeposit", pcCoin coin)]
   EMax n -> [("emax", ppEpochInterval n)]
-  NOpt natural -> [("NOpt", ppNatural natural)]
+  NOpt n -> [("NOpt", ppWord16 n)]
   A0 i -> [("A0", viaShow i)]
   Rho u -> [("Rho", ppUnitInterval u)]
   Tau u -> [("Tau", ppUnitInterval u)]


### PR DESCRIPTION
# Description

Closes https://github.com/IntersectMBO/cardano-ledger/issues/4564

Presumably no PParam update has been made setting nOpt greater than 65535  (it's set to 500 in genesis). 

I checked that in functions using this value,  `fromIntegral` is  used to convert it to larger types (Integer) rather than smaller types. 

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
