### PR TITLE
Reduce memory usage with sharing

### DIFF
--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -105,6 +105,7 @@ library
     deepseq,
     mempack,
     microlens,
+    mtl,
     nothunks,
     plutus-ledger-api >=1.37,
     set-algebra,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -191,6 +191,7 @@ import Cardano.Ledger.Binary (
   DecShareCBOR (..),
   EncCBOR (..),
   FromCBOR (..),
+  Interns,
   ToCBOR (..),
   decNoShareCBOR,
  )
@@ -351,12 +352,18 @@ mkEnactState gs =
     , ensPrevGovActionIds = govStatePrevGovActionIds gs
     }
 
--- TODO: Implement Sharing: https://github.com/intersectmbo/cardano-ledger/issues/3486
 instance EraPParams era => DecShareCBOR (ConwayGovState era) where
-  decShareCBOR _ =
+  type
+    Share (ConwayGovState era) =
+      ( Interns (Credential 'Staking)
+      , Interns (KeyHash 'StakePool)
+      , Interns (Credential 'DRepRole)
+      , Interns (Credential 'HotCommitteeRole)
+      )
+  decShareCBOR is =
     decode $
       RecD ConwayGovState
-        <! From
+        <! D (decShareCBOR is)
         <! From
         <! From
         <! From

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -369,7 +369,7 @@ instance EraPParams era => DecShareCBOR (ConwayGovState era) where
         <! From
         <! From
         <! From
-        <! From
+        <! D (decShareCBOR is)
 
 instance EraPParams era => DecCBOR (ConwayGovState era) where
   decCBOR = decNoShareCBOR

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/DRepPulser.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/DRepPulser.hs
@@ -43,7 +43,12 @@ import Cardano.Ledger.Binary (
   DecShareCBOR (..),
   EncCBOR (..),
   FromCBOR (..),
+  Interns,
   ToCBOR (..),
+  decNoShareCBOR,
+  decodeMap,
+  decodeStrictSeq,
+  interns,
  )
 import Cardano.Ledger.Binary.Coders (
   Decode (..),
@@ -146,24 +151,24 @@ instance EraPParams era => EncCBOR (PulsingSnapshot era) where
         !> To psDRepState
         !> To psPoolDistr
 
--- TODO: Implement Sharing: https://github.com/intersectmbo/cardano-ledger/issues/3486
 instance EraPParams era => DecShareCBOR (PulsingSnapshot era) where
-  decShareCBOR _ =
+  type
+    Share (PulsingSnapshot era) =
+      ( Interns (Credential 'Staking)
+      , Interns (KeyHash 'StakePool)
+      , Interns (Credential 'DRepRole)
+      , Interns (Credential 'HotCommitteeRole)
+      )
+  decShareCBOR is@(_, ks, cd, _) =
     decode $
       RecD PulsingSnapshot
-        <! From
-        <! From
-        <! From
-        <! From
+        <! D (decodeStrictSeq (decShareCBOR is))
+        <! D (decodeMap (decShareCBOR cd) decCBOR)
+        <! D (decodeMap (interns cd <$> decCBOR) decCBOR) --TODO: implement sharing for DRepState
+        <! D (decodeMap (interns ks <$> decCBOR) decCBOR)
 
 instance EraPParams era => DecCBOR (PulsingSnapshot era) where
-  decCBOR =
-    decode $
-      RecD PulsingSnapshot
-        <! From
-        <! From
-        <! From
-        <! From
+  decCBOR = decNoShareCBOR
 
 instance EraPParams era => ToCBOR (PulsingSnapshot era) where
   toCBOR = toEraCBOR @era
@@ -436,13 +441,19 @@ instance EraPParams era => EncCBOR (DRepPulsingState era) where
     where
       (snap, ratstate) = finishDRepPulser x
 
--- TODO: Implement Sharing: https://github.com/intersectmbo/cardano-ledger/issues/3486
 instance EraPParams era => DecShareCBOR (DRepPulsingState era) where
-  decShareCBOR _ =
+  type
+    Share (DRepPulsingState era) =
+      ( Interns (Credential 'Staking)
+      , Interns (KeyHash 'StakePool)
+      , Interns (Credential 'DRepRole)
+      , Interns (Credential 'HotCommitteeRole)
+      )
+  decShareCBOR is =
     decode $
       RecD DRComplete
         <! From
-        <! From
+        <! D (decShareCBOR is)
 
 instance EraPParams era => DecCBOR (DRepPulsingState era) where
   decCBOR = decode (RecD DRComplete <! From <! From)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/DRepPulser.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/DRepPulser.hs
@@ -159,12 +159,12 @@ instance EraPParams era => DecShareCBOR (PulsingSnapshot era) where
       , Interns (Credential 'DRepRole)
       , Interns (Credential 'HotCommitteeRole)
       )
-  decShareCBOR is@(_, ks, cd, _) =
+  decShareCBOR is@(cs, ks, cd, _) =
     decode $
       RecD PulsingSnapshot
         <! D (decodeStrictSeq (decShareCBOR is))
         <! D (decodeMap (decShareCBOR cd) decCBOR)
-        <! D (decodeMap (interns cd <$> decCBOR) decCBOR) --TODO: implement sharing for DRepState
+        <! D (decodeMap (interns cd <$> decCBOR) (decShareCBOR cs))
         <! D (decodeMap (interns ks <$> decCBOR) decCBOR)
 
 instance EraPParams era => DecCBOR (PulsingSnapshot era) where
@@ -452,7 +452,7 @@ instance EraPParams era => DecShareCBOR (DRepPulsingState era) where
   decShareCBOR is =
     decode $
       RecD DRComplete
-        <! From
+        <! D (decShareCBOR is)
         <! D (decShareCBOR is)
 
 instance EraPParams era => DecCBOR (DRepPulsingState era) where

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
@@ -98,6 +98,7 @@ import Cardano.Ledger.Binary (
   ToCBOR (toCBOR),
   decNoShareCBOR,
   decodeEnumBounded,
+  decodeMap,
   decodeMapByKey,
   decodeNullStrictMaybe,
   decodeRecordNamed,
@@ -105,6 +106,7 @@ import Cardano.Ledger.Binary (
   encodeListLen,
   encodeNullStrictMaybe,
   encodeWord8,
+  interns,
   invalidKey,
  )
 import Cardano.Ledger.Binary.Coders (
@@ -291,13 +293,13 @@ instance EraPParams era => DecShareCBOR (GovActionState era) where
       , Interns (Credential 'DRepRole)
       , Interns (Credential 'HotCommitteeRole)
       )
-  decShareCBOR _ =
+  decShareCBOR (cs, ks, cd, ch) =
     decode $
       RecD GovActionState
         <! From
-        <! From
-        <! From
-        <! From
+        <! D (decodeMap (interns ch <$> decCBOR) decCBOR)
+        <! D (decodeMap (interns cd <$> decCBOR) decCBOR)
+        <! D (decodeMap (interns ks <$> decCBOR) decCBOR)
         <! From
         <! From
         <! From

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
@@ -19,7 +19,9 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Cardano.Ledger.Conway.Governance.Procedures (
@@ -92,6 +94,7 @@ import Cardano.Ledger.Binary (
   DecShareCBOR (..),
   EncCBOR (..),
   FromCBOR (fromCBOR),
+  Interns,
   ToCBOR (toCBOR),
   decNoShareCBOR,
   decodeEnumBounded,
@@ -280,8 +283,14 @@ instance EraPParams era => NoThunks (GovActionState era)
 
 instance EraPParams era => NFData (GovActionState era)
 
--- TODO: Implement Sharing: https://github.com/intersectmbo/cardano-ledger/issues/3486
 instance EraPParams era => DecShareCBOR (GovActionState era) where
+  type
+    Share (GovActionState era) =
+      ( Interns (Credential 'Staking)
+      , Interns (KeyHash 'StakePool)
+      , Interns (Credential 'DRepRole)
+      , Interns (Credential 'HotCommitteeRole)
+      )
   decShareCBOR _ =
     decode $
       RecD GovActionState

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -46,6 +46,8 @@ import Cardano.Ledger.Binary (
   EncCBOR (..),
   FromCBOR (..),
   ToCBOR (..),
+  internMap,
+  internSet,
  )
 import Cardano.Ledger.Binary.Coders (
   Decode (..),
@@ -77,7 +79,6 @@ import Cardano.Ledger.Conway.Governance (
   Voter (..),
   VotingProcedure (..),
   VotingProcedures (..),
-  foldlVotingProcedures,
   foldrVotingProcedures,
   gasAction,
   gasDRepVotesL,
@@ -122,6 +123,8 @@ import Control.State.Transition.Extended (
   tellEvent,
   (?!),
  )
+import Data.Bifunctor (bimap)
+import Data.Either (partitionEithers)
 import qualified Data.Foldable as F
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as Map
@@ -540,12 +543,11 @@ govTransition = do
     foldlM' processProposal st $
       indexedGovProps (SSeq.fromStrict (OSet.toStrictSeq gsProposalProcedures))
 
-  -- Inversion of the keys in VotingProcedures, where we can find the voters for every
-  -- govActionId
-  let (unknownGovActionIds, knownVotes, replacedVotes) =
+  let knownVotes = [(voter, gas) | (voter, _vote, gas) <- knownVotesWithCast]
+      (unknownGovActionIds, !knownVotesWithCast, replacedVotes) =
         foldrVotingProcedures
           -- strictness is not needed for `unknown` or `replaced`
-          ( \voter gaId _ (unknown, !known, replaced) ->
+          ( \voter gaId vp (unknown, !known, replaced) ->
               case Map.lookup gaId curGovActionIds of
                 Just gas ->
                   let isVoteReplaced =
@@ -556,19 +558,22 @@ govTransition = do
                       replaced'
                         | isVoteReplaced = Set.insert (voter, gaId) replaced
                         | otherwise = replaced
-                   in (unknown, (voter, gas) : known, replaced')
+                   in (unknown, (voter, vProcVote vp, gas) : known, replaced')
                 Nothing -> (gaId : unknown, known, replaced)
           )
           ([], [], Set.empty)
-          gsVotingProcedures
+          (VotingProcedures knownVoters)
       curGovActionIds = proposalsActionsMap proposals
-      isVoterKnown = \case
-        CommitteeVoter hotCred -> hotCred `Set.member` knownCommitteeMembers
-        DRepVoter cred -> cred `Map.member` knownDReps
-        StakePoolVoter poolId -> poolId `Map.member` knownStakePools
-      unknownVoters =
-        Map.keys $
-          Map.filterWithKey (\voter _ -> not (isVoterKnown voter)) (unVotingProcedures gsVotingProcedures)
+      internVoter = \case
+        CommitteeVoter hotCred -> CommitteeVoter <$> internSet hotCred knownCommitteeMembers
+        DRepVoter cred -> DRepVoter <$> internMap cred knownDReps
+        StakePoolVoter poolId -> StakePoolVoter <$> internMap poolId knownStakePools
+      (unknownVoters, knownVoters) =
+        bimap Set.fromList Map.fromList $
+          partitionEithers
+            [ maybe (Left voter) (\v -> Right (v, votes)) (internVoter voter)
+            | (voter, votes) <- Map.toList (unVotingProcedures gsVotingProcedures)
+            ]
 
   failOnNonEmpty unknownVoters VotersDoNotExist
   failOnNonEmpty unknownGovActionIds GovActionsDoNotExist
@@ -577,11 +582,9 @@ govTransition = do
   runTest $ checkVotersAreValid currentEpoch committeeState knownVotes
 
   let
-    addVoterVote ps voter govActionId VotingProcedure {vProcVote} =
-      proposalsAddVote voter vProcVote govActionId ps
-    updatedProposalStates =
-      cleanupProposalVotes $
-        foldlVotingProcedures addVoterVote proposals gsVotingProcedures
+    !updatedProposalStates =
+      let addVoterVote ps (voter, vote, gas) = proposalsAddVote voter vote (gasId gas) ps
+       in cleanupProposalVotes $ F.foldl' addVoterVote proposals knownVotesWithCast
     unregisteredDReps =
       let collectRemovals drepCreds = \case
             UnRegDRepTxCert drepCred _ -> Set.insert drepCred drepCreds

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
@@ -762,15 +762,8 @@ votingSpec =
       submitFailingVote (StakePoolVoter poolId) gaId $
         [injectFailure $ VotersDoNotExist [StakePoolVoter poolId]]
       dRepCred <- KeyHashObj <$> freshKeyHash
-      let votersDoNotExistFailure = injectFailure $ VotersDoNotExist [DRepVoter dRepCred]
-      vote <- arbitrary
-      submitBootstrapAwareFailingVote vote (DRepVoter dRepCred) gaId $
-        FailBootstrapAndPostBootstrap $
-          FailBoth
-            { bootstrapFailures =
-                [votersDoNotExistFailure, disallowedVoteFailure [(DRepVoter dRepCred, gaId)]]
-            , postBootstrapFailures = [votersDoNotExistFailure]
-            }
+      submitFailingVote (DRepVoter dRepCred) gaId $
+        [injectFailure $ VotersDoNotExist [DRepVoter dRepCred]]
     it "DRep votes are removed" $ do
       pp <- getsNES $ nesEsL . curPParamsEpochStateL
       gaId <- submitGovAction InfoAction
@@ -876,8 +869,6 @@ votingSpec =
             . constitutionAnchorL
       expectNoCurrentProposals
       conAnchor `shouldNotBe` anchor
-  where
-    disallowedVoteFailure = injectFailure . DisallowedVotesDuringBootstrap
 
 constitutionSpec ::
   forall era.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Governance.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Governance.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 
@@ -36,12 +37,14 @@ import Cardano.Ledger.Binary (
   DecShareCBOR (..),
   EncCBOR (encCBOR),
   FromCBOR (..),
+  Interns,
   ToCBOR (..),
   decNoShareCBOR,
  )
 import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
 import Cardano.Ledger.CertState (Obligations)
 import Cardano.Ledger.Core
+import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates, emptyPPPUpdates)
 import Control.DeepSeq (NFData (..))
@@ -68,6 +71,12 @@ class
   , EncCBOR (GovState era)
   , DecCBOR (GovState era)
   , DecShareCBOR (GovState era)
+  , Share (GovState era)
+      ~ ( Interns (Credential 'Staking)
+        , Interns (KeyHash 'StakePool)
+        , Interns (Credential 'DRepRole)
+        , Interns (Credential 'HotCommitteeRole)
+        )
   , ToCBOR (GovState era)
   , FromCBOR (GovState era)
   , Default (GovState era)
@@ -265,6 +274,13 @@ instance
   ) =>
   DecShareCBOR (ShelleyGovState era)
   where
+  type
+    Share (ShelleyGovState era) =
+      ( Interns (Credential 'Staking)
+      , Interns (KeyHash 'StakePool)
+      , Interns (Credential 'DRepRole)
+      , Interns (Credential 'HotCommitteeRole)
+      )
   decShareCBOR _ =
     decode $
       RecD ShelleyGovState

--- a/libs/cardano-data/CHANGELOG.md
+++ b/libs/cardano-data/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-data`
 
-## 1.2.3.2
+## 1.2.4.0
 
-*
+* Add `decodeOMap`
 
 ## 1.2.3.1
 

--- a/libs/cardano-data/cardano-data.cabal
+++ b/libs/cardano-data/cardano-data.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-data
-version: 1.2.3.1
+version: 1.2.4.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/libs/cardano-data/src/Data/OMap/Strict.hs
+++ b/libs/cardano-data/src/Data/OMap/Strict.hs
@@ -173,6 +173,8 @@ cons' v (OMap sseq kv)
 
 infixr 5 <||
 
+-- TODO: export along with others that are hidden or remove them completely.
+
 -- | \(O(\log n)\). Checks membership before snoc'ing.
 snoc :: HasOKey k v => OMap k v -> v -> OMap k v
 snoc omap@(OMap sseq kv) v

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.6.0.0
 
+* Add `decodeListLikeWithCountT`
+* Add `internMap`, `internSet`, ` internsFromSet`
+* Add `DecShareCBOR` for  `Set`
+* Add `Semigroup` instance for  `Interns`
 * Add `encodeMemPack` and `decodeMemPack` helper functions.
 * Remove `encodeSignKeyKES` and `decodeSignKeyKES`
 * Remove `EncCBOR` and `DecCBOR` instances for `SignKeyKES`

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Sharing.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Sharing.hs
@@ -17,6 +17,7 @@ module Cardano.Ledger.Binary.Decoding.Sharing (
   decSharePlusLensCBOR,
   decNoShareCBOR,
   interns,
+  internsFromSet,
   internsFromMap,
   internsFromVMap,
   internMap,
@@ -36,6 +37,7 @@ import Data.Kind
 import qualified Data.Map.Strict as Map (size)
 import Data.Map.Strict.Internal (Map (..))
 import Data.Primitive.Types (Prim)
+import qualified Data.Set as Set (size)
 import qualified Data.Set.Internal as Set (Set (..))
 import Data.VMap (VB, VMap, VP)
 import qualified Data.VMap as VMap
@@ -94,6 +96,15 @@ internSet k = go
         LT -> go l
         GT -> go r
         EQ -> Just kx
+
+internsFromSet :: Ord k => Set.Set k -> Interns k
+internsFromSet m =
+  Interns
+    [ Intern
+        { internMaybe = (`internSet` m)
+        , internWeight = Set.size m
+        }
+    ]
 
 internsFromMap :: Ord k => Map k a -> Interns k
 internsFromMap m =

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Sharing.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Sharing.hs
@@ -206,6 +206,11 @@ decSharePlusLensCBOR l = do
 decNoShareCBOR :: DecShareCBOR a => Decoder s a
 decNoShareCBOR = decShareCBOR mempty
 
+instance (Ord k, DecCBOR k) => DecShareCBOR (Set.Set k) where
+  type Share (Set.Set k) = Interns k
+  decShareCBOR kis = decodeSet (interns kis <$> decCBOR)
+  getShare = internsFromSet
+
 instance (Ord k, DecCBOR k, DecCBOR v) => DecShareCBOR (Map k v) where
   type Share (Map k v) = (Interns k, Interns v)
   decShareCBOR (kis, vis) = do

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.17.0.0
 
+* Add `DecShareCBOR` instances for `DRep` and `DRepState`
 * Added `ToPlutusData` instance for `NonZero`
 * `maxpool'` now expects `nOpt` to be a `NonZero Word16`
 * Add `HasZero` instance for `Coin` together with lifted conversion functions:

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
@@ -75,6 +75,7 @@ import Cardano.Ledger.Binary (
   decodeRecordNamed,
   decodeRecordNamedT,
   encodeListLen,
+  internsFromSet,
   toMemptyLens,
  )
 import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
@@ -189,7 +190,9 @@ instance Era era => EncCBOR (DState era) where
       <> encCBOR ir
 
 instance DecShareCBOR (DState era) where
-  type Share (DState era) = (Interns (Credential 'Staking), Interns (KeyHash 'StakePool))
+  type
+    Share (DState era) =
+      (Interns (Credential 'Staking), Interns (KeyHash 'StakePool), Interns (Credential 'DRepRole))
   decSharePlusCBOR =
     decodeRecordNamedT "DState" (const 4) $ do
       unified <- decSharePlusCBOR
@@ -316,8 +319,9 @@ authorizedHotCommitteeCredentials CommitteeState {csCommitteeCreds} =
         CommitteeMemberResigned {} -> acc
    in F.foldl' toHotCredSet Set.empty csCommitteeCreds
 
--- TODO: Implement sharing: https://github.com/intersectmbo/cardano-ledger/issues/3486
 instance Era era => DecShareCBOR (CommitteeState era) where
+  type Share (CommitteeState era) = Interns (Credential 'HotCommitteeRole)
+  getShare = internsFromSet . authorizedHotCommitteeCredentials
   decShareCBOR _ = CommitteeState <$> decCBOR
 
 instance Era era => DecCBOR (CommitteeState era) where
@@ -353,8 +357,15 @@ instance NoThunks (VState era)
 
 instance NFData (VState era)
 
--- TODO: Implement sharing: https://github.com/intersectmbo/cardano-ledger/issues/3486
 instance Era era => DecShareCBOR (VState era) where
+  type
+    Share (VState era) =
+      ( Interns (Credential 'Staking)
+      , Interns (Credential 'DRepRole)
+      , Interns (Credential 'HotCommitteeRole)
+      )
+  getShare VState {vsDReps, vsCommitteeState} =
+    (internsFromSet (foldMap drepDelegs vsDReps), fst (getShare vsDReps), getShare vsCommitteeState)
   decShareCBOR _ =
     decode $
       RecD VState
@@ -408,11 +419,21 @@ instance Era era => EncCBOR (CertState era) where
       <> encCBOR certDState
 
 instance Era era => DecShareCBOR (CertState era) where
-  type Share (CertState era) = (Interns (Credential 'Staking), Interns (KeyHash 'StakePool))
+  type
+    Share (CertState era) =
+      ( Interns (Credential 'Staking)
+      , Interns (KeyHash 'StakePool)
+      , Interns (Credential 'DRepRole)
+      , Interns (Credential 'HotCommitteeRole)
+      )
   decSharePlusCBOR = decodeRecordNamedT "CertState" (const 3) $ do
-    certVState <- lift decNoShareCBOR -- TODO: add sharing of DRep credentials
+    certVState <-
+      decSharePlusLensCBOR $
+        lens (\(cs, _, cd, ch) -> (cs, cd, ch)) (\(_, ks, _, _) (cs, cd, ch) -> (cs, ks, cd, ch))
     certPState <- decSharePlusLensCBOR _2
-    certDState <- decSharePlusCBOR
+    certDState <-
+      decSharePlusLensCBOR $
+        lens (\(cs, ks, cd, _) -> (cs, ks, cd)) (\(_, _, _, ch) (cs, ks, cd) -> (cs, ks, cd, ch))
     pure CertState {certPState, certDState, certVState}
 
 instance Default (CertState era) where

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/CertState.hs
@@ -72,9 +72,11 @@ import Cardano.Ledger.Binary (
   decNoShareCBOR,
   decSharePlusCBOR,
   decSharePlusLensCBOR,
+  decodeMap,
   decodeRecordNamed,
   decodeRecordNamedT,
   encodeListLen,
+  interns,
   internsFromSet,
   toMemptyLens,
  )
@@ -366,10 +368,10 @@ instance Era era => DecShareCBOR (VState era) where
       )
   getShare VState {vsDReps, vsCommitteeState} =
     (internsFromSet (foldMap drepDelegs vsDReps), fst (getShare vsDReps), getShare vsCommitteeState)
-  decShareCBOR _ =
+  decShareCBOR (cs, cd, _) =
     decode $
       RecD VState
-        <! From
+        <! D (decodeMap (interns cd <$> decCBOR) (decShareCBOR cs))
         <! D decNoShareCBOR
         <! From
 

--- a/libs/ledger-state/ledger-state.cabal
+++ b/libs/ledger-state/ledger-state.cabal
@@ -42,6 +42,7 @@ library
     cardano-ledger-alonzo,
     cardano-ledger-babbage,
     cardano-ledger-binary,
+    cardano-ledger-conway,
     cardano-ledger-core,
     cardano-ledger-mary,
     cardano-ledger-shelley,

--- a/libs/ledger-state/src/Cardano/Ledger/State/Orphans.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/Orphans.hs
@@ -14,6 +14,7 @@ import Cardano.Ledger.Babbage.TxBody
 import Cardano.Ledger.BaseTypes (TxIx (..))
 import Cardano.Ledger.Binary
 import Cardano.Ledger.Coin
+import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential
 import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
@@ -117,6 +118,10 @@ deriving via Enc Ptr instance PersistFieldSql Ptr
 deriving via Enc (ShelleyGovState CurrentEra) instance PersistField (ShelleyGovState CurrentEra)
 
 deriving via Enc (ShelleyGovState CurrentEra) instance PersistFieldSql (ShelleyGovState CurrentEra)
+
+deriving via Enc (ConwayGovState CurrentEra) instance PersistField (ConwayGovState CurrentEra)
+
+deriving via Enc (ConwayGovState CurrentEra) instance PersistFieldSql (ConwayGovState CurrentEra)
 
 deriving via Enc (AlonzoTxOut CurrentEra) instance PersistField (AlonzoTxOut CurrentEra)
 

--- a/libs/ledger-state/src/Cardano/Ledger/State/Query.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/Query.hs
@@ -65,7 +65,7 @@ insertUTxOState Shelley.UTxOState {..} = do
     UtxoState
       { utxoStateDeposited = utxosDeposited
       , utxoStateFees = utxosFees
-      , utxoStatePpups = utxosGovState
+      , utxoStateGovState = utxosGovState
       , utxoStateDonation = utxosDonation
       }
 
@@ -515,7 +515,7 @@ getLedgerState utxo LedgerState {..} dstate = do
             utxo
             utxoStateDeposited
             utxoStateFees
-            utxoStatePpups -- Maintain invariant
+            utxoStateGovState -- Maintain invariant
             utxoStateDonation
       , Shelley.lsCertState =
           Shelley.CertState

--- a/libs/ledger-state/src/Cardano/Ledger/State/Schema.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/Schema.hs
@@ -18,6 +18,7 @@ import Cardano.Ledger.Babbage.TxOut (BabbageTxOut)
 import Cardano.Ledger.BaseTypes (TxIx (..))
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Core (PParams)
+import Cardano.Ledger.Conway.Governance
 import qualified Cardano.Ledger.Credential as Credential
 import qualified Cardano.Ledger.Keys as Keys
 import qualified Cardano.Ledger.PoolParams as Shelley
@@ -78,7 +79,7 @@ LedgerState
 UtxoState
   deposited Coin
   fees Coin
-  ppups (Shelley.ShelleyGovState CurrentEra)
+  govState (ConwayGovState CurrentEra)
   donation Coin
 DState
   fGenDelegs FGenDelegs

--- a/libs/ledger-state/src/Cardano/Ledger/State/Schema.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/Schema.hs
@@ -17,8 +17,8 @@ module Cardano.Ledger.State.Schema where
 import Cardano.Ledger.Babbage.TxOut (BabbageTxOut)
 import Cardano.Ledger.BaseTypes (TxIx (..))
 import Cardano.Ledger.Coin
-import Cardano.Ledger.Core (PParams)
 import Cardano.Ledger.Conway.Governance
+import Cardano.Ledger.Core (PParams)
 import qualified Cardano.Ledger.Credential as Credential
 import qualified Cardano.Ledger.Keys as Keys
 import qualified Cardano.Ledger.PoolParams as Shelley

--- a/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
@@ -14,10 +14,10 @@ module Cardano.Ledger.State.UTxO where
 
 import Cardano.Ledger.Address
 import Cardano.Ledger.Alonzo.TxBody
-import Cardano.Ledger.Conway
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Coin
+import Cardano.Ledger.Conway
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential
 import Cardano.Ledger.EpochBoundary

--- a/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
@@ -14,7 +14,7 @@ module Cardano.Ledger.State.UTxO where
 
 import Cardano.Ledger.Address
 import Cardano.Ledger.Alonzo.TxBody
-import Cardano.Ledger.Babbage
+import Cardano.Ledger.Conway
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Coin
@@ -46,7 +46,7 @@ import Lens.Micro
 import Prettyprinter
 import Text.Printf
 
-type CurrentEra = BabbageEra
+type CurrentEra = ConwayEra
 
 --- Loading
 readNewEpochState ::


### PR DESCRIPTION
# Description

Fixes #3486

It will probably be easier to review it by commit rather than PR as a whole. Especially for changes to the GOV rule

## Memory benchmark

Here is run of a memory benchmark from the `ledger-state` package of loading a snapshot from `preprod` network

Before this PR:
```
Case                     Max          MaxOS           Live       Allocated    GCs
NewEpochState  1,136,825,184  2,834,300,928  1,136,825,184  24,981,680,224  5,816
```

With deserialization sharing implemented in this PR:
```
Case                   Max          MaxOS         Live       Allocated    GCs
NewEpochState  993,573,512  2,598,371,328  993,573,512  25,151,778,496  5,857
```

This benchamrk serves as confirmation that sharing works as expected during deserialization. Once we have integration ready for `cardano-node-10.3` we'll be able to test sharing during chain replay as well.

# Checklist

- [x] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [x] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
