### PR TITLE
Updated `SpecTranslate` instance of `AlonzoScript`, debug info improvements

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -24,8 +24,8 @@ source-repository-package
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `MAlonzo-code` BEFORE MERGE!
   subdir: generated
-  --sha256: sha256-by921yC1MaZI58kyrtEGGKqmt9jMnVsPLfQtP4raJPw=
-  tag: be51adff014214c15fed718d396bb8a6d955f9e1
+  --sha256: sha256-/YE/qwup2ijMB7bo5eWyBIM+gXZ3Z1g0NZyNSfRwoPY=
+  tag: 93041ddbf659e0dbc1981d73fecb439b0209d484
 
 -- NOTE: If you would like to update the above, look for the `MAlonzo-code`
 -- branch in the `formal-ledger-specifications` repo and copy the SHA of

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxow.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxow.hs
@@ -14,8 +14,12 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Utxow () where
 
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.TxCert (ConwayTxCert)
+import Cardano.Ledger.Conway.UTxO (getConwayWitsVKeyNeeded)
+import Cardano.Ledger.Core (EraTx (..))
+import Cardano.Ledger.Shelley.LedgerState (UTxOState (..))
 import Data.Bifunctor (Bifunctor (..))
 import qualified Data.Text as T
+import Lens.Micro ((^.))
 import qualified Lib as Agda
 import qualified Prettyprinter as PP
 import Test.Cardano.Ledger.Conformance (
@@ -41,6 +45,7 @@ import Test.Cardano.Ledger.Constrained.Conway (
  )
 import qualified Test.Cardano.Ledger.Generic.PrettyCore as PP
 import Test.Cardano.Ledger.Shelley.Utils (runSTS)
+import Test.Cardano.Ledger.TreeDiff (showExpr)
 
 instance
   ( IsConwayUniv fn
@@ -69,6 +74,12 @@ instance
      in
       PP.vcat
         [ "UTXOW"
+        , "Impl:"
+        , "witsVKeyNeeded"
+        , PP.ppString . showExpr $
+            getConwayWitsVKeyNeeded @ConwayEra (utxosUtxo st) (sig ^. bodyTxL)
+        , "witsVKeyHashes"
+        , "Spec:"
         , PP.ppString result
         , mempty
         , "UTXO"

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -149,8 +149,18 @@ instance NFData LEnv
 instance ToExpr a => ToExpr (HSSet a)
 
 instance ToExpr Credential where
-  toExpr (KeyHashObj h) = App "KeyHashObj" [agdaHashToExpr 28 h, toExpr h]
-  toExpr (ScriptObj h) = App "ScriptObj" [agdaHashToExpr 28 h, toExpr h]
+  toExpr (KeyHashObj h) =
+    App
+      "KeyHashObj"
+      [ agdaHashToExpr standardAddrHashSize h
+      , toExpr h
+      ]
+  toExpr (ScriptObj h) =
+    App
+      "ScriptObj"
+      [ agdaHashToExpr standardAddrHashSize h
+      , toExpr h
+      ]
 
 instance (ToExpr k, ToExpr v) => ToExpr (HSMap k v)
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -245,7 +245,7 @@ instance
   type SpecRep (AlonzoScript era) = Agda.Script
 
   toSpecRep (TimelockScript s) = Left <$> toSpecRep s
-  toSpecRep (PlutusScript _) = pure $ Right ()
+  toSpecRep (PlutusScript s) = Right . (,()) <$> toSpecRep s
 
 instance
   ( EraTxOut era

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Utils.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Utils.hs
@@ -6,13 +6,16 @@ module Test.Cardano.Ledger.Conformance.Utils where
 
 import Cardano.Crypto.Hash (ByteString, Hash, HashAlgorithm, hashFromBytes, hashToBytes, sizeHash)
 import Cardano.Crypto.Util (bytesToNatural, naturalToBytes)
-import Cardano.Ledger.Hashes (HASH)
+import Cardano.Ledger.Hashes (ADDRHASH, HASH)
 import qualified Data.ByteString.Base16 as B16
 import Data.Data (Proxy (..))
 import Test.Cardano.Ledger.TreeDiff (Expr, ToExpr (..))
 
 standardHashSize :: Int
 standardHashSize = fromIntegral . sizeHash $ Proxy @HASH
+
+standardAddrHashSize :: Int
+standardAddrHashSize = fromIntegral . sizeHash $ Proxy @ADDRHASH
 
 agdaHashToBytes :: Int -> Integer -> ByteString
 agdaHashToBytes hs = B16.encode . naturalToBytes hs . fromInteger


### PR DESCRIPTION
# Description

This PR updates the translation of `AlonzoScript` by including the script hash. I also added some additional debug information to conformance testing and made Agda credentials display the hashes correctly.

related https://github.com/IntersectMBO/formal-ledger-specifications/pull/628

# Checklist

- [ ] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
