### PR TITLE
Update haskellNix and CHaP and upgrade ghc-9.8.2 to 9.8.4

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -36,7 +36,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ghc: ["8.10.7", "9.2.8", "9.6.6", "9.8.2", "9.10.1"]
+        ghc: ["8.10.7", "9.2.8", "9.6.6", "9.8.4", "9.10.1"]
         os: [ubuntu-latest]
       fail-fast: false
 
@@ -213,7 +213,7 @@ jobs:
         - set-algebra
         - small-steps
         - vector-map
-        ghc: ["8.10.7", "9.2.8", "9.6.6", "9.8.2", "9.10.1"]
+        ghc: ["8.10.7", "9.2.8", "9.6.6", "9.8.4", "9.10.1"]
         os: [ubuntu-latest]
       fail-fast: false
 

--- a/cabal.project
+++ b/cabal.project
@@ -45,8 +45,8 @@ source-repository-package
 index-state:
   -- Bump this if you need newer packages from Hackage
   -- Bump this if you need newer packages from CHaP
-  , hackage.haskell.org 2024-11-20T00:00:00Z
-  , cardano-haskell-packages 2024-11-27T20:49:28Z
+  , hackage.haskell.org 2024-12-10T00:00:00Z
+  , cardano-haskell-packages 2024-12-11T15:05:22Z
 
 packages:
   -- == Byron era ==

--- a/flake.lock
+++ b/flake.lock
@@ -295,11 +295,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1733878317,
-        "narHash": "sha256-Bbr5dUxCH+s1BXfZ5BNxmOOnLZqZUdjeZVWN0KEak/Q=",
+        "lastModified": 1733956415,
+        "narHash": "sha256-QECLKb+pGFqfZBujt8XwZ/DgwVhw0WRwXBhoKR5LbN4=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "fa511ea6fd05774bbf97f187fd560658067ff7f7",
+        "rev": "6aeb986c46b6c854408d4cbf733f591190f53c5f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1732742574,
-        "narHash": "sha256-XUhDWQeChjNPcYluz8sCbs5vW+3jEYysxEhpKdFXbt0=",
+        "lastModified": 1733946732,
+        "narHash": "sha256-8RwIGx4z0LELkL5d8Xg85/O5yqox6mHtusrNoIqSeCU=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "375a4694472aa362b7abba0e8b7f3de787e90c91",
+        "rev": "6d857b7864e15267825582b785a6b1ce71942c1d",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1732062550,
-        "narHash": "sha256-7WEgL74nWqnuue00ZgFCRdmB9ZFMCdN94pMS8OJUUZE=",
+        "lastModified": 1733877006,
+        "narHash": "sha256-rNpSFS/ziUQBPgo6iAbKgU00yRpeCngv215TW0D+kCo=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "ad8f3fa0751f7e50ca7c1a6b49410ea92ccf003e",
+        "rev": "583f569545854160b6bc5606374bf5006a9f6929",
         "type": "github"
       },
       "original": {
@@ -295,11 +295,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1731372695,
-        "narHash": "sha256-QddLLOvRtrao9Ztuk1rYSXmepxH2/blYRfuRWx/QUyM=",
+        "lastModified": 1733878317,
+        "narHash": "sha256-Bbr5dUxCH+s1BXfZ5BNxmOOnLZqZUdjeZVWN0KEak/Q=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "54ddc77cd29c19779489d8f7fae14d70e90d8c68",
+        "rev": "fa511ea6fd05774bbf97f187fd560658067ff7f7",
         "type": "github"
       },
       "original": {
@@ -906,11 +906,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1731370260,
-        "narHash": "sha256-DsuG/LEJduoxwK+VbKubVsCfg1WFAUaewYAUFLW0FRU=",
+        "lastModified": 1733789551,
+        "narHash": "sha256-0tSxhYw3RqNEHYFYIwJZ99mFDpGr8Dekf+p2ZCEygYY=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "5b7b9fad43a035243f87f654ac5611f597ce5fc2",
+        "rev": "db7b3e7ae59867ce0ba21df45f57ea38f57710ab",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -179,7 +179,7 @@
           cabalProject.flake (
             lib.optionalAttrs (system == "x86_64-linux") {
               # on linux, build/test other supported compilers
-              variants = lib.genAttrs ["ghc8107" "ghc982"] (compiler-nix-name: {
+              variants = lib.genAttrs ["ghc8107" "ghc984"] (compiler-nix-name: {
                 inherit compiler-nix-name;
               });
             }


### PR DESCRIPTION
# Description

Update `hackahge.nix`,  `haskell.nix` and CHaP

Also use newer version of ghc-9.8

# Checklist

- [x] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
