### PR TITLE
Backport release `cardano-ledger-conway-1.18.1.0`

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-conway`
 
+## 1.18.1.0
+
+* Add a check to `MEMPOOL` rule that prevents unelected CC from voting.
+
 ## 1.18.0.0
 
 * Remove `SlotNo` from `CertEnv` and `CertsEnv`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-conway
-version: 1.18.0.0
+version: 1.18.1.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -592,8 +592,9 @@ instance
   wrapEvent = CertsEvent . CertEvent . DelegEvent
 
 instance
-  ( EraGov era
-  , EraTx era
+  ( EraTx era
+  , ConwayEraGov era
+  , ConwayEraTxBody era
   , EraRule "MEMPOOL" era ~ ConwayMEMPOOL era
   , PredicateFailure (EraRule "MEMPOOL" era) ~ ConwayMempoolPredFailure era
   , Event (EraRule "MEMPOOL" era) ~ ConwayMempoolEvent era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Mempool.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Mempool.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -23,6 +24,12 @@ import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..), FromCBOR, ToCBOR)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Era (ConwayEra, ConwayMEMPOOL)
+import Cardano.Ledger.Conway.Governance (
+  ConwayEraGov,
+  Voter (..),
+  authorizedElectedHotCommitteeCredentials,
+  unVotingProcedures,
+ )
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.Rules (LedgerEnv (..))
 import Control.DeepSeq (NFData)
@@ -36,12 +43,17 @@ import Control.State.Transition (
   State,
   TRC (TRC),
   TransitionRule,
+  failOnNonEmpty,
   judgmentContext,
   tellEvent,
   transitionRules,
  )
-import Data.Text (Text, pack)
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Data.Text as T (Text, pack)
 import GHC.Generics (Generic)
+import Lens.Micro ((^.))
 import NoThunks.Class (NoThunks)
 
 newtype ConwayMempoolPredFailure era = ConwayMempoolPredFailure Text
@@ -58,7 +70,7 @@ newtype ConwayMempoolEvent era = ConwayMempoolEvent Text
 type instance EraRuleEvent "MEMPOOL" (ConwayEra c) = ConwayMempoolEvent (ConwayEra c)
 
 instance
-  (EraTx era, EraGov era) =>
+  (EraTx era, ConwayEraTxBody era, ConwayEraGov era) =>
   STS (ConwayMEMPOOL era)
   where
   type State (ConwayMEMPOOL era) = LedgerState era
@@ -70,11 +82,27 @@ instance
 
   transitionRules = [mempoolTransition @era]
 
-mempoolTransition :: EraTx era => TransitionRule (ConwayMEMPOOL era)
+mempoolTransition ::
+  (EraTx era, ConwayEraTxBody era, ConwayEraGov era) => TransitionRule (ConwayMEMPOOL era)
 mempoolTransition = do
   TRC (_ledgerEnv, ledgerState, tx) <-
     judgmentContext
   -- This rule only gets invoked on transactions within the mempool.
   -- Add checks here that sanitize undesired transactions.
-  tellEvent . ConwayMempoolEvent . ("Mempool rule for tx " <>) . pack . show . txIdTx $ tx
+  tellEvent . ConwayMempoolEvent . ("Mempool rule for tx " <>) . T.pack . show $ txIdTx tx
+  let
+    authorizedElectedHotCreds = authorizedElectedHotCommitteeCredentials ledgerState
+    collectUnelectedCommitteeVotes !unelectedHotCreds voter _ =
+      case voter of
+        CommitteeVoter hotCred
+          | hotCred `Set.notMember` authorizedElectedHotCreds ->
+              Set.insert hotCred unelectedHotCreds
+        _ -> unelectedHotCreds
+    unelectedCommitteeVoters =
+      Map.foldlWithKey' collectUnelectedCommitteeVotes Set.empty $
+        unVotingProcedures (tx ^. bodyTxL . votingProceduresTxBodyL)
+    addPrefix =
+      ("Unelected committee members are not allowed to cast votes: " <>)
+  failOnNonEmpty unelectedCommitteeVoters $
+    ConwayMempoolPredFailure . addPrefix . T.pack . show . NE.toList
   pure ledgerState

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
@@ -12,6 +12,7 @@ module Test.Cardano.Ledger.Conway.Imp.LedgerSpec (spec) where
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
+import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Conway.Rules (
   ConwayLedgerEvent (..),
   ConwayLedgerPredFailure (..),
@@ -22,16 +23,18 @@ import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.DRep
 import Cardano.Ledger.Plutus (SLanguage (..), hashPlutusScript)
 import Cardano.Ledger.SafeHash (originalBytesSize)
-import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..), mkMempoolEnv)
+import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..), applyTx, mkMempoolEnv)
 import qualified Cardano.Ledger.Shelley.HardForks as HF (bootstrapPhase)
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.Rules (ShelleyLedgersEnv (..), ShelleyLedgersEvent (..))
 import Control.State.Transition.Extended
+import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import Lens.Micro ((&), (.~), (^.))
 import Lens.Micro.Mtl (use)
 import Test.Cardano.Ledger.Conway.ImpTest
+import Test.Cardano.Ledger.Core.Rational (IsRatio (..))
 import Test.Cardano.Ledger.Imp.Common
 import Test.Cardano.Ledger.Plutus.Examples (
   alwaysFailsWithDatum,
@@ -255,3 +258,42 @@ spec = do
           assertFailure $ "Unexpected failure while applyingTx: " <> show tx <> ": " <> show e
         Right (_, evs) ->
           length [ev | ev@(MempoolEvent (ConwayMempoolEvent _)) <- evs] `shouldBe` 1
+
+    it "Unelected Committee voting" $ whenPostBootstrap $ do
+      globals <- use impGlobalsL
+      slotNo <- use impLastTickG
+      _ <- registerInitialCommittee
+      ccCold <- KeyHashObj <$> freshKeyHash
+      curEpochNo <- getsNES nesELL
+      let action =
+            UpdateCommittee
+              SNothing
+              mempty
+              (Map.singleton ccCold (addEpochInterval curEpochNo (EpochInterval 7)))
+              (1 %! 1)
+      proposal <- mkProposal action
+      submitTx_ $
+        mkBasicTx (mkBasicTxBody & proposalProceduresTxBodyL .~ [proposal])
+      ccHot <- registerCommitteeHotKey ccCold
+      govActionId <- do
+        rewardAccount <- registerRewardAccount
+        submitTreasuryWithdrawals [(rewardAccount, Coin 1)]
+
+      nes <- use impNESL
+      let ls = nes ^. nesEsL . esLStateL
+          mempoolEnv = mkMempoolEnv nes slotNo
+      tx <-
+        fixupTx $
+          mkBasicTx $
+            mkBasicTxBody
+              & votingProceduresTxBodyL
+                .~ VotingProcedures
+                  ( Map.singleton
+                      (CommitteeVoter ccHot)
+                      (Map.singleton govActionId (VotingProcedure VoteYes SNothing))
+                  )
+
+      case applyTx globals mempoolEnv ls tx of
+        Left _ -> pure ()
+        Right _ -> assertFailure $ "Expected failure due to an unallowed vote: " <> show tx
+      withNoFixup $ submitTx_ tx


### PR DESCRIPTION
# Description

This is a backport of https://github.com/IntersectMBO/cardano-ledger/pull/4813

This backport will be used for `cardano-node-10.2`

# Checklist

- [ ] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
