### PR TITLE
Fix formal-ledger-specifications SRP check in ci

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -493,14 +493,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Check if provided formal-ledger-specifications SRP commit hash exists
+    - name: Check formal-ledger-specifications SRP commit hash
       run: |
         TAG=$(sed -ne \
-          '/ *location: *https:\/\/github.com\/IntersectMBO\/formal-ledger-specifications.git/,/--sha256/ p' \
+          '/ *location: *https:\/\/github.com\/IntersectMBO\/formal-ledger-specifications.git/,/tag:/ p' \
           cabal.project \
         | sed -ne 's/^ *tag: *//p')
+        if [ -z "$TAG" ]; then
+          echo "Error: IntersectMBO/formal-ledger-specifications SRP tag not found."
+          exit 1
+        fi
         git fetch https://github.com/intersectmbo/formal-ledger-specifications.git MAlonzo-code
-        git show -s $TAG || { \
+
+        git show -s "$TAG" || { \
           echo "Commit $TAG was not found on the MAlonzo-code branch of formal-ledger-specifications."
           exit 1
         }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -277,23 +277,19 @@ from [the Shelley ledger spec](./eras/shelley/formal-spec)).
 4. Add a link to the package near the bottom of [flake.nix](./flake.nix),
    following the existing examples.
 
-### To update the conformance test
+### To update the referenced Agda ledger spec
 
-To update the conformance test, do the following:
+To update the version of the Agda spec that the conformance tests are using:
 
-1. Clone the [Agda specification repo](https://github.com/IntersectMBO/formal-ledger-specifications)
-2. Run `nix-build -A ledger.hsSrc` in the cloned repo, take note of the output path
-   in the nix store
-3. Clone the [executable spec repo](https://github.com/input-output-hk/cardano-ledger-executable-spec)
-4. Replace the content of the repo cloned above with the files at `/nix/store/<output of the nix-build>/haskell/Ledger/*`
-   ```bash
-   rm -rf cardano-ledger-executable-spec/*
-   cp -r  /nix/store/<output of the nix-build>/haskell/Ledger/*  cardano-ledger-executable-spec
-   ```
-   Then make a commit and push it.
-5. In the `cardano-ledger` repo, edit `cabal.project`. Look for
-   `source-repository-package` that points to the executable spec repo, and
-   update the `tag` and `sha256` entries in that block.
+1. Locate the `MAlonzo-code` branch in the [formal-ledger-specifications repo](https://github.com/IntersectMBO/formal-ledger-specifications)
+2. Identify the SHA of the commit that you need, belonging to that branch
+3. In the `cardano-ledger` repository, update the `cabal.project` file by replacing the `tag` and `sha256` fields in the `source-repository-package` stanza with the appropriate values.
+
+You can determine the correct `sha256` like this:
+  * update the `tag` with the SHA of the chosen commit and run `cabal`. The resulting error message will include the expected `sha256` value.
+  * alternatively, use a tool like `nix-prefetch-git` to fetch and compute the `sha256`
+
+If the commit you need in `formal-ledger-specifications` is not on master, open a PR for your branch in the `formal-ledger-specifications` repository. This will create a branch with the updated generated code, which you can then use as described above. You will not be able to merge in `cardano-leder` master a reference to a commit not yet merged in `formal-ledger-specifications`.
 
 ### Additional documentation
 


### PR DESCRIPTION
# Description

It has been broken since we changed the order of `tag` and `--sha256` lines in cabal.project. 
This PR makes the check more robust as well: 
  * it works with both orders (tag followed by --sha256, and the other way around)
  * if something goes wrong with the parsing and the result is empty, the check will fail  (before it was passing, because `git show -s ` with no arguments doesn't error) 

Also included an update to the guide to updating the spec . 

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
