### PR TITLE
Move the list of predicate failures inside `OpaqueErrorString`

### DIFF
--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
@@ -27,7 +27,7 @@ spec ::
   forall era.
   ( Arbitrary (TxAuxData era)
   , AlonzoEraImp era
-  , BabbageEraTxOut era
+  , BabbageEraTxBody era
   , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
   , InjectRuleFailure "LEDGER" AlonzoUtxoPredFailure era
   , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
@@ -94,6 +94,10 @@ newtype ShelleyLedgersPredFailure era
   = LedgerFailure (PredicateFailure (EraRule "LEDGER" era)) -- Subtransition Failures
   deriving (Generic)
 
+instance
+  NFData (PredicateFailure (EraRule "LEDGER" era)) =>
+  NFData (ShelleyLedgersPredFailure era)
+
 type instance EraRuleFailure "LEDGERS" (ShelleyEra c) = ShelleyLedgersPredFailure (ShelleyEra c)
 
 type instance EraRuleEvent "LEDGERS" (ShelleyEra c) = ShelleyLedgersEvent (ShelleyEra c)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
@@ -76,7 +76,6 @@ import Cardano.Ledger.Conway.Rules (
 import Cardano.Ledger.DRep (DRep (..))
 import Cardano.Ledger.PoolDistr (IndividualPoolStake (..))
 import Constrained hiding (inject)
-import Data.Bifunctor (Bifunctor (..))
 import Data.Foldable (Foldable (..))
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -92,9 +91,10 @@ import Test.Cardano.Ledger.Common (Arbitrary (..))
 import Test.Cardano.Ledger.Conformance (
   ExecSpecRule (..),
   SpecTranslate (..),
-  computationResultToEither,
   integerToHash,
   runSpecTransM,
+  unComputationResult,
+  unComputationResult_,
  )
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (defaultTestConformance)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway (vkeyFromInteger)
@@ -403,10 +403,7 @@ instance IsConwayUniv fn => ExecSpecRule fn "RATIFY" Conway where
 
   signalSpec ctx _env _st = ratifySignalSpec ctx
 
-  runAgdaRule env st sig =
-    first (\case {})
-      . computationResultToEither
-      $ Agda.ratifyStep env st sig
+  runAgdaRule env st sig = unComputationResult_ $ Agda.ratifyStep env st sig
 
   extraInfo _ ctx env@RatifyEnv {..} st sig@(RatifySignal actions) _ =
     PP.vsep $ specExtraInfo : (actionAcceptedRatio <$> toList actions)
@@ -563,10 +560,7 @@ instance IsConwayUniv fn => ExecSpecRule fn "ENACT" Conway where
   environmentSpec _ = TrueSpec
   stateSpec = enactStateSpec
   signalSpec = enactSignalSpec
-  runAgdaRule env st sig =
-    first (\e -> error $ "ENACT failed with:\n" <> show e)
-      . computationResultToEither
-      $ Agda.enactStep env st sig
+  runAgdaRule env st sig = unComputationResult $ Agda.enactStep env st sig
 
   classOf = Just . nameEnact
 
@@ -595,10 +589,7 @@ instance IsConwayUniv fn => ExecSpecRule fn "EPOCH" Conway where
 
   signalSpec _ _ _ = epochSignalSpec
 
-  runAgdaRule env st sig =
-    first (\case {})
-      . computationResultToEither
-      $ Agda.epochStep env st sig
+  runAgdaRule env st sig = unComputationResult_ $ Agda.epochStep env st sig
 
   classOf = Just . nameEpoch
 
@@ -615,10 +606,7 @@ instance IsConwayUniv fn => ExecSpecRule fn "NEWEPOCH" Conway where
 
   signalSpec _ _ _ = epochSignalSpec
 
-  runAgdaRule env st sig =
-    first (\case {})
-      . computationResultToEither
-      $ Agda.newEpochStep env st sig
+  runAgdaRule env st sig = unComputationResult_ $ Agda.newEpochStep env st sig
 
 externalFunctions :: Agda.ExternalFunctions
 externalFunctions = Agda.MkExternalFunctions {..}

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
@@ -19,10 +19,7 @@ import Cardano.Ledger.Conway
 import Cardano.Ledger.Conway.TxCert (ConwayTxCert (..))
 import Cardano.Ledger.Crypto (StandardCrypto)
 import Constrained (lit)
-import Data.Bifunctor (first)
-import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
-import qualified Data.Text as T
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base
@@ -41,10 +38,7 @@ instance
   environmentSpec _ = certEnvSpec
   stateSpec ctx _ = certStateSpec (lit $ ccecDelegatees ctx)
   signalSpec _ = txCertSpec
-  runAgdaRule env st sig =
-    first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
-      . computationResultToEither
-      $ Agda.certStep env st sig
+  runAgdaRule env st sig = unComputationResult $ Agda.certStep env st sig
 
   classOf = Just . nameTxCert
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
@@ -14,10 +14,8 @@ import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Crypto (StandardCrypto)
 import Cardano.Ledger.Keys (KeyRole (..))
 import Constrained (lit)
-import Data.Bifunctor (bimap)
-import qualified Data.List.NonEmpty as NE
+import Data.Bifunctor (Bifunctor (..))
 import Data.Set (Set)
-import qualified Data.Text as T
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core ()
@@ -36,10 +34,9 @@ instance IsConwayUniv fn => ExecSpecRule fn "DELEG" Conway where
   signalSpec _ = conwayDelegCertSpec
 
   runAgdaRule env (Agda.MkCertState dState pState vState) sig =
-    bimap
-      (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
+    second
       (\dState' -> Agda.MkCertState dState' pState vState)
-      . computationResultToEither
+      . unComputationResult
       $ Agda.delegStep env dState sig
 
   classOf = Just . nameDelegCert

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Gov.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Gov.hs
@@ -1,15 +1,10 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -22,9 +17,6 @@ import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.TxIn (TxId)
-import Data.Bifunctor (first)
-import qualified Data.List.NonEmpty as NE
-import qualified Data.Text as T
 import Lens.Micro
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
@@ -66,10 +58,7 @@ instance
       , enactState
       )
 
-  runAgdaRule env st sig =
-    first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
-      . computationResultToEither
-      $ Agda.govStep env st sig
+  runAgdaRule env st sig = unComputationResult $ Agda.govStep env st sig
 
   translateInputs env@GovEnv {gePParams} st sig (txId, _proposalsSplit, enactState) = do
     agdaEnv <- expectRight $ runSpecTransM ctx $ toSpecRep env

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
@@ -22,9 +22,7 @@ import Cardano.Ledger.Conway.TxCert
 import Cardano.Ledger.Crypto (StandardCrypto)
 import Constrained (lit)
 import Data.Bifunctor (Bifunctor (..))
-import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
-import qualified Data.Text as T
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base
@@ -47,11 +45,8 @@ instance
   classOf = Just . nameGovCert
 
   runAgdaRule env (Agda.MkCertState dState pState vState) sig =
-    bimap
-      (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
-      (Agda.MkCertState dState pState)
-      . computationResultToEither
-      $ Agda.govCertStep env vState sig
+    second (Agda.MkCertState dState pState) . unComputationResult $
+      Agda.govCertStep env vState sig
 
 nameGovCert :: ConwayGovCert c -> String
 nameGovCert (ConwayRegDRep {}) = "ConwayRegDRep"

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledgers.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledgers.hs
@@ -11,14 +11,10 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Ledgers () where
 import Cardano.Ledger.Conway (Conway)
 import Cardano.Ledger.Conway.Governance (EnactState)
 import Constrained (Specification (..))
-import Data.Bifunctor (Bifunctor (..))
-import qualified Data.List.NonEmpty as NE
-import qualified Data.Text as T
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance (
   ExecSpecRule (..),
-  OpaqueErrorString (..),
-  computationResultToEither,
+  unComputationResult,
  )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway ()
 import Test.Cardano.Ledger.Constrained.Conway (IsConwayUniv)
@@ -29,7 +25,4 @@ instance IsConwayUniv fn => ExecSpecRule fn "LEDGERS" Conway where
   environmentSpec _ = TrueSpec
   stateSpec _ _ = TrueSpec
   signalSpec _ _ _ = TrueSpec
-  runAgdaRule env st sig =
-    first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
-      . computationResultToEither
-      $ Agda.ledgersStep env st sig
+  runAgdaRule env st sig = unComputationResult $ Agda.ledgersStep env st sig

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Pool.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Pool.hs
@@ -9,9 +9,6 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Pool where
 
 import Cardano.Ledger.Conway
 import Cardano.Ledger.Core (PoolCert (..))
-import Data.Bifunctor (first)
-import qualified Data.List.NonEmpty as NE
-import qualified Data.Text as T
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core ()
@@ -24,12 +21,9 @@ instance IsConwayUniv fn => ExecSpecRule fn "POOL" Conway where
 
   stateSpec _ _ = pStateSpec
 
-  signalSpec _ env st = poolCertSpec env st
+  signalSpec _ = poolCertSpec
 
-  runAgdaRule env st sig =
-    first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
-      . computationResultToEither
-      $ Agda.poolStep env st sig
+  runAgdaRule env st sig = unComputationResult $ Agda.poolStep env st sig
 
   classOf = Just . namePoolCert
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxo.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxo.hs
@@ -19,8 +19,6 @@ import Cardano.Ledger.Conway (Conway)
 import Cardano.Ledger.Core (EraPParams (..), ppMaxTxSizeL, sizeTxF)
 import Cardano.Ledger.Shelley.LedgerState (LedgerState (..), UTxOState (..))
 import Cardano.Ledger.Shelley.Rules (UtxoEnv (..))
-import Data.Bifunctor (Bifunctor (..))
-import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import Lens.Micro ((&), (.~), (^.))
 import qualified Lib as Agda
@@ -29,10 +27,9 @@ import qualified Prettyprinter as PP
 import Test.Cardano.Ledger.Common (Arbitrary (..), Gen, showExpr)
 import Test.Cardano.Ledger.Conformance (
   ExecSpecRule (..),
-  OpaqueErrorString (..),
   SpecTranslate (..),
-  computationResultToEither,
   runSpecTransM,
+  unComputationResult,
  )
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base (externalFunctions)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert ()
@@ -99,9 +96,8 @@ instance
   signalSpec ctx _ _ = utxoTxSpec ctx
 
   runAgdaRule env st sig =
-    first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
-      . computationResultToEither
-      $ Agda.utxoStep externalFunctions env st sig
+    unComputationResult $
+      Agda.utxoStep externalFunctions env st sig
 
   extraInfo _ ctx env@UtxoEnv {..} st@UTxOState {..} sig st' =
     PP.vcat

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -9,7 +9,9 @@ module Test.Cardano.Ledger.Conformance.Orphans where
 import Data.Bifunctor (Bifunctor (..))
 import Data.Default (Default)
 import Data.List (nub, sortOn)
+import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Set as Set
+import Data.Text (Text)
 import Data.Void (Void)
 import GHC.Generics (Generic)
 import Lib
@@ -249,6 +251,11 @@ instance ToExpr LEnv
 instance Default (HSMap k v)
 
 instance FixupSpecRep Void
+
+instance FixupSpecRep a => FixupSpecRep (NonEmpty a)
+
+instance FixupSpecRep Text where
+  fixup = id
 
 instance FixupSpecRep OpaqueErrorString
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -124,6 +124,7 @@ import Test.Cardano.Ledger.Conformance (
   SpecTranslationError,
   askCtx,
   hashToInteger,
+  showOpaqueErrorString,
   withCtx,
  )
 import Test.Cardano.Ledger.Constrained.Conway (DepositPurpose (..), IsConwayUniv)
@@ -719,7 +720,7 @@ instance
   where
   type SpecRep (ConwayGovPredFailure era) = OpaqueErrorString
 
-  toSpecRep e = pure . OpaqueErrorString . show $ toExpr e
+  toSpecRep = pure . showOpaqueErrorString
 
 instance SpecTranslate ctx (GovPurposeId r c) where
   type SpecRep (GovPurposeId r c) = (Agda.TxId, Integer)
@@ -1038,7 +1039,7 @@ instance
   where
   type SpecRep (ConwayCertPredFailure era) = OpaqueErrorString
 
-  toSpecRep = pure . OpaqueErrorString . showExpr
+  toSpecRep = pure . showOpaqueErrorString
 
 instance (SpecTranslate ctx a, Compactible a) => SpecTranslate ctx (CompactForm a) where
   type SpecRep (CompactForm a) = SpecRep a

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
@@ -215,4 +215,4 @@ instance
 
 instance SpecTranslate ctx (ConwayNewEpochPredFailure era) where
   type SpecRep (ConwayNewEpochPredFailure era) = OpaqueErrorString
-  toSpecRep = pure . OpaqueErrorString . show . toExpr
+  toSpecRep = pure . showOpaqueErrorString

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
@@ -28,7 +28,7 @@ import Test.Cardano.Ledger.Conway.TreeDiff
 
 instance ToExpr (PredicateFailure (EraRule "CERT" era)) => SpecTranslate ctx (ConwayCertsPredFailure era) where
   type SpecRep (ConwayCertsPredFailure era) = OpaqueErrorString
-  toSpecRep = pure . OpaqueErrorString . show . toExpr
+  toSpecRep = pure . showOpaqueErrorString
 
 instance
   ( SpecTranslate ctx (PParamsHKD Identity era)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
@@ -36,7 +36,6 @@ import Test.Cardano.Ledger.Conformance (
  )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
-import Test.Cardano.Ledger.Conway.TreeDiff
 
 instance
   ( SpecRep (PParamsHKD Identity era) ~ Agda.PParams
@@ -81,7 +80,7 @@ instance SpecTranslate ctx (ConwayDelegCert c) where
 instance SpecTranslate ctx (ConwayDelegPredFailure era) where
   type SpecRep (ConwayDelegPredFailure era) = OpaqueErrorString
 
-  toSpecRep e = pure . OpaqueErrorString . show $ toExpr e
+  toSpecRep = pure . showOpaqueErrorString
 
 instance SpecTranslate ctx (DState era) where
   type SpecRep (DState era) = Agda.DState

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -40,7 +39,6 @@ import qualified Data.Map.Strict as Map
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
-import Test.Cardano.Ledger.Conway.TreeDiff (showExpr)
 
 instance Crypto c => SpecTranslate ctx (ConwayGovCert c) where
   type SpecRep (ConwayGovCert c) = Agda.DCert
@@ -90,7 +88,7 @@ instance
 instance SpecTranslate ctx (ConwayGovCertPredFailure era) where
   type SpecRep (ConwayGovCertPredFailure era) = OpaqueErrorString
 
-  toSpecRep = pure . OpaqueErrorString . showExpr
+  toSpecRep = pure . showOpaqueErrorString
 
 instance SpecTranslate ctx (VState era) where
   type SpecRep (VState era) = Agda.GState

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledger.hs
@@ -21,7 +21,7 @@ import Control.State.Transition.Extended (STS (..))
 import Data.Functor.Identity (Identity)
 import Data.Maybe.Strict (StrictMaybe)
 import qualified Lib as Agda
-import Test.Cardano.Ledger.Conformance (OpaqueErrorString (..), askCtx)
+import Test.Cardano.Ledger.Conformance (OpaqueErrorString (..), askCtx, showOpaqueErrorString)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (SpecTranslate (..))
 import Test.Cardano.Ledger.Conway.TreeDiff (ToExpr (..))
 
@@ -55,4 +55,4 @@ instance
   where
   type SpecRep (ConwayLedgerPredFailure era) = OpaqueErrorString
 
-  toSpecRep e = pure . OpaqueErrorString . show $ toExpr e
+  toSpecRep = pure . showOpaqueErrorString

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledgers.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledgers.hs
@@ -19,9 +19,14 @@ import Cardano.Ledger.Shelley.LedgerState (AccountState (..))
 import Cardano.Ledger.Shelley.Rules (Identity, ShelleyLedgersEnv (..), ShelleyLedgersPredFailure)
 import Control.State.Transition.Extended (STS (..))
 import qualified Lib as Agda
-import Test.Cardano.Ledger.Conformance (OpaqueErrorString (..), SpecTranslate (..), askCtx)
+import Test.Cardano.Ledger.Conformance (
+  OpaqueErrorString (..),
+  SpecTranslate (..),
+  askCtx,
+  showOpaqueErrorString,
+ )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
-import Test.Cardano.Ledger.Conway.TreeDiff (ToExpr, showExpr)
+import Test.Cardano.Ledger.Conway.TreeDiff (ToExpr)
 
 instance
   ( EraPParams era
@@ -50,4 +55,4 @@ instance
   where
   type SpecRep (ShelleyLedgersPredFailure era) = OpaqueErrorString
 
-  toSpecRep = pure . OpaqueErrorString . showExpr
+  toSpecRep = pure . showOpaqueErrorString

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
@@ -18,7 +18,6 @@ import Data.Map.Strict (mapKeys)
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
-import Test.Cardano.Ledger.Conway.TreeDiff
 
 instance
   ( SpecRep (PParamsHKD Identity era) ~ Agda.PParams
@@ -33,7 +32,7 @@ instance
 instance SpecTranslate ctx (ShelleyPoolPredFailure era) where
   type SpecRep (ShelleyPoolPredFailure era) = OpaqueErrorString
 
-  toSpecRep e = pure . OpaqueErrorString . show $ toExpr e
+  toSpecRep = pure . showOpaqueErrorString
 
 instance SpecTranslate ctx (PState era) where
   type SpecRep (PState era) = Agda.PState

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Utxo.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Utxo.hs
@@ -18,7 +18,7 @@ import Cardano.Ledger.Shelley.Rules (UtxoEnv (..))
 import Control.State.Transition.Extended (STS (..))
 import Data.Functor.Identity (Identity)
 import qualified Lib as Agda
-import Test.Cardano.Ledger.Conformance (OpaqueErrorString (..))
+import Test.Cardano.Ledger.Conformance (OpaqueErrorString (..), showOpaqueErrorString)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (SpecTranslate (..))
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert ()
 import Test.Cardano.Ledger.Conway.TreeDiff (ToExpr (..))
@@ -46,4 +46,4 @@ instance
   where
   type SpecRep (ConwayUtxoPredFailure era) = OpaqueErrorString
 
-  toSpecRep e = pure . OpaqueErrorString . show $ toExpr e
+  toSpecRep = pure . showOpaqueErrorString

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Utxow.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Utxow.hs
@@ -10,8 +10,12 @@ module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Utxow () where
 
 import Cardano.Ledger.Conway.Core (AlonzoEraScript (..), AsItem, AsIx, Era, EraRule, EraTxCert (..))
 import Cardano.Ledger.Conway.Rules (ConwayUtxowPredFailure, PredicateFailure)
-import Test.Cardano.Ledger.Conformance (OpaqueErrorString (..), SpecTranslate (..))
-import Test.Cardano.Ledger.Conway.TreeDiff (ToExpr, showExpr)
+import Test.Cardano.Ledger.Conformance (
+  OpaqueErrorString (..),
+  SpecTranslate (..),
+  showOpaqueErrorString,
+ )
+import Test.Cardano.Ledger.Conway.TreeDiff (ToExpr)
 
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Utxo ()
 
@@ -26,4 +30,4 @@ instance
   where
   type SpecRep (ConwayUtxowPredFailure era) = OpaqueErrorString
 
-  toSpecRep = pure . OpaqueErrorString . showExpr
+  toSpecRep = pure . showOpaqueErrorString

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Utils.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Utils.hs
@@ -9,7 +9,6 @@ import Cardano.Crypto.Util (bytesToNatural, naturalToBytes)
 import Cardano.Ledger.Crypto (Crypto (..), StandardCrypto)
 import qualified Data.ByteString.Base16 as B16
 import Data.Data (Proxy (..))
-import qualified Lib as Agda
 import Test.Cardano.Ledger.TreeDiff (Expr, ToExpr (..))
 
 standardHashSize :: Int
@@ -26,7 +25,3 @@ hashToInteger = toInteger . bytesToNatural . hashToBytes
 
 integerToHash :: forall h a. HashAlgorithm h => Integer -> Maybe (Hash h a)
 integerToHash = hashFromBytes . naturalToBytes (fromIntegral . sizeHash $ Proxy @h) . fromInteger
-
-computationResultToEither :: Agda.ComputationResult e a -> Either e a
-computationResultToEither (Agda.Success x) = Right x
-computationResultToEither (Agda.Failure e) = Left e

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Ratify.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Ratify.hs
@@ -30,12 +30,13 @@ import Cardano.Ledger.Shelley.LedgerState (
   nesELL,
   nesEsL,
  )
+import Data.Bifunctor (Bifunctor (..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as Map
 import qualified Data.Sequence.Strict as SSeq
 import Lens.Micro ((&), (.~))
 import Lens.Micro.Mtl (use)
-import Test.Cardano.Ledger.Conformance ()
+import Test.Cardano.Ledger.Conformance (showOpaqueErrorString)
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway (
   ConwayRatifyExecContext (..),
  )
@@ -161,5 +162,6 @@ spec = withImpInit @(LedgerSpec Conway) $ describe "RATIFY" $ modifyImpInitProtV
         ratEnv
         ratSt
         ratSig
-        implRes'
-    impAnn "Conformance failed" $ implRes `shouldBeExpr` agdaRes
+        (first showOpaqueErrorString implRes')
+    impAnn "Conformance failed" $
+      first showOpaqueErrorString implRes `shouldBeExpr` agdaRes

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
@@ -402,6 +402,8 @@ instance Reflect era => TotalAda (UTxOState era) where
 -- we don't add in the _deposits, because it is invariant that this
 -- is equal to the sum of the key deposit map and the pool deposit map
 -- So these are accounted for in the instance (TotalAda (CertState era))
+-- TODO I'm not sure this is true ^
+-- Imp conformance tests show in logs that totalAda is off by the deposit amount
 
 instance Reflect era => TotalAda (UTxO era) where
   totalAda (UTxO m) = foldl accum mempty m


### PR DESCRIPTION
# Description

Previously if both the spec and implementation produce predicate failures when running a rule, the conformance test would still fail if the number of predicate failures was different. This PR fixes this issue my making all predicate failures equal no matter how many conditions were unsatisfied.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
