### PR TITLE
Fixed the certStateSpec

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Tests.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Tests.hs
@@ -126,8 +126,9 @@ specSuite ::
   Int -> Spec
 specSuite n = do
   soundSpecWith @(PState era) (5 * n) (pstateSpec !$! epochNoSpec)
-  soundSpecWith @(DState era) (5 * n) (dstateSpec @era !$! accountStateSpec !*! poolMapSpec)
-
+  soundSpecWith @(DState era)
+    (5 * n)
+    (dstateSpec @era !$! TrueSpec !*! accountStateSpec !*! poolMapSpec)
   soundSpecWith @(VState era)
     (10 * n)
     ( vstateSpec @_ @era
@@ -139,15 +140,15 @@ specSuite n = do
                  )
             )
     )
-
   soundSpecWith @(CertState era)
     (5 * n)
-    $ certStateSpec !$! TrueSpec !*! accountStateSpec !*! epochNoSpec
+    $ certStateSpec !$! (hasSize (rangeSize 6 10)) !*! accountStateSpec !*! epochNoSpec
+  soundSpecWith @(UTxOState era) (2 * n) (utxoStateGen @era)
   soundSpecWith @(UTxO era) (5 * n) (utxoSpec !$! delegationsSpec)
   soundSpecWith @(GovState era)
     (2 * n)
     (do x <- genFromSpec (pparamsSpec @ConwayFn); pure $ govStateSpec @era x)
-  soundSpecWith @(UTxOState era) (2 * n) (utxoStateGen @era)
+
   soundSpecWith @(LedgerState era)
     (2 * n)
     (ledgerStateSpec <$> genConwayFn pparamsSpec !*! accountStateSpec !*! epochNoSpec)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/WellFormed.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/WellFormed.hs
@@ -76,10 +76,11 @@ psX = do
 dsX :: forall era. EraSpecLedger era ConwayFn => Gen (DState era)
 dsX = do
   acct <- genFromSpec @ConwayFn @AccountState accountStateSpec
+  drepRoleSet <- genFromSpec @ConwayFn TrueSpec
   pools <-
     genFromSpec @ConwayFn @(Map (KeyHash 'StakePool (EraCrypto era)) (PoolParams (EraCrypto era)))
       (hasSize (rangeSize 8 8))
-  genFromSpec @ConwayFn @(DState era) (dstateSpec (lit acct) (lit pools))
+  genFromSpec @ConwayFn @(DState era) (dstateSpec @era (lit drepRoleSet) (lit acct) (lit pools))
 
 vsX :: forall era. EraSpecPParams era => Gen (VState era)
 vsX = do


### PR DESCRIPTION
addresses Issue #4775

1) Embedded in the UMap of the DState, is the virtual DRep map with type
Map  (Credential Staking c) (DRep c)

2) There is a related map in the VState
Map  (Credential 'DRepRole c) (DRepState c)

Given the following two facts
A. every   (Credential 'DRepRole c) corresponds to a unique DRep
B. Each DRepState contains a field  drepDelegs:: DRepState -> Set  (Credential Staking c) 

There is a sort of inversse relation between the two maps
For every  (Credential 'DRepRole c) in the Map in the VState, and every Set of Staking credentials associated with it, there is a corresponding entry in the DState Map, showing that each credential has delegated to the DRep uniquely identified by the  (Credential 'DRepRole cere is a function that computes the invariant
```
-- | Compute the map of DReps, to those that delegate to them,
--   from the delegation map (Map (Credential 'Staking) Drep) which is stored in the DState
--   This ensures that every staking Credential, delegates to exactly one DRep.
aggregateDRep ::
  Map (Credential 'Staking c) (DRep c) ->
  Map (Credential 'DRepRole c) (Set (Credential 'Staking c))
aggregateDRep m = Map.foldlWithKey accum Map.empty m
  where
    accum ans cred (DRepKeyHash kh) = Map.insertWith Set.union (KeyHashObj kh) (Set.singleton cred) ans
    accum ans cred (DRepScriptHash sh) = Map.insertWith Set.union (ScriptHashObj sh) (Set.singleton cred) ans
    accum ans _ _ = ans
```

Maintaining this invariant is crucial. The problem was that in our attempt to state this invariant, we over-constrained the system, and the generators could not solve the over-constrained system,

This PR slightly restructures things so the invariant is maintained, and the system is no longer over constrained.




<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
