### PR TITLE
Ts constrained witnessing take2

### DIFF
--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
@@ -136,19 +136,21 @@ import Test.Cardano.Ledger.Imp.Common hiding (arbitrary, forAll, prop, var, witn
 
 -- ================================================================
 
-data ConwayCertExecContext era = ConwayCertExecContext
-  { ccecWithdrawals :: !(Map RewardAccount Coin)
-  , ccecDeposits :: !(Map DepositPurpose Coin)
-  , ccecVotes :: !(VotingProcedures era)
-  , ccecDelegatees :: !(Set (Credential 'DRepRole))
-  -- ^ The UMap of the DState has a field with type: Map (Credential 'Staking) DRep
-  --   The VState field vsDReps has type: Map (Credential DRepRole) DRepState
-  --   The DRepState field drepDelegs has type: Set (Credential Staking)
-  --   Every (Credential 'DRepRole c) corresponds to a unique (DRep)
-  -- the ccecDelegatees field helps maintain that correspondance, It is used in
-  -- vstateSpec and bootstrapDStateSpec. Also see
-  -- getDelegatees :: DState era -> Map (Credential 'DRepRole) (Set (Credential 'Staking))
-  -- in Test.Cardano.Ledger.Constrained.Conway.LedgerTypes.Specs, which defines the exact correspondance.  }
+data ConwayCertExecContext era
+  = -- | The UMap of the DState has a field with type: Map (Credential 'Staking) DRep
+    --   The VState field vsDReps has type: Map (Credential DRepRole) DRepState
+    --   The DRepState field drepDelegs has type: Set (Credential Staking)
+    --   Every (Credential 'DRepRole c) corresponds to a unique (DRep)
+    -- the ccecDelegatees field helps maintain that correspondance, It is used in
+    -- vstateSpec and bootstrapDStateSpec. Also see
+    -- getDelegatees :: DState era -> Map (Credential 'DRepRole) (Set (Credential 'Staking))
+    -- in Test.Cardano.Ledger.Constrained.Conway.LedgerTypes.Specs, which defines the exact correspondance.  }
+    ConwayCertExecContext
+    { ccecWithdrawals :: !(Map RewardAccount Coin)
+    , ccecDeposits :: !(Map DepositPurpose Coin)
+    , ccecVotes :: !(VotingProcedures era)
+    , ccecDelegatees :: !(Set (Credential 'DRepRole))
+    }
   deriving (Generic, Eq, Show)
 
 instance HasSimpleRep (ConwayCertExecContext era)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
@@ -20,6 +20,7 @@
 
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base (
   ConwayCertExecContext (..),
+  conwayCertExecContextSpec,
   ConwayRatifyExecContext (..),
   nameEpoch,
   nameEnact,
@@ -126,8 +127,13 @@ import Cardano.Ledger.Keys (KeyRole (..), VKey (..))
 import Data.Either (isRight)
 import Data.Maybe (fromMaybe)
 import Data.Set (Set)
+import Test.Cardano.Ledger.Constrained.Conway.Utxo (witnessDepositPurpose)
+import Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse (WitUniv (..), witness)
 import Test.Cardano.Ledger.Conway.Arbitrary ()
-import Test.Cardano.Ledger.Imp.Common hiding (arbitrary, forAll, prop, var)
+import Test.Cardano.Ledger.Generic.Proof (Reflect)
+import Test.Cardano.Ledger.Imp.Common hiding (arbitrary, forAll, prop, var, witness)
+
+-- ================================================================
 
 data ConwayCertExecContext era = ConwayCertExecContext
   { ccecWithdrawals :: !(Map RewardAccount Coin)
@@ -137,7 +143,24 @@ data ConwayCertExecContext era = ConwayCertExecContext
   }
   deriving (Generic, Eq, Show)
 
-instance Era era => Arbitrary (ConwayCertExecContext era) where
+instance HasSimpleRep (ConwayCertExecContext era)
+instance (IsConwayUniv fn, Era era) => HasSpec fn (ConwayCertExecContext era)
+
+-- No particular constraints, other than witnessing
+conwayCertExecContextSpec ::
+  forall fn era.
+  (Reflect era, IsConwayUniv fn) =>
+  WitUniv era -> Specification fn (ConwayCertExecContext era)
+conwayCertExecContextSpec univ = constrained $ \ [var|ccec|] ->
+  match ccec $ \ [var|withdrawals|] [var|deposits|] _ [var|delegatees|] ->
+    [ assert $ witness univ (dom_ withdrawals)
+    , forAll (dom_ deposits) $ \dp -> satisfies dp (witnessDepositPurpose univ)
+    , witness univ delegatees
+    , assert $ sizeOf_ delegatees <=. 20
+    , assert $ sizeOf_ delegatees >=. 10
+    ]
+
+instance Reflect era => Arbitrary (ConwayCertExecContext era) where
   arbitrary =
     ConwayCertExecContext
       <$> arbitrary
@@ -155,7 +178,7 @@ instance Era era => EncCBOR (ConwayCertExecContext era) where
             !> To ccecVotes
             !> To ccecDelegatees
 
-instance Era era => DecCBOR (ConwayCertExecContext era) where
+instance Reflect era => DecCBOR (ConwayCertExecContext era) where
   decCBOR =
     decode $
       RecD ConwayCertExecContext

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
@@ -35,13 +35,14 @@ instance
   type ExecContext fn "CERT" Conway = (WitUniv Conway, ConwayCertExecContext Conway)
 
   genExecContext = do
-    univ <- genWitUniv @Conway 200
-    ccec <- genFromSpec @ConwayFn (conwayCertExecContextSpec univ)
+    univ <- genWitUniv @Conway 300
+    ccec <- genFromSpec @ConwayFn (conwayCertExecContextSpec univ 5)
     pure (univ, ccec)
 
   environmentSpec (univ, _) = certEnvSpec @fn @Conway univ
 
-  stateSpec (univ, ccecCtx) _ = certStateSpec @fn @Conway univ (ccecDelegatees ccecCtx)
+  stateSpec (univ, ccec) _ =
+    certStateSpec @fn @Conway univ (ccecDelegatees ccec) (ccecWithdrawals ccec)
 
   signalSpec (univ, _) env state = conwayTxCertSpec @fn @Conway univ env state
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -14,11 +15,7 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert (nameTxCert) whe
 
 import Cardano.Ledger.Conway
 import Cardano.Ledger.Conway.TxCert (ConwayTxCert (..))
-import Data.Map.Strict (Map)
 import Constrained
-import Data.Bifunctor (first)
-import qualified Data.List.NonEmpty as NE
-import qualified Data.Text as T
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base
@@ -30,26 +27,25 @@ import Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse
 
 instance
   IsConwayUniv fn =>
-  ExecSpecRule fn "CERT" Conway
+  ExecSpecRule fn "CERT" ConwayEra
   where
-  type ExecContext fn "CERT" Conway = (WitUniv Conway, ConwayCertExecContext Conway)
+  type ExecContext fn "CERT" ConwayEra = (WitUniv ConwayEra, ConwayCertExecContext ConwayEra)
 
   genExecContext = do
-    univ <- genWitUniv @Conway 300
+    univ <- genWitUniv @ConwayEra 300
     ccec <- genFromSpec @ConwayFn (conwayCertExecContextSpec univ 5)
     pure (univ, ccec)
 
-  environmentSpec (univ, _) = certEnvSpec @fn @Conway univ
+  environmentSpec (univ, _) = certEnvSpec @fn @ConwayEra univ
 
   stateSpec (univ, ccec) _ =
-    certStateSpec @fn @Conway univ (ccecDelegatees ccec) (ccecWithdrawals ccec)
+    certStateSpec @fn @ConwayEra univ (ccecDelegatees ccec) (ccecWithdrawals ccec)
 
-  signalSpec (univ, _) env state = conwayTxCertSpec @fn @Conway univ env state
+  signalSpec (univ, _) env state = conwayTxCertSpec @fn @ConwayEra univ env state
 
   runAgdaRule env st sig =
-    first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
-      . computationResultToEither
-      $ Agda.certStep env st sig
+    unComputationResult $
+      Agda.certStep env st sig
 
   classOf = Just . nameTxCert
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
@@ -2,20 +2,23 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert (nameTxCert) where
 
-import Cardano.Ledger.Address (RewardAccount)
-import Cardano.Ledger.BaseTypes (Inject)
-import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway
 import Cardano.Ledger.Conway.TxCert (ConwayTxCert (..))
-import Constrained (lit)
 import Data.Map.Strict (Map)
+import Constrained
+import Data.Bifunctor (first)
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Text as T
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base
@@ -23,18 +26,29 @@ import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg (nameDelegCert)
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.GovCert (nameGovCert)
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Pool (namePoolCert)
 import Test.Cardano.Ledger.Constrained.Conway
+import Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse
 
 instance
-  ( IsConwayUniv fn
-  , Inject (ConwayCertExecContext ConwayEra) (Map RewardAccount Coin)
-  ) =>
-  ExecSpecRule fn "CERT" ConwayEra
+  IsConwayUniv fn =>
+  ExecSpecRule fn "CERT" Conway
   where
-  type ExecContext fn "CERT" ConwayEra = ConwayCertExecContext ConwayEra
-  environmentSpec _ = certEnvSpec
-  stateSpec ctx _ = certStateSpec (lit $ ccecDelegatees ctx)
-  signalSpec _ = txCertSpec
-  runAgdaRule env st sig = unComputationResult $ Agda.certStep env st sig
+  type ExecContext fn "CERT" Conway = (WitUniv Conway, ConwayCertExecContext Conway)
+
+  genExecContext = do
+    univ <- genWitUniv @Conway 200
+    ccec <- genFromSpec @ConwayFn (conwayCertExecContextSpec univ)
+    pure (univ, ccec)
+
+  environmentSpec (univ, _) = certEnvSpec @fn @Conway univ
+
+  stateSpec (univ, ccecCtx) _ = certStateSpec @fn @Conway univ (ccecDelegatees ccecCtx)
+
+  signalSpec (univ, _) env state = conwayTxCertSpec @fn @Conway univ env state
+
+  runAgdaRule env st sig =
+    first (\e -> OpaqueErrorString (T.unpack e) NE.:| [])
+      . computationResultToEither
+      $ Agda.certStep env st sig
 
   classOf = Just . nameTxCert
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
@@ -30,10 +30,10 @@ instance
   IsConwayUniv fn =>
   ExecSpecRule fn "CERTS" ConwayEra
   where
-  type ExecContext fn "CERTS" Conway = (WitUniv Conway, ConwayCertExecContext Conway)
+  type ExecContext fn "CERTS" ConwayEra = (WitUniv ConwayEra, ConwayCertExecContext ConwayEra)
 
   genExecContext = do
-    univ <- genWitUniv @Conway 300
+    univ <- genWitUniv @ConwayEra 300
     ccec <- genFromSpec @fn (conwayCertExecContextSpec univ 5)
     pure (univ, ccec)
 
@@ -42,13 +42,13 @@ instance
   stateSpec (univ, context) _ =
     constrained $ \x ->
       match x $ \vstate pstate dstate ->
-        [ satisfies vstate (vStateSpec @_ @Conway univ (ccecDelegatees context))
-        , satisfies pstate (pStateSpec @_ @Conway univ)
+        [ satisfies vstate (vStateSpec @_ @ConwayEra univ (ccecDelegatees context))
+        , satisfies pstate (pStateSpec @_ @ConwayEra univ)
         , -- temporary workaround because Spec does some extra tests, that the implementation does not, in the bootstrap phase.
           satisfies dstate (bootstrapDStateSpec univ (ccecDelegatees context) (ccecWithdrawals context))
         ]
 
-  signalSpec (univ, _) env state = txCertsSpec @Conway @fn univ env state
+  signalSpec (univ, _) env state = txCertsSpec @ConwayEra @fn univ env state
 
   runAgdaRule env st sig = unComputationResult $ Agda.certsStep env st sig
   classOf = Just . nameCerts
@@ -57,7 +57,7 @@ instance
     -- The results of runConformance are Agda types, the `ctx` is a Haskell type, we extract and translate the Withdrawal keys.
     specWithdrawalCredSet <-
       translateWithContext () (Map.keysSet (Map.mapKeys raCredential (ccecWithdrawals ccec)))
-    (implResTest, agdaResTest, _) <- runConformance @"CERTS" @fn @Conway ctx env st sig
+    (implResTest, agdaResTest, _) <- runConformance @"CERTS" @fn @ConwayEra ctx env st sig
     case (implResTest, agdaResTest) of
       (Right haskell, Right spec) ->
         checkConformance @"CERTS" @ConwayEra @fn

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
@@ -34,7 +34,7 @@ instance
 
   genExecContext = do
     univ <- genWitUniv @Conway 300
-    ccec <- genFromSpec @fn (conwayCertExecContextSpec univ)
+    ccec <- genFromSpec @fn (conwayCertExecContextSpec univ 5)
     pure (univ, ccec)
 
   environmentSpec _ = certsEnvSpec

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
@@ -2,18 +2,21 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg (nameDelegCert) where
 
+import Cardano.Ledger.BaseTypes (Inject (..))
 import Cardano.Ledger.Conway
 import Cardano.Ledger.Conway.TxCert (ConwayDelegCert (..))
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Keys (KeyRole (..))
-import Constrained (lit)
-import Data.Bifunctor (Bifunctor (..))
+import Constrained
+import Data.Bifunctor (bimap)
+import qualified Data.List.NonEmpty as NE
 import Data.Set (Set)
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
@@ -22,13 +25,26 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 import Test.Cardano.Ledger.Constrained.Conway
+import Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse
 
-instance IsConwayUniv fn => ExecSpecRule fn "DELEG" ConwayEra where
-  type ExecContext fn "DELEG" ConwayEra = Set (Credential 'DRepRole)
+instance
+  Inject
+    (WitUniv Conway, Set (Credential 'DRepRole StandardCrypto))
+    (Set (Credential 'DRepRole StandardCrypto))
+  where
+  inject (_, x) = x
+
+instance IsConwayUniv fn => ExecSpecRule fn "DELEG" Conway where
+  type ExecContext fn "DELEG" Conway = (WitUniv Conway, Set (Credential 'DRepRole StandardCrypto))
+
+  genExecContext = do
+    univ <- genWitUniv @Conway 200
+    delegatees <- genFromSpec @ConwayFn (delegateeSpec univ)
+    pure (univ, delegatees)
 
   environmentSpec _ = delegEnvSpec
 
-  stateSpec ctx _ = certStateSpec (lit ctx)
+  stateSpec (univ, delegatee) _ = certStateSpec univ delegatee
 
   signalSpec _ = conwayDelegCertSpec
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
@@ -20,6 +20,10 @@ import qualified Data.List.NonEmpty as NE
 import Data.Set (Set)
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base (
+  ConwayCertExecContext (..),
+  conwayCertExecContextSpec,
+ )
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert ()
@@ -29,22 +33,23 @@ import Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse
 
 instance
   Inject
-    (WitUniv Conway, Set (Credential 'DRepRole StandardCrypto))
+    (WitUniv Conway, ConwayCertExecContext Conway)
     (Set (Credential 'DRepRole StandardCrypto))
   where
-  inject (_, x) = x
+  inject (_, x) = ccecDelegatees x
 
 instance IsConwayUniv fn => ExecSpecRule fn "DELEG" Conway where
-  type ExecContext fn "DELEG" Conway = (WitUniv Conway, Set (Credential 'DRepRole StandardCrypto))
+  type ExecContext fn "DELEG" Conway = (WitUniv Conway, ConwayCertExecContext Conway)
 
   genExecContext = do
-    univ <- genWitUniv @Conway 200
-    delegatees <- genFromSpec @ConwayFn (delegateeSpec univ)
-    pure (univ, delegatees)
+    univ <- genWitUniv @Conway 300
+    ccec <- genFromSpec @ConwayFn (conwayCertExecContextSpec univ 5)
+    pure (univ, ccec)
 
   environmentSpec _ = delegEnvSpec
 
-  stateSpec (univ, delegatee) _ = certStateSpec univ delegatee
+  stateSpec (univ, ccec) _env =
+    certStateSpec @_ @Conway univ (ccecDelegatees ccec) (ccecWithdrawals ccec)
 
   signalSpec _ = conwayDelegCertSpec
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
@@ -15,8 +15,7 @@ import Cardano.Ledger.Conway.TxCert (ConwayDelegCert (..))
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Keys (KeyRole (..))
 import Constrained
-import Data.Bifunctor (bimap)
-import qualified Data.List.NonEmpty as NE
+import Data.Bifunctor (second)
 import Data.Set (Set)
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
@@ -33,23 +32,23 @@ import Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse
 
 instance
   Inject
-    (WitUniv Conway, ConwayCertExecContext Conway)
-    (Set (Credential 'DRepRole StandardCrypto))
+    (WitUniv ConwayEra, ConwayCertExecContext ConwayEra)
+    (Set (Credential 'DRepRole))
   where
   inject (_, x) = ccecDelegatees x
 
-instance IsConwayUniv fn => ExecSpecRule fn "DELEG" Conway where
-  type ExecContext fn "DELEG" Conway = (WitUniv Conway, ConwayCertExecContext Conway)
+instance IsConwayUniv fn => ExecSpecRule fn "DELEG" ConwayEra where
+  type ExecContext fn "DELEG" ConwayEra = (WitUniv ConwayEra, ConwayCertExecContext ConwayEra)
 
   genExecContext = do
-    univ <- genWitUniv @Conway 300
+    univ <- genWitUniv @ConwayEra 300
     ccec <- genFromSpec @ConwayFn (conwayCertExecContextSpec univ 5)
     pure (univ, ccec)
 
   environmentSpec _ = delegEnvSpec
 
   stateSpec (univ, ccec) _env =
-    certStateSpec @_ @Conway univ (ccecDelegatees ccec) (ccecWithdrawals ccec)
+    certStateSpec @_ @ConwayEra univ (ccecDelegatees ccec) (ccecWithdrawals ccec)
 
   signalSpec _ = conwayDelegCertSpec
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
@@ -40,14 +40,14 @@ instance
   type ExecContext fn "GOVCERT" Conway = (WitUniv Conway, ConwayCertExecContext Conway)
 
   genExecContext = do
-    univ <- genWitUniv @Conway 200
-    ccec <- genFromSpec @ConwayFn (conwayCertExecContextSpec univ)
+    univ <- genWitUniv @Conway 300
+    ccec <- genFromSpec @ConwayFn (conwayCertExecContextSpec univ 5)
     pure (univ, ccec)
 
   environmentSpec (univ, _) = govCertEnvSpec univ
 
-  -- stateSpec ctx _env = certStateSpec (lit $ ccecDelegatees ctx)
-  stateSpec (univ, ccecCtx) _env = certStateSpec univ (ccecDelegatees ccecCtx)
+  stateSpec (univ, ccec) _env =
+    certStateSpec @fn @Conway univ (ccecDelegatees ccec) (ccecWithdrawals ccec)
 
   signalSpec (univ, _) = govCertSpec univ
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -27,27 +28,27 @@ import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base (
 import Test.Cardano.Ledger.Constrained.Conway
 import Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse
 
-instance Inject (WitUniv Conway, ConwayCertExecContext Conway) (Map (RewardAccount StandardCrypto) Coin) where
+instance Inject (WitUniv ConwayEra, ConwayCertExecContext ConwayEra) (Map RewardAccount Coin) where
   inject (_, x) = ccecWithdrawals x
 
-instance Inject (WitUniv Conway, ConwayCertExecContext Conway) (VotingProcedures Conway) where
+instance Inject (WitUniv ConwayEra, ConwayCertExecContext ConwayEra) (VotingProcedures ConwayEra) where
   inject (_, x) = ccecVotes x
 
 instance
   IsConwayUniv fn =>
-  ExecSpecRule fn "GOVCERT" Conway
+  ExecSpecRule fn "GOVCERT" ConwayEra
   where
-  type ExecContext fn "GOVCERT" Conway = (WitUniv Conway, ConwayCertExecContext Conway)
+  type ExecContext fn "GOVCERT" ConwayEra = (WitUniv ConwayEra, ConwayCertExecContext ConwayEra)
 
   genExecContext = do
-    univ <- genWitUniv @Conway 300
+    univ <- genWitUniv @ConwayEra 300
     ccec <- genFromSpec @ConwayFn (conwayCertExecContextSpec univ 5)
     pure (univ, ccec)
 
   environmentSpec (univ, _) = govCertEnvSpec univ
 
   stateSpec (univ, ccec) _env =
-    certStateSpec @fn @Conway univ (ccecDelegatees ccec) (ccecWithdrawals ccec)
+    certStateSpec @fn @ConwayEra univ (ccecDelegatees ccec) (ccecWithdrawals ccec)
 
   signalSpec (univ, _) = govCertSpec univ
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Pool.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Pool.hs
@@ -12,10 +12,6 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Pool where
 
 import Cardano.Ledger.Conway
 import Cardano.Ledger.Core (PoolCert (..))
-import Cardano.Ledger.Core
-import Data.Bifunctor (first)
-import qualified Data.List.NonEmpty as NE
-import qualified Data.Text as T
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core ()
@@ -24,14 +20,13 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool ()
 import Test.Cardano.Ledger.Constrained.Conway
 import Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse
 
-
-instance IsConwayUniv fn => ExecSpecRule fn "POOL" Conway where
-  type ExecContext fn "POOL" Conway = WitUniv Conway
+instance IsConwayUniv fn => ExecSpecRule fn "POOL" ConwayEra where
+  type ExecContext fn "POOL" ConwayEra = WitUniv ConwayEra
   environmentSpec ctx = poolEnvSpec ctx
 
   stateSpec ctx _ = pStateSpec ctx
 
-  signalSpec wituniv env st = poolCertSpec @fn @Conway wituniv env st
+  signalSpec wituniv env st = poolCertSpec @fn @ConwayEra wituniv env st
 
   runAgdaRule env st sig = unComputationResult $ Agda.poolStep env st sig
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Pool.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Pool.hs
@@ -2,6 +2,9 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -9,19 +12,26 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Pool where
 
 import Cardano.Ledger.Conway
 import Cardano.Ledger.Core (PoolCert (..))
+import Cardano.Ledger.Core
+import Data.Bifunctor (first)
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Text as T
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool ()
 import Test.Cardano.Ledger.Constrained.Conway
+import Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse
 
-instance IsConwayUniv fn => ExecSpecRule fn "POOL" ConwayEra where
-  environmentSpec _ = poolEnvSpec
 
-  stateSpec _ _ = pStateSpec
+instance IsConwayUniv fn => ExecSpecRule fn "POOL" Conway where
+  type ExecContext fn "POOL" Conway = WitUniv Conway
+  environmentSpec ctx = poolEnvSpec ctx
 
-  signalSpec _ = poolCertSpec
+  stateSpec ctx _ = pStateSpec ctx
+
+  signalSpec wituniv env st = poolCertSpec @fn @Conway wituniv env st
 
   runAgdaRule env st sig = unComputationResult $ Agda.poolStep env st sig
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
   ExecSpecRule (..),

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -149,8 +149,8 @@ instance NFData LEnv
 instance ToExpr a => ToExpr (HSSet a)
 
 instance ToExpr Credential where
-  toExpr (KeyHashObj h) = App "KeyHashObj" [agdaHashToExpr standardHashSize h]
-  toExpr (ScriptObj h) = App "ScriptObj" [agdaHashToExpr standardHashSize h]
+  toExpr (KeyHashObj h) = App "KeyHashObj" [agdaHashToExpr 28 h, toExpr h]
+  toExpr (ScriptObj h) = App "ScriptObj" [agdaHashToExpr 28 h, toExpr h]
 
 instance (ToExpr k, ToExpr v) => ToExpr (HSMap k v)
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -1211,9 +1211,6 @@ committeeCredentialToStrictMaybe ::
 committeeCredentialToStrictMaybe (CommitteeHotCredential c) = SJust c
 committeeCredentialToStrictMaybe (CommitteeMemberResigned _) = SNothing
 
-instance HasSimpleRep DepositPurpose
-instance IsConwayUniv fn => HasSpec fn DepositPurpose
-
 instance SpecTranslate ctx DepositPurpose where
   type SpecRep DepositPurpose = Agda.DepositPurpose
   toSpecRep (CredentialDeposit cred) =

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/ExecSpecRule/MiniTrace.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/ExecSpecRule/MiniTrace.hs
@@ -149,7 +149,7 @@ classifyFirst' f (x : _) p = maybe p (\s -> classify True s p) (f x)
 nameRatify :: RatifySignal era -> String
 nameRatify (RatifySignal xs) = show (length xs) ++ " GovActionStates"
 
-nameGovSignal :: GovSignal Conway -> String
+nameGovSignal :: GovSignal Proof.ConwayEra -> String
 nameGovSignal (GovSignal (VotingProcedures m) os cs) = show (Map.size m) ++ " " ++ show (OSet.size os) ++ " " ++ show (length cs)
 
 nameAlonzoTx :: AlonzoTx era -> String

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/ExecSpecRule/MiniTrace.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/ExecSpecRule/MiniTrace.hs
@@ -2,22 +2,25 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.MiniTrace where
 
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..))
 import Cardano.Ledger.BaseTypes (Inject (..))
+import Cardano.Ledger.Conway (Conway)
 import Cardano.Ledger.Conway.Governance (
   RatifySignal (..),
   VotingProcedures (..),
  )
 import Cardano.Ledger.Conway.Rules (GovSignal (..))
-import Cardano.Ledger.Core (EraRule)
+import Cardano.Ledger.Core
 import Constrained hiding (inject)
 import Control.State.Transition.Extended (STS (..))
 import qualified Data.List.NonEmpty as NE
@@ -28,7 +31,8 @@ import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Constrained.Conway.Instances (ConwayFn)
 import Test.Cardano.Ledger.Generic.PrettyCore (PrettyA (..))
-import Test.Cardano.Ledger.Generic.Proof
+import Test.Cardano.Ledger.Generic.Proof (WitRule (..), goSTS)
+import qualified Test.Cardano.Ledger.Generic.Proof as Proof
 
 -- \| This is where most of the ExecSpecRule instances are defined
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway (
@@ -57,17 +61,17 @@ minitraceEither ::
   Gen (Either [String] [Signal (EraRule s e)])
 minitraceEither witrule Proxy n0 = do
   ctxt <- genExecContext @fn @s @e
-  env <- genFromSpec @fn (environmentSpec @fn @s @e ctxt)
+  env <- genFromSpec @fn @(ExecEnvironment fn s e) (environmentSpec @fn @s @e ctxt)
   let env2 :: Environment (EraRule s e)
       env2 = inject env
-  !state0 <- genFromSpec @fn (stateSpec @fn @s @e ctxt env)
+  !state0 <- genFromSpec @fn @(ExecState fn s e) (stateSpec @fn @s @e ctxt env)
   let go :: State (EraRule s e) -> Int -> Gen (Either [String] [Signal (EraRule s e)])
       go _ 0 = pure (Right [])
       go state n = do
-        signal <- genFromSpec @fn (signalSpec @fn @s @e ctxt env state)
+        signal <- genFromSpec @fn @(ExecSignal fn s e) (signalSpec @fn @s @e ctxt env state)
         let signal2 :: Signal (EraRule s e)
             signal2 = inject signal
-        goSTS
+        goSTS @s @e @(Gen (Either [String] [Signal (EraRule s e)]))
           witrule
           env2
           state
@@ -120,8 +124,8 @@ minitraceProp ::
   Int ->
   (Signal (EraRule s e) -> String) ->
   Gen Property
-minitraceProp witrule Proxy n0 namef = do
-  ans <- minitraceEither @ConwayFn @s @e witrule Proxy n0
+minitraceProp witrule proxy n0 namef = do
+  ans <- minitraceEither @ConwayFn @s @e witrule proxy n0
   case ans of
     Left zs -> pure $ counterexample (unlines zs) (property False)
     Right sigs -> pure $ classifyFirst namef sigs $ property True
@@ -146,31 +150,51 @@ classifyFirst' f (x : _) p = maybe p (\s -> classify True s p) (f x)
 nameRatify :: RatifySignal era -> String
 nameRatify (RatifySignal xs) = show (length xs) ++ " GovActionStates"
 
-nameGovSignal :: GovSignal ConwayEra -> String
+nameGovSignal :: GovSignal Conway -> String
 nameGovSignal (GovSignal (VotingProcedures m) os cs) = show (Map.size m) ++ " " ++ show (OSet.size os) ++ " " ++ show (length cs)
 
 nameAlonzoTx :: AlonzoTx era -> String
 nameAlonzoTx (AlonzoTx _body _wits isV _auxdata) = show isV
 
--- | Run one check
-check :: IO ()
-check = quickCheck (withMaxSuccess 50 (minitraceProp (CERT Conway) (Proxy @ConwayFn) 50 nameTxCert))
-
 -- | Run a minitrace for every instance of ExecRuleSpec
 spec :: Spec
 spec = do
   describe "50 MiniTrace tests with trace length of 50" $ do
-    prop "POOL" (withMaxSuccess 50 (minitraceProp (POOL Conway) (Proxy @ConwayFn) 50 namePoolCert))
-    prop "DELEG" (withMaxSuccess 50 (minitraceProp (DELEG Conway) (Proxy @ConwayFn) 50 nameDelegCert))
-    prop "GOVCERT" (withMaxSuccess 50 (minitraceProp (GOVCERT Conway) (Proxy @ConwayFn) 50 nameGovCert))
-    prop "CERT" (withMaxSuccess 50 (minitraceProp (CERT Conway) (Proxy @ConwayFn) 50 nameTxCert))
-    prop "CERTS" (withMaxSuccess 50 (minitraceProp (CERTS Conway) (Proxy @ConwayFn) 50 nameCerts))
-    prop "RATIFY" (withMaxSuccess 50 (minitraceProp (RATIFY Conway) (Proxy @ConwayFn) 50 nameRatify))
-    prop "ENACT" (withMaxSuccess 50 (minitraceProp (ENACT Conway) (Proxy @ConwayFn) 50 nameEnact))
+    prop
+      "POOL"
+      (withMaxSuccess 50 (minitraceProp (POOL Proof.Conway) (Proxy @ConwayFn) 50 namePoolCert))
+    prop
+      "DELEG"
+      (withMaxSuccess 50 (minitraceProp (DELEG Proof.Conway) (Proxy @ConwayFn) 50 nameDelegCert))
+    prop
+      "GOVCERT"
+      ( withMaxSuccess
+          50
+          (minitraceProp @"GOVCERT" @Conway (GOVCERT Proof.Conway) (Proxy @ConwayFn) 50 nameGovCert)
+      )
+    prop
+      "CERT"
+      (withMaxSuccess 50 (minitraceProp @_ @_ (CERT Proof.Conway) (Proxy @ConwayFn) 50 nameTxCert))
+    prop
+      "CERTS"
+      ( withMaxSuccess
+          50
+          (minitraceProp @"CERTS" @Conway (CERTS Proof.Conway) (Proxy @ConwayFn) 50 nameCerts)
+      )
+    prop
+      "RATIFY"
+      (withMaxSuccess 50 (minitraceProp (RATIFY Proof.Conway) (Proxy @ConwayFn) 50 nameRatify))
+    -- prop "ENACT" (withMaxSuccess 50 (minitraceProp (ENACT Proof.Conway) (Proxy @ConwayFn) 50 nameEnact))
     -- These properties do not have working 'signalSpec' Specifications yet.
-    xprop "GOV" (withMaxSuccess 50 (minitraceProp (GOV Conway) (Proxy @ConwayFn) 50 nameGovSignal))
-    xprop "UTXO" (withMaxSuccess 50 (minitraceProp (UTXO Conway) (Proxy @ConwayFn) 50 nameAlonzoTx))
-    xprop "EPOCH" (withMaxSuccess 50 (minitraceProp (EPOCH Conway) (Proxy @ConwayFn) 50 nameEpoch))
+    xprop
+      "GOV"
+      (withMaxSuccess 50 (minitraceProp (GOV Proof.Conway) (Proxy @ConwayFn) 50 nameGovSignal))
+    xprop
+      "UTXO"
+      (withMaxSuccess 50 (minitraceProp (UTXO Proof.Conway) (Proxy @ConwayFn) 50 nameAlonzoTx))
+    xprop
+      "EPOCH"
+      (withMaxSuccess 50 (minitraceProp (EPOCH Proof.Conway) (Proxy @ConwayFn) 50 nameEpoch))
     xprop
       "NEWEPOCH"
-      (withMaxSuccess 50 (minitraceProp (NEWEPOCH Conway) (Proxy @ConwayFn) 50 nameEpoch))
+      (withMaxSuccess 50 (minitraceProp (NEWEPOCH Proof.Conway) (Proxy @ConwayFn) 50 nameEpoch))

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/ExecSpecRule/MiniTrace.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/ExecSpecRule/MiniTrace.hs
@@ -31,7 +31,7 @@ import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Constrained.Conway.Instances (ConwayFn)
 import Test.Cardano.Ledger.Generic.PrettyCore (PrettyA (..))
-import Test.Cardano.Ledger.Generic.Proof (WitRule (..), goSTS)
+import Test.Cardano.Ledger.Generic.Proof (Proof (..), WitRule (..), goSTS)
 import qualified Test.Cardano.Ledger.Generic.Proof as Proof
 
 -- \| This is where most of the ExecSpecRule instances are defined
@@ -120,12 +120,11 @@ minitraceProp ::
   , PrettyA (State (EraRule s e))
   ) =>
   WitRule s e ->
-  Proxy ConwayFn ->
   Int ->
   (Signal (EraRule s e) -> String) ->
   Gen Property
-minitraceProp witrule proxy n0 namef = do
-  ans <- minitraceEither @ConwayFn @s @e witrule proxy n0
+minitraceProp witrule n0 namef = do
+  ans <- minitraceEither @ConwayFn @s @e witrule (Proxy @ConwayFn) n0
   case ans of
     Left zs -> pure $ counterexample (unlines zs) (property False)
     Right sigs -> pure $ classifyFirst namef sigs $ property True
@@ -162,39 +161,39 @@ spec = do
   describe "50 MiniTrace tests with trace length of 50" $ do
     prop
       "POOL"
-      (withMaxSuccess 50 (minitraceProp (POOL Proof.Conway) (Proxy @ConwayFn) 50 namePoolCert))
+      (withMaxSuccess 50 (minitraceProp (POOL Conway) 50 namePoolCert))
     prop
       "DELEG"
-      (withMaxSuccess 50 (minitraceProp (DELEG Proof.Conway) (Proxy @ConwayFn) 50 nameDelegCert))
+      (withMaxSuccess 50 (minitraceProp (DELEG Conway) 50 nameDelegCert))
     prop
       "GOVCERT"
       ( withMaxSuccess
           50
-          (minitraceProp @"GOVCERT" @Conway (GOVCERT Proof.Conway) (Proxy @ConwayFn) 50 nameGovCert)
+          (minitraceProp (GOVCERT Conway) 50 nameGovCert)
       )
     prop
       "CERT"
-      (withMaxSuccess 50 (minitraceProp @_ @_ (CERT Proof.Conway) (Proxy @ConwayFn) 50 nameTxCert))
+      (withMaxSuccess 50 (minitraceProp (CERT Conway) 50 nameTxCert))
     prop
       "CERTS"
       ( withMaxSuccess
           50
-          (minitraceProp @"CERTS" @Conway (CERTS Proof.Conway) (Proxy @ConwayFn) 50 nameCerts)
+          (minitraceProp (CERTS Conway) 50 nameCerts)
       )
     prop
       "RATIFY"
-      (withMaxSuccess 50 (minitraceProp (RATIFY Proof.Conway) (Proxy @ConwayFn) 50 nameRatify))
-    -- prop "ENACT" (withMaxSuccess 50 (minitraceProp (ENACT Proof.Conway) (Proxy @ConwayFn) 50 nameEnact))
+      (withMaxSuccess 50 (minitraceProp (RATIFY Conway) 50 nameRatify))
+    -- prop "ENACT" (withMaxSuccess 50 (minitraceProp (ENACT Conway) (Proxy @ConwayFn) 50 nameEnact))
     -- These properties do not have working 'signalSpec' Specifications yet.
     xprop
       "GOV"
-      (withMaxSuccess 50 (minitraceProp (GOV Proof.Conway) (Proxy @ConwayFn) 50 nameGovSignal))
+      (withMaxSuccess 50 (minitraceProp (GOV Conway) 50 nameGovSignal))
     xprop
       "UTXO"
-      (withMaxSuccess 50 (minitraceProp (UTXO Proof.Conway) (Proxy @ConwayFn) 50 nameAlonzoTx))
+      (withMaxSuccess 50 (minitraceProp (UTXO Conway) 50 nameAlonzoTx))
     xprop
       "EPOCH"
-      (withMaxSuccess 50 (minitraceProp (EPOCH Proof.Conway) (Proxy @ConwayFn) 50 nameEpoch))
+      (withMaxSuccess 50 (minitraceProp (EPOCH Conway) 50 nameEpoch))
     xprop
       "NEWEPOCH"
-      (withMaxSuccess 50 (minitraceProp (NEWEPOCH Proof.Conway) (Proxy @ConwayFn) 50 nameEpoch))
+      (withMaxSuccess 50 (minitraceProp (NEWEPOCH Conway) 50 nameEpoch))

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
@@ -28,16 +28,16 @@ spec = do
       xprop "EPOCH" $ conformsToImpl @"EPOCH" @ConwayFn @ConwayEra
       xprop "NEWEPOCH" $ conformsToImpl @"NEWEPOCH" @ConwayFn @ConwayEra
     describe "Blocks transition graph" $ do
-      prop "DELEG" $ conformsToImpl @"DELEG" @ConwayFn @ConwayEra
-      prop "GOVCERT" $ conformsToImpl @"GOVCERT" @ConwayFn @ConwayEra
-      prop "POOL" $ conformsToImpl @"POOL" @ConwayFn @ConwayEra
-      prop "CERT" $ conformsToImpl @"CERT" @ConwayFn @ConwayEra
-      prop "CERTS" $ conformsToImpl @"CERTS" @ConwayFn @ConwayEra
-      prop "GOV" $ conformsToImpl @"GOV" @ConwayFn @ConwayEra
-      prop "UTXO" $ conformsToImpl @"UTXO" @ConwayFn @ConwayEra
-      xprop "UTXOW" $ conformsToImpl @"UTXOW" @ConwayFn @ConwayEra
-      xprop "LEDGER" $ conformsToImpl @"LEDGER" @ConwayFn @ConwayEra
-      xprop "LEDGERS" $ conformsToImpl @"LEDGERS" @ConwayFn @ConwayEra
+      prop "DELEG" $ conformsToImpl @"DELEG" @ConwayFn @Conway
+      prop "GOVCERT" $ conformsToImpl @"GOVCERT" @ConwayFn @Conway
+      prop "POOL" $ conformsToImpl @"POOL" @ConwayFn @Conway
+      -- prop "CERT" $ conformsToImpl @"CERT" @ConwayFn @Conway
+      -- prop "CERTS" $ conformsToImpl @"CERTS" @ConwayFn @Conway
+      prop "GOV" $ conformsToImpl @"GOV" @ConwayFn @Conway
+      prop "UTXO" $ conformsToImpl @"UTXO" @ConwayFn @Conway
+      xprop "UTXOW" $ conformsToImpl @"UTXOW" @ConwayFn @Conway
+      xprop "LEDGER" $ conformsToImpl @"LEDGER" @ConwayFn @Conway
+      xprop "LEDGERS" $ conformsToImpl @"LEDGERS" @ConwayFn @Conway
     describe "ImpTests" $ do
       RatifyImp.spec
       Imp.spec

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
@@ -28,16 +28,16 @@ spec = do
       xprop "EPOCH" $ conformsToImpl @"EPOCH" @ConwayFn @ConwayEra
       xprop "NEWEPOCH" $ conformsToImpl @"NEWEPOCH" @ConwayFn @ConwayEra
     describe "Blocks transition graph" $ do
-      prop "DELEG" $ conformsToImpl @"DELEG" @ConwayFn @Conway
-      prop "GOVCERT" $ conformsToImpl @"GOVCERT" @ConwayFn @Conway
-      prop "POOL" $ conformsToImpl @"POOL" @ConwayFn @Conway
-      prop "CERT" $ conformsToImpl @"CERT" @ConwayFn @Conway
-      prop "CERTS" $ conformsToImpl @"CERTS" @ConwayFn @Conway
-      prop "GOV" $ conformsToImpl @"GOV" @ConwayFn @Conway
-      prop "UTXO" $ conformsToImpl @"UTXO" @ConwayFn @Conway
-      xprop "UTXOW" $ conformsToImpl @"UTXOW" @ConwayFn @Conway
-      xprop "LEDGER" $ conformsToImpl @"LEDGER" @ConwayFn @Conway
-      xprop "LEDGERS" $ conformsToImpl @"LEDGERS" @ConwayFn @Conway
+      prop "DELEG" $ conformsToImpl @"DELEG" @ConwayFn @ConwayEra
+      prop "GOVCERT" $ conformsToImpl @"GOVCERT" @ConwayFn @ConwayEra
+      prop "POOL" $ conformsToImpl @"POOL" @ConwayFn @ConwayEra
+      prop "CERT" $ conformsToImpl @"CERT" @ConwayFn @ConwayEra
+      prop "CERTS" $ conformsToImpl @"CERTS" @ConwayFn @ConwayEra
+      prop "GOV" $ conformsToImpl @"GOV" @ConwayFn @ConwayEra
+      prop "UTXO" $ conformsToImpl @"UTXO" @ConwayFn @ConwayEra
+      xprop "UTXOW" $ conformsToImpl @"UTXOW" @ConwayFn @ConwayEra
+      xprop "LEDGER" $ conformsToImpl @"LEDGER" @ConwayFn @ConwayEra
+      xprop "LEDGERS" $ conformsToImpl @"LEDGERS" @ConwayFn @ConwayEra
     describe "ImpTests" $ do
       RatifyImp.spec
       Imp.spec

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
@@ -31,8 +31,8 @@ spec = do
       prop "DELEG" $ conformsToImpl @"DELEG" @ConwayFn @Conway
       prop "GOVCERT" $ conformsToImpl @"GOVCERT" @ConwayFn @Conway
       prop "POOL" $ conformsToImpl @"POOL" @ConwayFn @Conway
-      -- prop "CERT" $ conformsToImpl @"CERT" @ConwayFn @Conway
-      -- prop "CERTS" $ conformsToImpl @"CERTS" @ConwayFn @Conway
+      prop "CERT" $ conformsToImpl @"CERT" @ConwayFn @Conway
+      prop "CERTS" $ conformsToImpl @"CERTS" @ConwayFn @Conway
       prop "GOV" $ conformsToImpl @"GOV" @ConwayFn @Conway
       prop "UTXO" $ conformsToImpl @"UTXO" @ConwayFn @Conway
       xprop "UTXOW" $ conformsToImpl @"UTXOW" @ConwayFn @Conway

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -15,97 +15,98 @@ source-repository head
   subdir: libs/cardano-ledger-test
 
 library
-  exposed-modules:
-    Test.Cardano.Ledger.Alonzo.Tools
-    Test.Cardano.Ledger.Constrained.Ast
-    Test.Cardano.Ledger.Constrained.Classes
-    Test.Cardano.Ledger.Constrained.Combinators
-    Test.Cardano.Ledger.Constrained.Conway
-    Test.Cardano.Ledger.Constrained.Conway.Cert
-    Test.Cardano.Ledger.Constrained.Conway.Certs
-    Test.Cardano.Ledger.Constrained.Conway.Deleg
-    Test.Cardano.Ledger.Constrained.Conway.Epoch
-    Test.Cardano.Ledger.Constrained.Conway.Gov
-    Test.Cardano.Ledger.Constrained.Conway.GovCert
-    Test.Cardano.Ledger.Constrained.Conway.Instances
-    Test.Cardano.Ledger.Constrained.Conway.Instances.Basic
-    Test.Cardano.Ledger.Constrained.Conway.Instances.Ledger
-    Test.Cardano.Ledger.Constrained.Conway.Instances.Ledgers
-    Test.Cardano.Ledger.Constrained.Conway.Instances.PParams
-    Test.Cardano.Ledger.Constrained.Conway.Instances.TxBody
-    Test.Cardano.Ledger.Constrained.Conway.Ledger
-    Test.Cardano.Ledger.Constrained.Conway.LedgerTypes.Specs
-    Test.Cardano.Ledger.Constrained.Conway.LedgerTypes.Tests
-    Test.Cardano.Ledger.Constrained.Conway.LedgerTypes.WellFormed
-    Test.Cardano.Ledger.Constrained.Conway.Ledgers
-    Test.Cardano.Ledger.Constrained.Conway.NewEpoch
-    Test.Cardano.Ledger.Constrained.Conway.PParams
-    Test.Cardano.Ledger.Constrained.Conway.ParametricSpec
-    Test.Cardano.Ledger.Constrained.Conway.Pool
-    Test.Cardano.Ledger.Constrained.Conway.TxBodySpec
-    Test.Cardano.Ledger.Constrained.Conway.Utxo
-    Test.Cardano.Ledger.Constrained.Env
-    Test.Cardano.Ledger.Constrained.Examples
-    Test.Cardano.Ledger.Constrained.Lenses
-    Test.Cardano.Ledger.Constrained.Monad
-    Test.Cardano.Ledger.Constrained.Pairing
-    Test.Cardano.Ledger.Constrained.Preds.CertState
-    Test.Cardano.Ledger.Constrained.Preds.Certs
-    Test.Cardano.Ledger.Constrained.Preds.LedgerState
-    Test.Cardano.Ledger.Constrained.Preds.NewEpochState
-    Test.Cardano.Ledger.Constrained.Preds.PParams
-    Test.Cardano.Ledger.Constrained.Preds.Repl
-    Test.Cardano.Ledger.Constrained.Preds.Tx
-    Test.Cardano.Ledger.Constrained.Preds.TxOut
-    Test.Cardano.Ledger.Constrained.Preds.UTxO
-    Test.Cardano.Ledger.Constrained.Preds.Universes
-    Test.Cardano.Ledger.Constrained.Rewrite
-    Test.Cardano.Ledger.Constrained.Scripts
-    Test.Cardano.Ledger.Constrained.Shrink
-    Test.Cardano.Ledger.Constrained.Size
-    Test.Cardano.Ledger.Constrained.Solver
-    Test.Cardano.Ledger.Constrained.Spec
-    Test.Cardano.Ledger.Constrained.SpecClass
-    Test.Cardano.Ledger.Constrained.Stage
-    Test.Cardano.Ledger.Constrained.Tests
-    Test.Cardano.Ledger.Constrained.Trace.Actions
-    Test.Cardano.Ledger.Constrained.Trace.DrepCertTx
-    Test.Cardano.Ledger.Constrained.Trace.Pipeline
-    Test.Cardano.Ledger.Constrained.Trace.SimpleTx
-    Test.Cardano.Ledger.Constrained.Trace.Tests
-    Test.Cardano.Ledger.Constrained.Trace.TraceMonad
-    Test.Cardano.Ledger.Constrained.TypeRep
-    Test.Cardano.Ledger.Constrained.Utils
-    Test.Cardano.Ledger.Constrained.Vars
-    Test.Cardano.Ledger.EraClass
-    Test.Cardano.Ledger.Examples.AlonzoAPI
-    Test.Cardano.Ledger.Examples.AlonzoBBODY
-    Test.Cardano.Ledger.Examples.AlonzoCollectInputs
-    Test.Cardano.Ledger.Examples.AlonzoValidTxUTXOW
-    Test.Cardano.Ledger.Examples.BabbageFeatures
-    Test.Cardano.Ledger.Examples.STSTestUtils
-    Test.Cardano.Ledger.Generic.AggPropTests
-    Test.Cardano.Ledger.Generic.ApplyTx
-    Test.Cardano.Ledger.Generic.Fields
-    Test.Cardano.Ledger.Generic.Functions
-    Test.Cardano.Ledger.Generic.GenState
-    Test.Cardano.Ledger.Generic.Indexed
-    Test.Cardano.Ledger.Generic.MockChain
-    Test.Cardano.Ledger.Generic.ModelState
-    Test.Cardano.Ledger.Generic.PrettyCore
-    Test.Cardano.Ledger.Generic.PrettyTest
-    Test.Cardano.Ledger.Generic.Proof
-    Test.Cardano.Ledger.Generic.Properties
-    Test.Cardano.Ledger.Generic.Same
-    Test.Cardano.Ledger.Generic.Scriptic
-    Test.Cardano.Ledger.Generic.Trace
-    Test.Cardano.Ledger.Generic.TxGen
-    Test.Cardano.Ledger.Generic.Updaters
-    Test.Cardano.Ledger.NoThunks
-    Test.Cardano.Ledger.STS
-    Test.Cardano.Ledger.TestableEra
-    Test.Cardano.Ledger.Tickf
-    Test.Cardano.Ledger.ValueFromList
+    exposed-modules:
+        Test.Cardano.Ledger.Alonzo.Tools
+        Test.Cardano.Ledger.Constrained.Ast
+        Test.Cardano.Ledger.Constrained.Utils
+        Test.Cardano.Ledger.Constrained.Classes
+        Test.Cardano.Ledger.Constrained.Combinators
+        Test.Cardano.Ledger.Constrained.Env
+        Test.Cardano.Ledger.Constrained.Examples
+        Test.Cardano.Ledger.Constrained.Lenses
+        Test.Cardano.Ledger.Constrained.Monad
+        Test.Cardano.Ledger.Constrained.Pairing
+        Test.Cardano.Ledger.Constrained.Stage
+        Test.Cardano.Ledger.Constrained.Preds.PParams
+        Test.Cardano.Ledger.Constrained.Preds.Universes
+        Test.Cardano.Ledger.Constrained.Preds.TxOut
+        Test.Cardano.Ledger.Constrained.Preds.Tx
+        Test.Cardano.Ledger.Constrained.Preds.CertState
+        Test.Cardano.Ledger.Constrained.Preds.Repl
+        Test.Cardano.Ledger.Constrained.Preds.Certs
+        Test.Cardano.Ledger.Constrained.Preds.LedgerState
+        Test.Cardano.Ledger.Constrained.Preds.NewEpochState
+        Test.Cardano.Ledger.Constrained.Preds.UTxO
+        Test.Cardano.Ledger.Constrained.Trace.TraceMonad
+        Test.Cardano.Ledger.Constrained.Trace.SimpleTx
+        Test.Cardano.Ledger.Constrained.Trace.Actions
+        Test.Cardano.Ledger.Constrained.Trace.Pipeline
+        Test.Cardano.Ledger.Constrained.Trace.Tests
+        Test.Cardano.Ledger.Constrained.Trace.DrepCertTx
+        Test.Cardano.Ledger.Constrained.Spec
+        Test.Cardano.Ledger.Constrained.SpecClass
+        Test.Cardano.Ledger.Constrained.Tests
+        Test.Cardano.Ledger.Constrained.TypeRep
+        Test.Cardano.Ledger.Constrained.Vars
+        Test.Cardano.Ledger.Constrained.Rewrite
+        Test.Cardano.Ledger.Constrained.Shrink
+        Test.Cardano.Ledger.Constrained.Scripts
+        Test.Cardano.Ledger.Constrained.Size
+        Test.Cardano.Ledger.Constrained.Solver
+        Test.Cardano.Ledger.Constrained.Conway
+        Test.Cardano.Ledger.Constrained.Conway.Cert
+        Test.Cardano.Ledger.Constrained.Conway.Certs
+        Test.Cardano.Ledger.Constrained.Conway.Deleg
+        Test.Cardano.Ledger.Constrained.Conway.Epoch
+        Test.Cardano.Ledger.Constrained.Conway.Gov
+        Test.Cardano.Ledger.Constrained.Conway.GovCert
+        Test.Cardano.Ledger.Constrained.Conway.Instances.Basic
+        Test.Cardano.Ledger.Constrained.Conway.Instances.Ledger
+        Test.Cardano.Ledger.Constrained.Conway.Instances.Ledgers
+        Test.Cardano.Ledger.Constrained.Conway.Instances.TxBody
+        Test.Cardano.Ledger.Constrained.Conway.Instances.PParams
+        Test.Cardano.Ledger.Constrained.Conway.Instances
+        Test.Cardano.Ledger.Constrained.Conway.TxBodySpec
+        Test.Cardano.Ledger.Constrained.Conway.Ledger
+        Test.Cardano.Ledger.Constrained.Conway.Ledgers
+        Test.Cardano.Ledger.Constrained.Conway.NewEpoch
+        Test.Cardano.Ledger.Constrained.Conway.PParams
+        Test.Cardano.Ledger.Constrained.Conway.Pool
+        Test.Cardano.Ledger.Constrained.Conway.Utxo
+        Test.Cardano.Ledger.Constrained.Conway.ParametricSpec
+        Test.Cardano.Ledger.Constrained.Conway.LedgerTypes.Specs
+        Test.Cardano.Ledger.Constrained.Conway.LedgerTypes.WellFormed
+        Test.Cardano.Ledger.Constrained.Conway.LedgerTypes.Tests
+        Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse
+        Test.Cardano.Ledger.Examples.BabbageFeatures
+        Test.Cardano.Ledger.Examples.AlonzoValidTxUTXOW
+        Test.Cardano.Ledger.Examples.AlonzoBBODY
+        Test.Cardano.Ledger.Examples.AlonzoCollectInputs
+        Test.Cardano.Ledger.Examples.AlonzoAPI
+        Test.Cardano.Ledger.Examples.STSTestUtils
+        Test.Cardano.Ledger.EraClass
+        Test.Cardano.Ledger.Generic.AggPropTests
+        Test.Cardano.Ledger.Generic.ApplyTx
+        Test.Cardano.Ledger.Generic.Indexed
+        Test.Cardano.Ledger.Generic.Fields
+        Test.Cardano.Ledger.Generic.Functions
+        Test.Cardano.Ledger.Generic.GenState
+        Test.Cardano.Ledger.Generic.TxGen
+        Test.Cardano.Ledger.Generic.Proof
+        Test.Cardano.Ledger.Generic.MockChain
+        Test.Cardano.Ledger.Generic.ModelState
+        Test.Cardano.Ledger.Generic.PrettyCore
+        Test.Cardano.Ledger.Generic.PrettyTest
+        Test.Cardano.Ledger.Generic.Properties
+        Test.Cardano.Ledger.Generic.Same
+        Test.Cardano.Ledger.Generic.Scriptic
+        Test.Cardano.Ledger.Generic.Trace
+        Test.Cardano.Ledger.Generic.Updaters
+        Test.Cardano.Ledger.NoThunks
+        Test.Cardano.Ledger.STS
+        Test.Cardano.Ledger.TestableEra
+        Test.Cardano.Ledger.ValueFromList
+        Test.Cardano.Ledger.Tickf
 
   hs-source-dirs: src
   default-language: Haskell2010
@@ -118,61 +119,62 @@ library
     -Wredundant-constraints
     -Wunused-packages
 
-  build-depends:
-    FailT,
-    QuickCheck,
-    array,
-    base >=4.14 && <5,
-    bech32,
-    bytestring,
-    cardano-crypto,
-    cardano-crypto-class,
-    cardano-crypto-wrapper,
-    cardano-data,
-    cardano-ledger-allegra:{cardano-ledger-allegra, testlib},
-    cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
-    cardano-ledger-alonzo-test,
-    cardano-ledger-api,
-    cardano-ledger-babbage:{cardano-ledger-babbage, testlib},
-    cardano-ledger-babbage-test,
-    cardano-ledger-binary:{cardano-ledger-binary, testlib},
-    cardano-ledger-byron,
-    cardano-ledger-conway:{cardano-ledger-conway, testlib},
-    cardano-ledger-core:{cardano-ledger-core, testlib},
-    cardano-ledger-mary,
-    cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
-    cardano-ledger-shelley-ma-test,
-    cardano-ledger-shelley-test,
-    cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib},
-    cardano-slotting:{cardano-slotting, testlib},
-    cardano-strict-containers,
-    constrained-generators,
-    containers,
-    cryptonite,
-    data-default,
-    deepseq,
-    formatting,
-    groups,
-    hashable,
-    haskeline,
-    hspec,
-    microlens,
-    mtl,
-    nothunks,
-    plutus-ledger-api >=1.0 && <2.0,
-    prettyprinter,
-    random,
-    set-algebra,
-    small-steps:{small-steps, testlib},
-    tasty,
-    tasty-hunit,
-    tasty-quickcheck,
-    text,
-    time,
-    transformers,
-    unordered-containers,
-    vector,
-    vector-map,
+    build-depends:
+        cryptonite,
+        array,
+        base >=4.14 && <5,
+        bech32,
+        bytestring,
+        cardano-data,
+        cardano-crypto-class,
+        cardano-crypto-wrapper,
+        cardano-crypto,
+        cardano-ledger-allegra:{cardano-ledger-allegra, testlib},
+        cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
+        cardano-ledger-alonzo-test,
+        cardano-ledger-api,
+        cardano-ledger-babbage:{cardano-ledger-babbage, testlib},
+        cardano-ledger-babbage-test,
+        cardano-ledger-byron,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-conway:{cardano-ledger-conway, testlib},
+        cardano-ledger-core:{cardano-ledger-core, testlib},
+        cardano-ledger-mary,
+        cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
+        cardano-ledger-shelley-test,
+        cardano-ledger-shelley-ma-test,
+        cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib},
+        cardano-slotting:{cardano-slotting, testlib},
+        deepseq,
+        containers,
+        formatting,
+        groups,
+        haskeline,
+        hashable,
+        vector-map,
+        data-default,
+        microlens,
+        mtl,
+        nothunks,
+        hspec,
+        plutus-ledger-api >=1.0 && <2.0,
+        prettyprinter,
+        QuickCheck,
+        small-steps:{small-steps, testlib},
+        set-algebra,
+        cardano-strict-containers,
+        tasty,
+        tasty-hunit,
+        tasty-quickcheck,
+        text,
+        time,
+        transformers,
+        tree-diff,
+        unordered-containers,
+        vector,
+        constrained-generators,
+        random,
+        FailT
 
 test-suite cardano-ledger-test
   type: exitcode-stdio-1.0

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -15,98 +15,98 @@ source-repository head
   subdir: libs/cardano-ledger-test
 
 library
-    exposed-modules:
-        Test.Cardano.Ledger.Alonzo.Tools
-        Test.Cardano.Ledger.Constrained.Ast
-        Test.Cardano.Ledger.Constrained.Utils
-        Test.Cardano.Ledger.Constrained.Classes
-        Test.Cardano.Ledger.Constrained.Combinators
-        Test.Cardano.Ledger.Constrained.Env
-        Test.Cardano.Ledger.Constrained.Examples
-        Test.Cardano.Ledger.Constrained.Lenses
-        Test.Cardano.Ledger.Constrained.Monad
-        Test.Cardano.Ledger.Constrained.Pairing
-        Test.Cardano.Ledger.Constrained.Stage
-        Test.Cardano.Ledger.Constrained.Preds.PParams
-        Test.Cardano.Ledger.Constrained.Preds.Universes
-        Test.Cardano.Ledger.Constrained.Preds.TxOut
-        Test.Cardano.Ledger.Constrained.Preds.Tx
-        Test.Cardano.Ledger.Constrained.Preds.CertState
-        Test.Cardano.Ledger.Constrained.Preds.Repl
-        Test.Cardano.Ledger.Constrained.Preds.Certs
-        Test.Cardano.Ledger.Constrained.Preds.LedgerState
-        Test.Cardano.Ledger.Constrained.Preds.NewEpochState
-        Test.Cardano.Ledger.Constrained.Preds.UTxO
-        Test.Cardano.Ledger.Constrained.Trace.TraceMonad
-        Test.Cardano.Ledger.Constrained.Trace.SimpleTx
-        Test.Cardano.Ledger.Constrained.Trace.Actions
-        Test.Cardano.Ledger.Constrained.Trace.Pipeline
-        Test.Cardano.Ledger.Constrained.Trace.Tests
-        Test.Cardano.Ledger.Constrained.Trace.DrepCertTx
-        Test.Cardano.Ledger.Constrained.Spec
-        Test.Cardano.Ledger.Constrained.SpecClass
-        Test.Cardano.Ledger.Constrained.Tests
-        Test.Cardano.Ledger.Constrained.TypeRep
-        Test.Cardano.Ledger.Constrained.Vars
-        Test.Cardano.Ledger.Constrained.Rewrite
-        Test.Cardano.Ledger.Constrained.Shrink
-        Test.Cardano.Ledger.Constrained.Scripts
-        Test.Cardano.Ledger.Constrained.Size
-        Test.Cardano.Ledger.Constrained.Solver
-        Test.Cardano.Ledger.Constrained.Conway
-        Test.Cardano.Ledger.Constrained.Conway.Cert
-        Test.Cardano.Ledger.Constrained.Conway.Certs
-        Test.Cardano.Ledger.Constrained.Conway.Deleg
-        Test.Cardano.Ledger.Constrained.Conway.Epoch
-        Test.Cardano.Ledger.Constrained.Conway.Gov
-        Test.Cardano.Ledger.Constrained.Conway.GovCert
-        Test.Cardano.Ledger.Constrained.Conway.Instances.Basic
-        Test.Cardano.Ledger.Constrained.Conway.Instances.Ledger
-        Test.Cardano.Ledger.Constrained.Conway.Instances.Ledgers
-        Test.Cardano.Ledger.Constrained.Conway.Instances.TxBody
-        Test.Cardano.Ledger.Constrained.Conway.Instances.PParams
-        Test.Cardano.Ledger.Constrained.Conway.Instances
-        Test.Cardano.Ledger.Constrained.Conway.TxBodySpec
-        Test.Cardano.Ledger.Constrained.Conway.Ledger
-        Test.Cardano.Ledger.Constrained.Conway.Ledgers
-        Test.Cardano.Ledger.Constrained.Conway.NewEpoch
-        Test.Cardano.Ledger.Constrained.Conway.PParams
-        Test.Cardano.Ledger.Constrained.Conway.Pool
-        Test.Cardano.Ledger.Constrained.Conway.Utxo
-        Test.Cardano.Ledger.Constrained.Conway.ParametricSpec
-        Test.Cardano.Ledger.Constrained.Conway.LedgerTypes.Specs
-        Test.Cardano.Ledger.Constrained.Conway.LedgerTypes.WellFormed
-        Test.Cardano.Ledger.Constrained.Conway.LedgerTypes.Tests
-        Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse
-        Test.Cardano.Ledger.Examples.BabbageFeatures
-        Test.Cardano.Ledger.Examples.AlonzoValidTxUTXOW
-        Test.Cardano.Ledger.Examples.AlonzoBBODY
-        Test.Cardano.Ledger.Examples.AlonzoCollectInputs
-        Test.Cardano.Ledger.Examples.AlonzoAPI
-        Test.Cardano.Ledger.Examples.STSTestUtils
-        Test.Cardano.Ledger.EraClass
-        Test.Cardano.Ledger.Generic.AggPropTests
-        Test.Cardano.Ledger.Generic.ApplyTx
-        Test.Cardano.Ledger.Generic.Indexed
-        Test.Cardano.Ledger.Generic.Fields
-        Test.Cardano.Ledger.Generic.Functions
-        Test.Cardano.Ledger.Generic.GenState
-        Test.Cardano.Ledger.Generic.TxGen
-        Test.Cardano.Ledger.Generic.Proof
-        Test.Cardano.Ledger.Generic.MockChain
-        Test.Cardano.Ledger.Generic.ModelState
-        Test.Cardano.Ledger.Generic.PrettyCore
-        Test.Cardano.Ledger.Generic.PrettyTest
-        Test.Cardano.Ledger.Generic.Properties
-        Test.Cardano.Ledger.Generic.Same
-        Test.Cardano.Ledger.Generic.Scriptic
-        Test.Cardano.Ledger.Generic.Trace
-        Test.Cardano.Ledger.Generic.Updaters
-        Test.Cardano.Ledger.NoThunks
-        Test.Cardano.Ledger.STS
-        Test.Cardano.Ledger.TestableEra
-        Test.Cardano.Ledger.ValueFromList
-        Test.Cardano.Ledger.Tickf
+  exposed-modules:
+    Test.Cardano.Ledger.Alonzo.Tools
+    Test.Cardano.Ledger.Constrained.Ast
+    Test.Cardano.Ledger.Constrained.Classes
+    Test.Cardano.Ledger.Constrained.Combinators
+    Test.Cardano.Ledger.Constrained.Conway
+    Test.Cardano.Ledger.Constrained.Conway.Cert
+    Test.Cardano.Ledger.Constrained.Conway.Certs
+    Test.Cardano.Ledger.Constrained.Conway.Deleg
+    Test.Cardano.Ledger.Constrained.Conway.Epoch
+    Test.Cardano.Ledger.Constrained.Conway.Gov
+    Test.Cardano.Ledger.Constrained.Conway.GovCert
+    Test.Cardano.Ledger.Constrained.Conway.Instances
+    Test.Cardano.Ledger.Constrained.Conway.Instances.Basic
+    Test.Cardano.Ledger.Constrained.Conway.Instances.Ledger
+    Test.Cardano.Ledger.Constrained.Conway.Instances.Ledgers
+    Test.Cardano.Ledger.Constrained.Conway.Instances.PParams
+    Test.Cardano.Ledger.Constrained.Conway.Instances.TxBody
+    Test.Cardano.Ledger.Constrained.Conway.Ledger
+    Test.Cardano.Ledger.Constrained.Conway.LedgerTypes.Specs
+    Test.Cardano.Ledger.Constrained.Conway.LedgerTypes.Tests
+    Test.Cardano.Ledger.Constrained.Conway.LedgerTypes.WellFormed
+    Test.Cardano.Ledger.Constrained.Conway.Ledgers
+    Test.Cardano.Ledger.Constrained.Conway.NewEpoch
+    Test.Cardano.Ledger.Constrained.Conway.PParams
+    Test.Cardano.Ledger.Constrained.Conway.ParametricSpec
+    Test.Cardano.Ledger.Constrained.Conway.Pool
+    Test.Cardano.Ledger.Constrained.Conway.TxBodySpec
+    Test.Cardano.Ledger.Constrained.Conway.Utxo
+    Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse
+    Test.Cardano.Ledger.Constrained.Env
+    Test.Cardano.Ledger.Constrained.Examples
+    Test.Cardano.Ledger.Constrained.Lenses
+    Test.Cardano.Ledger.Constrained.Monad
+    Test.Cardano.Ledger.Constrained.Pairing
+    Test.Cardano.Ledger.Constrained.Preds.CertState
+    Test.Cardano.Ledger.Constrained.Preds.Certs
+    Test.Cardano.Ledger.Constrained.Preds.LedgerState
+    Test.Cardano.Ledger.Constrained.Preds.NewEpochState
+    Test.Cardano.Ledger.Constrained.Preds.PParams
+    Test.Cardano.Ledger.Constrained.Preds.Repl
+    Test.Cardano.Ledger.Constrained.Preds.Tx
+    Test.Cardano.Ledger.Constrained.Preds.TxOut
+    Test.Cardano.Ledger.Constrained.Preds.UTxO
+    Test.Cardano.Ledger.Constrained.Preds.Universes
+    Test.Cardano.Ledger.Constrained.Rewrite
+    Test.Cardano.Ledger.Constrained.Scripts
+    Test.Cardano.Ledger.Constrained.Shrink
+    Test.Cardano.Ledger.Constrained.Size
+    Test.Cardano.Ledger.Constrained.Solver
+    Test.Cardano.Ledger.Constrained.Spec
+    Test.Cardano.Ledger.Constrained.SpecClass
+    Test.Cardano.Ledger.Constrained.Stage
+    Test.Cardano.Ledger.Constrained.Tests
+    Test.Cardano.Ledger.Constrained.Trace.Actions
+    Test.Cardano.Ledger.Constrained.Trace.DrepCertTx
+    Test.Cardano.Ledger.Constrained.Trace.Pipeline
+    Test.Cardano.Ledger.Constrained.Trace.SimpleTx
+    Test.Cardano.Ledger.Constrained.Trace.Tests
+    Test.Cardano.Ledger.Constrained.Trace.TraceMonad
+    Test.Cardano.Ledger.Constrained.TypeRep
+    Test.Cardano.Ledger.Constrained.Utils
+    Test.Cardano.Ledger.Constrained.Vars
+    Test.Cardano.Ledger.EraClass
+    Test.Cardano.Ledger.Examples.AlonzoAPI
+    Test.Cardano.Ledger.Examples.AlonzoBBODY
+    Test.Cardano.Ledger.Examples.AlonzoCollectInputs
+    Test.Cardano.Ledger.Examples.AlonzoValidTxUTXOW
+    Test.Cardano.Ledger.Examples.BabbageFeatures
+    Test.Cardano.Ledger.Examples.STSTestUtils
+    Test.Cardano.Ledger.Generic.AggPropTests
+    Test.Cardano.Ledger.Generic.ApplyTx
+    Test.Cardano.Ledger.Generic.Fields
+    Test.Cardano.Ledger.Generic.Functions
+    Test.Cardano.Ledger.Generic.GenState
+    Test.Cardano.Ledger.Generic.Indexed
+    Test.Cardano.Ledger.Generic.MockChain
+    Test.Cardano.Ledger.Generic.ModelState
+    Test.Cardano.Ledger.Generic.PrettyCore
+    Test.Cardano.Ledger.Generic.PrettyTest
+    Test.Cardano.Ledger.Generic.Proof
+    Test.Cardano.Ledger.Generic.Properties
+    Test.Cardano.Ledger.Generic.Same
+    Test.Cardano.Ledger.Generic.Scriptic
+    Test.Cardano.Ledger.Generic.Trace
+    Test.Cardano.Ledger.Generic.TxGen
+    Test.Cardano.Ledger.Generic.Updaters
+    Test.Cardano.Ledger.NoThunks
+    Test.Cardano.Ledger.STS
+    Test.Cardano.Ledger.TestableEra
+    Test.Cardano.Ledger.Tickf
+    Test.Cardano.Ledger.ValueFromList
 
   hs-source-dirs: src
   default-language: Haskell2010
@@ -119,62 +119,62 @@ library
     -Wredundant-constraints
     -Wunused-packages
 
-    build-depends:
-        cryptonite,
-        array,
-        base >=4.14 && <5,
-        bech32,
-        bytestring,
-        cardano-data,
-        cardano-crypto-class,
-        cardano-crypto-wrapper,
-        cardano-crypto,
-        cardano-ledger-allegra:{cardano-ledger-allegra, testlib},
-        cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
-        cardano-ledger-alonzo-test,
-        cardano-ledger-api,
-        cardano-ledger-babbage:{cardano-ledger-babbage, testlib},
-        cardano-ledger-babbage-test,
-        cardano-ledger-byron,
-        cardano-ledger-binary:{cardano-ledger-binary, testlib},
-        cardano-ledger-conway:{cardano-ledger-conway, testlib},
-        cardano-ledger-core:{cardano-ledger-core, testlib},
-        cardano-ledger-mary,
-        cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
-        cardano-ledger-shelley-test,
-        cardano-ledger-shelley-ma-test,
-        cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib},
-        cardano-slotting:{cardano-slotting, testlib},
-        deepseq,
-        containers,
-        formatting,
-        groups,
-        haskeline,
-        hashable,
-        vector-map,
-        data-default,
-        microlens,
-        mtl,
-        nothunks,
-        hspec,
-        plutus-ledger-api >=1.0 && <2.0,
-        prettyprinter,
-        QuickCheck,
-        small-steps:{small-steps, testlib},
-        set-algebra,
-        cardano-strict-containers,
-        tasty,
-        tasty-hunit,
-        tasty-quickcheck,
-        text,
-        time,
-        transformers,
-        tree-diff,
-        unordered-containers,
-        vector,
-        constrained-generators,
-        random,
-        FailT
+  build-depends:
+    FailT,
+    QuickCheck,
+    array,
+    base >=4.14 && <5,
+    bech32,
+    bytestring,
+    cardano-crypto,
+    cardano-crypto-class,
+    cardano-crypto-wrapper,
+    cardano-data,
+    cardano-ledger-allegra:{cardano-ledger-allegra, testlib},
+    cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
+    cardano-ledger-alonzo-test,
+    cardano-ledger-api,
+    cardano-ledger-babbage:{cardano-ledger-babbage, testlib},
+    cardano-ledger-babbage-test,
+    cardano-ledger-binary:{cardano-ledger-binary, testlib},
+    cardano-ledger-byron,
+    cardano-ledger-conway:{cardano-ledger-conway, testlib},
+    cardano-ledger-core:{cardano-ledger-core, testlib},
+    cardano-ledger-mary,
+    cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
+    cardano-ledger-shelley-ma-test,
+    cardano-ledger-shelley-test,
+    cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib},
+    cardano-slotting:{cardano-slotting, testlib},
+    cardano-strict-containers,
+    constrained-generators,
+    containers,
+    cryptonite,
+    data-default,
+    deepseq,
+    formatting,
+    groups,
+    hashable,
+    haskeline,
+    hspec,
+    microlens,
+    mtl,
+    nothunks,
+    plutus-ledger-api >=1.0 && <2.0,
+    prettyprinter,
+    random,
+    set-algebra,
+    small-steps:{small-steps, testlib},
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck,
+    text,
+    time,
+    transformers,
+    tree-diff,
+    unordered-containers,
+    vector,
+    vector-map,
 
 test-suite cardano-ledger-test
   type: exitcode-stdio-1.0

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
@@ -50,8 +50,8 @@ bootstrapDStateSpec ::
   WitUniv era ->
   -- Set of credentials, each uniquely identifying a DRep,
   -- Every delegation of a stake credential to a DRep should be in this set.
-  Set (Credential 'DRepRole (EraCrypto era)) ->
-  Map (RewardAccount (EraCrypto era)) Coin ->
+  Set (Credential 'DRepRole) ->
+  Map RewardAccount Coin ->
   Specification fn (DState era)
 bootstrapDStateSpec univ delegatees withdrawals =
   constrained $ \ [var| dstate |] ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
@@ -19,25 +19,25 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..), credKeyHash, credScriptHash)
 import Cardano.Ledger.Keys (KeyRole (..))
 import Constrained
-import Constrained.Base (Pred (..))
 import Data.Foldable (toList)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq, fromList)
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Data.Word (Word64)
 import Test.Cardano.Ledger.Constrained.Conway.Cert
-import Test.Cardano.Ledger.Constrained.Conway.Deleg (someZeros)
+import Test.Cardano.Ledger.Constrained.Conway.Deleg (keyHashWdrl, rewDepMapSpec2)
 import Test.Cardano.Ledger.Constrained.Conway.Instances
 import Test.Cardano.Ledger.Constrained.Conway.PParams (pparamsSpec)
 import Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse
 
 -- =======================================================
 
+setMapMaybe :: Ord a => (t -> Maybe a) -> Set t -> Set a
+setMapMaybe f set = Set.foldr' (\x s -> maybe s (`Set.insert` s) $ f x) mempty set
+
 -- The current spec is written to specify the phase when Voting goes into effect (the Post BootStrap phase)
 -- The implementation is written to implement the phase before Voting goes into effect (the BootStrap phase)
--- This affects the Certs rule beacuse in the Post Bootstrap Phase, the spec tests that the (Credential 'Staking c)
+-- This affects the Certs rule because in the Post Bootstrap Phase, the spec tests that the (Credential 'Staking c)
 -- of every withdrawal, is delegated to some DRep, and that every Withdrawal is consistent with some Rewards entry.
 -- This is tested in the Spec, but it is not tested in implementation.
 -- A hardfork, sometime in the future will turn this test on.
@@ -48,60 +48,52 @@ bootstrapDStateSpec ::
   forall fn era.
   EraSpecTxOut era fn =>
   WitUniv era ->
+  -- Set of credentials, each uniquely identifying a DRep,
+  -- Every delegation of a stake credential to a DRep should be in this set.
   Set (Credential 'DRepRole (EraCrypto era)) ->
   Map (RewardAccount (EraCrypto era)) Coin ->
   Specification fn (DState era)
 bootstrapDStateSpec univ delegatees withdrawals =
-  let isKey (ScriptHashObj _) = False
-      isKey (KeyHashObj _) = True
-      withdrawalPairs = Map.toList (Map.mapKeys raCredential (Map.map coinToWord64 withdrawals))
-      withdrawalKeys = Map.keysSet (Map.mapKeys raCredential withdrawals)
-      setMapMaybe f = Set.foldr' (\x s -> maybe s (`Set.insert` s) $ f x) mempty
-   in constrained $ \ [var| dstate |] ->
-        match dstate $ \ [var| rewardMap |] futureGenDelegs genDelegs [var|irewards|] ->
-          [ assert $ sizeOf_ futureGenDelegs ==. (if hasGenDelegs @era [] then 3 else 0)
-          , match genDelegs $ \gd ->
-              [ witness univ (dom_ gd)
-              , witness univ (rng_ gd)
-              , assert $ sizeOf_ gd ==. (if hasGenDelegs @era [] then 3 else 0)
-              ]
-          , match irewards $ \w x y z -> [sizeOf_ w ==. 0, sizeOf_ x ==. 0, y ==. lit mempty, z ==. lit mempty]
-          , match [var| rewardMap |] $ \ [var| rdMap |] [var| ptrMap |] [var| sPoolMap |] [var|dRepDelegs|] ->
-              [ witness univ (dom_ dRepDelegs)
-              , witness univ (rng_ dRepDelegs)
-              , witness univ (dom_ rdMap)
-              , assertExplain (pure "dom sPoolMap is a subset of dom rdMap") $ dom_ sPoolMap `subset_` dom_ rdMap
-              , assertExplain (pure "dom ptrMap is empty") $ dom_ ptrMap ==. mempty
-              , assertExplain (pure "some rewards (not in withdrawals) are zero") $
-                  forAll rdMap $
-                    \ [var| keycoinpair |] -> match keycoinpair $ \cred [var| rdpair |] ->
-                      -- Apply this only to entries NOT IN the withdrawal set, since withdrawals already set the reward in the RDPair.
-                      whenTrue (not_ (member_ cred (lit withdrawalKeys))) (satisfies rdpair someZeros)
-              , forAll (lit (Set.filter isKey withdrawalKeys)) $ \cred -> assert $ member_ cred (dom_ dRepDelegs)
-              , forAll' dRepDelegs $ \_ dRep ->
+  constrained $ \ [var| dstate |] ->
+    match dstate $ \ [var| uMap |] futureGenDelegs genDelegs [var|irewards|] ->
+      [ -- futureGenDelegs
+        assert $ sizeOf_ futureGenDelegs ==. (if hasGenDelegs @era [] then 3 else 0)
+      , -- genDelegs
+        match genDelegs $ \gd ->
+          [ witness univ (dom_ gd)
+          , witness univ (rng_ gd)
+          , assert $ sizeOf_ gd ==. (if hasGenDelegs @era [] then 3 else 0)
+          ]
+      , -- irewards
+        match irewards $ \w x y z -> [sizeOf_ w ==. 0, sizeOf_ x ==. 0, y ==. lit mempty, z ==. lit mempty]
+      , -- uMap
+        match [var| uMap |] $ \ [var| rdMap |] [var| ptrMap |] [var| sPoolMap |] [var|dRepMap|] ->
+          [ -- rdMap
+            satisfies rdMap (rewDepMapSpec2 univ withdrawals)
+          , -- dRepMap
+            dependsOn dRepMap rdMap
+          , reify rdMap id $ \ [var|rdm|] ->
+              [ witness univ (dom_ dRepMap)
+              , assert $ subset_ (lit (keyHashWdrl withdrawals)) (dom_ dRepMap)
+              , witness univ (rng_ dRepMap)
+              , assert $ subset_ (dom_ dRepMap) (dom_ rdm)
+              , -- All DReps delegated to are known delegatees
+                forAll' dRepMap $ \_ dRep ->
                   [ (caseOn dRep)
                       (branch $ \kh -> assert (kh `member_` lit (setMapMaybe credKeyHash delegatees)))
                       (branch $ \sh -> assert (sh `member_` lit (setMapMaybe credScriptHash delegatees)))
                       (branch $ \_ -> assert True)
                       (branch $ \_ -> assert True)
                   ]
-              , forAll (lit withdrawalPairs) $ \ [var| pair |] ->
-                  match pair $ \ [var| cred |] [var| coin |] ->
-                    [ assert $ member_ cred (dom_ rdMap)
-                    , (caseOn (lookup_ cred rdMap))
-                        -- Nothing
-                        ( branch $ \_ -> FalsePred (pure ("credential " ++ show cred ++ " not in rdMap, bootstrapCertStateSpec"))
-                        )
-                        -- Just
-                        ( branch $ \ [var| rdpair |] ->
-                            match rdpair $ \rew _deposit -> assert $ rew ==. coin
-                        )
-                    ]
               ]
+          , -- sPoolMap
+            dependsOn sPoolMap rdMap
+          , reify rdMap id $ \ [var|rdmp|] ->
+              assertExplain (pure "dom sPoolMap is a subset of dom rdMap") $ dom_ sPoolMap `subset_` dom_ rdmp
+          , -- ptrMap
+            assertExplain (pure "dom ptrMap is empty") $ dom_ ptrMap ==. mempty
           ]
-
-coinToWord64 :: Coin -> Word64
-coinToWord64 (Coin n) = fromIntegral n
+      ]
 
 txZero :: EraTx era => Tx era
 txZero = mkBasicTx mkBasicTxBody

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
@@ -54,8 +54,8 @@ someZeros = constrained $ \ [var| someRdpair |] ->
 rewDepMapSpec ::
   (Era era, IsConwayUniv fn) =>
   WitUniv era ->
-  Map (RewardAccount (EraCrypto era)) Coin ->
-  Specification fn (Map (Credential 'Staking (EraCrypto era)) RDPair)
+  Map RewardAccount Coin ->
+  Specification fn (Map (Credential 'Staking) RDPair)
 rewDepMapSpec univ wdrl =
   let n = wvSize univ
       m = Map.size wdrl
@@ -75,15 +75,15 @@ rewDepMapSpec2 ::
   forall fn era.
   (Era era, IsConwayUniv fn) =>
   WitUniv era ->
-  Map (RewardAccount (EraCrypto era)) Coin ->
-  Specification fn (Map (Credential 'Staking (EraCrypto era)) RDPair)
+  Map RewardAccount Coin ->
+  Specification fn (Map (Credential 'Staking) RDPair)
 rewDepMapSpec2 univ wdrl =
   let n = wvSize univ
       m = Map.size wdrl
       maxRewDepSize = fromIntegral (n - (m + 2)) -- (2 * n - (m + 2))
-      withdrawalPairs :: [(Credential 'Staking (EraCrypto era), Word64)]
+      withdrawalPairs :: [(Credential 'Staking, Word64)]
       withdrawalPairs = Map.toList (Map.mapKeys raCredential (Map.map coinToWord64 wdrl))
-      withdrawalKeys :: Set (Credential 'Staking (EraCrypto era))
+      withdrawalKeys :: Set (Credential 'Staking)
       withdrawalKeys = Map.keysSet (Map.mapKeys raCredential wdrl)
    in constrained $ \ [var|rdmap|] ->
         [ -- size of rdmap, can't be bigger than the witness set (n keys + n scripts)
@@ -109,10 +109,10 @@ rewDepMapSpec2 univ wdrl =
 coinToWord64 :: Coin -> Word64
 coinToWord64 (Coin n) = fromIntegral n
 
-wdrlCredentials :: Map (RewardAccount c) Coin -> Set (Credential 'Staking c)
+wdrlCredentials :: Map RewardAccount Coin -> Set (Credential 'Staking)
 wdrlCredentials m = Set.map raCredential (Map.keysSet m)
 
-keyHashWdrl :: Map (RewardAccount c) Coin -> Set (Credential 'Staking c)
+keyHashWdrl :: Map RewardAccount Coin -> Set (Credential 'Staking)
 keyHashWdrl m = Set.filter isKeyHash (wdrlCredentials m)
   where
     isKeyHash (KeyHashObj _) = True
@@ -122,7 +122,7 @@ dStateSpec ::
   forall fn era.
   (IsConwayUniv fn, EraSpecDeleg era) =>
   WitUniv era ->
-  Map (RewardAccount (EraCrypto era)) Coin ->
+  Map (RewardAccount) Coin ->
   Specification fn (DState era)
 dStateSpec univ wdrls = constrained $ \ [var| dstate |] ->
   match dstate $ \ [var| uMap |] [var|futureGenDelegs|] [var|genDelegs|] [var|irewards|] ->
@@ -240,7 +240,7 @@ shelleyDelegCertSpec ::
   WitUniv era ->
   ConwayDelegEnv era ->
   DState era ->
-  Specification fn (ShelleyDelegCert (EraCrypto era))
+  Specification fn (ShelleyDelegCert)
 shelleyDelegCertSpec univ (ConwayDelegEnv _pp pools) ds =
   let rewardMap = unUnify $ rewards ds
       delegMap = unUnify $ delegations ds

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/GovCert.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/GovCert.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ViewPatterns #-}
 
 -- | Specs necessary to generate, environment, state, and signal
@@ -28,8 +30,6 @@ import Test.Cardano.Ledger.Constrained.Conway.Instances.Ledger
 import Test.Cardano.Ledger.Constrained.Conway.PParams
 import Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse
 
--- import Constrained(Specification)
-
 -- | There are no hard constraints on VState, other than witnessing, and delegatee conformance
 --   which must align with the conwayCertExecContextSpec
 vStateSpec ::
@@ -41,22 +41,23 @@ vStateSpec ::
 vStateSpec univ delegatees = constrained $ \ [var|vstate|] ->
   match vstate $ \ [var|dreps|] [var|committeestate|] [var|_numdormant|] ->
     [ match committeestate $ \ [var|committeemap|] -> witness univ (dom_ committeemap)
-    , assert $ dom_ dreps ==. (lit delegatees)
+    , assert $ dom_ dreps ==. (lit delegatees) -- TODO, there are missing constraints about the (rng_ dreps)
     , forAll dreps $ \ [var|pair|] ->
         match pair $ \ [var|drep|] [var|drepstate|] ->
-          [ witness univ drep
+          [ dependsOn drepstate drep
+          , witness univ drep
           , match drepstate $
               \_expiry _anchor _deposit [var|delegs|] -> witness univ delegs
           ]
     ]
 
 govCertSpec ::
-  IsConwayUniv fn =>
+  (IsConwayUniv fn, Era era, EraCrypto era ~ StandardCrypto) =>
   WitUniv era ->
   ConwayGovCertEnv (ConwayEra StandardCrypto) ->
   CertState (ConwayEra StandardCrypto) ->
   Specification fn (ConwayGovCert StandardCrypto)
-govCertSpec _univ ConwayGovCertEnv {..} certState =
+govCertSpec univ ConwayGovCertEnv {..} certState =
   let vs = certVState certState
       reps = lit $ Map.keysSet $ vsDReps vs
       deposits = Map.map drepDeposit (vsDReps vs)
@@ -75,10 +76,10 @@ govCertSpec _univ ConwayGovCertEnv {..} certState =
           -- The weights on each 'branchW' case try to make it likely
           -- that each branch is choosen with similar frequency
           -- ConwayRegDRep
-
           ( branchW 1 $ \ [var|keyreg|] [var|coinreg|] _ ->
               [ assert $ not_ $ member_ keyreg (dom_ (lit deposits))
               , assert $ coinreg ==. lit (cgcePParams ^. ppDRepDepositL)
+              , witness univ keyreg
               ]
           )
           -- ConwayUnRegDRep -- Commented out on purpose, to make conformance tests pass.
@@ -89,13 +90,22 @@ govCertSpec _univ ConwayGovCertEnv {..} certState =
           (branchW 3 $ \_credUnreg _coinUnreg -> False)
           -- ConwayUpdateDRep
           ( branchW 1 $ \ [var|keyupdate|] _ ->
-              member_ keyupdate reps
+              [witness univ keyupdate, assert $ member_ keyupdate reps]
           )
           -- ConwayAuthCommitteeHotKey
-          ( branchW 1 $ \ [var|coldCredAuth|] _ -> [ccCertSpec coldCredAuth, notYetResigned commiteeStatus coldCredAuth]
+          ( branchW 1 $ \ [var|coldCredAuth|] [var|hotcred|] ->
+              [ ccCertSpec coldCredAuth
+              , notYetResigned commiteeStatus coldCredAuth
+              , witness univ coldCredAuth
+              , witness univ hotcred
+              ]
           )
           -- ConwayResignCommitteeColdKey
-          ( branchW 1 $ \ [var|coldCredResign|] _ -> [ccCertSpec coldCredResign, notYetResigned commiteeStatus coldCredResign]
+          ( branchW 1 $ \ [var|coldCredResign|] _ ->
+              [ witness univ coldCredResign
+              , ccCertSpec coldCredResign
+              , notYetResigned commiteeStatus coldCredResign
+              ]
           )
 
 -- | Operations for authenticating a HotKey, or resigning a ColdKey are illegal
@@ -122,11 +132,16 @@ notYetResigned committeeStatus coldcred =
   )
 
 govCertEnvSpec ::
-  forall fn era.
+  forall fn.
   IsConwayUniv fn =>
-  WitUniv era ->
+  WitUniv (ConwayEra StandardCrypto) ->
   Specification fn (ConwayGovCertEnv (ConwayEra StandardCrypto))
-govCertEnvSpec _univ =
-  constrained $ \gce ->
-    match gce $ \pp _ _ _ ->
-      satisfies pp pparamsSpec
+govCertEnvSpec univ =
+  constrained $ \ [var|gce|] ->
+    match gce $ \ [var|pp|] _ [var|committee|] [var|proposalmap|] ->
+      [ satisfies pp pparamsSpec
+      , unsafeExists (\x -> [satisfies x (committeeWitness univ), assert $ committee ==. cSJust_ x])
+      , assert $ sizeOf_ (dom_ proposalmap) <=. lit 5
+      , assert $ sizeOf_ (dom_ proposalmap) >=. lit 1
+      , forAll (rng_ proposalmap) $ \x -> satisfies x (govActionStateWitness univ)
+      ]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/GovCert.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/GovCert.hs
@@ -36,7 +36,7 @@ vStateSpec ::
   forall fn era.
   (IsConwayUniv fn, Era era) =>
   WitUniv era ->
-  Set (Credential 'DRepRole (EraCrypto era)) ->
+  Set (Credential 'DRepRole) ->
   Specification fn (VState era)
 vStateSpec univ delegatees = constrained $ \ [var|vstate|] ->
   match vstate $ \ [var|dreps|] [var|committeestate|] [var|_numdormant|] ->
@@ -52,11 +52,11 @@ vStateSpec univ delegatees = constrained $ \ [var|vstate|] ->
     ]
 
 govCertSpec ::
-  (IsConwayUniv fn, Era era, EraCrypto era ~ StandardCrypto) =>
+  (IsConwayUniv fn, Era era) =>
   WitUniv era ->
-  ConwayGovCertEnv (ConwayEra StandardCrypto) ->
-  CertState (ConwayEra StandardCrypto) ->
-  Specification fn (ConwayGovCert StandardCrypto)
+  ConwayGovCertEnv ConwayEra ->
+  CertState ConwayEra ->
+  Specification fn ConwayGovCert
 govCertSpec univ ConwayGovCertEnv {..} certState =
   let vs = certVState certState
       reps = lit $ Map.keysSet $ vsDReps vs
@@ -134,8 +134,8 @@ notYetResigned committeeStatus coldcred =
 govCertEnvSpec ::
   forall fn.
   IsConwayUniv fn =>
-  WitUniv (ConwayEra StandardCrypto) ->
-  Specification fn (ConwayGovCertEnv (ConwayEra StandardCrypto))
+  WitUniv ConwayEra ->
+  Specification fn (ConwayGovCertEnv ConwayEra)
 govCertEnvSpec univ =
   constrained $ \ [var|gce|] ->
     match gce $ \ [var|pp|] _ [var|committee|] [var|proposalmap|] ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -1678,7 +1678,7 @@ class Coercible a b => CoercibleLike a b where
     TypeSpec fn a ->
     Specification fn b
 
-instance (Typeable krole, Crypto c) => CoercibleLike (KeyHash krole c) (KeyHash 'Witness c) where
+instance Typeable krole => CoercibleLike (KeyHash krole) (KeyHash 'Witness) where
   coerceSpec (ExplainSpec es x) = explainSpecOpt es (coerceSpec x)
   coerceSpec (TypeSpec z excl) = TypeSpec z $ coerceKeyRole <$> excl
   coerceSpec (MemberSpec s) = MemberSpec $ coerceKeyRole <$> s
@@ -1692,8 +1692,8 @@ instance (Typeable krole, Crypto c) => CoercibleLike (KeyHash krole c) (KeyHash 
   getCoerceSpec ::
     forall (fn :: [Type] -> Type -> Type).
     IsConwayUniv fn =>
-    TypeSpec fn (KeyHash krole c) ->
-    Specification fn (KeyHash 'Witness c)
+    TypeSpec fn (KeyHash krole) ->
+    Specification fn (KeyHash 'Witness)
   getCoerceSpec x = TypeSpec @fn x mempty
 
 instance CoercibleLike (CompactForm Coin) Word64 where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -27,6 +27,10 @@
 {-# OPTIONS_GHC -O0 #-}
 #endif
 
+#if __GLASGOW_HASKELL__ <= 966
+{-# OPTIONS_GHC -O0 #-}
+#endif
+
 -- | This module provides the necessary instances of `HasSpec`
 -- and `HasSimpleRep` to write specs for the environments,
 -- states, and signals in the STS rules of the Ledger. Note some simple

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
@@ -60,8 +60,9 @@ import qualified Data.VMap as VMap
 import System.IO.Unsafe (unsafePerformIO)
 import Test.Cardano.Ledger.Constrained.Conway.Gov (govProposalsSpec)
 import Test.Cardano.Ledger.Constrained.Conway.Instances
+import Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse
 import Test.Cardano.Ledger.Generic.PrettyCore
-import Test.QuickCheck (generate)
+import Test.QuickCheck hiding (forAll, witness)
 
 -- ===========================================================
 
@@ -79,7 +80,7 @@ class
   EraSpecLedger era fn
   where
   govStateSpec :: PParams era -> Specification fn (GovState era)
-  newEpochStateSpec :: PParams era -> Specification fn (NewEpochState era)
+  newEpochStateSpec :: PParams era -> WitUniv era -> Specification fn (NewEpochState era)
 
 instance IsConwayUniv fn => EraSpecLedger ShelleyEra fn where
   govStateSpec = shelleyGovStateSpec
@@ -165,32 +166,75 @@ protVersCanfollow =
   constrained $ \ [var|pair|] ->
     match pair $ \ [var|protver1|] [var|protver2|] -> canFollow protver1 protver2
 
+-- ====================================================================
+-- To generate a standalone VState using vstateSpec, we need a map of DRep credentials,
+-- to a set of Credentials of Stakers who delegated to that DRep. If we use a completely
+-- random map, it is highly likeley (almost a certainty) that the map
+-- does not have witnessed credentials. So we need a spec that generates
+-- a map with witnessed credentials. In a non standalone use of vstateSpec, the map
+-- is computed as the inverse of the DStates (Map Credential DRep) which has
+-- witnessed credentials, so we need this only for StandAlone uses of vstateSpec.
+
+goodDrep ::
+  forall era.
+  Era era =>
+  EraUniverse era =>
+  Specification
+    ConwayFn
+    ( Map
+        (Credential 'DRepRole (EraCrypto era))
+        (Set.Set (Credential 'Staking (EraCrypto era)))
+    )
+goodDrep =
+  let goodWitUniv = eraWitUniv @era 100
+   in constrained $ \dRepMap ->
+        [ forAll dRepMap $ \pair ->
+            [ satisfies (fst_ pair) (witCredSpec @ConwayFn @era goodWitUniv)
+            , satisfies (snd_ pair) (hasSize (rangeSize 1 5))
+            , forAll (snd_ pair) (`satisfies` (witCredSpec @ConwayFn @era goodWitUniv))
+            ]
+        , satisfies (dom_ dRepMap) (hasSize (rangeSize 6 10))
+        ]
+
 -- ========================================================================
 -- The CertState specs
 -- ========================================================================
 
+-- | BE SURE the parameter
+--   delegated :: Term fn (Map (Credential 'DRepRole c) (Set (Credential 'Staking c))
+--   has been witnessed with the same WitUniv as the parameter 'univ', or this will fail
+--   For a standalone test of vstateSpec one may use goodDrep above, and pass
+--   'eraUniv' as the actual parameter for the formal parameter 'univ'
+--   Note, that in certStateSpec, the call to vstateSpec is passed a witnessed 'delegated'
+--   that comes from the dstateSpec.
 vstateSpec ::
   forall fn era.
   (IsConwayUniv fn, Era era) =>
+  WitUniv era ->
   Term fn EpochNo ->
   Term fn (Map (Credential 'DRepRole) (Set (Credential 'Staking))) ->
   Specification fn (VState era)
-vstateSpec epoch delegated = constrained $ \ [var|vstate|] ->
+vstateSpec univ epoch delegated = constrained $ \ [var|vstate|] ->
   match vstate $ \ [var|dreps|] [var|comstate|] [var|numdormant|] ->
     [ dependsOn dreps delegated
+    , witness univ (dom_ dreps)
     , assert $ dom_ dreps ==. dom_ delegated
     , forAll dreps $ \ [var|pair|] ->
         match pair $ \ [var|drep|] [var|drepstate|] ->
-          match drepstate $ \ [var|expiry|] _anchor [var|drepDdeposit|] [var|delegs|] ->
-            onJust (lookup_ drep delegated) $ \ [var|delegSet|] ->
-              [ assertExplain (pure "all delegatees have delegated") $ delegs ==. delegSet
-              , assertExplain (pure "epoch of expiration must follow the current epoch") $ epoch <=. expiry
-              , assertExplain (pure "no deposit is 0") $ lit (Coin 0) <=. drepDdeposit
-              ]
+          [ satisfies drep (witCredSpec univ)
+          , match drepstate $ \ [var|expiry|] _anchor [var|drepDdeposit|] [var|delegs|] ->
+              onJust (lookup_ drep delegated) $ \ [var|delegSet|] ->
+                [ assertExplain (pure "all delegatees have delegated") $ delegs ==. delegSet
+                , witness univ delegSet
+                , assertExplain (pure "epoch of expiration must follow the current epoch") $ epoch <=. expiry
+                , assertExplain (pure "no deposit is 0") $ lit (Coin 0) <=. drepDdeposit
+                ]
+          ]
     , assertExplain (pure "num dormant epochs should not be too large") $
         [epoch <=. numdormant, numdormant <=. epoch + (lit (EpochNo 10))]
     , dependsOn numdormant epoch -- Solve epoch first.
-    , match comstate $ \ [var|commap|] -> satisfies commap (hasSize (rangeSize 1 4))
+    , match comstate $ \ [var|commap|] ->
+        [witness univ (dom_ commap), satisfies commap (hasSize (rangeSize 1 4))]
     ]
 
 -- Extract the map of DReps, to those that delegate to them, from the DState
@@ -214,21 +258,28 @@ aggregateDRep m = Map.foldlWithKey accum Map.empty m
 dstateSpec ::
   forall era fn.
   EraSpecLedger era fn =>
-  Term fn (Set (Credential 'DRepRole)) ->
+  WitUniv era ->
+  Term fn (Set (Credential 'DRepRole (EraCrypto era))) ->
   Term fn AccountState ->
   Term fn (Map (KeyHash 'StakePool) PoolParams) ->
   Specification fn (DState era)
-dstateSpec drepRoleCredSet acct poolreg = constrained $ \ [var| ds |] ->
+dstateSpec univ drepRoleCredSet acct poolreg = constrained $ \ [var| ds |] ->
   match ds $ \ [var|umap|] [var|futureGenDelegs|] [var|genDelegs|] [var|irewards|] ->
     match umap $ \ [var|rdMap|] [var|ptrmap|] [var|sPoolMap|] [var|dRepMap|] ->
-      [ -- This field, dRepMap, is passed to vstateSpec to enforce that the set of DReps
+      [ -- The "inverse" of this field, dRepMap, is passed to vstateSpec to enforce that the set of DReps
         -- delegated to actually are registered and appear in the DState, and that every credential
         -- delegated to a DRep, appears in the set of credentials for that DRep.
+        -- The inverse is computed by getDelagatees, and the call site is in certStateSpec.
         -- The dRepMap depends on the rdMap, so it is computed afterwards, forced by the reify
+        dependsOn dRepMap rdMap
         reify rdMap id $ \ [var|rdm|] ->
-          [ assert $ subset_ (dom_ dRepMap) (dom_ rdm)
-          , -- , assert $ sizeOf_ (dom_ dRepMap) >=. lit 1
-            forAll dRepMap $ \ [var|pair|] ->
+          [ witness univ (dom_ dRepMap)
+          , witness univ (rng_ dRepMap)
+          -- This will fail unless 'drepRoleCredSet' is witnessed at the call site of dstateSpec
+          , Explain (pure "'drepRoleCredSet' is witnessed at the call site of dstateSpec") 
+                    (witness univ drepRoleCredSet) 
+          , assert $ subset_ (dom_ dRepMap) (dom_ rdm)
+          , forAll dRepMap $ \ [var|pair|] ->
               match pair $ \_ [var|drep|] ->
                 (caseOn drep)
                   (branchW 3 $ \keyhash -> assert $ member_ (con @"KeyHashObj" keyhash) drepRoleCredSet)
@@ -236,26 +287,34 @@ dstateSpec drepRoleCredSet acct poolreg = constrained $ \ [var| ds |] ->
                   (branchW 1 $ \_abstain -> True)
                   (branchW 1 $ \_noconfidence -> True)
           ]
-      , genHint 5 sPoolMap
-      , assertExplain (pure "The delegations delegate to actual pools") $
-          forAll (rng_ sPoolMap) (\ [var|keyhash|] -> member_ keyhash (dom_ poolreg))
-      , assertExplain (pure "dom sPoolMap is a subset of dom rdMap") $ dom_ sPoolMap `subset_` dom_ rdMap
-      , -- reify here, forces us to solve for ptrmap, before sovling for rdMap
-        whenTrue (hasPtrs (Proxy @era)) (reify ptrmap id (\ [var|pm|] -> domEqualRng pm rdMap))
+      , dependsOn rdMap ptrmap
       , whenTrue (not_ (hasPtrs (Proxy @era))) (assert $ ptrmap ==. lit Map.empty)
-      , satisfies irewards (irewardSpec @era acct)
+      , whenTrue
+          (hasPtrs (Proxy @era))
+          [ witness univ (rng_ ptrmap)
+          , -- reify here, forces us to solve for ptrmap, before solving for rdMap
+            reify ptrmap id (\ [var|pm|] -> domEqualRng pm rdMap)
+          ]
+      , dependsOn sPoolMap rdMap
+      , witness univ (dom_ rdMap) -- rdMap is random, except that it is witnessed
+      , genHint 5 sPoolMap
+      , assertExplain (pure "dom sPoolMap is a subset of dom rdMap") $ dom_ sPoolMap `subset_` dom_ rdMap
+      , assertExplain (pure "The delegations delegate to actual pools") $
+          forAll (rng_ sPoolMap) (\ [var|keyhash|] -> member_ keyhash (dom_ poolreg))   
+      , satisfies irewards (irewardSpec @era univ acct)
       , satisfies
           futureGenDelegs
           (hasSize (if hasGenDelegs @era [] then (rangeSize 0 3) else (rangeSize 0 0)))
-      , match genDelegs $ \ [var|gd|] ->
-          satisfies
-            gd
-            ( hasSize
-                ( if hasGenDelegs @era []
-                    then (rangeSize 1 4)
-                    else (rangeSize 0 0)
-                )
-            )
+      , match genDelegs $ \ [var|gdmap|] ->
+          [ if hasGenDelegs @era []
+              then satisfies gdmap (hasSize (rangeSize 1 4))
+              else satisfies gdmap (hasSize (rangeSize 0 0))
+          , witness univ (dom_ gdmap)
+          , witness univ (rng_ gdmap)
+          ]
+      , whenTrue (not_ (hasPtrs (Proxy @era))) (assert $ ptrmap ==. lit Map.empty)
+        -- reify here, forces us to solve for ptrmap, before sovling for rdMap
+      , whenTrue (hasPtrs (Proxy @era)) (reify ptrmap id (\ [var|pm|] -> domEqualRng pm rdMap))
       ]
 
 epochNoSpec :: IsConwayUniv fn => Specification fn EpochNo
@@ -263,11 +322,18 @@ epochNoSpec = constrained $ \epoch -> epoch >=. 99
 
 pstateSpec ::
   (IsConwayUniv fn, Era era) =>
+  WitUniv era ->
   Term fn EpochNo ->
   Specification fn (PState era)
-pstateSpec currepoch = constrained $ \ [var|pState|] ->
+pstateSpec univ currepoch = constrained $ \ [var|pState|] ->
   match pState $ \ [var|stakePoolParams|] [var|futureStakePoolParams|] [var|retiring|] [var|pooldeposits|] ->
-    [ assertExplain (pure "dom of retiring is a subset of dom of stakePoolParams") $
+    [ witness univ (dom_ stakePoolParams)
+    , witness univ (rng_ stakePoolParams)
+    , witness univ (dom_ futureStakePoolParams)
+    , witness univ (rng_ futureStakePoolParams)
+    , witness univ (dom_ retiring)
+    , witness univ (dom_ pooldeposits)
+    , assertExplain (pure "dom of retiring is a subset of dom of stakePoolParams") $
         dom_ retiring `subset_` dom_ stakePoolParams
     , assertExplain (pure "dom of deposits is dom of stakePoolParams") $
         dom_ pooldeposits ==. dom_ stakePoolParams
@@ -300,43 +366,46 @@ accountStateSpec =
 certStateSpec ::
   forall era fn.
   EraSpecLedger era fn =>
-  Term fn (Set (Credential 'DRepRole)) ->
+  WitUniv era ->
+  Term fn (Set (Credential 'DRepRole (EraCrypto era))) ->
   Term fn AccountState ->
   Term fn EpochNo ->
   Specification fn (CertState era)
-certStateSpec drepRoleCredSet acct epoch = constrained $ \ [var|certState|] ->
+certStateSpec univ drepRoleCredSet acct epoch = constrained $ \ [var|certState|] ->
   match certState $ \ [var|vState|] [var|pState|] [var|dState|] ->
-    [ satisfies pState (pstateSpec epoch)
+    [ satisfies pState (pstateSpec univ epoch)
     , reify pState psStakePoolParams $ \ [var|poolreg|] ->
         [ dependsOn dState poolreg
-        , satisfies dState (dstateSpec drepRoleCredSet acct poolreg)
+        , satisfies dState (dstateSpec univ drepRoleCredSet acct poolreg)
         ]
     , reify dState getDelegatees $ \ [var|delegatees|] ->
-        [ satisfies vState (vstateSpec epoch delegatees)
-        ]
+        satisfies vState (vstateSpec univ epoch delegatees)
     ]
 
 -- ==============================================================
 -- Specs for UTxO and UTxOState
 -- ==============================================================
 
-utxoSpec ::
+utxoSpecWit ::
   forall era fn.
-  EraSpecLedger era fn =>
-  Term fn (Map (Credential 'Staking) (KeyHash 'StakePool)) ->
+  -- EraSpecLedger era fn =>
+  EraSpecTxOut era fn =>
+  WitUniv era ->
+  Term fn (Map (Credential 'Staking (EraCrypto era)) (KeyHash 'StakePool (EraCrypto era))) ->
   Specification fn (UTxO era)
-utxoSpec delegs = constrained $ \ [var|utxo|] ->
+utxoSpecWit univ delegs = constrained $ \ [var|utxo|] ->
   match utxo $ \ [var|utxomap|] ->
-    [ forAll (rng_ utxomap) (\ [var|output|] -> correctTxOut delegs output)
+    [ forAll (rng_ utxomap) (\ [var|out|] -> txOutSpec univ delegs out)
     ]
 
 utxoStateSpec ::
   forall era fn.
   EraSpecLedger era fn =>
   PParams era ->
+  WitUniv era ->
   Term fn (CertState era) ->
   Specification fn (UTxOState era)
-utxoStateSpec pp certstate =
+utxoStateSpec pp univ certstate =
   constrained $ \ [var|utxoState|] ->
     match utxoState $ \ [var|utxo|] [var|deposits|] [var|fees|] [var|gov|] [var|distr|] [var|donation|] ->
       [ assert $ donation ==. lit (Coin 0)
@@ -345,7 +414,7 @@ utxoStateSpec pp certstate =
           (sumObligation . obligationCertState)
           (\ [var|depositsum|] -> assert $ deposits ==. depositsum)
       , assert $ lit (Coin 0) <=. fees
-      , reify certstate getDelegs (\ [var|delegs|] -> satisfies utxo (utxoSpec delegs))
+      , reify certstate getDelegs (\ [var|delegs|] -> satisfies utxo (utxoSpecWit univ delegs))
       , satisfies gov (govStateSpec @era @fn pp)
       , reify utxo (updateStakeDistribution pp mempty mempty) (\ [var|i|] -> distr ==. i)
       ]
@@ -400,16 +469,20 @@ ledgerStateSpec ::
   forall era fn.
   EraSpecLedger era fn =>
   PParams era ->
-  Term fn AccountState ->
+  WitUniv era ->
+  Term fn AccountState ->univ 
   Term fn EpochNo ->
   Specification fn (LedgerState era)
-ledgerStateSpec pp acct epoch =
+ledgerStateSpec pp univ acct epoch =
   constrained $ \ [var|ledgerState|] ->
     match ledgerState $ \ [var|utxoS|] [var|csg|] ->
-      [ exists
+      [ exists 
           (\eval -> pure . Map.keysSet . getDelegatees . certDState $ eval csg)
-          (\delegatees -> csg `satisfies` certStateSpec @era @fn delegatees acct epoch)
-      , reify csg id (\ [var|certstate|] -> satisfies utxoS (utxoStateSpec @era @fn pp certstate))
+          (\ drepRoleCredSet -> 
+              [ witness univ drepRoleCredSet
+              , satisfies csg 
+                          (certStateSpec @era @fn univ drepRoleCredSet acct epoch) ])
+      , reify csg id (\ [var|certstate|] -> satisfies utxoS (utxoStateSpec @era @fn pp univ certstate))
       ]
 
 -- ===========================================================
@@ -457,14 +530,15 @@ epochStateSpec ::
   forall era fn.
   EraSpecLedger era fn =>
   PParams era ->
+  WitUniv era ->
   Term fn EpochNo ->
   Specification fn (EpochState era)
-epochStateSpec pp epoch =
+epochStateSpec pp univ epoch =
   constrained $ \ [var|epochState|] ->
     match epochState $ \ [var|acctst|] [var|eLedgerState|] [var|snaps|] [var|nonmyopic|] ->
       Block
         [ dependsOn eLedgerState acctst
-        , satisfies eLedgerState (ledgerStateSpec pp acctst epoch)
+        , satisfies eLedgerState (ledgerStateSpec pp univ acctst epoch)
         , reify eLedgerState getMarkSnapShot $ \ [var|marksnap|] -> satisfies snaps (snapShotsSpec marksnap)
         , match nonmyopic $ \ [var|x|] [var|c|] -> [genHint 0 x, assert $ c ==. lit (Coin 0)]
         ]
@@ -478,8 +552,9 @@ newEpochStateSpecUTxO ::
   forall era fn.
   (EraSpecLedger era fn, StashedAVVMAddresses era ~ UTxO era) =>
   PParams era ->
+  WitUniv era ->
   Specification fn (NewEpochState era)
-newEpochStateSpecUTxO pp =
+newEpochStateSpecUTxO pp univ =
   constrained
     ( \ [var|newEpochStateUTxO|] ->
         match
@@ -488,7 +563,7 @@ newEpochStateSpecUTxO pp =
               Block
                 [ -- reify eno id (\ [var|epoch|] -> satisfies epochstate (epochStateSpec @era @fn pp epoch))
                   -- dependsOn eno epochstate
-                  satisfies epochstate (epochStateSpec @era @fn pp eno)
+                  satisfies epochstate (epochStateSpec @era @fn pp univ eno)
                 , satisfies stashAvvm (constrained (\ [var|u|] -> u ==. lit (UTxO @era Map.empty)))
                 , reify epochstate getPoolDistr $ \ [var|pd|] -> pooldistr ==. pd
                 , match blocksPrev (genHint 3)
@@ -503,15 +578,16 @@ newEpochStateSpecUnit ::
   forall era fn.
   (EraSpecLedger era fn, StashedAVVMAddresses era ~ ()) =>
   PParams era ->
+  WitUniv era ->
   Specification fn (NewEpochState era)
-newEpochStateSpecUnit pp =
+newEpochStateSpecUnit pp univ =
   constrained
     ( \ [var|newEpochStateUnit|] ->
         match
           (newEpochStateUnit :: Term fn (NewEpochState era))
           ( \ [var|eno|] [var|blocksPrev|] [var|blocksCurr|] [var|epochstate|] _mpulser [var|pooldistr|] [var|stashAvvm|] ->
               Block
-                [ satisfies epochstate (epochStateSpec @era @fn pp eno)
+                [ satisfies epochstate (epochStateSpec @era @fn pp univ eno)
                 , satisfies stashAvvm (constrained (\ [var|x|] -> x ==. lit ()))
                 , reify epochstate getPoolDistr $ \ [var|pd|] -> pooldistr ==. pd
                 , match blocksPrev (genHint 3)
@@ -522,8 +598,6 @@ newEpochStateSpecUnit pp =
 
 -- ===============================
 
--- ===================
-
 dRepToCred :: DRep -> Maybe (Credential 'DRepRole)
 dRepToCred (DRepKeyHash kh) = Just $ KeyHashObj kh
 dRepToCred (DRepScriptHash sh) = Just $ ScriptHashObj sh
@@ -531,8 +605,22 @@ dRepToCred _ = Nothing
 
 -- ===================================
 
+goC :: IO ()
+goC = do
+  univ <- generate $ genWitUniv @Shelley 8
+  print univ
+  cs <-
+    generate $
+      genFromSpec $
+        certStateSpec @Shelley @ConwayFn
+          univ
+          (lit (AccountState (Coin 100) (Coin 100)))
+          (lit (EpochNo 100))
+  putStrLn (show (prettyA cs))
+
 try10 :: IO ()
 try10 = do
+  univ <- generate $ genWitUniv @Shelley 10
   m <-
     generate $
       genFromSpec
@@ -543,6 +631,15 @@ try10 = do
             , forAll' x $ \_ s -> sizeOf_ s ==. 2
             ]
         )
-  b <- generate $ genFromSpec @ConwayFn (vstateSpec @ConwayFn @ShelleyEra (lit (EpochNo 100)) (lit m))
+  b <-
+    generate $ genFromSpec @ConwayFn (vstateSpec @ConwayFn @Shelley univ (lit (EpochNo 100)) (lit m))
   putStrLn (show (prettyA m))
   putStrLn (show (prettyA b))
+
+_go :: forall era. EraSpecTxOut era ConwayFn => IO ()
+_go = do
+  univ <- generate $ genWitUniv @era 25
+  m <- generate $ Map.fromList <$> vectorOf 5 arbitrary
+  ans <- generate $ genFromSpec @ConwayFn (utxoSpecWit univ (lit m))
+  putStrLn (show (prettyA univ))
+  putStrLn (show (prettyA ans))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
@@ -176,13 +176,12 @@ protVersCanfollow =
 
 goodDrep ::
   forall era.
-  Era era =>
   WitUniv era ->
   Specification
     ConwayFn
     ( Map
-        (Credential 'DRepRole (EraCrypto era))
-        (Set.Set (Credential 'Staking (EraCrypto era)))
+        (Credential 'DRepRole)
+        (Set.Set (Credential 'Staking))
     )
 goodDrep univ =
   constrained $ \dRepMap ->
@@ -382,7 +381,7 @@ utxoSpecWit ::
   -- EraSpecLedger era fn =>
   EraSpecTxOut era fn =>
   WitUniv era ->
-  Term fn (Map (Credential 'Staking (EraCrypto era)) (KeyHash 'StakePool (EraCrypto era))) ->
+  Term fn (Map (Credential 'Staking) (KeyHash 'StakePool)) ->
   Specification fn (UTxO era)
 utxoSpecWit univ delegs = constrained $ \ [var|utxo|] ->
   match utxo $ \ [var|utxomap|] ->
@@ -589,7 +588,7 @@ dRepToCred (DRepKeyHash kh) = Just $ KeyHashObj kh
 dRepToCred (DRepScriptHash sh) = Just $ ScriptHashObj sh
 dRepToCred _ = Nothing
 
-credToDrep :: Credential 'DRepRole c -> DRep c
+credToDrep :: Credential 'DRepRole -> DRep
 credToDrep (KeyHashObj kh) = DRepKeyHash kh
 credToDrep (ScriptHashObj sh) = DRepScriptHash sh
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
@@ -61,7 +61,6 @@ import System.IO.Unsafe (unsafePerformIO)
 import Test.Cardano.Ledger.Constrained.Conway.Gov (govProposalsSpec)
 import Test.Cardano.Ledger.Constrained.Conway.Instances
 import Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse
-import Test.Cardano.Ledger.Generic.PrettyCore
 import Test.QuickCheck hiding (forAll, witness)
 
 -- ===========================================================
@@ -178,23 +177,22 @@ protVersCanfollow =
 goodDrep ::
   forall era.
   Era era =>
-  EraUniverse era =>
+  WitUniv era ->
   Specification
     ConwayFn
     ( Map
         (Credential 'DRepRole (EraCrypto era))
         (Set.Set (Credential 'Staking (EraCrypto era)))
     )
-goodDrep =
-  let goodWitUniv = eraWitUniv @era 100
-   in constrained $ \dRepMap ->
-        [ forAll dRepMap $ \pair ->
-            [ satisfies (fst_ pair) (witCredSpec @ConwayFn @era goodWitUniv)
-            , satisfies (snd_ pair) (hasSize (rangeSize 1 5))
-            , forAll (snd_ pair) (`satisfies` (witCredSpec @ConwayFn @era goodWitUniv))
-            ]
-        , satisfies (dom_ dRepMap) (hasSize (rangeSize 6 10))
+goodDrep univ =
+  constrained $ \dRepMap ->
+    [ forAll dRepMap $ \pair ->
+        [ satisfies (fst_ pair) (witCredSpec @ConwayFn @era univ)
+        , satisfies (snd_ pair) (hasSize (rangeSize 1 5))
+        , forAll (snd_ pair) (`satisfies` (witCredSpec @ConwayFn @era univ))
         ]
+    , satisfies (dom_ dRepMap) (hasSize (rangeSize 6 10))
+    ]
 
 -- ========================================================================
 -- The CertState specs
@@ -259,49 +257,46 @@ dstateSpec ::
   forall era fn.
   EraSpecLedger era fn =>
   WitUniv era ->
-  Term fn (Set (Credential 'DRepRole (EraCrypto era))) ->
   Term fn AccountState ->
   Term fn (Map (KeyHash 'StakePool) PoolParams) ->
   Specification fn (DState era)
-dstateSpec univ drepRoleCredSet acct poolreg = constrained $ \ [var| ds |] ->
+dstateSpec univ acct poolreg = constrained $ \ [var| ds |] ->
   match ds $ \ [var|umap|] [var|futureGenDelegs|] [var|genDelegs|] [var|irewards|] ->
     match umap $ \ [var|rdMap|] [var|ptrmap|] [var|sPoolMap|] [var|dRepMap|] ->
-      [ -- The "inverse" of this field, dRepMap, is passed to vstateSpec to enforce that the set of DReps
-        -- delegated to actually are registered and appear in the DState, and that every credential
-        -- delegated to a DRep, appears in the set of credentials for that DRep.
-        -- The inverse is computed by getDelagatees, and the call site is in certStateSpec.
-        -- The dRepMap depends on the rdMap, so it is computed afterwards, forced by the reify
-        dependsOn dRepMap rdMap
+      [ dependsOn dRepMap rdMap
+      , -- The dRepMap depends on the rdMap, so it is computed afterwards, forced by the reify
         reify rdMap id $ \ [var|rdm|] ->
           [ witness univ (dom_ dRepMap)
           , witness univ (rng_ dRepMap)
-          -- This will fail unless 'drepRoleCredSet' is witnessed at the call site of dstateSpec
-          , Explain (pure "'drepRoleCredSet' is witnessed at the call site of dstateSpec") 
-                    (witness univ drepRoleCredSet) 
           , assert $ subset_ (dom_ dRepMap) (dom_ rdm)
           , forAll dRepMap $ \ [var|pair|] ->
-              match pair $ \_ [var|drep|] ->
+              match pair $ \ [var|_stakecred|] [var|drep|] ->
                 (caseOn drep)
-                  (branchW 3 $ \keyhash -> assert $ member_ (con @"KeyHashObj" keyhash) drepRoleCredSet)
-                  (branchW 3 $ \scripthash -> assert $ member_ (con @"ScriptHashObj" scripthash) drepRoleCredSet)
+                  (branchW 3 $ \keyhash -> witness univ keyhash)
+                  (branchW 3 $ \scripthash -> witness univ scripthash)
                   (branchW 1 $ \_abstain -> True)
                   (branchW 1 $ \_noconfidence -> True)
           ]
-      , dependsOn rdMap ptrmap
       , whenTrue (not_ (hasPtrs (Proxy @era))) (assert $ ptrmap ==. lit Map.empty)
       , whenTrue
           (hasPtrs (Proxy @era))
           [ witness univ (rng_ ptrmap)
+          , dependsOn rdMap ptrmap
           , -- reify here, forces us to solve for ptrmap, before solving for rdMap
+            -- If there are Ptrs, then the range of the Ptrs must equal the domain of the rdMap
             reify ptrmap id (\ [var|pm|] -> domEqualRng pm rdMap)
           ]
+      , witness univ (dom_ rdMap) -- rdMap must be witnessed, whether of not there are Ptrs
       , dependsOn sPoolMap rdMap
-      , witness univ (dom_ rdMap) -- rdMap is random, except that it is witnessed
-      , genHint 5 sPoolMap
-      , assertExplain (pure "dom sPoolMap is a subset of dom rdMap") $ dom_ sPoolMap `subset_` dom_ rdMap
-      , assertExplain (pure "The delegations delegate to actual pools") $
-          forAll (rng_ sPoolMap) (\ [var|keyhash|] -> member_ keyhash (dom_ poolreg))   
-      , satisfies irewards (irewardSpec @era univ acct)
+      , -- reify here, forces us to solve for rdMap, before solving for sPoolMap
+        reify rdMap Map.keysSet $ \ [var|rdcreds|] ->
+          [ genHint 5 sPoolMap
+          , assertExplain (pure "dom sPoolMap is a subset of dom rdMap") $ dom_ sPoolMap `subset_` rdcreds
+          , assertExplain (pure "The delegations delegate to actual pools") $
+              forAll (rng_ sPoolMap) (\ [var|keyhash|] -> member_ keyhash (dom_ poolreg))
+          ]
+      , -- futureGenDelegs and genDelegs and irewards can be solved in any order
+        satisfies irewards (irewardSpec @era univ acct)
       , satisfies
           futureGenDelegs
           (hasSize (if hasGenDelegs @era [] then (rangeSize 0 3) else (rangeSize 0 0)))
@@ -312,9 +307,6 @@ dstateSpec univ drepRoleCredSet acct poolreg = constrained $ \ [var| ds |] ->
           , witness univ (dom_ gdmap)
           , witness univ (rng_ gdmap)
           ]
-      , whenTrue (not_ (hasPtrs (Proxy @era))) (assert $ ptrmap ==. lit Map.empty)
-        -- reify here, forces us to solve for ptrmap, before sovling for rdMap
-      , whenTrue (hasPtrs (Proxy @era)) (reify ptrmap id (\ [var|pm|] -> domEqualRng pm rdMap))
       ]
 
 epochNoSpec :: IsConwayUniv fn => Specification fn EpochNo
@@ -367,16 +359,15 @@ certStateSpec ::
   forall era fn.
   EraSpecLedger era fn =>
   WitUniv era ->
-  Term fn (Set (Credential 'DRepRole (EraCrypto era))) ->
   Term fn AccountState ->
   Term fn EpochNo ->
   Specification fn (CertState era)
-certStateSpec univ drepRoleCredSet acct epoch = constrained $ \ [var|certState|] ->
+certStateSpec univ acct epoch = constrained $ \ [var|certState|] ->
   match certState $ \ [var|vState|] [var|pState|] [var|dState|] ->
     [ satisfies pState (pstateSpec univ epoch)
     , reify pState psStakePoolParams $ \ [var|poolreg|] ->
         [ dependsOn dState poolreg
-        , satisfies dState (dstateSpec univ drepRoleCredSet acct poolreg)
+        , satisfies dState (dstateSpec univ acct poolreg)
         ]
     , reify dState getDelegatees $ \ [var|delegatees|] ->
         satisfies vState (vstateSpec univ epoch delegatees)
@@ -470,18 +461,13 @@ ledgerStateSpec ::
   EraSpecLedger era fn =>
   PParams era ->
   WitUniv era ->
-  Term fn AccountState ->univ 
+  Term fn AccountState ->
   Term fn EpochNo ->
   Specification fn (LedgerState era)
 ledgerStateSpec pp univ acct epoch =
   constrained $ \ [var|ledgerState|] ->
     match ledgerState $ \ [var|utxoS|] [var|csg|] ->
-      [ exists 
-          (\eval -> pure . Map.keysSet . getDelegatees . certDState $ eval csg)
-          (\ drepRoleCredSet -> 
-              [ witness univ drepRoleCredSet
-              , satisfies csg 
-                          (certStateSpec @era @fn univ drepRoleCredSet acct epoch) ])
+      [ satisfies csg (certStateSpec @era @fn univ acct epoch)
       , reify csg id (\ [var|certstate|] -> satisfies utxoS (utxoStateSpec @era @fn pp univ certstate))
       ]
 
@@ -603,43 +589,8 @@ dRepToCred (DRepKeyHash kh) = Just $ KeyHashObj kh
 dRepToCred (DRepScriptHash sh) = Just $ ScriptHashObj sh
 dRepToCred _ = Nothing
 
+credToDrep :: Credential 'DRepRole c -> DRep c
+credToDrep (KeyHashObj kh) = DRepKeyHash kh
+credToDrep (ScriptHashObj sh) = DRepScriptHash sh
+
 -- ===================================
-
-goC :: IO ()
-goC = do
-  univ <- generate $ genWitUniv @Shelley 8
-  print univ
-  cs <-
-    generate $
-      genFromSpec $
-        certStateSpec @Shelley @ConwayFn
-          univ
-          (lit (AccountState (Coin 100) (Coin 100)))
-          (lit (EpochNo 100))
-  putStrLn (show (prettyA cs))
-
-try10 :: IO ()
-try10 = do
-  univ <- generate $ genWitUniv @Shelley 10
-  m <-
-    generate $
-      genFromSpec
-        @ConwayFn
-        @(Map (Credential 'DRepRole) (Set (Credential 'Staking)))
-        ( constrained $ \x ->
-            [ assert $ sizeOf_ x ==. 5
-            , forAll' x $ \_ s -> sizeOf_ s ==. 2
-            ]
-        )
-  b <-
-    generate $ genFromSpec @ConwayFn (vstateSpec @ConwayFn @Shelley univ (lit (EpochNo 100)) (lit m))
-  putStrLn (show (prettyA m))
-  putStrLn (show (prettyA b))
-
-_go :: forall era. EraSpecTxOut era ConwayFn => IO ()
-_go = do
-  univ <- generate $ genWitUniv @era 25
-  m <- generate $ Map.fromList <$> vectorOf 5 arbitrary
-  ans <- generate $ genFromSpec @ConwayFn (utxoSpecWit univ (lit m))
-  putStrLn (show (prettyA univ))
-  putStrLn (show (prettyA ans))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Tests.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Tests.hs
@@ -28,7 +28,6 @@ import Cardano.Ledger.UTxO (UTxO (..))
 import Constrained hiding (Value)
 import Data.Kind (Type)
 import Data.Map (Map)
-import qualified Data.Set as Set
 import Data.Typeable
 import Test.Cardano.Ledger.Constrained.Conway ()
 import Test.Cardano.Ledger.Constrained.Conway.Cert (
@@ -48,13 +47,9 @@ import Test.QuickCheck (
   Gen,
   Property,
   counterexample,
-  generate,
   property,
   withMaxSuccess,
  )
-
-import System.IO.Unsafe
-import Test.Cardano.Ledger.Constrained.Conway.LedgerTypes.Specs (certStateSpec, dstateSpec)
 
 -- ====================================================================================
 -- Some Specifications are constrained by types (say 'x') that do not appear in the type being
@@ -185,8 +180,8 @@ spec = do
     soundSpecWith @(ProtVer, ProtVer) 100 (pure protVersCanfollow)
     soundSpecWith @InstantaneousRewards
       20
-      (irewardSpec @Shelley (eraWitUniv @Shelley 50) !$! accountStateSpec)
-    soundSpecWith @(SnapShots StandardCrypto)
+      (irewardSpec @ShelleyEra (eraWitUniv @ShelleyEra 50) !$! accountStateSpec)
+    soundSpecWith @SnapShots
       10
       (snapShotsSpec <$> ((lit . getMarkSnapShot) <$> (wff @(LedgerState ConwayEra) @ConwayEra)))
   specSuite @ShelleyEra 10

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/WellFormed.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/WellFormed.hs
@@ -154,13 +154,13 @@ snapsX pp = do
   acct <- genFromSpec @ConwayFn @AccountState accountStateSpec
   epoch <- genFromSpec @ConwayFn @EpochNo epochNoSpec
   ls <- genFromSpec @ConwayFn @(LedgerState era) (ledgerStateSpec pp univ (lit acct) (lit epoch))
-  genFromSpec @ConwayFn @(SnapShots (EraCrypto era)) (snapShotsSpec (lit (getMarkSnapShot ls)))
+  genFromSpec @ConwayFn @SnapShots (snapShotsSpec (lit (getMarkSnapShot ls)))
 
 instanRewX :: forall era. EraSpecTxOut era ConwayFn => Gen InstantaneousRewards
 instanRewX = do
   univ <- genWitUniv @era 50
   acct <- genFromSpec @ConwayFn @AccountState accountStateSpec
-  genFromSpec @ConwayFn @(InstantaneousRewards (EraCrypto era))
+  genFromSpec @ConwayFn @InstantaneousRewards
     (irewardSpec @era @ConwayFn univ (lit acct))
 
 -- ==============================================================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/WellFormed.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/WellFormed.hs
@@ -79,11 +79,10 @@ dsX :: forall era. EraSpecLedger era ConwayFn => Gen (DState era)
 dsX = do
   univ <- genWitUniv 25
   acct <- genFromSpec @ConwayFn @AccountState accountStateSpec
-  drepRoleSet <- genFromSpec @ConwayFn TrueSpec
   pools <-
     genFromSpec @ConwayFn @(Map (KeyHash 'StakePool) PoolParams)
       (hasSize (rangeSize 8 8))
-  genFromSpec @ConwayFn @(DState era) (dstateSpec @era univ (lit drepRoleSet) (lit acct) (lit pools))
+  genFromSpec @ConwayFn @(DState era) (dstateSpec @era univ (lit acct) (lit pools))
 
 vsX :: forall era. GenScript era => Gen (VState era)
 vsX = do
@@ -101,7 +100,8 @@ csX = do
   univ <- genWitUniv 25
   acct <- genFromSpec @ConwayFn @AccountState accountStateSpec
   epoch <- genFromSpec @ConwayFn @EpochNo epochNoSpec
-  genFromSpec @ConwayFn @(CertState era) (certStateSpec univ (lit acct) (lit epoch))
+  genFromSpec @ConwayFn @(CertState era)
+    (certStateSpec univ (lit acct) (lit epoch))
 
 utxoX :: forall era. EraSpecLedger era ConwayFn => Gen (UTxO era)
 utxoX = do

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/ParametricSpec.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/ParametricSpec.hs
@@ -27,17 +27,19 @@
 module Test.Cardano.Ledger.Constrained.Conway.ParametricSpec (
   module SimplePParams,
   EraSpecTxOut (..),
+  txOutSpec,
   EraSpecCert (..),
   EraSpecDeleg (..),
   delegatedStakeReference,
   CertKey (..),
 ) where
 
-import Cardano.Ledger.Allegra (AllegraEra)
-import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.TxOut (AlonzoEraTxOut (..), AlonzoTxOut (..))
-import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.Babbage.TxOut (BabbageTxOut (..))
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Allegra (Allegra)
+import Cardano.Ledger.Alonzo (Alonzo)
+import Cardano.Ledger.Babbage (Babbage)
 import Cardano.Ledger.BaseTypes hiding (inject)
 import Cardano.Ledger.CertState
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
@@ -45,11 +47,11 @@ import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential, StakeReference (..))
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
-import Cardano.Ledger.Mary (MaryEra, MaryValue)
-import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Ledger.Mary (Mary)
+import Cardano.Ledger.Shelley (Shelley)
 import Cardano.Ledger.Shelley.LedgerState (AccountState (..), StashedAVVMAddresses)
-import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
 import Constrained hiding (Value)
+import Constrained.Base (Pred (..))
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Word (Word64)
@@ -62,6 +64,12 @@ import Test.Cardano.Ledger.Constrained.Conway.Instances.Ledger (
  )
 import Test.Cardano.Ledger.Constrained.Conway.Instances.PParams
 import qualified Test.Cardano.Ledger.Constrained.Conway.Instances.PParams as SimplePParams
+import Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse (
+  GenScript,
+  WitUniv (..),
+  witBootstrapAddress,
+  witness,
+ )
 
 -- ===========================================================
 
@@ -76,16 +84,14 @@ class
   , HasSpec fn (TxOut era)
   , IsNormalType (TxOut era)
   , EraTxOut era
+  , GenScript era
   , IsConwayUniv fn
   ) =>
   EraSpecTxOut era fn
   where
-  irewardSpec :: Term fn AccountState -> Specification fn InstantaneousRewards
+  irewardSpec ::
+    WitUniv era -> Term fn AccountState -> Specification fn (InstantaneousRewards (EraCrypto era))
   hasPtrs :: proxy era -> Term fn Bool
-  correctTxOut ::
-    Term fn (Map (Credential 'Staking) (KeyHash 'StakePool)) ->
-    Term fn (TxOut era) ->
-    Pred fn
 
   -- | Extract a Value from a TxOut
   txOutValue_ :: Term fn (TxOut era) -> Term fn (Value era)
@@ -93,98 +99,94 @@ class
   -- | Extract a Coin from a TxOut
   txOutCoin_ :: Term fn (TxOut era) -> Term fn Coin
 
-betterTxOutShelley ::
-  (EraTxOut era, Value era ~ Coin, IsConwayUniv fn) =>
-  Term fn (Map (Credential 'Staking) (KeyHash 'StakePool)) ->
-  Term fn (ShelleyTxOut era) ->
-  Pred fn
-betterTxOutShelley delegs txOut =
-  match txOut $ \ [var|addr|] [var|val|] ->
-    [ match val $ \ [var|c|] -> [0 <. c, c <=. fromIntegral (maxBound :: Word64)]
-    , (caseOn addr)
-        ( branch $ \ [var|network|] _ [var|stakeref|] ->
-            [ assert $ network ==. lit Testnet
-            , satisfies stakeref (delegatedStakeReference delegs)
-            ]
-        )
-        ( branch $ \bootstrapAddr ->
-            match bootstrapAddr $ \_ [var|nm|] _ ->
-              (caseOn nm)
-                (branch $ \_ -> False)
-                (branch $ \_ -> True)
-        )
-    ]
+  -- | Extract an Addr from a TxOut
+  txOutAddr_ :: Term fn (TxOut era) -> Term fn (Addr (EraCrypto era))
 
-betterTxOutMary ::
-  (EraTxOut era, Value era ~ MaryValue, IsConwayUniv fn) =>
-  Term fn (Map (Credential 'Staking) (KeyHash 'StakePool)) ->
-  Term fn (ShelleyTxOut era) ->
-  Pred fn
-betterTxOutMary delegs txOut =
-  match txOut $ \ [var|addr|] [var|val|] ->
-    [ match val $ \ [var|c|] -> [0 <. c, c <=. fromIntegral (maxBound :: Word64)]
-    , (caseOn addr)
-        ( branch $ \ [var|network|] _ [var|stakeref|] ->
-            [ assert $ network ==. lit Testnet
-            , satisfies stakeref (delegatedStakeReference delegs)
-            ]
-        )
-        ( branch $ \bootstrapAddr ->
-            match bootstrapAddr $ \_ [var|nm|] _ ->
-              (caseOn nm)
-                (branch $ \_ -> False)
-                (branch $ \_ -> True)
-        )
-    ]
+instance IsConwayUniv fn => EraSpecTxOut Shelley fn where
+  irewardSpec = instantaneousRewardsSpec
+  hasPtrs _proxy = lit True
 
-betterTxOutAlonzo ::
-  (AlonzoEraTxOut era, Value era ~ MaryValue, IsConwayUniv fn) =>
-  Term fn (Map (Credential 'Staking) (KeyHash 'StakePool)) ->
-  Term fn (AlonzoTxOut era) ->
-  Pred fn
-betterTxOutAlonzo delegs txOut =
-  match txOut $ \ [var|addr|] [var|val|] _ ->
-    [ match val $ \ [var|c|] -> [0 <. c, c <=. fromIntegral (maxBound :: Word64)]
-    , (caseOn addr)
-        ( branch $ \ [var|network|] _ [var|stakeref|] ->
-            [ assert $ network ==. lit Testnet
-            , satisfies stakeref (delegatedStakeReference delegs)
-            ]
-        )
-        ( branch $ \bootstrapAddr ->
-            match bootstrapAddr $ \_ _nm _ -> False
-            {-
-            (caseOn nm)
-              (branch $ \_ -> False)
-              (branch $ \_ -> True) -}
-        )
-    ]
+  -- correctTxOut = betterTxOutShelley
+  -- correctTxOut = txOutSpec mempty
+  txOutValue_ x = sel @1 x
+  txOutCoin_ x = sel @1 x
+  txOutAddr_ x = sel @0 x
 
-betterTxOutBabbage ::
-  ( EraTxOut era
-  , Value era ~ MaryValue
-  , IsNormalType (Script era)
-  , HasSpec fn (Script era)
-  , IsConwayUniv fn
-  ) =>
-  Term fn (Map (Credential 'Staking) (KeyHash 'StakePool)) ->
-  Term fn (BabbageTxOut era) ->
+instance IsConwayUniv fn => EraSpecTxOut Allegra fn where
+  irewardSpec = instantaneousRewardsSpec
+  hasPtrs _proxy = lit True
+
+  -- correctTxOut = betterTxOutShelley
+  txOutValue_ x = sel @1 x
+  txOutCoin_ x = sel @1 x
+  txOutAddr_ x = sel @0 x
+
+instance IsConwayUniv fn => EraSpecTxOut Mary fn where
+  irewardSpec = instantaneousRewardsSpec
+  hasPtrs _proxy = lit True
+
+  -- correctTxOut = betterTxOutMary
+  txOutValue_ x = sel @1 x
+  txOutCoin_ x = maryValueCoin_ (sel @1 x)
+  txOutAddr_ x = sel @0 x
+
+instance IsConwayUniv fn => EraSpecTxOut Alonzo fn where
+  irewardSpec = instantaneousRewardsSpec
+  hasPtrs _proxy = lit True
+
+  -- correctTxOut = betterTxOutAlonzo
+  txOutValue_ x = sel @1 x
+  txOutCoin_ x = maryValueCoin_ (sel @1 x)
+  txOutAddr_ x = sel @0 x
+
+instance IsConwayUniv fn => EraSpecTxOut Babbage fn where
+  irewardSpec = instantaneousRewardsSpec
+  hasPtrs _proxy = lit True
+
+  -- correctTxOut = betterTxOutBabbage
+  txOutValue_ x = sel @1 x
+  txOutCoin_ x = maryValueCoin_ (sel @1 x)
+  txOutAddr_ x = sel @0 x
+
+instance IsConwayUniv fn => EraSpecTxOut Conway fn where
+  irewardSpec _ _ = constrained $ \ [var|irewards|] ->
+    match irewards $ \ [var|reserves|] [var|treasury|] [var|deltaRes|] [var|deltaTreas|] ->
+      [ reserves ==. lit Map.empty
+      , treasury ==. lit Map.empty
+      , deltaRes ==. lit (DeltaCoin 0)
+      , deltaTreas ==. lit (DeltaCoin 0)
+      ]
+  hasPtrs _proxy = lit False
+
+  -- correctTxOut = betterTxOutBabbage
+  txOutValue_ x = sel @1 x
+  txOutCoin_ x = maryValueCoin_ (sel @1 x)
+  txOutAddr_ x = sel @0 x
+
+-- ===========================================================================
+
+-- | An Era polymorhic Specification for type family TxOut
+txOutSpec ::
+  forall fn era.
+  EraSpecTxOut era fn =>
+  WitUniv era ->
+  Term fn (Map (Credential 'Staking (EraCrypto era)) (KeyHash 'StakePool (EraCrypto era))) ->
+  Term fn (TxOut era) ->
   Pred fn
-betterTxOutBabbage delegs txOut =
-  match txOut $ \ [var|addr|] [var|val|] _ _ ->
-    [ match val $ \c -> [0 <. c, c <=. fromIntegral (maxBound :: Word64)]
-    , (caseOn addr)
-        ( branch $ \ [var|network|] _ [var|stakeref|] ->
-            [ assert $ network ==. lit Testnet
+txOutSpec univ delegs txOut =
+  Block
+    [ assert $ 0 <. txOutCoin_ @era txOut
+    , assert $ txOutCoin_ @era txOut <=. fromIntegral (maxBound :: Word64)
+    , (caseOn (txOutAddr_ @era txOut))
+        -- Network -> Credential -> StakeRefernce -> Addr
+        ( branchW 2 $ \ [var|network|] [var|payCred|] [var|stakeref|] ->
+            [ witness univ payCred -- satisfies payCred (payCredSpec univ)
+            , assert $ network ==. lit Testnet
             , satisfies stakeref (delegatedStakeReference delegs)
             ]
         )
-        ( branch $ \bootstrapAddr ->
-            match bootstrapAddr $ \_ [var|nm|] _ ->
-              (caseOn nm)
-                (branch $ \_ -> False)
-                (branch $ \_ -> True)
-        )
+        -- BootstrapAddress -> Addr
+        (branchW 1 $ \bootstrapAddr -> satisfies bootstrapAddr (witBootstrapAddress univ))
     ]
 
 -- | Generate random Stake references that have a high probability of being delegated.
@@ -201,17 +203,20 @@ delegatedStakeReference delegs =
       (branchW 1 $ \_null -> True) -- just an occaisional NullRef
 
 instantaneousRewardsSpec ::
-  forall fn.
-  IsConwayUniv fn =>
+  forall era fn.
+  (IsConwayUniv fn, Era era) =>
+  WitUniv era ->
   Term fn AccountState ->
-  Specification fn InstantaneousRewards
-instantaneousRewardsSpec acct = constrained $ \ [var| irewards |] ->
+  Specification fn (InstantaneousRewards (EraCrypto era))
+instantaneousRewardsSpec univ acct = constrained $ \ [var| irewards |] ->
   match acct $ \ [var| acctRes |] [var| acctTreas |] ->
     match irewards $ \ [var| reserves |] [var| treasury |] [var| deltaRes |] [var| deltaTreas |] ->
       [ dependsOn acctRes reserves
       , dependsOn acctRes deltaRes
       , dependsOn acctTreas treasury
       , dependsOn acctTreas deltaTreas
+      , witness univ (dom_ reserves)
+      , witness univ (dom_ treasury)
       , assertExplain (pure "deltaTreausry and deltaReserves sum to 0") $ negate deltaRes ==. deltaTreas
       , forAll (rng_ reserves) (\ [var| x |] -> x >=. (lit (Coin 0)))
       , forAll (rng_ treasury) (\ [var| y |] -> y >=. (lit (Coin 0)))
@@ -219,50 +224,3 @@ instantaneousRewardsSpec acct = constrained $ \ [var| irewards |] ->
       , assert $ (toDelta_ (foldMap_ id (rng_ treasury))) - deltaTreas <=. toDelta_ acctTreas
       ]
 
-instance IsConwayUniv fn => EraSpecTxOut ShelleyEra fn where
-  irewardSpec = instantaneousRewardsSpec
-  hasPtrs _proxy = lit True
-  correctTxOut = betterTxOutShelley
-  txOutValue_ x = sel @1 x
-  txOutCoin_ x = sel @1 x
-
-instance IsConwayUniv fn => EraSpecTxOut AllegraEra fn where
-  irewardSpec = instantaneousRewardsSpec
-  hasPtrs _proxy = lit True
-  correctTxOut = betterTxOutShelley
-  txOutValue_ x = sel @1 x
-  txOutCoin_ x = sel @1 x
-
-instance IsConwayUniv fn => EraSpecTxOut MaryEra fn where
-  irewardSpec = instantaneousRewardsSpec
-  hasPtrs _proxy = lit True
-  correctTxOut = betterTxOutMary
-  txOutValue_ x = sel @1 x
-  txOutCoin_ x = maryValueCoin_ (sel @1 x)
-
-instance IsConwayUniv fn => EraSpecTxOut AlonzoEra fn where
-  irewardSpec = instantaneousRewardsSpec
-  hasPtrs _proxy = lit True
-  correctTxOut = betterTxOutAlonzo
-  txOutValue_ x = sel @1 x
-  txOutCoin_ x = maryValueCoin_ (sel @1 x)
-
-instance IsConwayUniv fn => EraSpecTxOut BabbageEra fn where
-  irewardSpec = instantaneousRewardsSpec
-  hasPtrs _proxy = lit True
-  correctTxOut = betterTxOutBabbage
-  txOutValue_ x = sel @1 x
-  txOutCoin_ x = maryValueCoin_ (sel @1 x)
-
-instance IsConwayUniv fn => EraSpecTxOut ConwayEra fn where
-  irewardSpec _ = constrained $ \ [var|irewards|] ->
-    match irewards $ \ [var|reserves|] [var|treasury|] [var|deltaRes|] [var|deltaTreas|] ->
-      [ reserves ==. lit Map.empty
-      , treasury ==. lit Map.empty
-      , deltaRes ==. lit (DeltaCoin 0)
-      , deltaTreas ==. lit (DeltaCoin 0)
-      ]
-  hasPtrs _proxy = lit False
-  correctTxOut = betterTxOutBabbage
-  txOutValue_ x = sel @1 x
-  txOutCoin_ x = maryValueCoin_ (sel @1 x)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/ParametricSpec.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/ParametricSpec.hs
@@ -34,12 +34,10 @@ module Test.Cardano.Ledger.Constrained.Conway.ParametricSpec (
   CertKey (..),
 ) where
 
-import Cardano.Ledger.Alonzo.TxOut (AlonzoEraTxOut (..), AlonzoTxOut (..))
-import Cardano.Ledger.Babbage.TxOut (BabbageTxOut (..))
 import Cardano.Ledger.Address (Addr (..))
-import Cardano.Ledger.Allegra (Allegra)
-import Cardano.Ledger.Alonzo (Alonzo)
-import Cardano.Ledger.Babbage (Babbage)
+import Cardano.Ledger.Allegra (AllegraEra)
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.BaseTypes hiding (inject)
 import Cardano.Ledger.CertState
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
@@ -47,8 +45,8 @@ import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential, StakeReference (..))
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
-import Cardano.Ledger.Mary (Mary)
-import Cardano.Ledger.Shelley (Shelley)
+import Cardano.Ledger.Mary (MaryEra)
+import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.LedgerState (AccountState (..), StashedAVVMAddresses)
 import Constrained hiding (Value)
 import Constrained.Base (Pred (..))
@@ -90,7 +88,7 @@ class
   EraSpecTxOut era fn
   where
   irewardSpec ::
-    WitUniv era -> Term fn AccountState -> Specification fn (InstantaneousRewards (EraCrypto era))
+    WitUniv era -> Term fn AccountState -> Specification fn InstantaneousRewards
   hasPtrs :: proxy era -> Term fn Bool
 
   -- | Extract a Value from a TxOut
@@ -100,9 +98,9 @@ class
   txOutCoin_ :: Term fn (TxOut era) -> Term fn Coin
 
   -- | Extract an Addr from a TxOut
-  txOutAddr_ :: Term fn (TxOut era) -> Term fn (Addr (EraCrypto era))
+  txOutAddr_ :: Term fn (TxOut era) -> Term fn Addr
 
-instance IsConwayUniv fn => EraSpecTxOut Shelley fn where
+instance IsConwayUniv fn => EraSpecTxOut ShelleyEra fn where
   irewardSpec = instantaneousRewardsSpec
   hasPtrs _proxy = lit True
 
@@ -112,7 +110,7 @@ instance IsConwayUniv fn => EraSpecTxOut Shelley fn where
   txOutCoin_ x = sel @1 x
   txOutAddr_ x = sel @0 x
 
-instance IsConwayUniv fn => EraSpecTxOut Allegra fn where
+instance IsConwayUniv fn => EraSpecTxOut AllegraEra fn where
   irewardSpec = instantaneousRewardsSpec
   hasPtrs _proxy = lit True
 
@@ -121,7 +119,7 @@ instance IsConwayUniv fn => EraSpecTxOut Allegra fn where
   txOutCoin_ x = sel @1 x
   txOutAddr_ x = sel @0 x
 
-instance IsConwayUniv fn => EraSpecTxOut Mary fn where
+instance IsConwayUniv fn => EraSpecTxOut MaryEra fn where
   irewardSpec = instantaneousRewardsSpec
   hasPtrs _proxy = lit True
 
@@ -130,7 +128,7 @@ instance IsConwayUniv fn => EraSpecTxOut Mary fn where
   txOutCoin_ x = maryValueCoin_ (sel @1 x)
   txOutAddr_ x = sel @0 x
 
-instance IsConwayUniv fn => EraSpecTxOut Alonzo fn where
+instance IsConwayUniv fn => EraSpecTxOut AlonzoEra fn where
   irewardSpec = instantaneousRewardsSpec
   hasPtrs _proxy = lit True
 
@@ -139,7 +137,7 @@ instance IsConwayUniv fn => EraSpecTxOut Alonzo fn where
   txOutCoin_ x = maryValueCoin_ (sel @1 x)
   txOutAddr_ x = sel @0 x
 
-instance IsConwayUniv fn => EraSpecTxOut Babbage fn where
+instance IsConwayUniv fn => EraSpecTxOut BabbageEra fn where
   irewardSpec = instantaneousRewardsSpec
   hasPtrs _proxy = lit True
 
@@ -148,7 +146,7 @@ instance IsConwayUniv fn => EraSpecTxOut Babbage fn where
   txOutCoin_ x = maryValueCoin_ (sel @1 x)
   txOutAddr_ x = sel @0 x
 
-instance IsConwayUniv fn => EraSpecTxOut Conway fn where
+instance IsConwayUniv fn => EraSpecTxOut ConwayEra fn where
   irewardSpec _ _ = constrained $ \ [var|irewards|] ->
     match irewards $ \ [var|reserves|] [var|treasury|] [var|deltaRes|] [var|deltaTreas|] ->
       [ reserves ==. lit Map.empty
@@ -170,7 +168,7 @@ txOutSpec ::
   forall fn era.
   EraSpecTxOut era fn =>
   WitUniv era ->
-  Term fn (Map (Credential 'Staking (EraCrypto era)) (KeyHash 'StakePool (EraCrypto era))) ->
+  Term fn (Map (Credential 'Staking) (KeyHash 'StakePool)) ->
   Term fn (TxOut era) ->
   Pred fn
 txOutSpec univ delegs txOut =
@@ -207,7 +205,7 @@ instantaneousRewardsSpec ::
   (IsConwayUniv fn, Era era) =>
   WitUniv era ->
   Term fn AccountState ->
-  Specification fn (InstantaneousRewards (EraCrypto era))
+  Specification fn InstantaneousRewards
 instantaneousRewardsSpec univ acct = constrained $ \ [var| irewards |] ->
   match acct $ \ [var| acctRes |] [var| acctTreas |] ->
     match irewards $ \ [var| reserves |] [var| treasury |] [var| deltaRes |] [var| deltaTreas |] ->
@@ -223,4 +221,3 @@ instantaneousRewardsSpec univ acct = constrained $ \ [var| irewards |] ->
       , assert $ (toDelta_ (foldMap_ id (rng_ reserves))) - deltaRes <=. toDelta_ acctRes
       , assert $ (toDelta_ (foldMap_ id (rng_ treasury))) - deltaTreas <=. toDelta_ acctTreas
       ]
-

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Pool.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Pool.hs
@@ -69,7 +69,7 @@ poolCertSpec ::
   WitUniv era ->
   PoolEnv era ->
   PState era ->
-  Specification fn (PoolCert (EraCrypto era))
+  Specification fn PoolCert
 poolCertSpec univ (PoolEnv e pp) ps =
   constrained $ \pc ->
     (caseOn pc)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/TxBodySpec.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/TxBodySpec.hs
@@ -18,7 +18,7 @@ module Test.Cardano.Ledger.Constrained.Conway.TxBodySpec where
 
 import Cardano.Ledger.BaseTypes (Network (..))
 import Cardano.Ledger.Coin
-import Cardano.Ledger.Conway (Conway)
+import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Rules (CertsEnv (..))
 import Cardano.Ledger.Core
 
@@ -56,12 +56,12 @@ import Test.QuickCheck hiding (forAll, witness)
 import Prelude hiding (seq)
 
 import Cardano.Ledger.Address (Withdrawals (..))
-import Cardano.Ledger.Allegra (Allegra)
-import Cardano.Ledger.Alonzo (Alonzo)
-import Cardano.Ledger.Babbage (Babbage)
+import Cardano.Ledger.Allegra (AllegraEra)
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.CertState (lookupDepositDState, lookupDepositVState)
-import Cardano.Ledger.Mary (Mary)
-import Cardano.Ledger.Shelley (Shelley)
+import Cardano.Ledger.Mary (MaryEra)
+import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.AdaPots (Consumed (..), Produced (..), consumedTxBody, producedTxBody)
 import Cardano.Ledger.Shelley.LedgerState (CertState (..), PState (..))
 import Data.Text (pack)
@@ -287,19 +287,19 @@ go2 = do
 
 go :: IO ()
 go = do
-  univ <- generate $ genWitUniv @Allegra 5
+  univ <- generate $ genWitUniv @AllegraEra 5
   wdrls <- generate $ genFromSpec @ConwayFn (constrained $ \x -> witness univ x)
   delegatees <- generate $ genFromSpec @ConwayFn (delegateeSpec univ)
-  certsEnv <- generate $ genFromSpec @ConwayFn @(CertsEnv Allegra) certsEnvSpec
+  certsEnv <- generate $ genFromSpec @ConwayFn @(CertsEnv AllegraEra) certsEnvSpec
   certState <-
     generate $
-      genFromSpec @ConwayFn @(CertState Allegra)
-        (certStateSpec @ConwayFn @Allegra univ delegatees wdrls)
+      genFromSpec @ConwayFn @(CertState AllegraEra)
+        (certStateSpec @ConwayFn @AllegraEra univ delegatees wdrls)
 
   cert <-
     generate $
-      genFromSpec @ConwayFn @(TxCert Allegra) $
-        (shelleyTxCertSpec @ConwayFn @Allegra univ (projectEnv certsEnv) certState)
+      genFromSpec @ConwayFn @(TxCert AllegraEra) $
+        (shelleyTxCertSpec @ConwayFn @AllegraEra univ (projectEnv certsEnv) certState)
           <> (witShelleyTxCert univ)
   -- The problem with this is that the CertState does not have any
   -- thing from the universe, so any Cert that requires a member_ of someting

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/TxBodySpec.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/TxBodySpec.hs
@@ -52,7 +52,7 @@ import Test.Cardano.Ledger.Constrained.Conway.LedgerTypes.Specs (EraSpecLedger (
 import Test.Cardano.Ledger.Constrained.Conway.ParametricSpec
 import Test.Cardano.Ledger.Generic.Proof (Reflect)
 import qualified Test.Cardano.Ledger.Generic.Proof as Proof
-import Test.QuickCheck hiding (forAll)
+import Test.QuickCheck hiding (forAll, witness)
 import Prelude hiding (seq)
 
 import Cardano.Ledger.Address (Withdrawals (..))
@@ -263,11 +263,12 @@ go2 ::
   IO ()
 go2 = do
   univ <- generate $ genWitUniv 25
+  wdrls <- generate $ genFromSpec @ConwayFn (constrained $ \x -> witness univ x)
   delegatees <- generate $ genFromSpec @ConwayFn (delegateeSpec univ)
   certState <-
     generate $
       genFromSpec @ConwayFn @(CertState era)
-        (certStateSpec @ConwayFn @era univ delegatees) -- (lit (AccountState (Coin 1000) (Coin 100))) (lit (EpochNo 100)))
+        (certStateSpec @ConwayFn @era univ delegatees wdrls) -- (lit (AccountState (Coin 1000) (Coin 100))) (lit (EpochNo 100)))
         -- error "STOP"
   certsEnv <- generate $ genFromSpec @ConwayFn @(CertsEnv era) certsEnvSpec
 
@@ -287,12 +288,13 @@ go2 = do
 go :: IO ()
 go = do
   univ <- generate $ genWitUniv @Allegra 5
+  wdrls <- generate $ genFromSpec @ConwayFn (constrained $ \x -> witness univ x)
   delegatees <- generate $ genFromSpec @ConwayFn (delegateeSpec univ)
   certsEnv <- generate $ genFromSpec @ConwayFn @(CertsEnv Allegra) certsEnvSpec
   certState <-
     generate $
       genFromSpec @ConwayFn @(CertState Allegra)
-        (certStateSpec @ConwayFn @Allegra univ delegatees)
+        (certStateSpec @ConwayFn @Allegra univ delegatees wdrls)
 
   cert <-
     generate $

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
@@ -38,6 +38,7 @@ import Cardano.Ledger.CertState (
  )
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Core (
+  Era (..),
   EraPParams (..),
   EraTx,
   EraTxAuxData (..),
@@ -64,13 +65,13 @@ import Test.Cardano.Ledger.Conway.Arbitrary ()
 import Test.Cardano.Ledger.Conway.TreeDiff ()
 import Test.Cardano.Ledger.Core.Utils (testGlobals)
 
-instance HasSimpleRep (DepositPurpose c)
-instance (Crypto c, IsConwayUniv fn) => HasSpec fn (DepositPurpose c)
+instance HasSimpleRep DepositPurpose
+instance IsConwayUniv fn => HasSpec fn DepositPurpose
 
 witnessDepositPurpose ::
   forall fn era.
   (Era era, IsConwayUniv fn) =>
-  WitUniv era -> Specification fn (DepositPurpose (EraCrypto era))
+  WitUniv era -> Specification fn DepositPurpose
 witnessDepositPurpose univ = constrained $ \ [var|depPurpose|] ->
   (caseOn depPurpose)
     -- CredentialDeposit !(Credential 'Staking c)
@@ -82,11 +83,11 @@ witnessDepositPurpose univ = constrained $ \ [var|depPurpose|] ->
     -- GovActionDeposit
     (branch $ \_ -> True)
 
-data DepositPurpose c
-  = CredentialDeposit !(Credential 'Staking c)
-  | PoolDeposit !(KeyHash 'StakePool c)
-  | DRepDeposit !(Credential 'DRepRole c)
-  | GovActionDeposit !(GovActionId c)
+data DepositPurpose
+  = CredentialDeposit !(Credential 'Staking)
+  | PoolDeposit !(KeyHash 'StakePool)
+  | DRepDeposit !(Credential 'DRepRole)
+  | GovActionDeposit !GovActionId
   deriving (Generic, Eq, Show, Ord)
 
 instance Arbitrary DepositPurpose where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/WitnessUniverse.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/WitnessUniverse.hs
@@ -1,0 +1,855 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+module Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse where
+
+import qualified Cardano.Chain.Common as Byron
+import Cardano.Crypto (SigningKey)
+import Cardano.Crypto.Signing (toVerification)
+import Cardano.Ledger.Address (BootstrapAddress (..), RewardAccount (..))
+import Cardano.Ledger.Allegra (Allegra)
+import Cardano.Ledger.Allegra.Scripts (
+  AllegraEraScript (..),
+  pattern RequireTimeExpire,
+  pattern RequireTimeStart,
+ )
+import Cardano.Ledger.Alonzo (Alonzo)
+import Cardano.Ledger.Alonzo.Scripts (AlonzoEraScript (..), AsIx (..), PlutusPurpose)
+import Cardano.Ledger.Alonzo.TxWits (AlonzoEraTxWits (..), Redeemers (..), TxDats (..))
+import Cardano.Ledger.Babbage (Babbage)
+import Cardano.Ledger.BaseTypes (Network (..), SlotNo (..))
+import Cardano.Ledger.Binary (EncCBOR (encCBOR))
+import Cardano.Ledger.Binary.Coders (Encode (..), encode, (!>))
+import Cardano.Ledger.Conway (Conway)
+import Cardano.Ledger.Conway.TxCert
+import Cardano.Ledger.Core
+import Cardano.Ledger.Credential
+import Cardano.Ledger.Crypto
+import Cardano.Ledger.DRep (DRep (..))
+import Cardano.Ledger.Keys (
+  BootstrapWitness,
+  GenDelegPair (..),
+  KeyHash (..),
+  KeyRole (..),
+  VKey,
+  WitVKey,
+  hashKey,
+  makeBootstrapWitness,
+ )
+import Cardano.Ledger.Mary (Mary)
+import Cardano.Ledger.Mary.Value ()
+import Cardano.Ledger.Plutus.Data (Data (..), hashData)
+import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
+import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.SafeHash (SafeHash, extractHash)
+import Cardano.Ledger.Shelley (Shelley)
+import Cardano.Ledger.Shelley.Scripts
+import Cardano.Ledger.Shelley.TxCert
+import Constrained hiding (Value)
+import Constrained.Base (Pred (..), addToErrorSpec, hasSize, rangeSize)
+import Control.DeepSeq (NFData (..), deepseq)
+import Control.Monad (replicateM)
+import qualified Data.List.NonEmpty as NE
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Data.Sequence.Strict as Seq
+import Data.Set (Set)
+import qualified Data.Set as Set
+import qualified Data.TreeDiff as Tree (Expr (..))
+import Data.Typeable
+import GHC.Generics
+import Lens.Micro
+import System.IO.Unsafe (unsafePerformIO)
+import Test.Cardano.Ledger.Allegra.TreeDiff ()
+import Test.Cardano.Ledger.Common (ToExpr (..))
+import Test.Cardano.Ledger.Constrained.Conway.Instances.Ledger
+import Test.Cardano.Ledger.Constrained.Preds.Universes (genAddrPair)
+import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..), mkWitnessVKey)
+import Test.Cardano.Ledger.Generic.PrettyCore
+import Test.Cardano.Ledger.Generic.Proof (Reflect)
+import qualified Test.Cardano.Ledger.Generic.Proof as Proof
+import Test.QuickCheck hiding (forAll, witness)
+
+-- import Cardano.Ledger.Conway.Governance(GovActionId(..)) TxId and GovActionIX, no need to witness
+-- import Cardano.Ledger.TxIn (TxId (..)) Hash of a TxBody, no need to witness
+-- import Test.Cardano.Ledger.Constrained.Conway.Utxo(DepositPurpose(..))
+
+{-
+Will need a winessing Spec for this
+data ConwayCertExecContext era = ConwayCertExecContext
+  { ccecWithdrawals :: !(Map (RewardAccount (EraCrypto era)) Coin)
+  , ccecDeposits :: !(Map (DepositPurpose (EraCrypto era)) Coin)
+  , ccecVotes :: !(VotingProcedures era)
+  }
+  deriving (Generic, Eq, Show)
+-}
+
+-- ===============================================
+-- Move these somewhere else?
+
+instance Era era => HasSimpleRep (TxDats era) where
+  type SimpleRep (TxDats era) = Map (DataHash (EraCrypto era)) (Data era)
+  toSimpleRep (TxDats m) = m
+  fromSimpleRep m = TxDats m
+
+instance (IsConwayUniv fn, Era era) => HasSpec fn (TxDats era)
+
+instance AlonzoEraScript era => HasSimpleRep (Redeemers era) where
+  type SimpleRep (Redeemers era) = Map (PlutusPurpose AsIx era) (Data era, ExUnits)
+  toSimpleRep (Redeemers m) = m
+  fromSimpleRep m = Redeemers m
+
+instance
+  ( IsConwayUniv fn
+  , Crypto (EraCrypto era)
+  , ShelleyEraScript era
+  , NativeScript era ~ MultiSig era
+  ) =>
+  HasSpec fn (MultiSig era)
+  where
+  type TypeSpec fn (MultiSig era) = ()
+  emptySpec = ()
+  combineSpec _ _ = TrueSpec
+  genFromTypeSpec _ = pureGen $ genNestedMultiSig 2
+  cardinalTypeSpec _ = TrueSpec
+  shrinkWithTypeSpec _ = shrink
+  conformsTo _ _ = True
+  toPreds _ _ = toPred True
+
+-- ========================================================================
+-- We need witnesses when the Tx has values of type 'hashtype' inside, because
+-- the witnesses allows one to recover proof (ProofType hashtype era) that
+-- the Tx author both knows, and controls, the thing that was Hashed,
+-- i.e. (TypeHashed hashtype era). The witness (WitnessType hashtype era)
+-- is NOT ALWAYS the same as the (ProofType hashtype era), since it can depend on
+-- the Tx. All the strange class preconditions are required by conformance testing.
+
+-- deriving instance Typeable r => Generic (KeyHash r c)
+
+class
+  ( Eq (ProofType hashtype era)
+  , EncCBOR (ProofType hashtype era)
+  , ToExpr (ProofType hashtype era)
+  , NFData (ProofType hashtype era)
+  , NFData hashtype
+  , Eq hashtype
+  ) =>
+  HasWitness hashtype era
+  where
+  type ProofType hashtype era
+  type WitnessType hashtype era
+  type TypeHashed hashtype era
+  hash :: TypeHashed hashtype era -> hashtype
+  mkWitness :: ProofType hashtype era -> WitnessType hashtype era
+  getTypeHashed :: ProofType hashtype era -> TypeHashed hashtype era
+  prettyHash :: hashtype -> PDoc
+
+-- ============================================================
+
+-- | A WitBlock is desined to have five purposes
+--   1) To efficiently constrain objects to be witnessed when using constraint generators
+--      the (Set hashtype) allows efficient constraints like :: (member_ t) (lit (wbHash witblock))
+--   2) To efficiently compute witnesses from a 'hashtype'
+--      the (Map hashtype (ProofType hashtype era)) can be used like this
+--      case Map.lookup hash (wbMap witblock) of
+--        Just base -> mkWitness base
+--        Nothing -> error "Missing hash. perhaps generator did not constrain the hash to be witnessed?"
+--   3) When (HasWitness hashtype era) holds, the WitBlock can be computed from only [ProofType hashtype era]
+--      using 'getTypeHashed'. This makes Gen and CBOR instances, especially easy. We compute only with
+--      [ProofType hashtype era] and then reconstruct the rest
+--   4) WitBlock is a Monoid, so we can combine them easily
+--   5) We can easily to make (Gen (WitBlock t era)), so we can make them for testing.
+data WitBlock t era where
+  WitBlock :: (Era era, HasWitness t era) => Set t -> Map t (ProofType t era) -> WitBlock t era
+
+instance ToExpr t => ToExpr (WitBlock t era) where
+  toExpr (WitBlock x y) = Tree.App "WitBlock" [toExpr x, toExpr y]
+
+wbHash :: WitBlock t era -> Set t
+wbHash (WitBlock x _) = x
+wbMap :: WitBlock t era -> Map t (ProofType t era)
+wbMap (WitBlock _ y) = y
+
+-- | when we print a WitBlock, we are only interested in the hashes, not the witnesses
+instance PrettyA (WitBlock t era) where
+  prettyA (WitBlock hashset _) = ppSet (prettyHash @t @era) hashset
+
+instance Show (WitBlock t era) where
+  show x = show (prettyA x)
+
+instance NFData (WitBlock t era) where
+  rnf (WitBlock x y) = deepseq (rnf x) (deepseq (rnf y) ())
+
+instance Eq (WitBlock t era) where
+  (WitBlock x y) == (WitBlock a b) = x == a && y == b
+
+-- ==========================================================================
+-- (HasWitness t era) Instances for several different types of hash and hashed types
+
+-- A short descriptive name for a long complicated thing
+type BodyHash era = SafeHash (EraCrypto era) EraIndependentTxBody
+
+-- ========
+-- KeyHash and VKey
+-- KeyPair seems to be missing a lot of instances, so we define them here
+
+instance (Typeable r, Crypto c) => EncCBOR (KeyPair r c) where
+  encCBOR (KeyPair x y) = encode $ Rec KeyPair !> To x !> To y
+
+deriving instance Typeable r => Eq (KeyPair r StandardCrypto)
+
+instance Crypto c => ToExpr (KeyPair r c) where
+  toExpr (KeyPair x y) = Tree.App "KeyPair" [toExpr x, Tree.App (take 10 (show y)) []]
+
+instance (Reflect era, EraCrypto era ~ c, Crypto c) => HasWitness (KeyHash 'Witness c) era where
+  type ProofType (KeyHash 'Witness c) era = KeyPair 'Witness c
+  type WitnessType (KeyHash 'Witness c) era = (BodyHash era -> WitVKey 'Witness c)
+  type TypeHashed (KeyHash 'Witness c) era = VKey 'Witness c
+  hash x = hashKey x
+  mkWitness keypair safehash = mkWitnessVKey safehash keypair
+  getTypeHashed (KeyPair x _) = x
+  prettyHash x = prettyA x
+
+-- ========
+-- ScriptHash and Scripts
+-- NewScript needed because (Script era) is a type family, and hence can't have instances
+
+newtype NewScript era = NewScript {unNew :: Script era}
+deriving newtype instance NFData (Script era) => NFData (NewScript era)
+deriving newtype instance EraScript era => Eq (NewScript era)
+deriving newtype instance EraScript era => EncCBOR (NewScript era)
+instance (EraScript era, ToExpr (NativeScript era)) => ToExpr (NewScript era) where
+  toExpr (NewScript script) = case getNativeScript script of
+    Just s -> toExpr s
+    Nothing -> Tree.App "PlutusScript" []
+
+instance
+  ( GenScript era
+  , EraCrypto era ~ c
+  ) =>
+  HasWitness (ScriptHash c) era
+  where
+  type ProofType (ScriptHash c) era = NewScript era
+  type WitnessType (ScriptHash c) era = Script era
+  type TypeHashed (ScriptHash c) era = ProofType (ScriptHash c) era
+  hash (NewScript x) = hashScript x
+  mkWitness (NewScript script) = script
+  getTypeHashed x = x
+  prettyHash x = prettyA x
+
+-- ========
+-- BootstrapAddress and SigningKey
+-- BootstrapAddress is a convoluted hash of the SigningKey,
+-- understood only by the Byron programmers (don't ask)
+
+instance ToExpr SigningKey where toExpr sk = Tree.App (show sk) []
+
+instance (Reflect era, EraCrypto era ~ c) => HasWitness (BootstrapAddress c) era where
+  type ProofType (BootstrapAddress c) era = SigningKey
+  type WitnessType (BootstrapAddress c) era = (BodyHash era -> BootstrapWitness (EraCrypto era))
+  type TypeHashed (BootstrapAddress c) era = SigningKey
+
+  -- \| Don't ask about this, its related to the magic genAddrPair, which, like
+  --   all things Byron, I don't understand. It generates a Byron address and
+  --   its signing key for test purposes, and the signing key, uniquely determines
+  --   the Byron address (for Testnet) as defined in method 'hash' below. I am certain, this
+  --   is not how Byron address work in real life, but it works for test purposes.
+  hash signkey =
+    let verificationKey = toVerification signkey
+        asd = Byron.VerKeyASD verificationKey
+        attrs =
+          Byron.AddrAttributes
+            (Just (Byron.HDAddressPayload "a compressed lenna.png"))
+            (Byron.NetworkTestnet 0)
+     in BootstrapAddress (Byron.makeAddress asd attrs)
+  mkWitness signkey bodyhash =
+    let bootAddr = hash @(BootstrapAddress c) @era signkey
+     in makeBootstrapWitness
+          (extractHash bodyhash)
+          signkey
+          (Byron.addrAttributes (unBootstrapAddress bootAddr))
+  getTypeHashed signkey = signkey
+  prettyHash x = prettyA x
+
+-- ========
+-- DataHash and Data
+-- note the type synonym
+-- type (DataHash c) = SafeHash c EraIndependentData
+
+instance (EraScript era, EraCrypto era ~ c) => HasWitness (DataHash c) era where
+  type ProofType (DataHash c) era = Data era
+  type WitnessType (DataHash c) era = Data era
+  type TypeHashed (DataHash c) era = Data era
+  hash x = hashData x
+  mkWitness script = script
+  getTypeHashed x = x
+  prettyHash x = pcDataHash x
+
+-- ==============================================
+-- The WitUniv type is 4 WitBlocks, there are some missing instances
+
+data WitUniv era
+  = WitUniv
+  { wvVKey :: WitBlock (KeyHash 'Witness (EraCrypto era)) era
+  , wvBoot :: WitBlock (BootstrapAddress (EraCrypto era)) era
+  , wvScript :: WitBlock (ScriptHash (EraCrypto era)) era
+  , wvDats :: WitBlock (DataHash (EraCrypto era)) era
+  }
+  deriving (Eq, NFData, ToExpr, Generic)
+
+-- Non deriveable instances for WitUniv
+
+instance Proof.Reflect era => PrettyA (WitUniv era) where
+  prettyA (WitUniv keys boot script dats) =
+    ppRecord
+      "WitnessUniverse"
+      [ ("keys", ppSet pcKeyHash (wbHash keys))
+      , ("boot", ppSet pcByronAddress (wbHash boot))
+      , ("scripts", ppSet pcScriptHash (wbHash script))
+      , ("dats", ppSet ppSafeHash (wbHash dats))
+      ]
+
+instance Proof.Reflect era => Show (WitUniv era) where show x = show (prettyA x)
+
+instance Era era => EncCBOR (WitUniv era) where
+  encCBOR (WitUniv w x y z) = encode $ Rec WitUniv !> To w !> To x !> To y !> To z
+
+-- ====================================================================
+-- Purpose 1) To efficiently constrain objects to be witnessed when using constraint generators
+-- the (Set hashtype) allows efficient constraints like :: (member_ t) (lit (wbHash witblock))
+
+explainWit :: String -> WitUniv era -> Specification fn t -> Specification fn t
+explainWit str (WitUniv (WitBlock s _) _ _ _) spec =
+  addToErrorSpec
+    (pure ("While witnessing " ++ str ++ " with WitUniv of size " ++ show (Set.size s)))
+    spec
+
+witKeyHashSpec ::
+  forall fn era krole.
+  (Era era, IsConwayUniv fn, Typeable krole) =>
+  WitUniv era -> Specification fn (KeyHash krole (EraCrypto era))
+witKeyHashSpec univ =
+  explainWit "(KeyHash r c)" univ $
+    constrained $
+      \ [var|keyhash|] ->
+        Explain (pure "witnessing (KeyHash r c)") $
+          Assert $
+            member_ (coerce_ keyhash) (lit (wbHash (wvVKey univ)))
+
+witScriptHashSpec ::
+  forall fn era.
+  (Era era, IsConwayUniv fn) =>
+  WitUniv era -> Specification fn (ScriptHash (EraCrypto era))
+witScriptHashSpec univ =
+  explainWit "(ScriptHash c)" univ $
+    constrained $
+      \ [var|scripthash|] -> member_ scripthash (lit (wbHash (wvScript univ)))
+
+witBootstrapAddress ::
+  forall fn era.
+  (Era era, IsConwayUniv fn) =>
+  WitUniv era -> Specification fn (BootstrapAddress (EraCrypto era))
+witBootstrapAddress univ =
+  explainWit "(BootstrapAddress c)" univ $
+    constrained $
+      \ [var|bootAddr|] -> member_ bootAddr (lit (wbHash (wvBoot univ)))
+
+witCredSpec ::
+  forall fn era krole.
+  (IsConwayUniv fn, Era era, Typeable krole) =>
+  WitUniv era -> Specification fn (Credential krole (EraCrypto era))
+witCredSpec univ =
+  explainWit "(Credential c)" univ $
+    constrained $ \ [var|cred|] ->
+      [ (caseOn cred)
+          -- ScriptHash c -> Credential
+          (branchW 1 $ \ [var|scripthash|] -> satisfies scripthash (witScriptHashSpec univ))
+          -- KeyHash kr c -> Credential
+          (branchW 1 $ \ [var|keyhash|] -> satisfies keyhash (witKeyHashSpec univ))
+      ]
+
+witDRepSpec ::
+  forall fn era.
+  (IsConwayUniv fn, Era era) =>
+  WitUniv era -> Specification fn (DRep (EraCrypto era))
+witDRepSpec univ =
+  explainWit "(DRep c)" univ $
+    constrained $ \ [var|drep|] ->
+      [ (caseOn drep)
+          -- KeyHash kr c -> Drep
+          (branchW 3 $ \ [var|keyhash|] -> satisfies keyhash (witKeyHashSpec univ))
+          -- ScriptHash c -> DRep
+          (branchW 3 $ \ [var|scripthash|] -> satisfies scripthash (witScriptHashSpec univ))
+          -- DRepAlwaysObstain
+          (branchW 1 $ \_ -> assert True)
+          -- DRepAlwaysNoConfidence
+          (branchW 1 $ \_ -> assert True)
+      ]
+
+-- | Used only in Withdrawals, other RewardAccounts, not being withdrawn do not need witnessing
+witRewardAccountSpec ::
+  forall fn era.
+  (Era era, IsConwayUniv fn) =>
+  WitUniv era -> Specification fn (RewardAccount (EraCrypto era))
+witRewardAccountSpec univ =
+  explainWit "(RewardAccount c)" univ $
+    constrained $ \ [var|rewaccount|] ->
+      match rewaccount $ \ [var|network|] [var|raCred|] ->
+        [ assert $ network ==. lit (Testnet)
+        , satisfies raCred (witCredSpec @fn @era univ)
+        ]
+
+owners_ ::
+  (Crypto c, IsConwayUniv fn) => Term fn (PoolParams c) -> Term fn (Set (KeyHash 'Staking c))
+owners_ = sel @6
+
+witPoolParamsSpec ::
+  forall fn era.
+  (Era era, IsConwayUniv fn) =>
+  WitUniv era -> Specification fn (PoolParams (EraCrypto era))
+witPoolParamsSpec univ =
+  explainWit "(PoolParams c)" univ $
+    constrained $ \ [var|poolparams|] ->
+      [ forAll (owners_ poolparams) $ \ [var|ownerKeyHash|] -> satisfies ownerKeyHash (witKeyHashSpec univ)
+      , satisfies (owners_ poolparams) (hasSize (rangeSize 1 3))
+      ]
+
+witGenDelegPairSpec ::
+  forall fn era.
+  (Era era, IsConwayUniv fn) =>
+  WitUniv era -> Specification fn (GenDelegPair (EraCrypto era))
+witGenDelegPairSpec univ =
+  explainWit "(GenDelegPair  c)" univ $
+    constrained $ \ [var|gdpair|] ->
+      match gdpair $ \ [var|keyhash|] [var|_hash|] -> satisfies keyhash (witKeyHashSpec univ)
+
+-- | Constrains all the Certificate Authors. Sometimes thay are keyHashes, and sometimes Credentials
+witShelleyTxCert ::
+  forall fn era.
+  (Era era, IsConwayUniv fn) =>
+  WitUniv era -> Specification fn (ShelleyTxCert era)
+witShelleyTxCert univ =
+  explainWit ("(ShelleyTxCert " ++ "typeRep (Proxy @era)" ++ ")") univ $
+    constrained $ \ [var|txcert|] ->
+      (caseOn txcert)
+        ( branchW 5 $ \delegcert ->
+            (caseOn delegcert)
+              (branch $ \_register -> TruePred)
+              (branch $ \unregisterAuthor -> satisfies unregisterAuthor (witCredSpec univ))
+              (branch $ \delegateAuthor _ -> satisfies delegateAuthor (witCredSpec univ))
+        )
+        ( branchW 3 $ \poolcert ->
+            (caseOn poolcert)
+              (branch $ \registerPoolParams -> satisfies registerPoolParams (witPoolParamsSpec univ))
+              (branch $ \retirePoolAuthor _ -> satisfies retirePoolAuthor (witKeyHashSpec univ))
+        )
+        ( branchW 1 $ \genesiscert -> match genesiscert $ \authorkey _ _ -> satisfies authorkey (witKeyHashSpec univ)
+        )
+        (branchW 1 $ \_mircert -> FalsePred (pure "NO MIR"))
+
+-- | Constrains all the Certificate Authors. Sometimes thay are keyHashes, and sometimes Credentials
+witConwayTxCert ::
+  forall fn era.
+  (Era era, IsConwayUniv fn) =>
+  WitUniv era -> Specification fn (ConwayTxCert era)
+witConwayTxCert univ =
+  explainWit ("(ConwayTxCert " ++ "typeRep (Proxy @era)" ++ ")") univ $
+    constrained $ \ [var|txcert|] ->
+      (caseOn txcert)
+        ( branch $ \delegcert ->
+            (caseOn delegcert)
+              ( branch $ \registerAuthor deposit ->
+                  (caseOn deposit)
+                    (branch $ \_ -> TruePred)
+                    (branch $ \_ -> satisfies registerAuthor (witCredSpec univ))
+              )
+              (branch $ \unregisterAuthor _ -> satisfies unregisterAuthor (witCredSpec univ))
+              (branch $ \delegateAuthor _ -> satisfies delegateAuthor (witCredSpec univ))
+              (branch $ \registerdelegateAuthor _ _ -> satisfies registerdelegateAuthor (witCredSpec univ))
+        )
+        ( branch $ \poolcert ->
+            (caseOn poolcert)
+              (branch $ \registerPoolParams -> satisfies registerPoolParams (witPoolParamsSpec univ))
+              (branch $ \retirePoolAuthor _ -> satisfies retirePoolAuthor (witKeyHashSpec univ))
+        )
+        ( branch $ \govcert ->
+            (caseOn govcert)
+              (branch $ \regdrepAuthor _ _ -> satisfies regdrepAuthor (witCredSpec univ))
+              (branch $ \unregdrepAuthor _ -> satisfies unregdrepAuthor (witCredSpec univ))
+              (branch $ \updatedrepAuthor _ -> satisfies updatedrepAuthor (witCredSpec univ))
+              (branch $ \authorizeAuthor _ -> satisfies authorizeAuthor (witCredSpec univ))
+              (branch $ \resignAuthor _ -> satisfies resignAuthor (witCredSpec univ))
+        )
+
+-- =====================================================================
+-- Purpose 2) To efficiently compute witnesses from a 'hashtype'
+-- the (Map hashtype (ProofType hashtype era)) can be used like this
+--     case Map.lookup hash (wbMap witblock) of
+--        Just base -> mkWitness base
+--        Nothing -> error "Missing hash. perhaps generator did not constrain the hash to be witnessed?"
+
+witnessBootAddr ::
+  forall era.
+  Proof.Reflect era =>
+  BodyHash era -> BootstrapAddress (EraCrypto era) -> WitUniv era -> TxWits era
+witnessBootAddr bodyhash bootaddr wu = case Map.lookup bootaddr (wbMap (wvBoot wu)) of
+  Just x ->
+    (mkBasicTxWits @era)
+      & bootAddrTxWitsL
+        .~ (Set.singleton (mkWitness @(BootstrapAddress (EraCrypto era)) @era x bodyhash))
+  Nothing -> error ("missing BootstrapAddress in WitUnv " ++ show bootaddr)
+
+witnessKeyHash ::
+  forall era.
+  Reflect era =>
+  BodyHash era -> KeyHash 'Witness (EraCrypto era) -> WitUniv era -> TxWits era
+witnessKeyHash bodyhash keyhash wu = case Map.lookup keyhash (wbMap (wvVKey wu)) of
+  Just x ->
+    (mkBasicTxWits @era)
+      & addrTxWitsL
+        .~ (Set.singleton (mkWitness @(KeyHash 'Witness (EraCrypto era)) @era x bodyhash))
+  Nothing -> error ("missing key hash in WitUnv " ++ show keyhash)
+
+witnessScriptHash ::
+  forall era. EraTxWits era => ScriptHash (EraCrypto era) -> WitUniv era -> TxWits era
+witnessScriptHash scripthash wu = case Map.lookup scripthash (wbMap (wvScript wu)) of
+  Just (NewScript script) -> (mkBasicTxWits @era) & scriptTxWitsL .~ (Map.insert scripthash script Map.empty)
+  Nothing -> error ("missing script hash in WitUnv " ++ show scripthash)
+
+witnessDataHash ::
+  forall era. AlonzoEraTxWits era => DataHash (EraCrypto era) -> WitUniv era -> TxWits era
+witnessDataHash datahash wu = case Map.lookup datahash (wbMap (wvDats wu)) of
+  Just d -> (mkBasicTxWits @era) & datsTxWitsL .~ TxDats (Map.insert datahash d Map.empty)
+  Nothing -> error ("missing data hash in WitUnv " ++ show datahash)
+
+-- =========================================================
+-- Purpose 3) When (HasWitness hashtype era) holds, the WitBlock can be computed from
+-- only [ProofType hashtype era] using 'getTypeHashed'. This makes Gen and CBOR instances,
+-- especially easy. We compute only with [ProofType hashtype era] and then reconstruct the rest
+
+-- | Reconstruct a (WitBlock t era) from only a [ProofType t era]
+blockFromProofList ::
+  forall t era. (Era era, Ord t, HasWitness t era) => [ProofType t era] -> WitBlock t era
+blockFromProofList baselist =
+  WitBlock
+    (Set.fromList hashlist)
+    (Map.fromList (zip hashlist baselist))
+  where
+    hashlist = map (hash @t @era . getTypeHashed @t @era) baselist
+
+-- ===============================================================
+-- Purpose 4) WitBlock is a Monoid, so we can combine them easily
+
+instance Ord t => Semigroup (WitBlock t era) where
+  (WitBlock x y) <> (WitBlock a b) = WitBlock (x <> a) (y <> b)
+
+instance (Era era, Ord t, HasWitness t era) => Monoid (WitBlock t era) where
+  mempty = (WitBlock mempty mempty)
+
+-- | Easy to extend Monoid from WitBlock to WitUniv
+instance Era era => Semigroup (WitUniv era) where
+  x <> y =
+    WitUniv
+      { wvVKey = wvVKey x <> wvVKey y
+      , wvBoot = wvBoot x <> wvBoot y
+      , wvScript = wvScript x <> wvScript y
+      , wvDats = wvDats x <> wvDats y
+      }
+
+instance (Reflect era, HasWitness (ScriptHash (EraCrypto era)) era) => Monoid (WitUniv era) where
+  mempty = WitUniv {wvVKey = mempty, wvBoot = mempty, wvScript = mempty, wvDats = mempty}
+
+-- =======================================================================
+-- Purpose 5) We can easily to make (Gen (WitBlock t era)), so we can make them for testing.
+-- this is facilitated by the methods of the (HasWitness t era) instances
+-- and the special property that WitBlock can be computed from [ProofList]
+
+genWitBlock ::
+  forall t era.
+  (Era era, Ord t, HasWitness t era) => Int -> Gen (ProofType t era) -> Gen (WitBlock t era)
+genWitBlock n g = blockFromProofList <$> vectorOf n g
+
+instance (Era era, Typeable t) => EncCBOR (WitBlock t era) where
+  encCBOR (WitBlock _ m) = encCBOR (Map.elems m)
+
+genWitUniv ::
+  forall era.
+  (GenScript era, HasWitness (ScriptHash (EraCrypto era)) era) =>
+  Int -> Gen (WitUniv era)
+genWitUniv n =
+  WitUniv
+    <$> genWitBlock n (arbitrary @(KeyPair 'Witness (EraCrypto era)))
+    <*> genWitBlock n (snd <$> genAddrPair Testnet)
+    <*> genWitBlock n (NewScript <$> genScript @era)
+    <*> genWitBlock n (arbitrary @(Data era))
+
+-- Use this for small tests only (otherwise increase from 100 to something larger)
+-- or use (genWitUniv n) instead of arbitrary for some bigger 'n'
+instance
+  (HasWitness (ScriptHash (EraCrypto era)) era, GenScript era) =>
+  Arbitrary (WitUniv era)
+  where
+  arbitrary = genWitUniv 100
+
+-- ==================================================================================
+-- Generating random native-scripts in every era. Needed to generate a random WitUniv)
+
+genNestedMultiSig :: forall era. ShelleyEraScript era => Int -> Gen (NativeScript era)
+genNestedMultiSig depth
+  | depth > 0 =
+      oneof $
+        nonRecTimelocks ++ [requireAllOf depth, requireAnyOf depth, requireMOf depth]
+  | otherwise = oneof nonRecTimelocks
+  where
+    nonRecTimelocks = [requireSignature]
+    requireSignature = RequireSignature @era <$> genKeyHash
+    requireAllOf k = do
+      n <- choose (0, 4)
+      RequireAllOf . Seq.fromList <$> replicateM n (genNestedMultiSig @era (k - 1))
+    requireAnyOf k = do
+      n <- choose (1, 4)
+      RequireAnyOf . Seq.fromList <$> replicateM n (genNestedMultiSig @era (k - 1))
+    requireMOf k = do
+      n <- choose (0, 4)
+      m <- choose (0, n)
+      RequireMOf m . Seq.fromList <$> replicateM n (genNestedMultiSig @era (k - 1))
+    genKeyHash :: Gen (KeyHash 'Witness (EraCrypto era))
+    genKeyHash = arbitrary
+
+genNestedTimelock :: forall era. AllegraEraScript era => Int -> Gen (NativeScript era)
+genNestedTimelock depth
+  | depth > 0 =
+      oneof $
+        nonRecTimelocks ++ [requireAllOf depth, requireAnyOf depth, requireMOf depth]
+  | otherwise = oneof nonRecTimelocks
+  where
+    nonRecTimelocks =
+      [ requireSignature
+      , requireTimeStart (SlotNo minBound)
+      , requireTimeExpire (SlotNo maxBound)
+      ]
+    requireSignature = RequireSignature <$> genKeyHash
+    requireAllOf k = do
+      n <- choose (2, 3) -- lift nonNegativeSingleDigitInt
+      RequireAllOf . Seq.fromList <$> replicateM n (genNestedTimelock @era (k - 1))
+    requireAnyOf k = do
+      n <- choose (2, 3) -- lift positiveSingleDigitInt
+      RequireAnyOf . Seq.fromList <$> replicateM n (genNestedTimelock @era (k - 1))
+    requireMOf k = do
+      n <- choose (2, 3) -- lift nonNegativeSingleDigitInt
+      m <- choose (0, n)
+      RequireMOf m . Seq.fromList <$> replicateM n (genNestedTimelock @era (k - 1))
+    requireTimeStart (SlotNo validFrom) = do
+      minSlotNo <- choose (minBound, validFrom)
+      pure $ RequireTimeStart (SlotNo minSlotNo)
+    requireTimeExpire (SlotNo validTill) = do
+      maxSlotNo <- choose (validTill, maxBound)
+      pure $ RequireTimeExpire (SlotNo maxSlotNo)
+    genKeyHash :: Gen (KeyHash 'Witness (EraCrypto era))
+    genKeyHash = arbitrary
+
+-- =======================================================================
+-- Tools for Parametric Witnessing
+-- ==============================================================
+
+-- | The class of things we know how to witness. This way you don't
+--   have to remember long complicated names.
+class Witnessed fn era t where
+  witness :: WitUniv era -> Term fn t -> Pred fn
+
+instance (IsConwayUniv fn, Era era, Typeable r, EraCrypto era ~ c) => Witnessed fn era (KeyHash r c) where
+  witness univ t = satisfies t (witKeyHashSpec univ)
+
+instance (IsConwayUniv fn, Era era, EraCrypto era ~ c) => Witnessed fn era (ScriptHash c) where
+  witness univ t = satisfies2 (pure "BAD-SCRIPT-HASH") t (witScriptHashSpec univ)
+
+instance (IsConwayUniv fn, Era era, Typeable r, EraCrypto era ~ c) => Witnessed fn era (Credential r c) where
+  witness univ t = satisfies t (witCredSpec univ)
+
+instance (IsConwayUniv fn, Era era, EraCrypto era ~ c) => Witnessed fn era (BootstrapAddress c) where
+  witness univ t = satisfies t (witBootstrapAddress univ)
+
+instance (IsConwayUniv fn, Era era, EraCrypto era ~ c) => Witnessed fn era (DRep c) where
+  witness univ t = satisfies t (witDRepSpec univ)
+
+instance (IsConwayUniv fn, Era era, EraCrypto era ~ c) => Witnessed fn era (RewardAccount c) where
+  witness univ t = satisfies t (witRewardAccountSpec univ)
+
+instance (IsConwayUniv fn, Era era, EraCrypto era ~ c) => Witnessed fn era (PoolParams c) where
+  witness univ t = satisfies t (witPoolParamsSpec univ)
+
+instance (IsConwayUniv fn, Era era, EraCrypto era ~ c) => Witnessed fn era (GenDelegPair c) where
+  witness univ t = satisfies t (witGenDelegPairSpec univ)
+
+instance (IsConwayUniv fn, Era era) => Witnessed fn era (ShelleyTxCert era) where
+  witness univ t = satisfies t (witShelleyTxCert univ)
+
+instance (IsConwayUniv fn, Era era) => Witnessed fn era (ConwayTxCert era) where
+  witness univ t = satisfies t (witConwayTxCert univ)
+
+instance (Era era, HasSpec fn t, Ord t, Witnessed fn era t) => Witnessed fn era (Set t) where
+  witness univ t =
+    forAll
+      t
+      ( \x ->
+          assertExplain (pure ("While witnessing " ++ show (typeRep (Proxy @(Set t))))) $
+            witness univ x
+      )
+
+instance (Era era, HasSpec fn t, HasSpec fn v, Ord t, Witnessed fn era t) => Witnessed fn era (Map t v) where
+  witness univ t =
+    assertExplain (pure ("While witnessing " ++ show (typeRep (Proxy @(Map t v))))) $
+      forAll (dom_ t) (witness univ)
+
+instance (Era era, HasSpec fn t, Witnessed fn era t) => Witnessed fn era [t] where
+  witness univ t =
+    assertExplain (pure ("While witnessing " ++ show (typeRep (Proxy @([t]))))) $
+      forAll t (witness univ)
+
+-- ===================================================================
+
+-- | Parametric TxCert
+class (EraTxCert era, HasSpec fn (TxCert era)) => EraSpecTxCert fn era where
+  witTxCert :: WitUniv era -> Specification fn (TxCert era)
+
+instance IsConwayUniv fn => EraSpecTxCert fn Shelley where
+  witTxCert = witShelleyTxCert
+instance IsConwayUniv fn => EraSpecTxCert fn Allegra where
+  witTxCert = witShelleyTxCert
+instance IsConwayUniv fn => EraSpecTxCert fn Mary where
+  witTxCert = witShelleyTxCert
+instance IsConwayUniv fn => EraSpecTxCert fn Alonzo where
+  witTxCert = witShelleyTxCert
+instance IsConwayUniv fn => EraSpecTxCert fn Babbage where
+  witTxCert = witShelleyTxCert
+instance IsConwayUniv fn => EraSpecTxCert fn Conway where
+  witTxCert = witConwayTxCert
+
+-- | Parametric Script
+class (Reflect era, ToExpr (NativeScript era), NFData (Script era)) => GenScript era where
+  genScript :: Gen (Script era)
+
+instance GenScript Shelley where genScript = genNestedMultiSig 2
+instance GenScript Allegra where genScript = genNestedTimelock @Allegra 2
+instance GenScript Mary where genScript = genNestedTimelock @Mary 2
+instance GenScript Alonzo where genScript = fromNativeScript <$> genNestedTimelock @Alonzo 2
+instance GenScript Babbage where genScript = fromNativeScript <$> genNestedTimelock @Babbage 2
+instance GenScript Conway where genScript = fromNativeScript <$> genNestedTimelock @Conway 2
+
+-- ===============================================================
+-- examples
+spec1 :: WitUniv Shelley -> Specification ConwayFn (Set (ScriptHash StandardCrypto))
+spec1 univ =
+  constrained $ \ [var|setHash|] -> [assert $ sizeOf_ setHash ==. 11, witness univ setHash]
+
+go1 :: IO ()
+go1 = do
+  univ <- generate $ genWitUniv @Shelley 5
+  {-
+  -- print (witScriptHashSpec @ConwayFn univ)
+  print (spec1 univ)
+  case (spec1 univ) of
+    SuspendedSpec {} -> putStrLn "YES"
+    _ -> putStrLn "NO"
+
+  putStrLn "\n\n(simplifySpec (spec1 univ))"
+  print (simplifySpec (spec1 univ))
+
+  putStrLn "\n\n(explainSpec (pure VVV) (simplifySpec(spec1 univ)))"
+  print (explainSpec (pure "VVV") (simplifySpec(spec1 univ))) -}
+  ans <- generate $ genFromSpec (spec1 univ)
+  putStrLn (show (prettyA ans))
+
+spec2 ::
+  WitUniv Shelley ->
+  Set (ScriptHash StandardCrypto) ->
+  Specification ConwayFn (Set (ScriptHash StandardCrypto))
+spec2 univ big =
+  constrained $ \ [var|setHash|] ->
+    [ assert $ subset_ (lit big) setHash
+    , witness univ setHash
+    ]
+go2 :: IO ()
+go2 = do
+  univ <- generate $ genWitUniv @Shelley 5
+  big <- generate arbitrary
+  ans <- generate $ genFromSpec (spec2 univ big)
+  putStrLn (show (prettyA ans))
+
+-- =================================================================
+explainSpec2 :: HasSpec fn a => NE.NonEmpty String -> Specification fn a -> Specification fn a
+explainSpec2 es spec = case simplifySpec spec of
+  ErrorSpec es' -> ErrorSpec (es <> es')
+  TypeSpec tyspec cs1 -> case guardTypeSpec (NE.toList es) tyspec of
+    TypeSpec tyspec2 [] -> TypeSpec tyspec2 cs1
+    other -> other
+  SuspendedSpec v p -> SuspendedSpec v (assertExplain es p)
+  MemberSpec xs -> constrained $ \x -> [assertExplain es $ satisfies x (MemberSpec xs)]
+  s -> s
+
+satisfies2 ::
+  forall fn a. HasSpec fn a => NE.NonEmpty String -> Term fn a -> Specification fn a -> Pred fn
+satisfies2 nes e (ExplainSpec [] x) = satisfies2 nes e x
+satisfies2 nes e (ExplainSpec (w : ws) x) = satisfies2 (nes <> (w NE.:| ws)) e x
+satisfies2 _ _ TrueSpec = TruePred
+satisfies2 nes e (MemberSpec nonempty) = assertExplain nes $ elem_ e (lit (NE.toList nonempty))
+satisfies2 nes t (SuspendedSpec x p) = assertExplain nes $ Subst x t p
+satisfies2 nes e (TypeSpec s cant)
+  | null cant = toPreds e s
+  | otherwise =
+      Explain (pure (show e ++ " `notElem` " ++ show cant) <> nes) $
+        Assert (not_ (elem_ e $ lit cant))
+          <> toPreds e s
+satisfies2 nes _ (ErrorSpec e) = FalsePred (nes <> e)
+
+-- ======================================================================
+
+conwayWitUniv :: Int -> WitUniv Conway
+conwayWitUniv n = unsafePerformIO $ generate $ genWitUniv @Conway n
+
+babbageWitUniv :: Int -> WitUniv Babbage
+babbageWitUniv n = unsafePerformIO $ generate $ genWitUniv @Babbage n
+
+alonzoWitUniv :: Int -> WitUniv Alonzo
+alonzoWitUniv n = unsafePerformIO $ generate $ genWitUniv @Alonzo n
+
+maryWitUniv :: Int -> WitUniv Mary
+maryWitUniv n = unsafePerformIO $ generate $ genWitUniv @Mary n
+
+allegraWitUniv :: Int -> WitUniv Allegra
+allegraWitUniv n = unsafePerformIO $ generate $ genWitUniv @Allegra n
+
+shelleyWitUniv :: Int -> WitUniv Shelley
+shelleyWitUniv n = unsafePerformIO $ generate $ genWitUniv @Shelley n
+
+class EraUniverse era where
+  eraWitUniv :: Int -> WitUniv era
+
+instance EraUniverse Conway where eraWitUniv = conwayWitUniv
+instance EraUniverse Babbage where eraWitUniv = babbageWitUniv
+instance EraUniverse Alonzo where eraWitUniv = alonzoWitUniv
+instance EraUniverse Mary where eraWitUniv = maryWitUniv
+instance EraUniverse Allegra where eraWitUniv = allegraWitUniv
+instance EraUniverse Shelley where eraWitUniv = shelleyWitUniv

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -692,10 +692,10 @@ instance PrettyA AuxiliaryDataHash where
 ppSafeHash :: SafeHash index -> PDoc
 ppSafeHash x = ppHash (extractHash x)
 
-pcDataHash :: DataHash era -> PDoc
+pcDataHash :: DataHash -> PDoc
 pcDataHash dh = trim (ppSafeHash dh)
 
-instance PrettyA (SafeHash x y) where
+instance PrettyA (SafeHash x) where
   prettyA = ppSafeHash
 
 ppEpochNo :: EpochNo -> Doc ann
@@ -2548,10 +2548,10 @@ pcAddr (AddrBootstrap x) = "BootAddr" <+> pcByronAddress x
 
 instance PrettyA Addr where prettyA = pcAddr
 
-pcByronAddress :: BootstrapAddress c -> PDoc
+pcByronAddress :: BootstrapAddress -> PDoc
 pcByronAddress (BootstrapAddress (Byron.Address x _ _)) = ppString (take 10 (show x))
 
-instance PrettyA (BootstrapAddress c) where prettyA = pcByronAddress
+instance PrettyA BootstrapAddress where prettyA = pcByronAddress
 
 -- | Value is a type family, so it has no PrettyA instance.
 pcCoreValue :: Proof era -> Value era -> PDoc
@@ -2665,9 +2665,6 @@ pcHashScript Shelley s = ppString "Hash " <> pcScriptHash (hashScript @era s)
 
 instance (Script era ~ AlonzoScript era, Reflect era) => PrettyA (AlonzoScript era) where
   prettyA = pcScript reify
-
-pcDataHash :: DataHash -> PDoc
-pcDataHash dh = trim (ppSafeHash dh)
 
 instance PrettyA DataHash where
   prettyA = pcDataHash

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Proof.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Proof.hs
@@ -140,6 +140,7 @@ class
   , EraTx era
   , EraUTxO era
   , EraTxAuxData era
+  , EraScript era
   , ShelleyEraTxCert era
   ) =>
   Reflect era
@@ -264,7 +265,12 @@ runSTS' (ENACT _proof) x = runShelleyBase (applySTSTest x)
 runSTS' (TALLY _proof) x = runShelleyBase (applySTSTest x)
 runSTS' (EPOCH _proof) x = runShelleyBase (applySTSTest x)
 runSTS' (NEWEPOCH _proof) x = runShelleyBase (applySTSTest x)
-runSTS' _ x = runShelleyBase (applySTSTest x)
+runSTS' (CERT _proof) x = runShelleyBase (applySTSTest x)
+runSTS' (CERTS _proof) x = runShelleyBase (applySTSTest x)
+runSTS' (DELEG _proof) x = runShelleyBase (applySTSTest x)
+runSTS' (POOL _proof) x = runShelleyBase (applySTSTest x)
+runSTS' (GOVCERT _proof) x = runShelleyBase (applySTSTest x)
+runSTS' (GOV _proof) x = runShelleyBase (applySTSTest x)
 
 -- | Like runSTS, but makes the components of the TRC triple explicit.
 --   in case you can't remember, in ghci type

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -47,12 +47,12 @@ import Test.Tasty.QuickCheck hiding (witness)
 -- | Several tests need some semi-randomcontext, this supplies that context
 genContext ::
   Gen
-    ( WitUniv (ConwayEra StandardCrypto)
-    , Set (Credential 'DRepRole StandardCrypto)
-    , Map (RewardAccount StandardCrypto) Coin
+    ( WitUniv ConwayEra
+    , Set (Credential 'DRepRole)
+    , Map RewardAccount Coin
     )
 genContext = do
-  univ <- genWitUniv @(ConwayEra StandardCrypto) 200
+  univ <- genWitUniv @ConwayEra 200
   delegatees <- genFromSpec @ConwayFn (delegateeSpec univ)
   wdrls <- genFromSpec @ConwayFn (constrained $ \x -> (witness univ x))
   pure (univ, delegatees, wdrls)
@@ -229,7 +229,7 @@ prop_POOL =
         stsPropertyV2 @"POOL" @ConwayFn
           (poolEnvSpec conwayWitUniv)
           (\_env -> pStateSpec conwayWitUniv)
-          (\env st -> poolCertSpec @ConwayFn @(ConwayEra StandardCrypto) conwayWitUniv env st)
+          (\env st -> poolCertSpec @ConwayFn @ConwayEra conwayWitUniv env st)
           $ \_env _st _sig _st' -> True
     )
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -30,9 +30,20 @@ import Test.Cardano.Ledger.Constrained.Conway.Pool
 import Test.Cardano.Ledger.Generic.PrettyCore
 import Test.Cardano.Ledger.Shelley.Utils
 
+import Cardano.Ledger.Credential (Credential)
+import Cardano.Ledger.Keys (KeyRole (..))
+import Data.Set (Set)
+import System.IO.Unsafe
+import Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse (WitUniv, genWitUniv)
 import Test.QuickCheck
 import Test.Tasty
 import Test.Tasty.QuickCheck
+
+conwayWitUniv :: WitUniv (ConwayEra StandardCrypto)
+conwayWitUniv = unsafePerformIO $ generate $ genWitUniv @(ConwayEra StandardCrypto) 100
+
+conwayDelegatees :: Set (Credential 'DRepRole StandardCrypto)
+conwayDelegatees = unsafePerformIO $ generate $ genFromSpec @ConwayFn (delegateeSpec conwayWitUniv)
 
 ------------------------------------------------------------------------
 -- Properties
@@ -170,9 +181,9 @@ prop_RATIFY =
 prop_CERT :: Property
 prop_CERT =
   stsPropertyV2 @"CERT" @ConwayFn
-    certEnvSpec
-    (\_env -> certStateSpecEx)
-    (\env st -> txCertSpec env st)
+    (certEnvSpec conwayWitUniv)
+    (\_env -> certStateSpec conwayWitUniv conwayDelegatees)
+    (\env st -> conwayTxCertSpec conwayWitUniv env st)
     -- TODO: we should probably check more things here
     $ \_env _st _sig _st' -> True
 
@@ -180,24 +191,24 @@ prop_DELEG :: Property
 prop_DELEG =
   stsPropertyV2 @"DELEG" @ConwayFn
     delegEnvSpec
-    (\_env -> certStateSpecEx)
+    (\_env -> certStateSpec conwayWitUniv conwayDelegatees)
     conwayDelegCertSpec
     $ \_env _st _sig _st' -> True
 
 prop_POOL :: Property
 prop_POOL =
   stsPropertyV2 @"POOL" @ConwayFn
-    poolEnvSpec
-    (\_env -> pStateSpec)
-    (\env st -> poolCertSpec env st)
+    (poolEnvSpec conwayWitUniv)
+    (\_env -> pStateSpec conwayWitUniv)
+    (\env st -> poolCertSpec @ConwayFn @(ConwayEra StandardCrypto) conwayWitUniv env st)
     $ \_env _st _sig _st' -> True
 
 prop_GOVCERT :: Property
 prop_GOVCERT =
   stsPropertyV2 @"GOVCERT" @ConwayFn
-    govCertEnvSpec
-    (\_env -> certStateSpecEx)
-    (\env st -> govCertSpec env st)
+    (govCertEnvSpec conwayWitUniv)
+    (\_env -> certStateSpec conwayWitUniv conwayDelegatees)
+    (\env st -> govCertSpec conwayWitUniv env st)
     $ \_env _st _sig _st' -> True
 
 prop_UTXOW :: Property

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -18,7 +18,7 @@ import Cardano.Ledger.Shelley.Rules hiding (epochNo, slotNo)
 import Control.Monad.Reader
 import Control.State.Transition.Extended
 
-import Constrained
+import Constrained hiding (forAll)
 
 import Test.Cardano.Ledger.Constrained.Conway.Cert
 import Test.Cardano.Ledger.Constrained.Conway.Deleg
@@ -30,20 +30,32 @@ import Test.Cardano.Ledger.Constrained.Conway.Pool
 import Test.Cardano.Ledger.Generic.PrettyCore
 import Test.Cardano.Ledger.Shelley.Utils
 
+import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Keys (KeyRole (..))
+import Constrained.Base (conformsToSpecE)
+import qualified Data.List.NonEmpty as NE
+import Data.Map (Map)
 import Data.Set (Set)
-import System.IO.Unsafe
-import Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse (WitUniv, genWitUniv)
-import Test.QuickCheck
+import Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse (WitUniv, genWitUniv, witness)
+import Test.QuickCheck hiding (witness)
 import Test.Tasty
-import Test.Tasty.QuickCheck
+import Test.Tasty.QuickCheck hiding (witness)
 
-conwayWitUniv :: WitUniv (ConwayEra StandardCrypto)
-conwayWitUniv = unsafePerformIO $ generate $ genWitUniv @(ConwayEra StandardCrypto) 100
+-- ==================================================
 
-conwayDelegatees :: Set (Credential 'DRepRole StandardCrypto)
-conwayDelegatees = unsafePerformIO $ generate $ genFromSpec @ConwayFn (delegateeSpec conwayWitUniv)
+-- | Several tests need some semi-randomcontext, this supplies that context
+genContext ::
+  Gen
+    ( WitUniv (ConwayEra StandardCrypto)
+    , Set (Credential 'DRepRole StandardCrypto)
+    , Map (RewardAccount StandardCrypto) Coin
+    )
+genContext = do
+  univ <- genWitUniv @(ConwayEra StandardCrypto) 200
+  delegatees <- genFromSpec @ConwayFn (delegateeSpec univ)
+  wdrls <- genFromSpec @ConwayFn (constrained $ \x -> (witness univ x))
+  pure (univ, delegatees, wdrls)
 
 ------------------------------------------------------------------------
 -- Properties
@@ -89,13 +101,19 @@ stsPropertyV2 specEnv specState specSig prop =
                 pure $ case res of
                   Left pfailures -> counterexample (show $ prettyA pfailures) $ property False
                   Right st' ->
-                    counterexample
-                      ( show $
-                          ppString "st' = "
-                            <> prettyA st'
-                            <> ppString ("\nspec = \n" ++ show (specState env))
-                      )
-                      $ conformsToSpec @fn st' (specState env) .&&. prop env st sig st'
+                    case conformsToSpecE @fn
+                      st
+                      (specState env)
+                      (pure "conformsToSpecE fails in STS tests") of
+                      Just es -> counterexample (unlines (NE.toList es)) False
+                      Nothing ->
+                        counterexample
+                          ( show $
+                              ppString "st' = "
+                                <> prettyA st'
+                                <> ppString ("\nspec = \n" ++ show (specState env))
+                          )
+                          $ prop env st sig st'
 
 -- STS properties ---------------------------------------------------------
 
@@ -180,36 +198,52 @@ prop_RATIFY =
 
 prop_CERT :: Property
 prop_CERT =
-  stsPropertyV2 @"CERT" @ConwayFn
-    (certEnvSpec conwayWitUniv)
-    (\_env -> certStateSpec conwayWitUniv conwayDelegatees)
-    (\env st -> conwayTxCertSpec conwayWitUniv env st)
-    -- TODO: we should probably check more things here
-    $ \_env _st _sig _st' -> True
+  forAll
+    genContext
+    ( \(conwayWitUniv, conwayDelegatees, conwayWdrls) ->
+        stsPropertyV2 @"CERT" @ConwayFn
+          (certEnvSpec conwayWitUniv)
+          (\_env -> certStateSpec conwayWitUniv conwayDelegatees conwayWdrls)
+          (\env st -> conwayTxCertSpec conwayWitUniv env st)
+          -- TODO: we should probably check more things here
+          $ \_env _st _sig _st' -> True
+    )
 
 prop_DELEG :: Property
 prop_DELEG =
-  stsPropertyV2 @"DELEG" @ConwayFn
-    delegEnvSpec
-    (\_env -> certStateSpec conwayWitUniv conwayDelegatees)
-    conwayDelegCertSpec
-    $ \_env _st _sig _st' -> True
+  forAll
+    genContext
+    ( \(conwayWitUniv, conwayDelegatees, conwayWdrls) ->
+        stsPropertyV2 @"DELEG" @ConwayFn
+          delegEnvSpec
+          (\_env -> certStateSpec conwayWitUniv conwayDelegatees conwayWdrls)
+          conwayDelegCertSpec
+          $ \_env _st _sig _st' -> True
+    )
 
 prop_POOL :: Property
 prop_POOL =
-  stsPropertyV2 @"POOL" @ConwayFn
-    (poolEnvSpec conwayWitUniv)
-    (\_env -> pStateSpec conwayWitUniv)
-    (\env st -> poolCertSpec @ConwayFn @(ConwayEra StandardCrypto) conwayWitUniv env st)
-    $ \_env _st _sig _st' -> True
+  forAll
+    genContext
+    ( \(conwayWitUniv, _, _) ->
+        stsPropertyV2 @"POOL" @ConwayFn
+          (poolEnvSpec conwayWitUniv)
+          (\_env -> pStateSpec conwayWitUniv)
+          (\env st -> poolCertSpec @ConwayFn @(ConwayEra StandardCrypto) conwayWitUniv env st)
+          $ \_env _st _sig _st' -> True
+    )
 
 prop_GOVCERT :: Property
 prop_GOVCERT =
-  stsPropertyV2 @"GOVCERT" @ConwayFn
-    (govCertEnvSpec conwayWitUniv)
-    (\_env -> certStateSpec conwayWitUniv conwayDelegatees)
-    (\env st -> govCertSpec conwayWitUniv env st)
-    $ \_env _st _sig _st' -> True
+  forAll
+    genContext
+    ( \(conwayWitUniv, conwayDelegatees, conwayWdrls) ->
+        stsPropertyV2 @"GOVCERT" @ConwayFn
+          (govCertEnvSpec conwayWitUniv)
+          (\_env -> certStateSpec conwayWitUniv conwayDelegatees conwayWdrls)
+          (\env st -> govCertSpec conwayWitUniv env st)
+          $ \_env _st _sig _st' -> True
+    )
 
 prop_UTXOW :: Property
 prop_UTXOW =

--- a/libs/constrained-generators/src/Constrained/Base.hs
+++ b/libs/constrained-generators/src/Constrained/Base.hs
@@ -1096,7 +1096,12 @@ conformsToSpecM a spec@(SuspendedSpec v ps) = do
     else
       fatalError
         ( NE.fromList
-            ["conformsToSpecM SuspendedSpec case", "  " ++ show a, "  (" ++ show spec ++ ")", "fails", ""]
+            [ "conformsToSpecM SuspendedSpec case on var " ++ show v
+            , "\n " ++ show a
+            , "\n  (" ++ show spec ++ ")"
+            , "fails"
+            , ""
+            ]
         )
 conformsToSpecM _ (ErrorSpec es) = fatalError ("conformsToSpecM ErrorSpec case" NE.<| es)
 
@@ -1156,7 +1161,7 @@ genFromSpecT (simplifySpec -> spec) = case spec of
           [ "genFromSpecT at type " ++ show (typeRep cant)
           , "    " ++ show spec
           , "  with mode " ++ show mode
-          , "  cant set " ++ unlines (map show cant)
+          , "  cant set {" ++ unlines (map show cant) ++ "}"
           ]
       )
       $
@@ -1704,11 +1709,10 @@ linearize preds graph = do
 
     go [] [] = pure []
     go [] ps
-      | null $ foldMap fst ps = do
-          res <- checkPreds mempty (map snd ps)
-          if res
-            then pure []
-            else genError1 ("Linearize const False")
+      | null $ foldMap fst ps =
+          case checkPredsE (pure "Linearizing fails") mempty (map snd ps) of
+            Nothing -> pure []
+            Just msgs -> genError msgs
       | otherwise =
           fatalError $
             NE.fromList
@@ -6076,3 +6080,132 @@ nubOrdMemberSpec message xs =
         , "The input is the empty list."
         ]
     )
+
+-- ==============================================================================
+-- Experimental changes to conformsToSpecM
+
+runTermE :: Env -> Term fn a -> Either (NE.NonEmpty String) a
+runTermE env = \case
+  Lit a -> Right a
+  V v -> case lookupEnv env v of
+    Just a -> Right a
+    Nothing -> Left (pure ("Couldn't find " ++ show v ++ " in " ++ show env))
+  App f ts -> do
+    vs <- mapMList (fmap Identity . runTermE env) ts
+    pure $ uncurryList_ runIdentity (sem f) vs
+
+checkPredsE ::
+  FunctionLike fn =>
+  NE.NonEmpty String ->
+  Env ->
+  [Pred fn] ->
+  Maybe (NE.NonEmpty String)
+checkPredsE msgs env ps =
+  -- and <$> mapM (checkPred env) ps
+  case catMaybes (fmap (checkPredE env msgs) ps) of
+    [] -> Nothing
+    (x : xs) -> Just (NE.nub (foldr (<>) x xs))
+
+checkPredE ::
+  forall fn.
+  FunctionLike fn =>
+  Env -> NE.NonEmpty String -> Pred fn -> Maybe (NE.NonEmpty String)
+checkPredE env msgs = \case
+  Monitor {} -> Nothing
+  Subst x t p -> checkPredE env msgs $ substitutePred x t p
+  Assert t -> case runTermE env t of
+    Right True -> Nothing
+    Right False ->
+      Just
+        (msgs <> pure ("Assert " ++ show t ++ " returns False") <> pure ("\nenv=\n" ++ show (pretty env)))
+    Left es -> Just (msgs <> es)
+  GenHint {} -> Nothing
+  p@(Reifies t' t f) ->
+    case runTermE env t of
+      Left es -> Just (msgs <> NE.fromList ["checkPredE: Reification fails", "  " ++ show p] <> es)
+      Right val -> case runTermE env t' of
+        Left es -> Just (msgs <> NE.fromList ["checkPredE: Reification fails", "  " ++ show p] <> es)
+        Right val' ->
+          if f val == val'
+            then Nothing
+            else
+              Just
+                ( msgs
+                    <> NE.fromList
+                      [ "checkPredE: Reification doesn't match up"
+                      , "  " ++ show p
+                      , show (f val) ++ " /= " ++ show val'
+                      ]
+                )
+  ForAll t (x :-> p) -> case runTermE env t of
+    Left es -> Just $ (msgs <> NE.fromList ["checkPredE: ForAll fails to run."] <> es)
+    Right set ->
+      let answers =
+            catMaybes
+              [ checkPredE env' (pure "Some items in ForAll fail") p
+              | v <- forAllToList set
+              , let env' = extendEnv x v env
+              ]
+       in case answers of
+            [] -> Nothing
+            (x : xs) -> Just (msgs <> NE.nub (foldr (<>) x xs))
+  Case t bs -> case runTermE env t of
+    Right v -> runCaseOn v (mapList thing bs) (\x val ps -> checkPredE (extendEnv x val env) msgs ps)
+    Left es -> Just (msgs <> pure "checkPredE: Case fails" <> es)
+  When bt p -> case runTermE env bt of
+    Right b -> if b then checkPredE env msgs p else Nothing
+    Left es -> Just (msgs <> pure "checkPredE: When fails" <> es)
+  TruePred -> Nothing
+  FalsePred es -> Just (msgs <> pure "checkPredE: FalsePred" <> es)
+  DependsOn {} -> Nothing
+  Block ps ->
+    case catMaybes (fmap (checkPredE env (pure "Some items in Block fail")) ps) of
+      [] -> Nothing
+      (x : xs) -> Just (msgs <> (NE.nub (foldr (<>) x xs)))
+  Let t (x :-> p) -> case runTermE env t of
+    Right val -> checkPredE (extendEnv x val env) msgs p
+    Left es -> Just (msgs <> pure "checkPredE: Let fails" <> es)
+  Exists k (x :-> p) ->
+    let eval :: forall b. Term fn b -> b
+        eval x = case runTermE env x of
+          Right v -> v
+          Left es -> error $ unlines $ NE.toList (msgs <> es)
+     in case k eval of
+          Result _ a -> checkPredE (extendEnv x a env) msgs p
+          FatalError ess es -> Just (msgs <> foldr1 (<>) ess <> es)
+          GenError ess es -> Just (msgs <> foldr1 (<>) ess <> es)
+  Explain es p -> checkPredE env (msgs <> es) p
+
+conformsToSpecE ::
+  forall fn a.
+  HasSpec fn a =>
+  a ->
+  Specification fn a ->
+  NE.NonEmpty String ->
+  Maybe (NE.NonEmpty String)
+conformsToSpecE a (ExplainSpec [] s) msgs = conformsToSpecE a s msgs
+conformsToSpecE a (ExplainSpec (x : xs) s) msgs = conformsToSpecE a s (msgs <> (x NE.:| xs))
+conformsToSpecE _ TrueSpec _ = Nothing
+conformsToSpecE a (MemberSpec as) msgs =
+  if elem a as
+    then Nothing
+    else
+      Just
+        ( msgs
+            <> NE.fromList
+              ["conformsToSpecE MemberSpec case", "  " ++ show a, "  not an element of", "  " ++ show as, ""]
+        )
+conformsToSpecE a spec@(TypeSpec s cant) msgs =
+  if notElem a cant && conformsTo @fn a s
+    then Nothing
+    else
+      Just
+        ( msgs
+            <> NE.fromList
+              ["conformsToSpecE TypeSpec case", "  " ++ show a, "  (" ++ show spec ++ ")", "fails", ""]
+        )
+conformsToSpecE a (SuspendedSpec v ps) msgs =
+  case checkPredE (singletonEnv v a) msgs ps of
+    Nothing -> Nothing
+    Just es -> Just (pure ("conformsToSpecE SuspendedSpec case on var " ++ show v ++ " fails") <> es)
+conformsToSpecE _ (ErrorSpec es) msgs = Just (msgs <> pure "conformsToSpecE ErrorSpec case" <> es)


### PR DESCRIPTION
Variant on PR #4732,  picks up where things went wrong rebasing on master where parameterization on Crypto was removed.

When we write generators the TxBody, we need to make sure that some of the types generated can be witnessed.
Most types that need witnessing are hashes, just generating a random hash will not do, since that hash has to be the
hash of an actual object that we can compute, given the hash. Since that usually impossible, we will have do it backwards,
i.e. generate the object, then return the hash, and remember the association for when it comes time to produce the witness.

This is the role of the data WitUniv.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
