### PR TITLE
Export constructor for `Url`

### DIFF
--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Add `PlutusDebugOverrides` argument to `debugPlutus`
 * Add `PlutusDebugOverrides` data type
 * Add `Read` instance for `Language`
+* Export constructor for `Url`
 
 ### `testlib`
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -41,7 +41,7 @@ module Cardano.Ledger.BaseTypes (
   invalidKey,
   mkNonceFromOutputVRF,
   mkNonceFromNumber,
-  Url,
+  Url (..),
   urlToText,
   textToUrl,
   DnsName,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -42,7 +42,6 @@ module Cardano.Ledger.BaseTypes (
   mkNonceFromOutputVRF,
   mkNonceFromNumber,
   Url (..),
-  urlToText,
   textToUrl,
   DnsName,
   dnsToText,


### PR DESCRIPTION
# Description

This PR exports the constructor of the `Url` datatype. This is necessary because, currently, the only way of constructing a `Url` is by using `textToUrl`, which requires setting a limit for the length in bytes of the `Url` and can fail. This is impractical because it forces the user to handle an error that should never happen if the length is calculated correctly (undermining the type safety). This requirement has no benefit (if `textToUrl` is considered as a smart constructor) because it ensures no invariants on the actual `Url` datatype, which can have any `Text` anyway, as long as the creator is able to establish an upper bound for its length.

# Checklist

- [x] Commits in meaningful sequence and with useful messages
- [x] Tests added or updated when needed
- [x] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
