### PR TITLE
Integration of MemPack

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -87,7 +87,7 @@ jobs:
       uses: input-output-hk/actions/haskell@latest
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: 3.12.1.0
+        cabal-version: 3.14
 
     - name: Configure to use libsodium
       run: |
@@ -266,7 +266,7 @@ jobs:
       uses: input-output-hk/actions/haskell@latest
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: 3.12.1.0
+        cabal-version: 3.14
 
     - name: Set up Ruby 2.7
       if: contains(fromJson(env.packages-with-ruby-cddl-tests), matrix.package)
@@ -432,7 +432,7 @@ jobs:
       uses: input-output-hk/actions/haskell@latest
       with:
         ghc-version: 9.10.1
-        cabal-version: 3.12.1.0
+        cabal-version: 3.14
 
     - name: Install gen-hie if not cached
       if: steps.cache-gen-hie.outputs.cache-hit != 'true'

--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.7.0.0
 
+* Add `MemPack` instance for `Timelock`
 * Remove deprecated `AuxiliaryData` type synonym
 * Deprecate `Allegra` type synonym
 * Remove crypto parametrization from `AllegraEra`

--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -74,6 +74,7 @@ library
     cborg,
     containers,
     deepseq,
+    mempack,
     microlens,
     nothunks,
     small-steps >=1.1,

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Scripts.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Scripts.hs
@@ -87,6 +87,7 @@ import Cardano.Ledger.Shelley.Scripts (
   pattern RequireMOf,
   pattern RequireSignature,
  )
+import Data.MemPack
 
 import Cardano.Slotting.Slot (SlotNo (..))
 import Control.DeepSeq (NFData (..))
@@ -209,7 +210,7 @@ instance Era era => DecCBOR (Annotator (TimelockRaw era)) where
 
 newtype Timelock era = TimelockConstr (MemoBytes TimelockRaw era)
   deriving (Eq, Generic)
-  deriving newtype (ToCBOR, NoThunks, NFData, SafeToHash)
+  deriving newtype (ToCBOR, NoThunks, NFData, SafeToHash, MemPack)
 
 instance Era era => EncCBOR (Timelock era)
 

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.0.0
 
+* Add `MemPack` instance for `Addr28Extra`, `DataHash32`, `AlonzoTxOut` and `PlutusScript AlonzoEra`
 * Deprecate `hashAlonzoTxAuxData`
 * Stop re-exporting deprecated `AuxiliaryDataHash` from `Cardano.Ledger.Alonzo.TxAuxData`
 * Deprecate `Alonzo` type synonym

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -89,6 +89,7 @@ library
     containers,
     data-default,
     deepseq,
+    mempack,
     microlens,
     mtl,
     nothunks,

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.11.0.0
 
+* Add `MemPack` instance for `BabbageTxOut` and `PlutusScript BabbageEra`
 * Deprecate `Babbage` type synonym
 * Remove crypto parametrization from `BabbageEra`
 

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -84,6 +84,7 @@ library
     cardano-strict-containers,
     containers,
     deepseq,
+    mempack,
     microlens,
     nothunks,
     plutus-ledger-api >=1.33,

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -6,6 +6,10 @@
 * Deprecate `Conway` type synonym
 * Remove crypto parametrization from `ConwayEra`
 
+### `testlib`
+
+* Add `Arbitrary` instance for `ConwayBbodyPredFailure` and `ConwayMempoolPredFailure`
+
 ## 1.18.0.0
 
 * Remove `SlotNo` from `CertEnv` and `CertsEnv`

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Add `MemPack` instance for `PlutusScript ConwayEra`
 * Deprecate `Conway` type synonym
 * Remove crypto parametrization from `ConwayEra`
 

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -103,6 +103,7 @@ library
     containers,
     data-default,
     deepseq,
+    mempack,
     microlens,
     nothunks,
     plutus-ledger-api >=1.37,

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -219,6 +219,17 @@ instance
   shrink = genericShrink
 
 instance
