### PR TITLE
Included the hash in plutus script translation

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -24,8 +24,8 @@ source-repository-package
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `MAlonzo-code` BEFORE MERGE!
   subdir: generated
-  --sha256: sha256-/YE/qwup2ijMB7bo5eWyBIM+gXZ3Z1g0NZyNSfRwoPY=
-  tag: 93041ddbf659e0dbc1981d73fecb439b0209d484
+  --sha256: sha256-fzvk/UcLDZbC+pe9K6gao8JQ/al+L+KdzyPxAaL1xiM=
+  tag: 098ebf75fc06635bf0a38a82f4086bbd840af7c0
 
 -- NOTE: If you would like to update the above, look for the `MAlonzo-code`
 -- branch in the `formal-ledger-specifications` repo and copy the SHA of

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -62,7 +62,9 @@ instance NFData BootstrapAddr
 
 instance NFData Timelock
 
-instance NFData HashedTimelock
+instance NFData HSTimelock
+
+instance NFData HSPlutusScript
 
 instance NFData UTxOState
 
@@ -204,7 +206,9 @@ instance ToExpr BootstrapAddr
 
 instance ToExpr Timelock
 
-instance ToExpr HashedTimelock
+instance ToExpr HSTimelock
+
+instance ToExpr HSPlutusScript
 
 instance ToExpr TxBody
 
@@ -306,7 +310,9 @@ instance FixupSpecRep BootstrapAddr
 
 instance FixupSpecRep Timelock
 
-instance FixupSpecRep HashedTimelock
+instance FixupSpecRep HSTimelock
+
+instance FixupSpecRep HSPlutusScript
 
 instance FixupSpecRep UTxOState
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -201,12 +201,13 @@ instance
   ) =>
   SpecTranslate ctx (Timelock era)
   where
-  type SpecRep (Timelock era) = Agda.HashedTimelock
+  type SpecRep (Timelock era) = Agda.HSTimelock
 
   toSpecRep tl =
-    Agda.HashedTimelock
+    Agda.HSTimelock
       <$> timelockToSpecRep tl
       <*> toSpecRep (hashScript @era $ TimelockScript tl)
+      <*> pure (fromIntegral $ originalBytesSize tl)
     where
       timelockToSpecRep x =
         case x of
@@ -231,9 +232,12 @@ instance
   ) =>
   SpecTranslate ctx (PlutusScript era)
   where
-  type SpecRep (PlutusScript era) = Agda.ScriptHash
+  type SpecRep (PlutusScript era) = Agda.HSPlutusScript
 
-  toSpecRep ps = toSpecRep . hashScript $ PlutusScript @era ps
+  toSpecRep ps =
+    Agda.MkHSPlutusScript
+      <$> toSpecRep (hashScript $ PlutusScript ps)
+      <*> pure (fromIntegral $ originalBytesSize ps)
 
 instance
   ( AlonzoEraScript era
@@ -245,7 +249,7 @@ instance
   type SpecRep (AlonzoScript era) = Agda.Script
 
   toSpecRep (TimelockScript s) = Left <$> toSpecRep s
-  toSpecRep (PlutusScript s) = Right . (,()) <$> toSpecRep s
+  toSpecRep (PlutusScript s) = Right <$> toSpecRep s
 
 instance
   ( EraTxOut era


### PR DESCRIPTION
# Description

This PR updates the translation of `Timelock` and `PlutusScript` so that the translations of both include the script hash and the serialized size of the script.

related https://github.com/IntersectMBO/formal-ledger-specifications/pull/630

# Checklist

- [ ] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
