### PR TITLE
Fix issues that prevent basic `sumbitTx` from passing conformance

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -24,8 +24,8 @@ source-repository-package
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `MAlonzo-code` BEFORE MERGE!
   subdir: generated
-  tag: cc93692f5a57a9a66956b232662152676f659954
-  --sha256: sha256-s9ikqfXmz1wBrk4qEFR/iOloKvMOPGTB5IpHO34NSLE=
+  tag: be51adff014214c15fed718d396bb8a6d955f9e1
+  --sha256: sha256-by921yC1MaZI58kyrtEGGKqmt9jMnVsPLfQtP4raJPw=
 -- NOTE: If you would like to update the above, look for the `MAlonzo-code`
 -- branch in the `formal-ledger-specifications` repo and copy the SHA of
 -- the commit you need. The `MAlonzo-code` branch functions like an alternative

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -48,6 +48,7 @@
 
 ### `testlib`
 
+* Add `runSTS`
 * Add `iteExpectLedgerRuleConformance` to `ImpTestEnv` for additionally checking conformance with ImpTests. #4748
   * Add lens `iteExpectLedgerRuleConformanceL`.
   * Add `modifyImpInitExpectLedgerRuleConformance`.

--- a/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
+++ b/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
@@ -26,10 +26,11 @@ library
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway
+        Test.Cardano.Ledger.Conformance.Utils
+        Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
 
     hs-source-dirs:   src
     other-modules:
-        Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool
         Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert
@@ -51,7 +52,6 @@ library
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Ledger
         Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Ledgers
         Test.Cardano.Ledger.Conformance.Orphans
-        Test.Cardano.Ledger.Conformance.Utils
 
     default-language: Haskell2010
     ghc-options:
@@ -66,6 +66,7 @@ library
         cardano-strict-containers,
         data-default,
         microlens,
+        microlens-mtl,
         mtl,
         cardano-ledger-api:testlib,
         cardano-ledger-binary:{cardano-ledger-binary, testlib},
@@ -123,11 +124,12 @@ test-suite tests
         cardano-ledger-conformance,
         cardano-ledger-core:{cardano-ledger-core, testlib},
         cardano-strict-containers,
+        cardano-ledger-executable-spec,
         cardano-ledger-shelley,
         cardano-ledger-alonzo,
         cardano-ledger-conway:{cardano-ledger-conway, testlib},
         cardano-ledger-test,
         cardano-ledger-executable-spec,
         microlens,
-        unliftio,
-        text
+        microlens-mtl,
+        unliftio

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
@@ -408,7 +408,7 @@ instance IsConwayUniv fn => ExecSpecRule fn "RATIFY" Conway where
       . computationResultToEither
       $ Agda.ratifyStep env st sig
 
-  extraInfo ctx env@RatifyEnv {..} st sig@(RatifySignal actions) _ =
+  extraInfo _ ctx env@RatifyEnv {..} st sig@(RatifySignal actions) _ =
     PP.vsep $ specExtraInfo : (actionAcceptedRatio <$> toList actions)
     where
       members = foldMap' (committeeMembers @Conway) $ ensCommittee (rsEnactState st)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxo.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxo.hs
@@ -103,7 +103,7 @@ instance
       . computationResultToEither
       $ Agda.utxoStep externalFunctions env st sig
 
