### PR TITLE
Deprecate `AuxiliaryDataHash`

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.7.0.0
 
+* Remove deprecated `AuxiliaryData` type synonym
 * Deprecate `Allegra` type synonym
 * Remove crypto parametrization from `AllegraEra`
 

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
@@ -96,8 +96,6 @@ instance EraTxAuxData AllegraEra where
 
   validateTxAuxData _ (AllegraTxAuxData md as) = as `deepseq` all validMetadatum md
 
-  hashTxAuxData aux = TxAuxDataHash (hashAnnotated aux)
-
 metadataAllegraTxAuxDataL :: Era era => Lens' (AllegraTxAuxData era) (Map Word64 Metadatum)
 metadataAllegraTxAuxDataL =
   lensMemoRawType atadrMetadata $ \txAuxDataRaw md -> txAuxDataRaw {atadrMetadata = md}

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
@@ -23,15 +23,11 @@ module Cardano.Ledger.Allegra.TxAuxData (
   metadataAllegraTxAuxDataL,
   AllegraEraTxAuxData (..),
   timelockScriptsAllegraTxAuxDataL,
-
-  -- * Deprecations
-  AuxiliaryData,
 )
 where
 
 import Cardano.Ledger.Allegra.Era (AllegraEra)
 import Cardano.Ledger.Allegra.Scripts (Timelock)
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
 import Cardano.Ledger.Binary (
   Annotator (..),
   DecCBOR (..),
@@ -100,7 +96,7 @@ instance EraTxAuxData AllegraEra where
 
   validateTxAuxData _ (AllegraTxAuxData md as) = as `deepseq` all validMetadatum md
 
-  hashTxAuxData aux = AuxiliaryDataHash (hashAnnotated aux)
+  hashTxAuxData aux = TxAuxDataHash (hashAnnotated aux)
 
 metadataAllegraTxAuxDataL :: Era era => Lens' (AllegraTxAuxData era) (Map Word64 Metadatum)
 metadataAllegraTxAuxDataL =
@@ -150,10 +146,6 @@ pattern AllegraTxAuxData blob sp <- (getMemoRawType -> AllegraTxAuxDataRaw blob 
     AllegraTxAuxData blob sp = mkMemoized $ AllegraTxAuxDataRaw blob sp
 
 {-# COMPLETE AllegraTxAuxData #-}
-
-type AuxiliaryData = AllegraTxAuxData
-
-{-# DEPRECATED AuxiliaryData "Use `AllegraTxAuxData` instead" #-}
 
 --------------------------------------------------------------------------------
 -- Serialisation

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxBody/Internal.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxBody/Internal.hs
@@ -52,7 +52,6 @@ import Cardano.Ledger.Allegra.Era (AllegraEra)
 import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
 import Cardano.Ledger.Allegra.TxCert ()
 import Cardano.Ledger.Allegra.TxOut ()
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.BaseTypes (SlotNo, StrictMaybe (SJust, SNothing))
 import Cardano.Ledger.Binary (Annotator, DecCBOR (..), EncCBOR (..), ToCBOR)
 import Cardano.Ledger.Binary.Coders (
@@ -106,7 +105,7 @@ data AllegraTxBodyRaw ma era = AllegraTxBodyRaw
   , atbrTxFee :: !Coin
   , atbrValidityInterval :: !ValidityInterval
   , atbrUpdate :: !(StrictMaybe (Update era))
-  , atbrAuxDataHash :: !(StrictMaybe AuxiliaryDataHash)
+  , atbrAuxDataHash :: !(StrictMaybe TxAuxDataHash)
   , atbrMint :: !ma
   }
 
@@ -261,7 +260,7 @@ pattern AllegraTxBody ::
   Coin ->
   ValidityInterval ->
   StrictMaybe (Update era) ->
-  StrictMaybe AuxiliaryDataHash ->
+  StrictMaybe TxAuxDataHash ->
   AllegraTxBody era
 pattern AllegraTxBody
   { atbInputs

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.0.0
 
+* Deprecate `hashAlonzoTxAuxData`
 * Stop re-exporting deprecated `AuxiliaryDataHash` from `Cardano.Ledger.Alonzo.TxAuxData`
 * Deprecate `Alonzo` type synonym
 * Remove crypto parametrization from `AlonzoEra`

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.0.0
 
+* Stop re-exporting deprecated `AuxiliaryDataHash` from `Cardano.Ledger.Alonzo.TxAuxData`
 * Deprecate `Alonzo` type synonym
 * Remove crypto parametrization from `AlonzoEra`
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
@@ -261,8 +261,6 @@ instance EraTxAuxData AlonzoEra where
         , atadrPlutus = mempty
         }
 
-  hashTxAuxData = hashAlonzoTxAuxData
-
   validateTxAuxData = validateAlonzoTxAuxData
 
 metadataAlonzoTxAuxDataL :: Era era => Lens' (AlonzoTxAuxData era) (Map Word64 Metadatum)
@@ -274,6 +272,7 @@ hashAlonzoTxAuxData ::
   x ->
   TxAuxDataHash
 hashAlonzoTxAuxData x = TxAuxDataHash (hashAnnotated x)
+{-# DEPRECATED hashAlonzoTxAuxData "In favor of `hashTxAuxData`" #-}
 
 validateAlonzoTxAuxData ::
   (AlonzoEraScript era, Script era ~ AlonzoScript era) =>

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
@@ -34,7 +34,6 @@ module Cardano.Ledger.Alonzo.TxAuxData (
   AlonzoEraTxAuxData (..),
   AlonzoTxAuxDataRaw,
   mkAlonzoTxAuxData,
-  AuxiliaryDataHash (..),
   hashAlonzoTxAuxData,
   validateAlonzoTxAuxData,
   getAlonzoTxAuxDataScripts,
@@ -56,7 +55,6 @@ import Cardano.Ledger.Alonzo.Scripts (
   plutusScriptLanguage,
   validScript,
  )
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
 import Cardano.Ledger.BaseTypes (ProtVer)
 import Cardano.Ledger.Binary (
   Annotator (..),
@@ -274,8 +272,8 @@ metadataAlonzoTxAuxDataL =
 hashAlonzoTxAuxData ::
   HashAnnotated x EraIndependentTxAuxData =>
   x ->
-  AuxiliaryDataHash
-hashAlonzoTxAuxData x = AuxiliaryDataHash (hashAnnotated x)
+  TxAuxDataHash
+hashAlonzoTxAuxData x = TxAuxDataHash (hashAnnotated x)
 
 validateAlonzoTxAuxData ::
   (AlonzoEraScript era, Script era ~ AlonzoScript era) =>

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody/Internal.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody/Internal.hs
@@ -98,7 +98,7 @@ import Cardano.Ledger.Alonzo.Scripts (
   AsIxItem (..),
   PlutusPurpose,
  )
-import Cardano.Ledger.Alonzo.TxAuxData (AuxiliaryDataHash (..))
+import Cardano.Ledger.Alonzo.TxAuxData ()
 import Cardano.Ledger.Alonzo.TxCert ()
 import Cardano.Ledger.Alonzo.TxOut
 import Cardano.Ledger.BaseTypes (
@@ -194,7 +194,7 @@ data AlonzoTxBodyRaw era = AlonzoTxBodyRaw
   , atbrReqSignerHashes :: Set (KeyHash 'Witness)
   , atbrMint :: !MultiAsset
   , atbrScriptIntegrityHash :: !(StrictMaybe ScriptIntegrityHash)
-  , atbrAuxDataHash :: !(StrictMaybe AuxiliaryDataHash)
+  , atbrAuxDataHash :: !(StrictMaybe TxAuxDataHash)
   , atbrTxNetworkId :: !(StrictMaybe Network)
   }
   deriving (Generic, Typeable)
@@ -409,7 +409,7 @@ pattern AlonzoTxBody ::
   Set (KeyHash 'Witness) ->
   MultiAsset ->
   StrictMaybe ScriptIntegrityHash ->
-  StrictMaybe AuxiliaryDataHash ->
+  StrictMaybe TxAuxDataHash ->
   StrictMaybe Network ->
   AlonzoTxBody era
 pattern AlonzoTxBody
@@ -498,7 +498,7 @@ withdrawals' :: AlonzoTxBody era -> Withdrawals
 vldt' :: AlonzoTxBody era -> ValidityInterval
 update' :: AlonzoTxBody era -> StrictMaybe (Update era)
 reqSignerHashes' :: AlonzoTxBody era -> Set (KeyHash 'Witness)
-adHash' :: AlonzoTxBody era -> StrictMaybe AuxiliaryDataHash
+adHash' :: AlonzoTxBody era -> StrictMaybe TxAuxDataHash
 mint' :: AlonzoTxBody era -> MultiAsset
 scriptIntegrityHash' :: AlonzoTxBody era -> StrictMaybe ScriptIntegrityHash
 txnetworkid' :: AlonzoTxBody era -> StrictMaybe Network

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -57,7 +57,6 @@ import Cardano.Ledger.Alonzo.TxWits (
   nullRedeemers,
  )
 import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded (..))
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (EncCBOR)
 import Cardano.Ledger.Coin (Coin (..))
@@ -263,7 +262,7 @@ genAlonzoTxBody ::
   Withdrawals ->
   Coin ->
   StrictMaybe (Update AlonzoEra) ->
-  StrictMaybe AuxiliaryDataHash ->
+  StrictMaybe TxAuxDataHash ->
   Gen (TxBody AlonzoEra, [Script AlonzoEra])
 genAlonzoTxBody _genenv utxo pparams currentslot input txOuts certs withdrawals fee updates auxDHash = do
   netid <- genM $ pure Testnet -- frequency [(2, pure Mainnet), (1, pure Testnet)]

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Examples/Consensus.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Examples/Consensus.hs
@@ -15,7 +15,7 @@ import Cardano.Ledger.Alonzo.Scripts (
   Prices (..),
  )
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), IsValid (..))
-import Cardano.Ledger.Alonzo.TxAuxData (AuxiliaryDataHash (..), mkAlonzoTxAuxData)
+import Cardano.Ledger.Alonzo.TxAuxData (mkAlonzoTxAuxData)
 import Cardano.Ledger.Alonzo.TxBody (AlonzoTxBody (..), AlonzoTxOut (..))
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), Redeemers (..), TxDats (..))
 import Cardano.Ledger.BaseTypes (NonNegativeInterval, StrictMaybe (..), boundRational)
@@ -124,7 +124,7 @@ exampleTxBodyAlonzo =
     (Set.singleton $ SLE.mkKeyHash 212) -- reqSignerHashes
     exampleMultiAsset -- mint
     (SJust $ mkDummySafeHash 42) -- scriptIntegrityHash
-    (SJust . AuxiliaryDataHash $ mkDummySafeHash 42) -- adHash
+    (SJust . TxAuxDataHash $ mkDummySafeHash 42) -- adHash
     (SJust Mainnet) -- txnetworkid
   where
     MaryValue _ exampleMultiAsset = SLE.exampleMultiAssetValue 3

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -14,7 +14,6 @@ import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..))
 import Cardano.Ledger.Alonzo.Tx (AlonzoTxBody (..))
-import Cardano.Ledger.Alonzo.TxAuxData (AuxiliaryDataHash)
 import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..))
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (EncCBOR (..))
@@ -46,7 +45,7 @@ instance Era era => Twiddle (ShelleyTxCert era) where
 instance Twiddle Withdrawals where
   twiddle v = twiddle v . toTerm v
 
