### PR TITLE
prepare for garnix

### DIFF
--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,0 +1,3 @@
+builds:
+  include:
+  - 'checks.*.*'


### PR DESCRIPTION
# Description

- Add garnix cache to the flake nix config.
- Add `garnix.yaml` that builds only `.#checks`.
- Adjust the flake outputs to make garnix build everything that Hydra did.

Garnix does not build the `hydraJobs` output
so move them all into the `checks` output,
adhering to the flake output schema
because garnix does not build nested attrsets.

Note that this replaces the layout of the `checks` output
but it should still include all the checks that it had previously.
So no checks are removed, they just have a different name.
I hope that's ok and no checks are referred to by name somewhere.

# Checklist

- [x] Commits in meaningful sequence and with useful messages
- ~~Tests added or updated when needed~~
- ~~`CHANGELOG.md` files updated for packages with externally visible changes~~
- ~~Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).~~
- ~~Version bounds in `.cabal` files updated when necessary~~
- ~~Code formatted (use `scripts/fourmolize.sh`)~~
- ~~Cabal files formatted (use `scripts/cabal-format.sh`)~~
- ~~[`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)~~
- [x] Self-reviewed the diff
