### PR TITLE
Add missing version bump in `cardano-ledger-shelley-ma-test`

### DIFF
--- a/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
+++ b/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-shelley-ma-test
-version: 1.2.2.4
+version: 1.2.2.5
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK
@@ -48,7 +48,7 @@ library
     bytestring,
     cardano-ledger-allegra:{cardano-ledger-allegra, testlib} >=1.6 && <1.7,
     cardano-ledger-binary:{cardano-ledger-binary, testlib} ^>=1.5,
-    cardano-ledger-core:{cardano-ledger-core, testlib} >=1.14,
+    cardano-ledger-core:{cardano-ledger-core, testlib} >=1.16,
     cardano-ledger-mary:{cardano-ledger-mary, testlib} >=1.7 && <1.8,
     cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.12,
     cardano-ledger-shelley-test >=1.1,


### PR DESCRIPTION
# Description

The version of `cardano-ledger-shelley-ma-test` wasn't bumped and its bounds weren't changed when it was changed to be compatible with `cardano-ledger-core-1.16.0.0`

# Checklist

- [x] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [x] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