-instance Twiddle AuxiliaryDataHash where
+instance Twiddle TxAuxDataHash where
   twiddle v = twiddle v . toTerm v
 
 instance Twiddle (Update AlonzoEra) where

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxAuxData.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxAuxData.hs
@@ -6,7 +6,6 @@ module Cardano.Ledger.Babbage.TxAuxData () where
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.TxAuxData (
   AlonzoTxAuxData (..),
-  hashAlonzoTxAuxData,
   metadataAlonzoTxAuxDataL,
   plutusScriptsAllegraTxAuxDataL,
   timelockScriptsAlonzoTxAuxDataL,
@@ -24,8 +23,6 @@ instance EraTxAuxData BabbageEra where
   metadataTxAuxDataL = metadataAlonzoTxAuxDataL
 
   upgradeTxAuxData = translateAlonzoTxAuxData
-
-  hashTxAuxData = hashAlonzoTxAuxData
 
   validateTxAuxData = validateAlonzoTxAuxData
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody/Internal.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxBody/Internal.hs
@@ -90,7 +90,6 @@ module Cardano.Ledger.Babbage.TxBody.Internal (
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.PParams (AlonzoPParams (appExtraEntropy), appD)
-import Cardano.Ledger.Alonzo.TxAuxData (AuxiliaryDataHash (..))
 import Cardano.Ledger.Alonzo.TxBody (alonzoRedeemerPointer, alonzoRedeemerPointerInverse)
 import Cardano.Ledger.Babbage.Era (BabbageEra)
 import Cardano.Ledger.Babbage.PParams (upgradeBabbagePParams)
@@ -177,7 +176,7 @@ data BabbageTxBodyRaw era = BabbageTxBodyRaw
     -- Operations on the TxBody in the BabbageEra depend upon this.
     -- We now store only the MultiAsset part of a Mary.Value.
     btbrScriptIntegrityHash :: !(StrictMaybe ScriptIntegrityHash)
-  , btbrAuxDataHash :: !(StrictMaybe AuxiliaryDataHash)
+  , btbrAuxDataHash :: !(StrictMaybe TxAuxDataHash)
   , btbrTxNetworkId :: !(StrictMaybe Network)
   }
   deriving (Generic, Typeable)
@@ -263,7 +262,7 @@ feeBabbageTxBodyL =
 {-# INLINEABLE feeBabbageTxBodyL #-}
 
 auxDataHashBabbageTxBodyL ::
-  BabbageEraTxBody era => Lens' (BabbageTxBody era) (StrictMaybe AuxiliaryDataHash)
+  BabbageEraTxBody era => Lens' (BabbageTxBody era) (StrictMaybe TxAuxDataHash)
 auxDataHashBabbageTxBodyL =
   lensMemoRawType btbrAuxDataHash $
     \txBodyRaw auxDataHash -> txBodyRaw {btbrAuxDataHash = auxDataHash}
@@ -601,7 +600,7 @@ pattern BabbageTxBody ::
   Set (KeyHash 'Witness) ->
   MultiAsset ->
   StrictMaybe ScriptIntegrityHash ->
-  StrictMaybe AuxiliaryDataHash ->
+  StrictMaybe TxAuxDataHash ->
   StrictMaybe Network ->
   BabbageTxBody era
 pattern BabbageTxBody
@@ -703,7 +702,7 @@ withdrawals' :: BabbageTxBody era -> Withdrawals
 vldt' :: BabbageTxBody era -> ValidityInterval
 update' :: BabbageTxBody era -> StrictMaybe (Update era)
 reqSignerHashes' :: BabbageTxBody era -> Set (KeyHash 'Witness)
-adHash' :: BabbageTxBody era -> StrictMaybe AuxiliaryDataHash
+adHash' :: BabbageTxBody era -> StrictMaybe TxAuxDataHash
 mint' :: BabbageTxBody era -> MultiAsset
 scriptIntegrityHash' :: BabbageTxBody era -> StrictMaybe ScriptIntegrityHash
 spendInputs' = btbrSpendInputs . getMemoRawType

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Examples/Consensus.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Examples/Consensus.hs
@@ -7,10 +7,7 @@ module Test.Cardano.Ledger.Babbage.Examples.Consensus where
 import Cardano.Ledger.Alonzo.Scripts (AlonzoPlutusPurpose (..), AlonzoScript (..), ExUnits (..))
 import Cardano.Ledger.Alonzo.Translation ()
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), IsValid (..))
-import Cardano.Ledger.Alonzo.TxAuxData (
-  AuxiliaryDataHash (..),
-  mkAlonzoTxAuxData,
- )
+import Cardano.Ledger.Alonzo.TxAuxData (mkAlonzoTxAuxData)
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), Redeemers (..), TxDats (..))
 import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.Babbage.Core
@@ -139,7 +136,7 @@ exampleTxBodyBabbage =
     (Set.singleton $ SLE.mkKeyHash 212) -- reqSignerHashes
     exampleMultiAsset -- mint
     (SJust $ SLE.mkDummySafeHash 42) -- scriptIntegrityHash
