### PR TITLE
Enumerate individual conway tests in conformance `Imp`

### DIFF
--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
@@ -32,7 +32,17 @@ import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway (ConwayTxBodyTransContext)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
 import Test.Cardano.Ledger.Constrained.Conway
-import Test.Cardano.Ledger.Conway.Imp qualified as ConwayImp (conwaySpec)
+import Test.Cardano.Ledger.Conway.Imp.BbodySpec qualified as Bbody
+import Test.Cardano.Ledger.Conway.Imp.CertsSpec qualified as Certs
+import Test.Cardano.Ledger.Conway.Imp.DelegSpec qualified as Deleg
+import Test.Cardano.Ledger.Conway.Imp.EnactSpec qualified as Enact
+import Test.Cardano.Ledger.Conway.Imp.EpochSpec qualified as Epoch
+import Test.Cardano.Ledger.Conway.Imp.GovCertSpec qualified as GovCert
+import Test.Cardano.Ledger.Conway.Imp.GovSpec qualified as Gov
+import Test.Cardano.Ledger.Conway.Imp.LedgerSpec qualified as Ledger
+import Test.Cardano.Ledger.Conway.Imp.RatifySpec qualified as Ratify
+import Test.Cardano.Ledger.Conway.Imp.UtxoSpec qualified as Utxo
+import Test.Cardano.Ledger.Conway.Imp.UtxosSpec qualified as Utxos
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Imp.Common hiding (Args)
 import UnliftIO (evaluateDeep)
@@ -140,4 +150,20 @@ spec =
           it "Submit constitution" $ do
             _ <- submitConstitution @ConwayEra SNothing
             passNEpochs 2
-        xdescribe "Conway Imp conformance" $ ConwayImp.conwaySpec @ConwayEra
+        describe "Conway Imp conformance" $ do
+          describe "BBODY" Bbody.spec
+          describe "CERTS" Certs.spec
+          xdescribe "DELEG" Deleg.spec
+          xdescribe "ENACT" Enact.spec
+          xdescribe "EPOCH" Epoch.spec
+          xdescribe "GOV" Gov.spec
+          -- GOVCERT tests enabling pending on these two issues in spec:
+          -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/634
+          -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/633
+          xdescribe "GOVCERT" GovCert.spec
+          -- LEDGER tests enabling pending (at least) on the implementation of scriptSize in the spec:
+          -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/620
+          xdescribe "LEDGER" Ledger.spec
+          xdescribe "RATIFY" Ratify.spec
+          xdescribe "UTXO" Utxo.spec
+          xdescribe "UTXOS" Utxos.spec


### PR DESCRIPTION
so that they can be enabled independently

# Description

Just a trivial PR, in order to capture information about which of the conway Imp tests are currently passing conformance, and some info about what should happen in order for some to pass.  

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