+  ( Era era
+  , Arbitrary (PredicateFailure (EraRule "LEDGERS" era))
+  ) =>
+  Arbitrary (ConwayBbodyPredFailure era)
+  where
+  arbitrary = genericArbitraryU
+
+instance Arbitrary (ConwayMempoolPredFailure era) where
+  arbitrary = genericArbitraryU
+
+instance
   ( EraTxOut era
   , Arbitrary (Value era)
   , Arbitrary (TxOut era)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/RoundTrip.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/RoundTrip.hs
@@ -76,15 +76,17 @@ roundTripConwayEraTypesSpec = do
 instance RuleListEra ConwayEra where
   type
     EraRules ConwayEra =
-      '[ "GOV"
-       , "UTXOS"
-       , "LEDGER"
-       , "CERTS"
+      '[ "BBODY"
        , "CERT"
+       , "CERTS"
        , "DELEG"
        , "GOVCERT"
-       , "UTXOW"
-       , "UTXO"
+       , "GOV"
+       , "LEDGER"
        , "LEDGERS"
+       , "MEMPOOL"
        , "POOL"
+       , "UTXO"
+       , "UTXOS"
+       , "UTXOW"
        ]

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.8.0.0
 
+* Add `MemPack` instance for `CompactValue` and `CompactForm MaryValue`
 * Deprecate `Mary` type synonym
 * Remove crypto parametrization from `MaryEra`
 

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -83,6 +83,7 @@ library
     containers,
     deepseq,
     groups,
+    mempack,
     microlens,
     nothunks,
     primitive,

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Add `MemPack` instance `ShelleyTxOut`
 * Deprecate `hashShelleyTxAuxData`
 * Stop re-exporting `ScriptHash` from `Cardano.Ledger.Shelley.Scripts`. Import it instead from `Cardano.Ledger.Hashes`.
 * Deprecate `Shelley` type synonym

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -111,6 +111,7 @@ library
     deepseq,
     groups,
     heapwords,
+    mempack,
     microlens,
     mtl,
     nothunks,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
@@ -38,6 +38,8 @@ import Cardano.Ledger.Binary (
   decodeRecordNamed,
   decodeRecordNamedT,
   encodeListLen,
+  encodeMap,
+  encodeMemPack,
   enforceDecoderVersion,
   ifDecoderVersionAtLeast,
   natVersion,
@@ -316,10 +318,12 @@ instance
   ) =>
   EncCBOR (UTxOState era)
   where
-  encCBOR (UTxOState ut dp fs us sd don) =
+  encCBOR (UTxOState utxo dp fs us sd don) =
     encode $
       Rec UTxOState
-        !> To ut
+        -- We need to define encoder with MemPack manually here instead of changing the `EncCBOR`
+        -- instance for `UTxO` in order to not affect some of the ledger state queries.
+        !> E (encodeMap encodeMemPack encodeMemPack . unUTxO) utxo
         !> To dp
         !> To fs
         !> To us

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
@@ -1102,23 +1102,23 @@ tests =
             mconcat
               [ "8700a1581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825410aa158"
               , "1ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a03848219271019"
-              , "03e8828383a0a00084a0a0a0a08482a0a0a0a084a0a0000086a1825820ee155ace9c4029"
-              , "2074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e250082583900cb9358529df4"
-              , "729c3246a2a033cb9821abbfd16de4888005904abc410d6a577e9441ad8ed9663931906e"
-              , "4d43ece8f82c712b1d0235affb060a1903e80185a0a092000000190800000000001864d8"
-              , "1e820001d81e820001d81e820001d81e8200018100020001009200000019080000000000"
-              , "1864d81e820001d81e820001d81e820001d81e820001810002000000810082a0a0008483"
-              , "a0a0a083a0a0a083a0a0a00082a000818300880082020082a000000000a0a0840185a080"
-              , "00820200a0a082a0a082a1581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b"
-              , "047b08254183820101015820c5e21ab1c9f6022d81c3b25e3436cb7f1df77f9652ae3e13"
-              , "10c28e621dd87b4c01a0"
+              , "03e8828383a0a00084a0a0a0a08482a0a0a0a084a0a0000086a15822ee155ace9c402920"
+              , "74cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e250000583d003900cb9358529d"
+              , "f4729c3246a2a033cb9821abbfd16de4888005904abc410d6a577e9441ad8ed966393190"
+              , "6e4d43ece8f82c712b1d0235affb06000a1903e80185a0a0920000001908000000000018"
+              , "64d81e820001d81e820001d81e820001d81e820001810002000100920000001908000000"
+              , "00001864d81e820001d81e820001d81e820001d81e820001810002000000810082a0a000"
+              , "8483a0a0a083a0a0a083a0a0a00082a000818300880082020082a000000000a0a0840185"
+              , "a08000820200a0a082a0a082a1581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006"
+              , "805b047b08254183820101015820c5e21ab1c9f6022d81c3b25e3436cb7f1df77f9652ae"
+              , "3e1310c28e621dd87b4c01a0"
               ]
        in testCase "ledger state golden test" $
             unless (actual == expected) $
               assertFailure . ansiDocToString $
                 Pretty.vsep
                   [ "Expected: " <> Pretty.viaShow expectedHex
-                  , "Actual: " <> Pretty.viaShow actualHex
+                  , "Actual:   " <> Pretty.viaShow actualHex
                   , "Difference:"
                   , Pretty.indent 2 $ diffExpr (CBORBytes expected) (CBORBytes actual)
                   ]

