### PR TITLE
Add missing version bump in `cardano-ledger-alonzo-test`

### DIFF
--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-alonzo-test
-version: 1.3.0.0
+version: 1.3.0.1
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK
@@ -50,7 +50,7 @@ library
     cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
     cardano-ledger-core:{cardano-ledger-core, testlib} >=1.15,
     cardano-ledger-mary >=1.4,
-    cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.14,
+    cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.15,
     cardano-ledger-shelley-ma-test >=1.2,
     cardano-ledger-shelley-test >=1.4.1,
     cardano-protocol-tpraos >=1.0,


### PR DESCRIPTION
# Description

The version of `cardano-ledger-alonzo-test` wasn't bumped and its bounds weren't changed when it was changed to be compatible with cardano-ledger-shelley-1.15.0.0

# Checklist

- [x] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
