### PR TITLE
Enable Imp conformance for DELEG

### DIFF
--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -18,6 +18,10 @@
   * `FromByronTranslationContext`
   * `GenesisDelegCert`, `MIRTarget`, `MIRCert`, `ShelleyDelegCert`
 
+### `testlib`
+
+* Add `disableImpInitExpectLedgerRuleConformance`. #4821
+
 ## 1.15.0.0
 
 * Change param of `PoolRank.desirability` to `Word16`

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -101,6 +101,7 @@ module Test.Cardano.Ledger.Shelley.ImpTest (
   impSetSeed,
   modifyImpInitProtVer,
   modifyImpInitExpectLedgerRuleConformance,
+  disableImpInitExpectLedgerRuleConformance,
 
   -- * Logging
   Doc,
@@ -643,6 +644,12 @@ modifyImpInitExpectLedgerRuleConformance f =
           impInitEnv impInit
             & iteExpectLedgerRuleConformanceL .~ f
       }
+
+disableImpInitExpectLedgerRuleConformance ::
+  SpecWith (ImpInit (LedgerSpec era)) ->
+  SpecWith (ImpInit (LedgerSpec era))
+disableImpInitExpectLedgerRuleConformance =
+  modifyImpInitExpectLedgerRuleConformance $ \_ _ _ _ _ -> pure ()
 
 impLedgerEnv :: EraGov era => NewEpochState era -> ImpTestM era (LedgerEnv era)
 impLedgerEnv nes = do

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
@@ -153,7 +153,7 @@ spec =
         describe "Conway Imp conformance" $ do
           describe "BBODY" Bbody.spec
           describe "CERTS" Certs.spec
-          xdescribe "DELEG" Deleg.spec
+          describe "DELEG" Deleg.spec
           xdescribe "ENACT" Enact.spec
           xdescribe "EPOCH" Epoch.spec
           xdescribe "GOV" Gov.spec


### PR DESCRIPTION
# Description

Part of #4770 

- Replace the use of `UnRegTxCert` with `UnRegDepositTxCert` to make conformance pass
- Override conformance-check for a test that requires missing pool retirement implementation in the spec.

# Checklist

- [x] Commits in meaningful sequence and with useful messages
- [x] Tests added or updated when needed
- ~~[ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))~~
- ~~[ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).~~
- ~~[ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))~~
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