--- a/flake.nix
+++ b/flake.nix
@@ -105,7 +105,7 @@
             # tools we want in our shell, from hackage
             tools =
               {
-                cabal = "3.12.1.0";
+                cabal = "3.14.1.0";
                 ghcid = "0.8.9";
               }
               // lib.optionalAttrs (config.compiler-nix-name == defaultCompiler) {

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.6.0.0
 
+* Add `encodeMemPack` and `decodeMemPack` helper functions.
 * Remove `encodeSignKeyKES` and `decodeSignKeyKES`
 * Remove `EncCBOR` and `DecCBOR` instances for `SignKeyKES`
 

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -66,6 +66,7 @@ library
     deepseq,
     formatting,
     iproute,
+    mempack,
     microlens,
     mtl,
     network,

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding.hs
@@ -36,6 +36,7 @@ module Cardano.Ledger.Binary.Decoding (
 
   -- * Helpers
   toStrictByteString,
+  decodeMemPack,
 )
 where
 
@@ -56,6 +57,7 @@ import Data.Bifunctor (bimap)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy.Internal as BSL
+import Data.MemPack
 import Data.Proxy (Proxy (Proxy))
 import Data.Text (Text)
 
@@ -268,3 +270,7 @@ decodeNestedCborBytes = decodeNestedCborTag >> decodeBytes
 -- Decode the bytes to get an @('Annotator' f)@ where f is a function that when given
 -- original bytes produces a value of type @t@, then apply @f@ to @('Full' bytes)@ to get
 -- the answer.
+
+-- | First decode as CBOR bytes and then use MemPack unpacker on it
+decodeMemPack :: MemPack a => Decoder s a
+decodeMemPack = unpackMonadFail . unBA =<< decodeByteArray

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs
@@ -53,7 +53,6 @@ import Cardano.Slotting.Slot (
   WithOrigin (..),
  )
 import Cardano.Slotting.Time (SystemStart (..))