-    (SJust . AuxiliaryDataHash $ SLE.mkDummySafeHash 42) -- adHash
+    (SJust . TxAuxDataHash $ SLE.mkDummySafeHash 42) -- adHash
     (SJust Mainnet) -- txnetworkid
   where
     MaryValue _ exampleMultiAsset = MarySLE.exampleMultiAssetValue 3

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
@@ -34,7 +34,6 @@ import Cardano.Ledger.Alonzo.Rules (
  )
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo (AlonzoUtxowPredFailure (..))
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.Babbage.Rules (
   BabbageUtxoPredFailure,
   BabbageUtxowPredFailure,
@@ -87,12 +86,12 @@ data ConwayUtxowPredFailure era
       !(Set ScriptHash)
   | -- | hash of the full metadata
     MissingTxBodyMetadataHash
-      !AuxiliaryDataHash
+      !TxAuxDataHash
   | -- | hash of the metadata included in the transaction body
     MissingTxMetadata
-      !AuxiliaryDataHash
+      !TxAuxDataHash
   | ConflictingMetadataHash
-      !(Mismatch 'RelEQ AuxiliaryDataHash)
+      !(Mismatch 'RelEQ TxAuxDataHash)
   | -- | Contains out of range values (string`s too long)
     InvalidMetadata
   | -- | extraneous scripts

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxAuxData.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxAuxData.hs
@@ -6,7 +6,6 @@ module Cardano.Ledger.Conway.TxAuxData () where
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.TxAuxData (
   AlonzoTxAuxData (..),
-  hashAlonzoTxAuxData,
   metadataAlonzoTxAuxDataL,
   plutusScriptsAllegraTxAuxDataL,
   timelockScriptsAlonzoTxAuxDataL,
@@ -24,8 +23,6 @@ instance EraTxAuxData ConwayEra where
   metadataTxAuxDataL = metadataAlonzoTxAuxDataL
 
   upgradeTxAuxData = translateAlonzoTxAuxData
-
-  hashTxAuxData = hashAlonzoTxAuxData
 
   validateTxAuxData = validateAlonzoTxAuxData
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody/Internal.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody/Internal.hs
@@ -60,7 +60,6 @@ module Cardano.Ledger.Conway.TxBody.Internal (
   conwayProposalsDeposits,
 ) where
 
-import Cardano.Ledger.Alonzo.TxAuxData (AuxiliaryDataHash (..))
 import Cardano.Ledger.Alonzo.TxBody (Indexable (..))
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.TxBody (
@@ -146,7 +145,7 @@ data ConwayTxBodyRaw era = ConwayTxBodyRaw
   , ctbrReqSignerHashes :: !(Set (KeyHash 'Witness))
   , ctbrMint :: !MultiAsset
   , ctbrScriptIntegrityHash :: !(StrictMaybe ScriptIntegrityHash)
-  , ctbrAuxDataHash :: !(StrictMaybe AuxiliaryDataHash)
+  , ctbrAuxDataHash :: !(StrictMaybe TxAuxDataHash)
   , ctbrTxNetworkId :: !(StrictMaybe Network)
   , ctbrVotingProcedures :: !(VotingProcedures era)
   , ctbrProposalProcedures :: !(OSet.OSet (ProposalProcedure era))
@@ -544,7 +543,7 @@ pattern ConwayTxBody ::
   Set (KeyHash 'Witness) ->
   MultiAsset ->
   StrictMaybe ScriptIntegrityHash ->
-  StrictMaybe AuxiliaryDataHash ->
+  StrictMaybe TxAuxDataHash ->
   StrictMaybe Network ->
   VotingProcedures era ->
   OSet.OSet (ProposalProcedure era) ->

--- a/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
+++ b/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
@@ -11,10 +11,7 @@ module Test.Cardano.Ledger.Conway.Examples.Consensus where
 
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), ExUnits (..))
 import Cardano.Ledger.Alonzo.Tx (IsValid (..))
-import Cardano.Ledger.Alonzo.TxAuxData (
-  AuxiliaryDataHash (..),
-  mkAlonzoTxAuxData,
- )
+import Cardano.Ledger.Alonzo.TxAuxData (mkAlonzoTxAuxData)
 import Cardano.Ledger.Alonzo.TxWits (Redeemers (..), TxDats (..))
 import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes
@@ -152,7 +149,7 @@ exampleTxBodyConway =
     (Set.singleton $ SLE.mkKeyHash 212) -- reqSignerHashes
     exampleMultiAsset -- mint
     (SJust $ mkDummySafeHash 42) -- scriptIntegrityHash
-    (SJust . AuxiliaryDataHash $ mkDummySafeHash 42) -- adHash
+    (SJust . TxAuxDataHash $ mkDummySafeHash 42) -- adHash
     (SJust Mainnet) -- txnetworkid
     (VotingProcedures mempty)
     mempty

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxAuxData.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxAuxData.hs
@@ -18,7 +18,6 @@ import Cardano.Ledger.Allegra.TxAuxData (
   metadataAllegraTxAuxDataL,
   timelockScriptsAllegraTxAuxDataL,
  )
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Mary.Era (MaryEra)
 import Cardano.Ledger.Mary.Scripts ()
@@ -38,7 +37,7 @@ instance EraTxAuxData MaryEra where
 
   validateTxAuxData _ (AllegraTxAuxData md as) = as `deepseq` all validMetadatum md
 
-  hashTxAuxData aux = AuxiliaryDataHash (hashAnnotated aux)
+  hashTxAuxData aux = TxAuxDataHash (hashAnnotated aux)
 
 instance AllegraEraTxAuxData MaryEra where
   timelockScriptsTxAuxDataL = timelockScriptsAllegraTxAuxDataL

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxAuxData.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxAuxData.hs
@@ -37,7 +37,5 @@ instance EraTxAuxData MaryEra where
 
   validateTxAuxData _ (AllegraTxAuxData md as) = as `deepseq` all validMetadatum md
 
-  hashTxAuxData aux = TxAuxDataHash (hashAnnotated aux)
-
 instance AllegraEraTxAuxData MaryEra where
   timelockScriptsTxAuxDataL = timelockScriptsAllegraTxAuxDataL

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody/Internal.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody/Internal.hs
@@ -47,7 +47,6 @@ where
 
 import Cardano.Ledger.Allegra.Core
 import Cardano.Ledger.Allegra.TxBody
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.Binary (Annotator, DecCBOR (..), EncCBOR (..), ToCBOR (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Mary.Era (MaryEra)
@@ -163,7 +162,7 @@ pattern MaryTxBody ::
   Coin ->
   ValidityInterval ->
   StrictMaybe (Update era) ->
-  StrictMaybe AuxiliaryDataHash ->
+  StrictMaybe TxAuxDataHash ->
   MultiAsset ->
   MaryTxBody era
 pattern MaryTxBody

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/Allegra/Examples/Consensus.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/Allegra/Examples/Consensus.hs
@@ -12,7 +12,6 @@ import Cardano.Ledger.Allegra.Core
 import Cardano.Ledger.Allegra.Scripts
 import Cardano.Ledger.Allegra.TxAuxData
 import Cardano.Ledger.Allegra.TxBody
-import Cardano.Ledger.AuxiliaryData
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Genesis (NoGenesis (..))
 import Cardano.Ledger.Shelley.PParams (Update (..))
@@ -56,9 +55,9 @@ exampleAllegraTxBody value =
     & auxDataHashTxBodyL .~ SJust auxiliaryDataHash
   where
     -- Dummy hash to decouple from the auxiliary data in 'exampleTx'.
-    auxiliaryDataHash :: AuxiliaryDataHash
+    auxiliaryDataHash :: TxAuxDataHash
     auxiliaryDataHash =
-      AuxiliaryDataHash $ mkDummySafeHash 30
+      TxAuxDataHash $ mkDummySafeHash 30
 
 exampleTimelock :: AllegraEraScript era => NativeScript era
 exampleTimelock =

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/AllegraEraGen.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/AllegraEraGen.hs
@@ -29,7 +29,6 @@ import Cardano.Ledger.Allegra.Scripts (
   pattern RequireTimeStart,
  )
 import Cardano.Ledger.Allegra.TxBody (AllegraTxBody (..))
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Binary (encCBOR, serialize')
 import Cardano.Ledger.Coin (Coin)
@@ -107,7 +106,7 @@ genTxBody ::
   Withdrawals ->
   Coin ->
   StrictMaybe (Update era) ->
-  StrictMaybe AuxiliaryDataHash ->
+  StrictMaybe TxAuxDataHash ->
   Gen (AllegraTxBody era, [Timelock era])
 genTxBody slot ins outs cert wdrl fee upd ad = do
   validityInterval <- genValidityInterval slot

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/MaryEraGen.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/MaryEraGen.hs
@@ -20,7 +20,6 @@ module Test.Cardano.Ledger.MaryEraGen (
 ) where
 
 import Cardano.Ledger.Allegra.Scripts (AllegraEraScript)
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
@@ -290,7 +289,7 @@ genTxBody ::
   Withdrawals ->
   Coin ->
   StrictMaybe (Update era) ->
-  StrictMaybe AuxiliaryDataHash ->
+  StrictMaybe TxAuxDataHash ->
   Gen (MaryTxBody era, [NativeScript era])
 genTxBody pparams slot ins outs cert wdrl fee upd meta = do
   validityInterval <- genValidityInterval slot

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Deprecate `hashShelleyTxAuxData`
 * Stop re-exporting `ScriptHash` from `Cardano.Ledger.Shelley.Scripts`. Import it instead from `Cardano.Ledger.Hashes`.
 * Deprecate `Shelley` type synonym
 * Deprecate `PPUpdateEnv`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
@@ -33,7 +33,6 @@ module Cardano.Ledger.Shelley.Rules.Utxow (
 )
 where
 
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.BaseTypes (
   Mismatch (..),
   Relation (..),
@@ -125,11 +124,11 @@ data ShelleyUtxowPredFailure era
   | UtxoFailure (PredicateFailure (EraRule "UTXO" era))
   | MIRInsufficientGenesisSigsUTXOW (Set (KeyHash 'Witness))
   | MissingTxBodyMetadataHash
-      !AuxiliaryDataHash -- hash of the full metadata
+      !TxAuxDataHash -- hash of the full metadata
   | MissingTxMetadata
-      !AuxiliaryDataHash -- hash of the metadata included in the transaction body
+      !TxAuxDataHash -- hash of the metadata included in the transaction body
   | ConflictingMetadataHash
-      !(Mismatch 'RelEQ AuxiliaryDataHash)
+      !(Mismatch 'RelEQ TxAuxDataHash)
   | -- Contains out of range values (strings too long)
     InvalidMetadata
   | ExtraneousScriptWitnessesUTXOW

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxAuxData.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxAuxData.hs
@@ -29,17 +29,9 @@ module Cardano.Ledger.Shelley.TxAuxData (
 )
 where
 
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
 import Cardano.Ledger.Binary (Annotator (..), DecCBOR (..), EncCBOR (..))
 import qualified Cardano.Ledger.Binary.Plain as Plain (ToCBOR)
-import Cardano.Ledger.Core (Era (..), EraTxAuxData (..))
-import Cardano.Ledger.Hashes (
-  EraIndependentTxAuxData,
-  HashAnnotated,
-  SafeHash,
-  SafeToHash (..),
-  hashAnnotated,
- )
+import Cardano.Ledger.Core
 import Cardano.Ledger.MemoBytes (
   EqRaw (..),
   Mem,
@@ -110,8 +102,8 @@ instance EraTxAuxData ShelleyEra where
 
   validateTxAuxData _ (ShelleyTxAuxData m) = all validMetadatum m
 
-  hashTxAuxData metadata =
-    AuxiliaryDataHash (makeHashWithExplicitProxys index metadata)
+  hashTxAuxData txAuxData =
+    TxAuxDataHash (makeHashWithExplicitProxys index txAuxData)
     where
       index = Proxy @EraIndependentTxAuxData
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxAuxData.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxAuxData.hs
@@ -47,7 +47,6 @@ import Cardano.Ledger.Metadata (Metadatum (..), validMetadatum)
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Control.DeepSeq (NFData)
 import Data.Map.Strict (Map)
-import Data.Typeable (Proxy (..))
 import Data.Word (Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
@@ -102,11 +101,6 @@ instance EraTxAuxData ShelleyEra where
 
   validateTxAuxData _ (ShelleyTxAuxData m) = all validMetadatum m
 
-  hashTxAuxData txAuxData =
-    TxAuxDataHash (makeHashWithExplicitProxys index txAuxData)
-    where
-      index = Proxy @EraIndependentTxAuxData
-
 instance EqRaw (ShelleyTxAuxData era)
 
 instance HashAnnotated (ShelleyTxAuxData era) EraIndependentTxAuxData where
@@ -116,6 +110,7 @@ hashShelleyTxAuxData ::
   ShelleyTxAuxData era ->
   SafeHash EraIndependentTxAuxData
 hashShelleyTxAuxData = hashAnnotated
+{-# DEPRECATED hashShelleyTxAuxData "In favor of `hashAnnotated`" #-}
 
 pattern ShelleyTxAuxData :: forall era. Era era => Map Word64 Metadatum -> ShelleyTxAuxData era
 pattern ShelleyTxAuxData m <-

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxBody.hs
@@ -39,7 +39,6 @@ module Cardano.Ledger.Shelley.TxBody (
 ) where
 
 import Cardano.Ledger.Address (RewardAccount (..), Withdrawals (..))
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Binary (
   Annotator (..),
@@ -107,7 +106,7 @@ data ShelleyTxBodyRaw era = ShelleyTxBodyRaw
   , stbrTxFee :: !Coin
   , stbrTTL :: !SlotNo
   , stbrUpdate :: !(StrictMaybe (Update era))
-  , stbrMDHash :: !(StrictMaybe AuxiliaryDataHash)
+  , stbrMDHash :: !(StrictMaybe TxAuxDataHash)
   }
   deriving (Generic, Typeable)
 
@@ -314,7 +313,7 @@ pattern ShelleyTxBody ::
   Coin ->
   SlotNo ->
   StrictMaybe (Update era) ->
-  StrictMaybe AuxiliaryDataHash ->
+  StrictMaybe TxAuxDataHash ->
   ShelleyTxBody era
 pattern ShelleyTxBody
   { stbInputs

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/UtxowSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/UtxowSpec.hs
@@ -9,7 +9,6 @@ module Test.Cardano.Ledger.Shelley.Imp.UtxowSpec (spec) where
 
 import qualified Cardano.Chain.Common as Byron
 import Cardano.Ledger.Address (Addr (..), BootstrapAddress (..))
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
@@ -111,7 +110,7 @@ spec = describe "UTXOW" $ do
   it "ConflictingMetadataHash" $ do
     auxData <- arbitrary @(TxAuxData era)
     let auxDataHash = hashTxAuxData auxData
-    wrongAuxDataHash <- arbitrary @AuxiliaryDataHash
+    wrongAuxDataHash <- arbitrary @TxAuxDataHash
     let tx =
           mkBasicTx mkBasicTxBody
             & bodyTxL . auxDataHashTxBodyL .~ SJust wrongAuxDataHash

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -140,7 +140,6 @@ import Cardano.Ledger.Address (
   RewardAccount (..),
   bootstrapKeyHash,
  )
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
 import Cardano.Ledger.BHeaderView (BHeaderView)
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
@@ -1020,7 +1019,7 @@ fixupAuxDataHash :: (EraTx era, Applicative m) => Tx era -> m (Tx era)
 fixupAuxDataHash tx
   | SNothing <- tx ^. bodyTxL . auxDataHashTxBodyL
   , SJust auxData <- tx ^. auxDataTxL =
-      pure (tx & bodyTxL . auxDataHashTxBodyL .~ SJust (AuxiliaryDataHash (hashAnnotated auxData)))
+      pure (tx & bodyTxL . auxDataHashTxBodyL .~ SJust (TxAuxDataHash (hashAnnotated auxData)))
   | otherwise = pure tx
 
 shelleyFixupTx ::

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
@@ -9,7 +9,6 @@ module Test.Cardano.Ledger.Shelley.TreeDiff (
   module Test.Cardano.Ledger.TreeDiff,
 ) where
 
-import Cardano.Ledger.AuxiliaryData
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.CertState (Obligations)
 import Cardano.Ledger.Core
@@ -176,7 +175,6 @@ instance ToExpr (ShelleyDelegPredFailure era)
 instance
   ( Era era
   , ToExpr (PredicateFailure (EraRule "UTXO" era))
-  , ToExpr AuxiliaryDataHash
   ) =>
   ToExpr (ShelleyUtxowPredFailure era)
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
@@ -16,7 +16,6 @@ import Cardano.Crypto.Hash as Hash
 import Cardano.Crypto.KES as KES
 import Cardano.Crypto.Seed as Seed
 import qualified Cardano.Crypto.VRF as VRF
-import Cardano.Ledger.AuxiliaryData
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin
 import Cardano.Ledger.EpochBoundary
@@ -432,9 +431,9 @@ exampleTxBodyShelley =
     (SJust auxiliaryDataHash)
   where
     -- Dummy hash to decouple from the auxiliaryData in 'exampleTx'.
-    auxiliaryDataHash :: AuxiliaryDataHash
+    auxiliaryDataHash :: TxAuxDataHash
     auxiliaryDataHash =
-      AuxiliaryDataHash $ mkDummySafeHash @EraIndependentTxAuxData 30
+      TxAuxDataHash $ mkDummySafeHash @EraIndependentTxAuxData 30
 
 exampleAuxDataMap :: Map Word64 Metadatum
 exampleAuxDataMap =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
@@ -31,7 +31,6 @@ module Test.Cardano.Ledger.Shelley.Generator.EraGen (
 )
 where
 
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.BaseTypes (Network (..), ShelleyBase, StrictMaybe)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
@@ -191,7 +190,7 @@ class
     Withdrawals ->
     Coin ->
     StrictMaybe (Update era) ->
-    StrictMaybe AuxiliaryDataHash ->
+    StrictMaybe TxAuxDataHash ->
     Gen (TxBody era, [Script era])
 
   -- | Generate era-specific auxiliary data

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/ShelleyEraGen.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/ShelleyEraGen.hs
@@ -11,7 +11,6 @@
 
 module Test.Cardano.Ledger.Shelley.Generator.ShelleyEraGen (genCoin) where
 
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley (ShelleyEra)
@@ -111,7 +110,7 @@ genTxBody ::
   Withdrawals ->
   Coin ->
   StrictMaybe (Update era) ->
-  StrictMaybe AuxiliaryDataHash ->
+  StrictMaybe TxAuxDataHash ->
   Gen (ShelleyTxBody era, [MultiSig era])
 genTxBody _pparams slot inputs outputs certs withdrawals fee update adHash = do
   ttl <- genTimeToLive slot

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.11.0.0
 
+* Expose new `TxAuxDataHash` and deprecate old `AuxiliaryDataHash`
 * Stop re-exporting `Crypto` and `StandardCrypto`, since they have been moved to `cardano-protocol-tpraos`
 * Removal of crypto parametrization:
   * `LatestKnownEra`

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/AuxData.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/AuxData.hs
@@ -32,5 +32,5 @@ import Cardano.Ledger.Alonzo.TxAuxData (
   mkAlonzoTxAuxData,
  )
 import Cardano.Ledger.Api.Era ()
-import Cardano.Ledger.Core (EraTxAuxData (..))
+import Cardano.Ledger.Core (EraTxAuxData (..), hashTxAuxData)
 import Cardano.Ledger.Shelley.TxAuxData (Metadatum (..), ShelleyTxAuxData (..))

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Body.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Body.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Cardano.Ledger.Api.Tx.Body (
   -- | Building and inspecting transaction outputs
@@ -16,6 +17,7 @@ module Cardano.Ledger.Api.Tx.Body (
   withdrawalsTxBodyL,
   Withdrawals (..),
   auxDataHashTxBodyL,
+  TxAuxDataHash (..),
   AuxiliaryDataHash,
   spendableInputsTxBodyF,
   allInputsTxBodyF,
@@ -77,7 +79,7 @@ import Cardano.Ledger.Babbage.TxBody (BabbageEraTxBody (..))
 import Cardano.Ledger.BaseTypes (SlotNo, StrictMaybe (..))
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway.TxBody (ConwayEraTxBody (..))
-import Cardano.Ledger.Core (EraTxBody (..), PParams, Value, txIdTxBody)
+import Cardano.Ledger.Core (EraTxBody (..), PParams, TxAuxDataHash (..), Value, txIdTxBody)
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Cardano.Ledger.Mary.Core (MaryEraTxBody (..))

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -44,7 +44,6 @@ import Cardano.Ledger.Alonzo (AlonzoTxAuxData, MaryValue)
 import Cardano.Ledger.Alonzo.PParams (OrdExUnits (OrdExUnits))
 import Cardano.Ledger.Alonzo.Scripts (AlonzoPlutusPurpose (..))
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), IsValid (..))
-import Cardano.Ledger.Alonzo.TxAuxData (AuxiliaryDataHash (..))
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), Redeemers (..), TxDats (..))
 import Cardano.Ledger.Babbage.TxOut (BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes
@@ -621,10 +620,10 @@ instance SpecTranslate ctx Withdrawals where
 
   toSpecRep (Withdrawals w) = toSpecRep w
 
-instance SpecTranslate ctx AuxiliaryDataHash where
-  type SpecRep AuxiliaryDataHash = Agda.DataHash
+instance SpecTranslate ctx TxAuxDataHash where
+  type SpecRep TxAuxDataHash = Agda.DataHash
 
-  toSpecRep (AuxiliaryDataHash x) = toSpecRep x
+  toSpecRep (TxAuxDataHash x) = toSpecRep x
 
 instance
   ( ConwayEraTxBody era

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.17.0.0
 
+* Extract `hashTxAuxData` from `EraTxAuxData` into a standalone function.
 * Add `TxAuxDataHash` and deprecate `AuxiliaryDayaHash` in its favor.
 * Deprecate `Cardano.Ledger.Crypto` module in favor of `cardano-protocol-tpraos:Cardano.Protocol.Crypto`
 * Deprecate `KESignable`, `SignedKES`, `SignKeyKES`, `VerKeyKES`, `VRFSignable`,

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.17.0.0
 
+* Extract `indexProxy` from `HashAnnotated` type class and deprecate it.
 * Extract `hashTxAuxData` from `EraTxAuxData` into a standalone function.
 * Add `TxAuxDataHash` and deprecate `AuxiliaryDayaHash` in its favor.
 * Deprecate `Cardano.Ledger.Crypto` module in favor of `cardano-protocol-tpraos:Cardano.Protocol.Crypto`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.17.0.0
 
+* Add `TxAuxDataHash` and deprecate `AuxiliaryDayaHash` in its favor.
 * Deprecate `Cardano.Ledger.Crypto` module in favor of `cardano-protocol-tpraos:Cardano.Protocol.Crypto`
 * Deprecate `KESignable`, `SignedKES`, `SignKeyKES`, `VerKeyKES`, `VRFSignable`,
   `CertifiedVRF`, `SignKeyVRF` and `VerKeyVRF` type synonyms.

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/AuxiliaryData.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/AuxiliaryData.hs
@@ -1,20 +1,19 @@
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
 
-module Cardano.Ledger.AuxiliaryData (
-  AuxiliaryDataHash (..),
+module Cardano.Ledger.AuxiliaryData
+  {-# DEPRECATED "Use `Cardano.Ledger.Hashes.TxAuxDataHash` instead" #-} (
+  AuxiliaryDataHash,
+  pattern AuxiliaryDataHash,
+  unsafeAuxiliaryDataHash,
 )
 where
 
-import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
-import Cardano.Ledger.Hashes (EraIndependentTxAuxData, SafeHash)
-import Control.DeepSeq (NFData (..))
-import Data.Aeson (ToJSON)
-import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks (..))
+import Cardano.Ledger.Hashes
 
-newtype AuxiliaryDataHash = AuxiliaryDataHash
-  { unsafeAuxiliaryDataHash :: SafeHash EraIndependentTxAuxData
-  }
-  deriving (Show, Eq, Ord, Generic, NoThunks, NFData, EncCBOR, DecCBOR, ToJSON)
+type AuxiliaryDataHash = TxAuxDataHash
+
+pattern AuxiliaryDataHash :: SafeHash EraIndependentTxAuxData -> TxAuxDataHash
+pattern AuxiliaryDataHash {unsafeAuxiliaryDataHash} <- (unTxAuxDataHash -> unsafeAuxiliaryDataHash)
+  where
+    AuxiliaryDataHash h = TxAuxDataHash h

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -69,7 +69,6 @@ import Cardano.Ledger.Address (
   decompactAddr,
   isBootstrapCompactAddr,
  )
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.BaseTypes (ProtVer (..))
 import Cardano.Ledger.Binary (
   Annotator,
@@ -199,7 +198,7 @@ class
 
   withdrawalsTxBodyL :: Lens' (TxBody era) Withdrawals
 
-  auxDataHashTxBodyL :: Lens' (TxBody era) (StrictMaybe AuxiliaryDataHash)
+  auxDataHashTxBodyL :: Lens' (TxBody era) (StrictMaybe TxAuxDataHash)
 
   -- | This getter will produce all inputs from the UTxO map that this transaction might
   -- spend, which ones will depend on the validity of the transaction itself. Starting in
@@ -456,7 +455,7 @@ class
   -- preserved. If you need to retain underlying bytes you can use `translateEraThroughCBOR`
   upgradeTxAuxData :: EraTxAuxData (PreviousEra era) => TxAuxData (PreviousEra era) -> TxAuxData era
 
-  hashTxAuxData :: TxAuxData era -> AuxiliaryDataHash
+  hashTxAuxData :: TxAuxData era -> TxAuxDataHash
 
   validateTxAuxData :: ProtVer -> TxAuxData era -> Bool
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -32,6 +32,7 @@ module Cardano.Ledger.Core (
   EraTxBody (..),
   txIdTxBody,
   EraTxAuxData (..),
+  hashTxAuxData,
   EraTxWits (..),
   EraScript (..),
   hashScript,
@@ -455,9 +456,11 @@ class
   -- preserved. If you need to retain underlying bytes you can use `translateEraThroughCBOR`
   upgradeTxAuxData :: EraTxAuxData (PreviousEra era) => TxAuxData (PreviousEra era) -> TxAuxData era
 
-  hashTxAuxData :: TxAuxData era -> TxAuxDataHash
-
   validateTxAuxData :: ProtVer -> TxAuxData era -> Bool
+
+-- | Compute a hash of `TxAuxData`
+hashTxAuxData :: EraTxAuxData era => TxAuxData era -> TxAuxDataHash
+hashTxAuxData = TxAuxDataHash . hashAnnotated
 
 -- | A collection of witnesses in a Tx
 class

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
@@ -76,7 +76,6 @@ module Cardano.Ledger.Hashes (
   -- ** Other operations
   castSafeHash,
   extractHash,
-  indexProxy,
 )
 where
 
@@ -386,10 +385,6 @@ instance Hash.HashAlgorithm h => SafeToHash (Hash.Hash h i) where
 -- can be easily derived (because their methods have default methods when the type is a
 -- newtype around a type that is 'SafeToHash'). For example,
 class SafeToHash x => HashAnnotated x i | x -> i where
-  -- TODO: move outside of type class
-  indexProxy :: x -> Proxy i
-  indexProxy _ = Proxy @i
-
   -- | Create a @('SafeHash' i)@, given @(`HashAnnotated` x i)@ instance.
   hashAnnotated :: x -> SafeHash i
   hashAnnotated = makeHashWithExplicitProxys (Proxy @i)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
@@ -50,6 +50,9 @@ module Cardano.Ledger.Hashes (
   ScriptHash (..),
   DataHash,
 
+  -- ** AuxiliaryData
+  TxAuxDataHash (..),
+
   -- ** @VRF@ Verification Key Hashes
   KeyRoleVRF (..),
   VRFVerKeyHash (..),
@@ -233,6 +236,15 @@ toVRFVerKeyHash = VRFVerKeyHash . Hash.castHash
 
 fromVRFVerKeyHash :: VRFVerKeyHash (r :: KeyRoleVRF) -> Hash.Hash HASH (VRF.VerKeyVRF v)
 fromVRFVerKeyHash = Hash.castHash . unVRFVerKeyHash
+
+--------------------------------------------------------------------------------
+-- Auxiliary Data Hashes
+--------------------------------------------------------------------------------
+
+newtype TxAuxDataHash = TxAuxDataHash
+  { unTxAuxDataHash :: SafeHash EraIndependentTxAuxData
+  }
+  deriving (Show, Eq, Ord, Generic, NoThunks, NFData, EncCBOR, DecCBOR, ToJSON)
 
 --------------------------------------------------------------------------------
 -- Genesis Keys Hashes

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/SafeHash.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/SafeHash.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+
 module Cardano.Ledger.SafeHash
   {-# DEPRECATED "Use `Cardano.Ledger.Hashes` instead" #-} (
   -- * SafeHash and SafeToHash
@@ -26,3 +30,8 @@ module Cardano.Ledger.SafeHash
 where
 
 import Cardano.Ledger.Hashes
+import Data.Proxy
+
+indexProxy :: forall x i. HashAnnotated x i => x -> Proxy i
+indexProxy _ = Proxy @i
+{-# DEPRECATED indexProxy "As useless and unused" #-}

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -48,7 +48,6 @@ where
 import qualified Cardano.Chain.Common as Byron
 import Cardano.Crypto.Hash.Class
 import Cardano.Ledger.Address
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
 import Cardano.Ledger.BaseTypes (
   ActiveSlotCoeff,
   BlocksMade (..),
@@ -352,8 +351,8 @@ instance Arbitrary ScriptHash where
 -- Cardano.Ledger.AuxiliaryDataHash ------------------------------------------------------
 ------------------------------------------------------------------------------------------
 
-instance Arbitrary AuxiliaryDataHash where
-  arbitrary = AuxiliaryDataHash <$> arbitrary
+instance Arbitrary TxAuxDataHash where
+  arbitrary = TxAuxDataHash <$> arbitrary
 
 ------------------------------------------------------------------------------------------
 -- Cardano.Ledger.Keys -------------------------------------------------------------------

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
@@ -16,7 +16,6 @@ module Test.Cardano.Ledger.TreeDiff (
 ) where
 
 import Cardano.Ledger.Address
-import Cardano.Ledger.AuxiliaryData
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.CertState
 import Cardano.Ledger.Coin
@@ -155,7 +154,7 @@ instance ToExpr a => ToExpr (Mismatch r a)
 instance ToExpr EpochInterval
 
 -- AuxiliaryData
-instance ToExpr AuxiliaryDataHash
+instance ToExpr TxAuxDataHash
 
 -- Plutus/ExUnits
 instance ToExpr Prices

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Classes.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Classes.hs
@@ -15,7 +15,6 @@ module Test.Cardano.Ledger.Constrained.Classes where
 
 import Cardano.Ledger.Alonzo.Scripts (AsIx, AsIxItem, PlutusPurpose)
 import Cardano.Ledger.Alonzo.TxOut (AlonzoTxOut (..))
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
 import Cardano.Ledger.Babbage.TxOut (BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes (EpochNo (..), ProtVer (..), SlotNo (..))
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
@@ -496,7 +495,7 @@ instance Count SlotNo where
 data TxAuxDataF era where
   TxAuxDataF :: Proof era -> TxAuxData era -> TxAuxDataF era
 
-hashTxAuxDataF :: Reflect era => TxAuxDataF era -> AuxiliaryDataHash
+hashTxAuxDataF :: Reflect era => TxAuxDataF era -> TxAuxDataHash
 hashTxAuxDataF (TxAuxDataF _ x) = hashTxAuxData x
 
 unTxAuxData :: TxAuxDataF era -> TxAuxData era

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -79,7 +79,7 @@ import Cardano.Ledger.Allegra.Scripts
 import Cardano.Ledger.Allegra.TxAuxData (AllegraTxAuxData (..))
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..))
 import Cardano.Ledger.Alonzo.Tx
-import Cardano.Ledger.Alonzo.TxAuxData (AlonzoTxAuxData (..), AuxiliaryDataHash)
+import Cardano.Ledger.Alonzo.TxAuxData (AlonzoTxAuxData (..))
 import Cardano.Ledger.Alonzo.TxOut
 import Cardano.Ledger.Alonzo.TxWits
 import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
@@ -204,7 +204,7 @@ type ConwayTxBodyTypes =
    , Set (KeyHash 'Witness)
    , MultiAsset
    , StrictMaybe ScriptIntegrityHash
-   , StrictMaybe AuxiliaryDataHash
+   , StrictMaybe TxAuxDataHash
    , StrictMaybe Network
    , VotingProcedures ConwayEra
    , SOS.OSet (ProposalProcedure ConwayEra)
@@ -815,8 +815,8 @@ instance IsConwayUniv fn => HasSpec fn AssetName
 instance HasSimpleRep PolicyID
 instance IsConwayUniv fn => HasSpec fn PolicyID
 
-instance HasSimpleRep AuxiliaryDataHash
-instance IsConwayUniv fn => HasSpec fn AuxiliaryDataHash
+instance HasSimpleRep TxAuxDataHash
+instance IsConwayUniv fn => HasSpec fn TxAuxDataHash
 
 instance HasSimpleRep (VotingProcedures era)
 instance (IsConwayUniv fn, Typeable era) => HasSpec fn (VotingProcedures era)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/TxBody.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/TxBody.hs
@@ -15,7 +15,6 @@ module Test.Cardano.Ledger.Constrained.Conway.Instances.TxBody where
 import Cardano.Ledger.Address (RewardAccount (..))
 import Cardano.Ledger.Allegra.TxBody (AllegraTxBody (..))
 import Cardano.Ledger.Alonzo.TxBody (AlonzoTxBody (..))
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..))
 import Cardano.Ledger.BaseTypes hiding (inject)
 import Cardano.Ledger.Binary (EncCBOR (..), Sized (..))
@@ -54,7 +53,7 @@ type ShelleyTxBodyTypes era =
    , Coin
    , SlotNo
    , Maybe (Update era)
-   , Maybe AuxiliaryDataHash
+   , Maybe TxAuxDataHash
    ]
 
 instance
@@ -123,7 +122,7 @@ type AllegraTxBodyTypes era =
    , Coin
    , ValidityInterval
    , Maybe (Update era)
-   , Maybe AuxiliaryDataHash
+   , Maybe TxAuxDataHash
    ]
 
 instance
@@ -192,7 +191,7 @@ type MaryTxBodyTypes era =
    , Coin
    , ValidityInterval
    , Maybe (Update era)
-   , Maybe AuxiliaryDataHash
+   , Maybe TxAuxDataHash
    , MultiAsset
    ]
 
@@ -269,7 +268,7 @@ type AlonzoTxBodyTypes era =
    , Set (KeyHash 'Witness)
    , MultiAsset
    , Maybe ScriptIntegrityHash
-   , Maybe AuxiliaryDataHash
+   , Maybe TxAuxDataHash
    , Maybe Network
    ]
 
@@ -363,7 +362,7 @@ type BabbageTxBodyTypes era =
    , Set (KeyHash 'Witness)
    , MultiAsset
    , Maybe ScriptIntegrityHash
-   , Maybe AuxiliaryDataHash
+   , Maybe TxAuxDataHash
    , Maybe Network
    ]
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
@@ -50,7 +50,6 @@ import Cardano.Ledger.Address (Addr (..), RewardAccount (..))
 import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
 import Cardano.Ledger.Alonzo.Tx (IsValid (..))
 import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded (..))
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
 import Cardano.Ledger.BaseTypes (
   EpochInterval (..),
   EpochNo (..),
@@ -324,7 +323,7 @@ data Rep era t where
   PayHashR :: Era era => Rep era (KeyHash 'Payment)
   TxR :: Era era => Proof era -> Rep era (TxF era)
   ScriptIntegrityHashR :: Era era => Rep era (SafeHash EraIndependentScriptIntegrity)
-  AuxiliaryDataHashR :: Era era => Rep era AuxiliaryDataHash
+  TxAuxDataHashR :: Era era => Rep era TxAuxDataHash
   GovActionR :: Era era => Rep era (GovAction era)
   WitVKeyR :: Era era => Proof era -> Rep era (WitVKey 'Witness)
   TxAuxDataR :: Era era => Proof era -> Rep era (TxAuxDataF era)
@@ -415,7 +414,7 @@ repHasInstances r = case r of
   LedgerStateR {} -> IsTypeable
   TxR {} -> IsEq
   ScriptIntegrityHashR {} -> IsOrd
-  AuxiliaryDataHashR {} -> IsOrd
+  TxAuxDataHashR {} -> IsOrd
   BootstrapWitnessR {} -> IsOrd
   SigningKeyR {} -> IsEq
   TxWitsR {} -> IsEq
@@ -661,7 +660,7 @@ synopsis (TxWitsR p) (TxWitsF _ x) = show ((unReflect pcWitnesses p x) :: PDoc)
 synopsis PayHashR k = "(KeyHash 'Payment " ++ show (keyHashSummary k) ++ ")"
 synopsis (TxR p) x = show (pcTx p (unTxF x))
 synopsis ScriptIntegrityHashR x = show (trim (ppHash (extractHash x)))
-synopsis AuxiliaryDataHashR (AuxiliaryDataHash x) = show (trim (ppHash (extractHash x)))
+synopsis TxAuxDataHashR (TxAuxDataHash x) = show (trim (ppHash (extractHash x)))
 synopsis GovActionR x = show (pcGovAction x)
 synopsis (WitVKeyR p) x = show ((unReflect pcWitVKey p x) :: PDoc)
 synopsis (TxAuxDataR _) x = show x
@@ -872,7 +871,7 @@ genSizedRep _ (TxR p) =
     Babbage -> TxF p <$> arbitrary
     Conway -> TxF p <$> arbitrary
 genSizedRep _ ScriptIntegrityHashR = arbitrary
-genSizedRep _ AuxiliaryDataHashR = arbitrary
+genSizedRep _ TxAuxDataHashR = arbitrary
 genSizedRep _ GovActionR = NoConfidence <$> arbitrary
 genSizedRep _ (WitVKeyR _) = arbitrary
 genSizedRep _ (TxAuxDataR p) = genTxAuxDataF p
@@ -1093,7 +1092,7 @@ shrinkRep (TxWitsR _p) _ = []
 shrinkRep PayHashR t = shrink t
 shrinkRep (TxR _) _ = []
 shrinkRep ScriptIntegrityHashR x = shrink x
-shrinkRep AuxiliaryDataHashR x = shrink x
+shrinkRep TxAuxDataHashR x = shrink x
 shrinkRep GovActionR _ = []
 shrinkRep (WitVKeyR _) x = shrink x
 shrinkRep (TxAuxDataR _) _ = []

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
@@ -16,7 +16,6 @@ import Cardano.Ledger.Alonzo.PParams (AlonzoEraPParams, ppCollateralPercentageL,
 import Cardano.Ledger.Alonzo.Tx (IsValid (..), ScriptIntegrityHash)
 import Cardano.Ledger.Alonzo.TxWits (TxDats (..))
 import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded (..))
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash)
 import Cardano.Ledger.BaseTypes (
   BlocksMade (..),
   EpochNo,
@@ -64,7 +63,13 @@ import Cardano.Ledger.Core (
 import Cardano.Ledger.Credential (Credential, Ptr)
 import Cardano.Ledger.DRep (DRep (..), DRepState (..))
 import Cardano.Ledger.EpochBoundary (SnapShot (..), SnapShots (..), Stake (..))
-import Cardano.Ledger.Hashes (DataHash, EraIndependentScriptIntegrity, SafeHash, ScriptHash (..))
+import Cardano.Ledger.Hashes (
+  DataHash,
+  EraIndependentScriptIntegrity,
+  SafeHash,
+  ScriptHash (..),
+  TxAuxDataHash (..),
+ )
 import Cardano.Ledger.Keys (GenDelegPair, GenDelegs (..), KeyHash, KeyRole (..))
 import Cardano.Ledger.Keys.Bootstrap (BootstrapWitness)
 import Cardano.Ledger.Keys.WitVKey (WitVKey (..))
@@ -1338,8 +1343,8 @@ reqSignerHashes = Var $ V "reqSignerHashes" (SetR WitHashR) No
 networkID :: Era era => Term era (Maybe Network)
 networkID = Var $ V "networkID" (MaybeR NetworkR) No
 
-adHash :: Era era => Term era (Maybe AuxiliaryDataHash)
-adHash = Var $ V "adHash" (MaybeR AuxiliaryDataHashR) No
+adHash :: Era era => Term era (Maybe TxAuxDataHash)
+adHash = Var $ V "adHash" (MaybeR TxAuxDataHashR) No
 
 wppHash :: Era era => Term era (Maybe (SafeHash EraIndependentScriptIntegrity))
 wppHash = Var $ V "wppHash" (MaybeR ScriptIntegrityHashR) No

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/EraClass.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/EraClass.hs
@@ -48,7 +48,7 @@ module Test.Cardano.Ledger.EraClass (
   EraTxWits (TxWits, mkBasicTxWits, addrTxWitsL, bootAddrTxWitsL, scriptTxWitsL),
   AlonzoEraTxWits (datsTxWitsL, rdmrsTxWitsL),
   -- TxAuxData
-  EraTxAuxData (TxAuxData, hashTxAuxData, validateTxAuxData),
+  EraTxAuxData (TxAuxData, validateTxAuxData),
   -- TxCerts
   EraTxCert (
     TxCert,

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
@@ -48,7 +48,6 @@ import Cardano.Ledger.Allegra.TxBody (AllegraTxBody (..))
 import Cardano.Ledger.Alonzo.PParams (AlonzoPParams (..), unOrdExUnits)
 import Cardano.Ledger.Alonzo.Scripts (CostModels, ExUnits (..), Prices)
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), IsValid (..))
-import Cardano.Ledger.Alonzo.TxAuxData (AuxiliaryDataHash)
 import Cardano.Ledger.Alonzo.TxBody (AlonzoTxBody (..), AlonzoTxOut (..))
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), Redeemers (..), TxDats (..))
 import Cardano.Ledger.Babbage.PParams (BabbagePParams (..))
@@ -134,7 +133,7 @@ data TxBodyField era
   | ReqSignerHashes (Set (KeyHash 'Witness))
   | Mint MultiAsset
   | WppHash (StrictMaybe ScriptIntegrityHash)
-  | AdHash (StrictMaybe AuxiliaryDataHash)
+  | AdHash (StrictMaybe TxAuxDataHash)
   | Txnetworkid (StrictMaybe Network)
   | ProposalProc (OSet.OSet (ProposalProcedure era))
   | VotingProc (VotingProcedures era)
@@ -159,7 +158,7 @@ pattern ReqSignerHashes' :: [KeyHash 'Witness] -> TxBodyField era -- A set
 
 pattern WppHash' :: [ScriptIntegrityHash] -> TxBodyField era -- 0 or 1 element
 
-pattern AdHash' :: [AuxiliaryDataHash] -> TxBodyField era -- 0 or 1 element
+pattern AdHash' :: [TxAuxDataHash] -> TxBodyField era -- 0 or 1 element
 
 pattern Txnetworkid' :: [Network] -> TxBodyField era -- 0 or 1 element
 
@@ -589,7 +588,7 @@ pattern Txnetworkid' x <-
   where
     Txnetworkid' x = Txnetworkid (toStrictMaybe x)
 
-adhashview :: TxBodyField era -> Maybe [AuxiliaryDataHash]
+adhashview :: TxBodyField era -> Maybe [TxAuxDataHash]
 adhashview (AdHash x) = Just (fromStrictMaybe x)
 adhashview _ = Nothing
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -64,7 +64,6 @@ import Cardano.Ledger.Alonzo.TxAuxData (
 import Cardano.Ledger.Alonzo.TxBody (AlonzoTxBody (..), AlonzoTxOut (..))
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), TxDats (..), unRedeemers, unTxDats)
 import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded (..))
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
 import Cardano.Ledger.Babbage.Core (CoinPerByte (..))
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure (..), BabbageUtxowPredFailure (..))
 import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
@@ -678,11 +677,11 @@ ppValidityInterval (ValidityInterval b a) =
 instance PrettyA ValidityInterval where
   prettyA = ppValidityInterval
 
-ppAuxiliaryDataHash :: AuxiliaryDataHash -> PDoc
-ppAuxiliaryDataHash (AuxiliaryDataHash h) = ppSexp "AuxiliaryDataHash" [ppSafeHash h]
+ppTxAuxDataHash :: TxAuxDataHash -> PDoc
+ppTxAuxDataHash (TxAuxDataHash h) = ppSexp "TxAuxDataHash" [ppSafeHash h]
 
-instance PrettyA AuxiliaryDataHash where
-  prettyA = ppAuxiliaryDataHash
+instance PrettyA TxAuxDataHash where
+  prettyA = ppTxAuxDataHash
 
 ppSafeHash :: SafeHash index -> PDoc
 ppSafeHash x = ppHash (extractHash x)
@@ -929,7 +928,7 @@ ppShelleyTxBody (TxBodyConstr (Memo (ShelleyTxBodyRaw ins outs cs withdrawals fe
     , ("fee", pcCoin fee)
     , ("timetolive", pcSlotNo ttl)
     , ("update", ppStrictMaybe ppUpdate upd)
-    , ("metadatahash", ppStrictMaybe ppAuxiliaryDataHash mdh)
+    , ("metadatahash", ppStrictMaybe ppTxAuxDataHash mdh)
     ]
 
 instance
@@ -1079,7 +1078,7 @@ pcTxBodyField proof x = case x of
   WppHash SNothing -> []
   WppHash (SJust h) -> [("integrity hash", trim (ppSafeHash h))]
   AdHash SNothing -> []
-  AdHash (SJust (AuxiliaryDataHash h)) -> [("aux data hash", trim (ppSafeHash h))]
+  AdHash (SJust (TxAuxDataHash h)) -> [("aux data hash", trim (ppSafeHash h))]
   Txnetworkid SNothing -> [("network id", ppString "Nothing")]
   Txnetworkid (SJust nid) -> [("network id", pcNetwork nid)]
   ProposalProc props -> [("proposing procedure", ppList pcProposalProcedure (toList props))]
@@ -1544,15 +1543,15 @@ ppConwayUtxowPredFailure proof = \case
   ConwayRules.ScriptWitnessNotValidatingUTXOW m ->
     ppSexp "ScriptWitnessNotValidatingUTXOW" [ppSet pcScriptHash m]
   ConwayRules.MissingTxBodyMetadataHash m ->
-    ppSexp " MissingTxMetadata" [ppAuxiliaryDataHash m]
+    ppSexp " MissingTxMetadata" [ppTxAuxDataHash m]
   ConwayRules.MissingTxMetadata m ->
-    ppSexp " MissingTxMetadata" [ppAuxiliaryDataHash m]
+    ppSexp " MissingTxMetadata" [ppTxAuxDataHash m]
   ConwayRules.ConflictingMetadataHash mm@(Mismatch _ _) ->
     let Mismatch {..} = mm
      in ppRecord
           "ConflictingMetadataHash"
-          [ ("Hash in the body", ppAuxiliaryDataHash mismatchSupplied)
-          , ("Hash of full metadata", ppAuxiliaryDataHash mismatchExpected)
+          [ ("Hash in the body", ppTxAuxDataHash mismatchSupplied)
+          , ("Hash of full metadata", ppTxAuxDataHash mismatchExpected)
           ]
   ConwayRules.InvalidMetadata ->
     ppSexp "InvalidMetadata" []
@@ -1787,14 +1786,14 @@ ppShelleyUtxowPredFailure (Shelley.UtxoFailure m) = ppSexp "UtxoFailure" [ppUTXO
 ppShelleyUtxowPredFailure (MIRInsufficientGenesisSigsUTXOW m) =
   ppSexp "MIRInsufficientGenesisSigsUTXOW" [ppSet pcKeyHash m]
 ppShelleyUtxowPredFailure (MissingTxBodyMetadataHash m) =
-  ppSexp " MissingTxMetadata" [ppAuxiliaryDataHash m]
+  ppSexp " MissingTxMetadata" [ppTxAuxDataHash m]
 ppShelleyUtxowPredFailure (MissingTxMetadata m) =
-  ppSexp " MissingTxMetadata" [ppAuxiliaryDataHash m]
+  ppSexp " MissingTxMetadata" [ppTxAuxDataHash m]
 ppShelleyUtxowPredFailure (ConflictingMetadataHash (Mismatch supplied expected)) =
   ppRecord
     "ConflictingMetadataHash"
-    [ ("Hash in the body", ppAuxiliaryDataHash supplied)
-    , ("Hash of full metadata", ppAuxiliaryDataHash expected)
+    [ ("Hash in the body", ppTxAuxDataHash supplied)
+    , ("Hash of full metadata", ppTxAuxDataHash expected)
     ]
 ppShelleyUtxowPredFailure InvalidMetadata =
   ppSexp "InvalidMetadata" []

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Same.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Same.hs
@@ -21,7 +21,6 @@ import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..))
 import Cardano.Ledger.Alonzo.TxBody (AlonzoTxBody (..))
 import Cardano.Ledger.Alonzo.TxSeq (AlonzoTxSeq (..))
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), Redeemers (..), TxDats (..))
-import Cardano.Ledger.AuxiliaryData (AuxiliaryDataHash (..))
 import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..))
 import Cardano.Ledger.Binary (sizedValue)
 import Cardano.Ledger.Block (Block (..))
@@ -404,7 +403,7 @@ sameShelleyTxBody proof (ShelleyTxBody i1 o1 c1 (Withdrawals w1) f1 s1 pu1 d1) (
   , ("Fee", eqVia pcCoin f1 f2)
   , ("TimeToLive", eqVia pcSlotNo s1 s2)
   , ("PPupdate", eqVia (\_ -> ppString "Update") pu1 pu2)
-  , ("AuxDataHash", eqVia (ppStrictMaybe (\(AuxiliaryDataHash h) -> trim (ppSafeHash h))) d1 d2)
+  , ("TxAuxDataHash", eqVia (ppStrictMaybe (\(TxAuxDataHash h) -> trim (ppSafeHash h))) d1 d2)
   ]
 
 sameAllegraTxBody ::
@@ -421,7 +420,7 @@ sameAllegraTxBody proof (AllegraTxBody i1 o1 c1 (Withdrawals w1) f1 v1 pu1 d1) (
   , ("Fee", eqVia pcCoin f1 f2)
   , ("ValidityInterval", eqVia ppValidityInterval v1 v2)
   , ("PPupdate", eqVia (\_ -> ppString "Update") pu1 pu2)
-  , ("AuxDataHash", eqVia (ppStrictMaybe (\(AuxiliaryDataHash h) -> trim (ppSafeHash h))) d1 d2)
+  , ("TxAuxDataHash", eqVia (ppStrictMaybe (\(TxAuxDataHash h) -> trim (ppSafeHash h))) d1 d2)
   ]
 
 sameMaryTxBody ::
@@ -438,7 +437,7 @@ sameMaryTxBody proof (MaryTxBody i1 o1 c1 (Withdrawals w1) f1 v1 pu1 d1 m1) (Mar
   , ("Fee", eqVia pcCoin f1 f2)
   , ("ValidityInterval", eqVia ppValidityInterval v1 v2)
   , ("PPupdate", eqVia (\_ -> ppString "Update") pu1 pu2)
-  , ("AuxDataHash", eqVia (ppStrictMaybe (\(AuxiliaryDataHash h) -> trim (ppSafeHash h))) d1 d2)
+  , ("TxAuxDataHash", eqVia (ppStrictMaybe (\(TxAuxDataHash h) -> trim (ppSafeHash h))) d1 d2)
   , ("Mint", eqVia multiAssetSummary m1 m2)
   ]
 
@@ -463,7 +462,7 @@ sameAlonzoTxBody
     , ("ReqSignerHashes", eqVia (ppSet pcKeyHash) r1 r2)
     , ("Mint", eqVia multiAssetSummary m1 m2)
     , ("ScriptIntegrityHash", eqVia (ppStrictMaybe (trim . ppSafeHash)) s1 s2)
-    , ("AuxDataHash", eqVia (ppStrictMaybe (\(AuxiliaryDataHash h) -> trim (ppSafeHash h))) d1 d2)
+    , ("TxAuxDataHash", eqVia (ppStrictMaybe (\(TxAuxDataHash h) -> trim (ppSafeHash h))) d1 d2)
     , ("NetworkId", eqVia (ppStrictMaybe pcNetwork) n1 n2)
     ]
 
@@ -493,7 +492,7 @@ sameBabbageTxBody
     , ("ReqSignerHashes", eqVia (ppSet pcKeyHash) r1 r2)
     , ("Mint", eqVia multiAssetSummary m1 m2)
     , ("ScriptIntegrityHash", eqVia (ppStrictMaybe (trim . ppSafeHash)) s1 s2)
-    , ("AuxDataHash", eqVia (ppStrictMaybe (\(AuxiliaryDataHash h) -> trim (ppSafeHash h))) d1 d2)
+    , ("TxAuxDataHash", eqVia (ppStrictMaybe (\(TxAuxDataHash h) -> trim (ppSafeHash h))) d1 d2)
     , ("NetworkId", eqVia (ppStrictMaybe pcNetwork) n1 n2)
     ]
 
@@ -522,7 +521,7 @@ sameConwayTxBody
     , ("ReqSignerHashes", eqVia (ppSet pcKeyHash) r1 r2)
     , ("Mint", eqVia multiAssetSummary m1 m2)
     , ("ScriptIntegrityHash", eqVia (ppStrictMaybe (trim . ppSafeHash)) s1 s2)
-    , ("AuxDataHash", eqVia (ppStrictMaybe (\(AuxiliaryDataHash h) -> trim (ppSafeHash h))) d1 d2)
+    , ("TxAuxDataHash", eqVia (ppStrictMaybe (\(TxAuxDataHash h) -> trim (ppSafeHash h))) d1 d2)
     , ("NetworkId", eqVia (ppStrictMaybe pcNetwork) n1 n2)
     ,
       ( "VotingProcedures"


### PR DESCRIPTION
# Description

This is PR adds `TxAuxDataHash` and deprecates `AauxiliaryDataHash` in its favor, because it does not follow the naming convention that we use for the rest for the types

Besides that a couple of other cleanup actions:
* Extract `hashTxAuxData` into a standalone function, since all current eras have and future eras will have the same imlpementation.
* Extract `indexProxy` out of `HashAnnotated` type class and deprecate it as useless.

# Checklist

- [x] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [x] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