-  extraInfo ctx env@UtxoEnv {..} st@UTxOState {..} sig st' =
+  extraInfo _ ctx env@UtxoEnv {..} st@UTxOState {..} sig st' =
     PP.vcat
       [ "Impl:"
       , PP.ppString (showConwayTxBalance uePParams ueCertState utxosUtxo sig)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -98,6 +98,8 @@ instance NFData TxBody
 
 instance NFData Tag
 
+instance NFData HSVKey
+
 instance NFData TxWitnesses
 
 instance NFData Tx
@@ -195,6 +197,8 @@ instance ToExpr HashedTimelock
 instance ToExpr TxBody
 
 instance ToExpr Tag
+
+instance ToExpr HSVKey
 
 instance ToExpr TxWitnesses
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -448,18 +448,20 @@ signatureFromInteger :: DSIGNAlgorithm v => Integer -> Maybe (SigDSIGN v)
 signatureFromInteger = rawDeserialiseSigDSIGN . naturalToBytes 64 . fromInteger
 
 instance Crypto c => SpecTranslate ctx (VKey k c) where
-  type SpecRep (VKey k c) = Integer
+  type SpecRep (VKey k c) = Agda.HSVKey
 
-  toSpecRep = pure . vkeyToInteger
+  toSpecRep x = do
+    let hvkVKey = vkeyToInteger x
+    hvkStoredHash <- toSpecRep (hashVerKeyDSIGN @_ @(ADDRHASH c) $ unVKey x)
+    pure Agda.MkHSVKey {..}
 
 instance DSIGNAlgorithm v => SpecTranslate ctx (SignedDSIGN v a) where
   type SpecRep (SignedDSIGN v a) = Integer
 
-  toSpecRep (SignedDSIGN x) =
-    pure . toInteger . bytesToNatural $ rawSerialiseSigDSIGN x
+  toSpecRep (SignedDSIGN x) = pure $ signatureToInteger x
 
 instance (Crypto c, Typeable k) => SpecTranslate ctx (WitVKey k c) where
-  type SpecRep (WitVKey k c) = (Integer, Integer)
+  type SpecRep (WitVKey k c) = (SpecRep (VKey k c), Integer)
 
   toSpecRep (WitVKey vk sk) = toSpecRep (vk, sk)
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
@@ -58,10 +58,8 @@ instance SpecTranslate ctx (ConwayDelegCert c) where
   type SpecRep (ConwayDelegCert c) = Agda.DCert
 
   toSpecRep (ConwayRegCert c d) =
-    Agda.Delegate
+    Agda.Reg
       <$> toSpecRep c
-      <*> pure Nothing
-      <*> pure Nothing
       <*> strictMaybe (pure 0) toSpecRep d
   toSpecRep (ConwayUnRegCert c d) =
     Agda.Dereg

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
@@ -35,7 +35,7 @@ import Test.Cardano.Ledger.Imp.Common hiding (Args)
 import UnliftIO (evaluateDeep)
 
 testImpConformance ::
-  forall era t.
+  forall era.
   ( ConwayEraImp era
   , ExecSpecRule ConwayFn "LEDGER" era
   , ExecContext ConwayFn "LEDGER" era ~ ConwayLedgerExecContext era
@@ -53,7 +53,6 @@ testImpConformance ::
   , ExecEnvironment ConwayFn "LEDGER" era ~ LedgerEnv era
   , Tx era ~ AlonzoTx era
   , SpecTranslate (ConwayTxBodyTransContext (EraCrypto era)) (TxBody era)
-  , ToExpr (SpecRep (PredicateFailure (EraRule "LEDGER" era)))
   ) =>
   Globals ->
   Either
@@ -62,8 +61,8 @@ testImpConformance ::
   ExecEnvironment ConwayFn "LEDGER" era ->
   ExecState ConwayFn "LEDGER" era ->
   ExecSignal ConwayFn "LEDGER" era ->
-  ImpM t ()
-testImpConformance globals impRuleResult env state signal = impAnn "`submitTx` conformance" $ do
+  Expectation
+testImpConformance _ impRuleResult env state signal = do
   let ctx =
         ConwayLedgerExecContext
           { clecPolicyHash =
@@ -101,22 +100,7 @@ testImpConformance globals impRuleResult env state signal = impAnn "`submitTx` c
           (toTestRep . inject @_ @(ExecState ConwayFn "LEDGER" era) . fst)
           impRuleResult
 
-  logString "implEnv"
-  logToExpr env
-  logString "implState"
-  logToExpr state
-  logString "implSignal"
-  logToExpr signal
-  logString "specEnv"
-  logToExpr specEnv
-  logString "specState"
-  logToExpr specState
-  logString "specSignal"
-  logToExpr specSignal
-  logString "Extra info:"
-  logDoc $ extraInfo @ConwayFn @"LEDGER" @era globals ctx env state signal impRuleResult
   when (impResponse /= agdaResponse) $ do
-    logDoc $ diffConformance impResponse agdaResponse
     assertFailure "Conformance failure"
 
 spec :: Spec

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Ratify.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Ratify.hs
@@ -34,6 +34,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as Map
 import qualified Data.Sequence.Strict as SSeq
 import Lens.Micro ((&), (.~))
+import Lens.Micro.Mtl (use)
 import Test.Cardano.Ledger.Conformance ()
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway (
   ConwayRatifyExecContext (..),
@@ -152,8 +153,10 @@ spec = withImpInit @(LedgerSpec Conway) $ describe "RATIFY" $ modifyImpInitProtV
     logString "Agda res:"
     logToExpr agdaRes
     logString "Extra information:"
+    globals <- use impGlobalsL
     logDoc $
       extraInfo @ConwayFn @"RATIFY" @Conway
+        globals
         execCtx
         ratEnv
         ratSt


### PR DESCRIPTION
# Description

This PR fixes some issues that prevent the conformance tests on most of the ImpTests from passing. 

The `VKey` type is now translated to a pair of the `VKey` and the hash of that `VKey`, similar to how `Timelock`s are translated.

`ConwayRegCert` now translates to the `Reg` certificate, which is a newly added certificate in the spec. The previous approach of translating that cert to `Deleg` did not work, because the `Deleg` cert always requires witnessing, while the legacy registration cert does not.

related: https://github.com/IntersectMBO/formal-ledger-specifications/pull/616

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