-import Codec.CBOR.ByteArray (ByteArray (..))
 import Codec.CBOR.ByteArray.Sliced (SlicedByteArray, fromByteArray)
 import Codec.CBOR.Term (Term (..))
 import Codec.Serialise as Serialise (Serialise (decode))

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
@@ -20,6 +20,7 @@ module Cardano.Ledger.Binary.Decoding.Decoder (
   getOriginalBytes,
   DecoderError (..),
   C.ByteOffset,
+  ByteArray (..),
   C.DecodeAction (..),
   C.TokenType (..),
 
@@ -171,7 +172,7 @@ import Cardano.Ledger.Binary.Plain (
  )
 import Cardano.Ledger.Binary.Version (Version, mkVersion64, natVersion)
 import Cardano.Slotting.Slot (WithOrigin, withOriginFromMaybe)
-import Codec.CBOR.ByteArray (ByteArray)
+import Codec.CBOR.ByteArray (ByteArray (..))
 import qualified Codec.CBOR.Decoding as C (
   ByteOffset,
   DecodeAction (..),

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding.hs
@@ -24,6 +24,7 @@ module Cardano.Ledger.Binary.Encoding (
 
   -- * Tools
   runByteBuilder,
+  encodeMemPack,
 )
 where
 
@@ -31,10 +32,12 @@ import qualified Cardano.Crypto.Hash.Class as C
 import Cardano.Ledger.Binary.Encoding.EncCBOR
 import Cardano.Ledger.Binary.Encoding.Encoder
 import Cardano.Ledger.Binary.Version
+import Codec.CBOR.ByteArray.Sliced (fromByteArray)
 import qualified Data.ByteString as BS
 import Data.ByteString.Builder (Builder)
 import Data.ByteString.Builder.Extra (safeStrategy, toLazyByteStringWith)
 import qualified Data.ByteString.Lazy as BSL
+import qualified Data.MemPack as MP
 
 -- | Serialize a Haskell value with a 'EncCBOR' instance to an external binary
 --   representation.
@@ -110,3 +113,7 @@ runByteBuilder :: Int -> Builder -> BS.ByteString
 runByteBuilder !sizeHint =
   BSL.toStrict . toLazyByteStringWith (safeStrategy sizeHint (2 * sizeHint)) mempty
 {-# NOINLINE runByteBuilder #-}
+
+-- | Encode as bytes using `MP.MemPack` and then encode those bytes as CBOR
+encodeMemPack :: MP.MemPack a => a -> Encoding
+encodeMemPack = encodeByteArray . fromByteArray . MP.pack

--- a/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/RoundTripSpec.hs
+++ b/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/RoundTripSpec.hs
@@ -49,7 +49,6 @@ import Cardano.Ledger.Binary
 import Cardano.Slotting.Block (BlockNo)
 import Cardano.Slotting.Slot (EpochNo, EpochSize, SlotNo, WithOrigin)
 import Cardano.Slotting.Time (SystemStart)
-import Codec.CBOR.ByteArray (ByteArray (..))
 import Codec.CBOR.ByteArray.Sliced (SlicedByteArray (..))
 import Control.Monad (when)
 import Data.Fixed (Nano, Pico)

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.17.0.0
 
+* Require `MemPack` instance for `TxOut` and `CompactForm (Value era)` for `EraTxOut` type class.
+* Add `decodeMemoBytes`
+* Add `MemPack` instance for `CompactAddr`, `TxIx`, `TxId`, `TxIn`, `CompactForm Coin`,
+  `KeyHash`, `ScriptHash`, `Credential`, `SafeHash`, `MemoBytes`, `Plutus`, `PlutusBinary`, `BinaryData` and `Datum`
+* Add `DecShareCBOR` instance for `TxIn`
 * Add `fromCborRigorousBothAddr`
 * Add `SlotNo32` and use it in `Ptr` definition
 * Add `mkPtrNormalized`

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -114,6 +114,7 @@ library
     heapwords,
     iproute,
     measures,
+    mempack,
     microlens,
     mtl,
     non-integral >=1.0,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
@@ -93,8 +93,8 @@ import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Cardano.Prelude (unsafeShortByteStringIndex)
 import Control.DeepSeq (NFData)
 import Control.Monad (guard, unless, when)
-import Control.Monad.Trans.Fail (runFail)
-import Control.Monad.Trans.State.Strict (StateT, evalStateT, get, modify', state)
+import Control.Monad.Trans.Fail (FailT (..), runFail)
+import Control.Monad.Trans.State.Strict (StateT (..), evalStateT, get, modify', state)
 import Data.Aeson (FromJSON (..), FromJSONKey (..), ToJSON (..), ToJSONKey (..), (.:), (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Encoding as Aeson
@@ -114,6 +114,7 @@ import Data.Default (Default (..))
 import Data.Function (fix)
 import Data.Map.Strict (Map)
 import Data.Maybe (fromMaybe)
+import Data.MemPack (MemPack, Unpack (..))
 import Data.Proxy (Proxy (..))
 import Data.Text (Text)
 import qualified Data.Text.Encoding as Text
@@ -382,7 +383,7 @@ bootstrapKeyHash (BootstrapAddress byronAddress) =
 
 newtype CompactAddr = UnsafeCompactAddr ShortByteString
   deriving stock (Eq, Generic, Ord)
-  deriving newtype (NoThunks, NFData)
+  deriving newtype (NoThunks, NFData, MemPack)
 
 instance Show CompactAddr where
   show c = show (decompactAddr c)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -160,6 +160,7 @@ import Data.Functor.Identity (Identity)
 import Data.Map.Strict (Map)
 import Data.Maybe (fromMaybe)
 import Data.Maybe.Strict
+import Data.MemPack
 import Data.Ratio (Ratio, denominator, numerator, (%))
 import Data.Scientific (
   Scientific,
@@ -809,7 +810,8 @@ newtype BlocksMade = BlocksMade
 -- | Transaction index.
 newtype TxIx = TxIx {unTxIx :: Word16}
   deriving stock (Eq, Ord, Show, Generic)
-  deriving newtype (NFData, Enum, Bounded, NoThunks, FromCBOR, ToCBOR, EncCBOR, DecCBOR, ToJSON)
+  deriving newtype
+    (NFData, Enum, Bounded, NoThunks, FromCBOR, ToCBOR, EncCBOR, DecCBOR, ToJSON, MemPack)
 
 -- | Construct a `TxIx` from a 16 bit unsigned integer
 mkTxIx :: Word16 -> TxIx

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -107,6 +107,7 @@ import Data.Map (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust)
 import Data.Maybe.Strict (StrictMaybe)
+import Data.MemPack
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import Data.Void (Void)
@@ -266,6 +267,7 @@ class
   , ToJSON (TxOut era)
   , DecCBOR (Value era)
   , DecCBOR (CompactForm (Value era))
+  , MemPack (CompactForm (Value era))
   , EncCBOR (Value era)
   , ToCBOR (TxOut era)
   , EncCBOR (TxOut era)
@@ -276,6 +278,7 @@ class
   , NFData (TxOut era)
   , Show (TxOut era)
   , Eq (TxOut era)
+  , MemPack (TxOut era)
   , EraPParams era
   ) =>
   EraTxOut era

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
@@ -102,6 +102,7 @@ import Data.ByteString.Short (ShortByteString, fromShort)
 import qualified Data.ByteString.Short as SBS (length)
 import Data.Default (Default (..))
 import Data.Map.Strict (Map)
+import Data.MemPack
 import Data.Typeable
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
@@ -167,6 +168,7 @@ newtype KeyHash (r :: KeyRole) = KeyHash
     , ToJSON
     , FromJSON
     , Default
+    , MemPack
     )
 
 instance HasKeyRole KeyHash
@@ -200,6 +202,7 @@ newtype ScriptHash
     , FromJSON
     , ToJSONKey
     , FromJSONKey
+    , MemPack
     )
 
 --------------------------------------------------------------------------------
@@ -323,11 +326,21 @@ newtype GenDelegs = GenDelegs
 -- to types which preserve their original serialization bytes.
 newtype SafeHash i = SafeHash (Hash.Hash HASH i)
   deriving
-    (Show, Eq, Ord, NoThunks, NFData, SafeToHash, HeapWords, ToCBOR, FromCBOR, EncCBOR, DecCBOR)
-
-deriving instance ToJSON (SafeHash i)
-
-deriving instance FromJSON (SafeHash i)
+    ( Show
+    , Eq
+    , Ord
+    , NoThunks
+    , NFData
+    , SafeToHash
+    , HeapWords
+    , ToCBOR
+    , FromCBOR
+    , EncCBOR
+    , DecCBOR
+    , ToJSON
+    , FromJSON
+    , MemPack
+    )
 
 instance Default (SafeHash i) where
   def = unsafeMakeSafeHash def

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes.hs
@@ -17,6 +17,7 @@ module Cardano.Ledger.MemoBytes (
   printMemo,
   shortToLazy,
   contentsEq,
+  decodeMemoBytes,
 
   -- * Memoized
   Memoized (RawType),

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Language.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Language.hs
@@ -91,6 +91,7 @@ import Data.ByteString.Short (ShortByteString, fromShort)
 import Data.Either (isRight)
 import Data.Ix (Ix)
 import Data.Kind (Type)
+import Data.MemPack
 import Data.Proxy (Proxy (..))
 import Data.Text (Text)
 import Data.Typeable (Typeable, gcast)
@@ -148,7 +149,7 @@ newtype Plutus (l :: Language) = Plutus
   { plutusBinary :: PlutusBinary
   }
   deriving stock (Show, Generic)
-  deriving newtype (Eq, Ord, SafeToHash, NoThunks, NFData)
+  deriving newtype (Eq, Ord, SafeToHash, NoThunks, NFData, MemPack)
 
 plutusSLanguage :: PlutusLanguage l => proxy l -> SLanguage l
 plutusSLanguage _ = isLanguage
@@ -200,7 +201,7 @@ plutusFromRunnable = Plutus . PlutusBinary . P.serialisedScript . plutusRunnable
 -- | Binary representation of a Plutus script.
 newtype PlutusBinary = PlutusBinary {unPlutusBinary :: ShortByteString}
   deriving stock (Eq, Ord, Generic)
-  deriving newtype (ToCBOR, FromCBOR, EncCBOR, DecCBOR, NFData, NoThunks)
+  deriving newtype (ToCBOR, FromCBOR, EncCBOR, DecCBOR, NFData, NoThunks, MemPack)
 
 instance Show PlutusBinary where
   show = show . B64.encode . fromShort . unPlutusBinary

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/UTxO.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/UTxO.hs
@@ -44,6 +44,7 @@ import Cardano.Ledger.Binary (
   FromCBOR (..),
   Interns,
   ToCBOR (..),
+  decNoShareCBOR,
   decodeMap,
  )
 import Cardano.Ledger.CertState (CertState)
@@ -102,7 +103,7 @@ instance
   where
   type Share (UTxO era) = Interns (Credential 'Staking)
   decShareCBOR credsInterns =
-    UTxO <$!> decodeMap decCBOR (decShareCBOR credsInterns)
+    UTxO <$!> decodeMap decNoShareCBOR (decShareCBOR credsInterns)
 
 deriving via
   Quiet (UTxO era)

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary/RoundTrip.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary/RoundTrip.hs
@@ -216,6 +216,11 @@ roundTripCoreEraTypesSpec = do
     roundTripAnnEraSpec @era @(TxWits era)
     roundTripAnnEraSpec @era @(TxBody era)
     roundTripAnnEraSpec @era @(Tx era)
+    prop ("MemPack/CBOR Roundtrip " <> show (typeRep $ Proxy @(TxOut era))) $
+      roundTripRangeExpectation @(TxOut era)
+        (mkTrip encodeMemPack decNoShareCBOR)
+        (eraProtVerLow @era)
+        (eraProtVerHigh @era)
   describe "Core State Types" $ do
     roundTripAnnEraSpec @era @BootstrapWitness
     roundTripShareEraSpec @era @SnapShots


### PR DESCRIPTION
# Description

Start using MemPack for `TxOut` serialization in the ledger state

This change is added in order to improve performance drastically, which
helps it two ways:

* First of all improving performance of serialziation of `TxIn` and `TxOut`
  when creating a ledger state snapshot improves the perforamnce two
  fold.
* Second of all more efficient serialization of `TxIn` and `TxOut` will
  improve performance of UTxOHD

For the second point to be valid `MemPack` serialization for `TxOut`s
need to be backwards compatible, whcih it is in this commit.

The reason why this optimization works is because:

1. We avoid a whole step of going from compact form to an uncompacted form
   of a TxOut before serializing it.
2. We use `MemPack` serialization that is quite a bit faster than `cborg`

# Checklist

- [x] Commits in meaningful sequence and with useful messages
- [x] Tests added or updated when needed
- [x] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
