### PR TITLE
Add functions to convert hashes to and from `VRFVerKeyHash`

### DIFF
--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Add `toVRFVerKeyHash` and `fromVRFVerKeyHash`
 * Change lens type of `hkdNOptL`, `ppNOptL`, and `ppuNOptL` to `Word16`
 * Add `epochFromSlot`
 * Remove usage of a `Reader` monad in `epochInfoEpoch`, `epochInfoFirst` and `epochInfoSize`.

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/Internal.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/Internal.hs
@@ -35,6 +35,8 @@ module Cardano.Ledger.Keys.Internal (
   KeyRoleVRF (..),
   VRFVerKeyHash (..),
   hashVerKeyVRF,
+  toVRFVerKeyHash,
+  fromVRFVerKeyHash,
 
   -- * Genesis delegations
   GenDelegPair (..),
@@ -373,4 +375,12 @@ deriving newtype instance Crypto c => Default (VRFVerKeyHash r c)
 
 hashVerKeyVRF ::
   Crypto c => VerKeyVRF c -> VRFVerKeyHash (r :: KeyRoleVRF) c
-hashVerKeyVRF = VRFVerKeyHash . Hash.castHash . VRF.hashVerKeyVRF
+hashVerKeyVRF = toVRFVerKeyHash . VRF.hashVerKeyVRF
+
+toVRFVerKeyHash ::
+  Hash.Hash (HASH c) (VRF.VerKeyVRF v) -> VRFVerKeyHash (r :: KeyRoleVRF) c
+toVRFVerKeyHash = VRFVerKeyHash . Hash.castHash
+
+fromVRFVerKeyHash ::
+  VRFVerKeyHash (r :: KeyRoleVRF) c -> Hash.Hash (HASH c) (VRF.VerKeyVRF v)
+fromVRFVerKeyHash = Hash.castHash . unVRFVerKeyHash


### PR DESCRIPTION
# Description

Downstream projects are using a different type for these hashes, and don't need to make the role distinctions that ledger does. However, they do need to provide hashes of this type when passing various records to ledger. Providing conversion functions makes the code cleaner and safer in the downstream projects, because they don't have to import `Cardano.Crypto.Hash` and call `castHash`. The conversion functions provide a type-specialized wrapping of it.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] ~New tests are added if needed and existing tests are updated~
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
- [ ] ~Versions are updated in `.cabal` and `CHANGELOG.md` files.~
- [ ] ~The version bounds in `.cabal` files for all affected packages are updated.~
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
