### PR TITLE
Added `NonZero`

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -63,8 +63,10 @@ import Cardano.Ledger.BaseTypes (
   ShelleyBase,
   StrictMaybe (..),
   epochInfo,
+  knownNonZero,
   networkId,
   systemStart,
+  (%.),
  )
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..), serialize)
 import Cardano.Ledger.Binary.Coders (
@@ -104,7 +106,6 @@ import Data.Coerce (coerce)
 import Data.Either (isRight)
 import Data.Foldable as F (foldl', sequenceA_, toList)
 import qualified Data.Map.Strict as Map
-import Data.Ratio ((%))
 import Data.Set (Set)
 import qualified Data.Set as Set
 import GHC.Generics (Generic)
@@ -331,7 +332,7 @@ validateInsufficientCollateral pp txBody bal =
   failureUnless (Val.scale (100 :: Int) bal >= Val.scale collPerc (toDeltaCoin txfee)) $
     InsufficientCollateral bal $
       rationalToCoinViaCeiling $
-        (fromIntegral collPerc * unCoin txfee) % 100
+        (fromIntegral collPerc * unCoin txfee) %. knownNonZero @100
   where
     txfee = txBody ^. feeTxBodyL -- Coin supplied to pay fees
     collPerc = pp ^. ppCollateralPercentageL

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
@@ -42,7 +42,6 @@ import Cardano.Ledger.Conway.TxBody ()
 import Cardano.Ledger.Conway.TxWits ()
 import Cardano.Ledger.Core
 import Cardano.Ledger.Val (Val (..))
-import Data.Ratio ((%))
 import GHC.Stack
 import Lens.Micro ((^.))
 
@@ -125,10 +124,10 @@ tierRefScriptFee multiplier sizeIncrement
   where
     go !acc !curTierPrice !n
       | n < sizeIncrement =
-          Coin $ floor (acc + (toInteger n % 1) * curTierPrice)
+          Coin $ floor (acc + toRational n * curTierPrice)
       | otherwise =
           go (acc + sizeIncrementRational * curTierPrice) (multiplier * curTierPrice) (n - sizeIncrement)
-    sizeIncrementRational = toInteger sizeIncrement % 1
+    sizeIncrementRational = toRational sizeIncrement
 
 instance AlonzoEraTx ConwayEra where
   isValidTxL = isValidAlonzoTxL

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 1.16.0.0
 
+* Changed the type of `sgSecurityParam` to `NonZero Word64`
+* Following functions now expect a `NonZero Word64` security parameter:
+  * `startStep`
+  * `createRUpd`
+  * `desirability`
+  * `getTopRankedPools`
+  * `getTopRankedPoolsVMap`
 * Remove `Era era` constraint from `sizeShelleyTxF` and `wireSizeShelleyTxF`
 * Add `MemPack` instance `ShelleyTxOut`
 * Deprecate `hashShelleyTxAuxData`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
@@ -52,6 +52,7 @@ import Cardano.Ledger.BaseTypes (
   EpochSize (..),
   Globals (..),
   Network,
+  NonZero (..),
   Nonce (..),
   PositiveUnitInterval,
   mkActiveSlotCoeff,
@@ -211,7 +212,7 @@ data ShelleyGenesis = ShelleyGenesis
   , sgNetworkMagic :: !Word32
   , sgNetworkId :: !Network
   , sgActiveSlotsCoeff :: !PositiveUnitInterval
-  , sgSecurityParam :: !Word64
+  , sgSecurityParam :: !(NonZero Word64)
   , sgEpochLength :: !EpochSize
   , sgSlotsPerKESPeriod :: !Word64
   , sgMaxKESEvolutions :: !Word64
@@ -634,14 +635,14 @@ validateGenesis
         let activeSlotsCoeff = unboundRational sgActiveSlotsCoeff
             minLength =
               EpochSize . ceiling $
-                fromIntegral @_ @Double (3 * sgSecurityParam)
+                fromIntegral @_ @Double (3 * unNonZero sgSecurityParam)
                   / fromRational activeSlotsCoeff
          in if minLength > sgEpochLength
               then
                 Just $
                   EpochNotLongEnough
                     sgEpochLength
-                    sgSecurityParam
+                    (unNonZero sgSecurityParam)
                     activeSlotsCoeff
                     minLength
               else Nothing
@@ -680,6 +681,6 @@ mkShelleyGlobals genesis epochInfoAc =
     systemStart = SystemStart $ sgSystemStart genesis
     k = sgSecurityParam genesis
     stabilityWindow =
-      computeStabilityWindow k (sgActiveSlotCoeff genesis)
+      computeStabilityWindow (unNonZero k) (sgActiveSlotCoeff genesis)
     randomnessStabilisationWindow =
-      computeRandomnessStabilisationWindow k (sgActiveSlotCoeff genesis)
+      computeRandomnessStabilisationWindow (unNonZero k) (sgActiveSlotCoeff genesis)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rewards.hs
@@ -58,6 +58,7 @@ import Control.Monad (guard)
 import Data.Foldable (fold, foldMap')
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Ratio ((%))
 import Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.VMap as VMap
@@ -289,7 +290,9 @@ rewardOnePoolMember
       pool = poolPs rewardInfo
       sigma = poolRelativeStake rewardInfo
       poolR = poolPot rewardInfo
-      stakeShare = StakeShare $ c %? unCoin totalStake
+      -- warning: totalStake could be zero!
+      stakeShare =
+        StakeShare $ c % unCoin totalStake
       r = memberRew poolR pool stakeShare sigma
 
 -- | Calculate single stake pool specific values for the reward computation.
@@ -332,7 +335,8 @@ mkPoolRewardInfo
     -- intermediate values needed for the individual reward calculations.
     Just blocksN ->
       let Coin pledge = ppPledge pool
-          pledgeRelative = pledge %? unCoin totalStake
+          -- warning: totalStake could be zero!
+          pledgeRelative = pledge % unCoin totalStake
           sigmaA = pstakeTot %? unCoin activeStake
           Coin maxP =
             if pledge <= ostake

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/StabilityWindow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/StabilityWindow.hs
@@ -17,9 +17,9 @@ computeStabilityWindow ::
   ActiveSlotCoeff ->
   Word64
 computeStabilityWindow k asc =
-  ceiling $ (3 * fromIntegral k) / f
+  ceiling $ (3 * fromIntegral k) /. f
   where
-    f = unboundRational . activeSlotVal $ asc
+    f = positiveUnitIntervalNonZeroRational . activeSlotVal $ asc
 
 -- | Calculate the randomness stabilisation window from the security param and
 -- the active slot coefficient.
@@ -31,6 +31,6 @@ computeRandomnessStabilisationWindow ::
   ActiveSlotCoeff ->
   Word64
 computeRandomnessStabilisationWindow k asc =
-  ceiling $ (4 * fromIntegral k) / f
+  ceiling $ (4 * fromIntegral k) /. f
   where
-    f = unboundRational . activeSlotVal $ asc
+    f = positiveUnitIntervalNonZeroRational . activeSlotVal $ asc

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -694,7 +694,7 @@ instance
           , sgNetworkMagic = 123456 -- Mainnet value: 764824073
           , sgNetworkId = Testnet
           , sgActiveSlotsCoeff = 20 %! 100 -- Mainnet value: 5 %! 100
-          , sgSecurityParam = 108 -- Mainnet value: 2160
+          , sgSecurityParam = knownNonZeroBounded @108 -- Mainnet value: 2160
           , sgEpochLength = 4320 -- Mainnet value: 432000
           , sgSlotsPerKESPeriod = 129600
           , sgMaxKESEvolutions = 62

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
@@ -353,7 +353,7 @@ exampleNewEpochState value ppp pp =
         epochState
         (Coin 1000)
         (activeSlotCoeff testGlobals)
-        10
+        (knownNonZeroBounded @10)
 
 exampleLedgerChainDepState :: Word64 -> ChainDepState
 exampleLedgerChainDepState seed =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Update.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Update.hs
@@ -24,6 +24,7 @@ import Cardano.Ledger.BaseTypes (
   BoundedRational,
   EpochInterval (..),
   NonNegativeInterval,
+  NonZero,
   Nonce (NeutralNonce),
   ProtVer (..),
   StrictMaybe (..),
@@ -34,6 +35,7 @@ import Cardano.Ledger.BaseTypes (
   mkVersion,
   mkVersion64,
   succVersion,
+  unsafeNonZero,
  )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rewards.hs
@@ -44,9 +44,15 @@ import Cardano.Ledger.BaseTypes (
   activeSlotVal,
   epochInfoPure,
   mkActiveSlotCoeff,
+  (%?),
  )
 import Cardano.Ledger.Binary (encCBOR, hashWithEncoder, natVersion, shelleyProtVer)
-import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..), rationalToCoinViaFloor, toDeltaCoin)
+import Cardano.Ledger.Coin (
+  Coin (..),
+  DeltaCoin (..),
+  rationalToCoinViaFloor,
+  toDeltaCoin,
+ )
 import Cardano.Ledger.Compactible
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.EpochBoundary (
@@ -485,8 +491,8 @@ rewardOld
         ]
       results = do
         (hk, pparams) <- VMap.toAscList poolParams
-        let sigma = if totalStake == 0 then 0 else fromIntegral pstake % fromIntegral totalStake
-            sigmaA = if activeStake == 0 then 0 else fromIntegral pstake % fromIntegral activeStake
+        let sigma = fromIntegral pstake %? fromIntegral totalStake
+            sigmaA = fromIntegral pstake %? fromIntegral activeStake
             blocksProduced = Map.lookup hk b
             actgr = poolStake hk delegs stake
             Coin pstake = sumAllStake actgr

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Genesis.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Genesis.hs
@@ -14,7 +14,7 @@ module Test.Cardano.Ledger.Shelley.Serialisation.Golden.Genesis (
 )
 where
 
-import Cardano.Ledger.BaseTypes (textToDns, textToUrl)
+import Cardano.Ledger.BaseTypes (knownNonZeroBounded, textToDns, textToUrl)
 import Cardano.Ledger.Binary (Tokens (..))
 import qualified Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Core (emptyPParams, ppDL, ppMaxBBSizeL, ppMaxBHSizeL)
@@ -195,7 +195,7 @@ exampleShelleyGenesis =
     , sgNetworkMagic = 4036000900
     , sgNetworkId = L.Testnet
     , sgActiveSlotsCoeff = unsafeBoundRational 0.259
-    , sgSecurityParam = 120842
+    , sgSecurityParam = knownNonZeroBounded @120842
     , sgEpochLength = EpochSize 1215
     , sgSlotsPerKESPeriod = 8541
     , sgMaxKESEvolutions = 28899

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -833,7 +833,7 @@ instance SpecTranslate ctx (ConwayPParams StrictMaybe era) where
     ppuKeyDeposit <- toSpecRep cppKeyDeposit
     ppuPoolDeposit <- toSpecRep cppPoolDeposit
     ppuEmax <- toSpecRep cppEMax
-    ppuNopt <- toSpecRep (fmap toInteger . strictMaybeToMaybe . unTHKD $ cppNOpt)
+    ppuNopt <- toSpecRep (fmap toInteger . strictMaybeToMaybe $ unTHKD cppNOpt)
     let
       ppuPv = Nothing
       ppuMinUTxOValue = Nothing -- minUTxOValue has been deprecated and is not supported in Conway

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 1.17.0.0
 
+* Added `ToPlutusData` instance for `NonZero`
+* `maxpool'` now expects `nOpt` to be a `NonZero Word16`
+* Add `HasZero` instance for `Coin` together with lifted conversion functions:
+  * `toCompactCoinNonZero`
+  * `fromCompactCoinNonZero`
+  * `unCoinNonZero`
+  * `toCoinNonZero`
+  * `compactCoinNonZero`
+* Add `Cardano.Ledger.BaseTypes.NonZero`
 * Remove `era` type parameter from `MemoBytes` type
 * Remove `Era era` constraint from:
   * `Memo` pattern
@@ -83,6 +92,7 @@
 
 ### `testlib`
 
+* Added `Arbitrary` and `ToExpr` instances for `NonZero`
 * Deprecate `genBadPtr`, `genAddrBadPtr` and `genCompactAddrBadPtr`
 * Remove crypto parametrization from types: `KeyPair` and `KeyPairs`
 

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -30,6 +30,7 @@ library
     Cardano.Ledger.AuxiliaryData
     Cardano.Ledger.BHeaderView
     Cardano.Ledger.BaseTypes
+    Cardano.Ledger.BaseTypes.NonZero
     Cardano.Ledger.Block
     Cardano.Ledger.CertState
     Cardano.Ledger.Coin

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -20,6 +20,7 @@
 
 module Cardano.Ledger.BaseTypes (
   module Slotting,
+  module NonZero,
   ProtVer (..),
   module Cardano.Ledger.Binary.Version,
   FixedPoint,
@@ -82,12 +83,14 @@ module Cardano.Ledger.BaseTypes (
 
   -- * Injection
   Inject (..),
+  positiveUnitIntervalNonZeroRational,
 )
 where
 
 import Cardano.Crypto.Hash
 import Cardano.Crypto.Util (SignableRepresentation (..))
 import qualified Cardano.Crypto.VRF as VRF
+import Cardano.Ledger.BaseTypes.NonZero as NonZero
 import Cardano.Ledger.Binary (
   CBORGroup (..),
   DecCBOR (decCBOR),
@@ -678,7 +681,7 @@ data Globals = Globals
   , randomnessStabilisationWindow :: !Word64
   -- ^ Number of slots before the end of the epoch at which we stop updating
   --   the candidate nonce for the next epoch.
-  , securityParameter :: !Word64
+  , securityParameter :: !(NonZero Word64)
   -- ^ Maximum number of blocks we are allowed to roll back
   , maxKESEvo :: !Word64
   -- ^ Maximum number of KES iterations
@@ -927,3 +930,6 @@ instance Inject a a where
 -- | Helper function for a common pattern of creating objects
 kindObject :: Text -> [Pair] -> Value
 kindObject name obj = object $ ("kind" .= name) : obj
+
+positiveUnitIntervalNonZeroRational :: PositiveUnitInterval -> NonZero Rational
+positiveUnitIntervalNonZeroRational = unsafeNonZero . unboundRational

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes/NonZero.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes/NonZero.hs
@@ -1,0 +1,173 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+
+module Cardano.Ledger.BaseTypes.NonZero (
+  KnownBounds (..),
+  HasZero (..),
+  WithinBounds,
+  NonZero,
+  unNonZero,
+  nonZero,
+  knownNonZero,
+  knownNonZeroBounded,
+  (%.),
+  bindNonZero,
+  mapNonZero,
+  unsafeNonZero,
+  toIntegerNonZero,
+  (/.),
+  nonZeroOr,
+  recipNonZero,
+  negateNonZero,
+  mulNonZero,
+  mulNonZeroNat,
+  toRatioNonZero,
+  (%?),
+) where
+
+import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR)
+import Control.DeepSeq (NFData)
+import Data.Aeson (FromJSON (..), ToJSON)
+import Data.Maybe (fromMaybe)
+import Data.Proxy (Proxy (..))
+import Data.Ratio (Ratio, numerator, (%))
+import Data.Typeable (Typeable)
+import Data.Word (Word16, Word32, Word64, Word8)
+import GHC.TypeLits
+import NoThunks.Class (NoThunks)
+#if __GLASGOW_HASKELL__ < 900
+import Numeric.Natural (Natural)
+#endif
+
+class KnownBounds a where
+  type MinBound a :: Nat
+  type MaxBound a :: Nat
+
+instance KnownBounds Word8 where
+  type MinBound Word8 = 0
+  type MaxBound Word8 = 0xFF
+
+instance KnownBounds Word16 where
+  type MinBound Word16 = 0
+  type MaxBound Word16 = 0xFFFF
+
+instance KnownBounds Word32 where
+  type MinBound Word32 = 0
+  type MaxBound Word32 = 0xFFFFFFFF
+
+instance KnownBounds Word64 where
+  type MinBound Word64 = 0
+  type MaxBound Word64 = 0xFFFFFFFFFFFFFFFF
+
+type WithinBounds n a = (MinBound a <= n, n <= MaxBound a)
+
+newtype NonZero a = NonZero {unNonZero :: a}
+  deriving (Eq, Ord, Show, NoThunks, NFData)
+  deriving newtype (EncCBOR, ToJSON)
+
+class HasZero a where
+  isZero :: a -> Bool
+  default isZero :: (Eq a, Num a) => a -> Bool
+  isZero = (== 0)
+
+instance HasZero Word8
+
+instance HasZero Word16
+
+instance HasZero Word32
+
+instance HasZero Word64
+
+instance HasZero Integer
+
+instance HasZero Int
+
+instance HasZero Natural
+
+instance HasZero a => HasZero (Ratio a) where
+  isZero = isZero . numerator
+
+instance (Typeable a, DecCBOR a, HasZero a) => DecCBOR (NonZero a) where
+  decCBOR = decCBOR >>= nonZeroM
+
+instance (FromJSON a, HasZero a) => FromJSON (NonZero a) where
+  parseJSON v = parseJSON v >>= nonZeroM
+
+knownNonZero ::
+  forall (n :: Nat).
+  (KnownNat n, 1 <= n) =>
+  NonZero Integer
+knownNonZero = NonZero (natVal $ Proxy @n)
+
+knownNonZeroBounded ::
+  forall (n :: Nat) a.
+  (KnownNat n, 1 <= n, WithinBounds n a, Num a) =>
+  NonZero a
+knownNonZeroBounded = NonZero (fromInteger . natVal $ Proxy @n)
+
+nonZero :: HasZero a => a -> Maybe (NonZero a)
+nonZero = nonZeroM
+
+nonZeroM :: (HasZero a, MonadFail m) => a -> m (NonZero a)
+nonZeroM x
+  | isZero x = fail "Encountered zero while trying to construct a NonZero value"
+  | otherwise = pure $ NonZero x
+
+nonZeroOr :: HasZero a => a -> NonZero a -> NonZero a
+nonZeroOr x d = fromMaybe d $ nonZero x
+
+mapNonZero :: (Eq b, HasZero b) => (a -> b) -> NonZero a -> Maybe (NonZero b)
+mapNonZero f (NonZero x) = nonZero $ f x
+
+bindNonZero :: (a -> NonZero b) -> NonZero a -> NonZero b
+bindNonZero f (NonZero x) = f x
+
+unsafeNonZero :: a -> NonZero a
+unsafeNonZero = NonZero
+
+infixl 7 %.
+(%.) :: Integral a => a -> NonZero a -> Ratio a
+x %. y = x % unNonZero y
+
+infixl 7 %?
+(%?) :: Integral a => a -> a -> Ratio a
+x %? y
+  | y == 0 = 0
+  | otherwise = x % y
+
+toIntegerNonZero :: Integral a => NonZero a -> NonZero Integer
+toIntegerNonZero (NonZero x) = NonZero $ toInteger x
+
+infixl 7 /.
+(/.) :: Fractional a => a -> NonZero a -> a
+x /. y = x / unNonZero y
+
+-- Common safe functions
+
+toRatioNonZero :: Integral a => NonZero a -> NonZero (Ratio a)
+toRatioNonZero (NonZero x) = NonZero $ x % 1
+
+recipNonZero :: Integral a => NonZero (Ratio a) -> NonZero (Ratio a)
+recipNonZero (NonZero x) = NonZero $ recip x
+
+negateNonZero :: NonZero Integer -> NonZero Integer
+negateNonZero (NonZero x) = NonZero $ negate x
+
+mulNonZero :: (Integral a, Integral b) => NonZero a -> NonZero b -> NonZero Integer
+mulNonZero (NonZero x) (NonZero y) = NonZero $ toInteger x * toInteger y
+
+mulNonZeroNat :: forall n a. (KnownNat n, 1 <= n, Integral a) => NonZero a -> NonZero Integer
+mulNonZeroNat (NonZero x) = NonZero (toInteger x * natVal (Proxy @n))

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
@@ -24,11 +24,23 @@ module Cardano.Ledger.Coin (
   integerToWord64,
   decodePositiveCoin,
   compactCoinOrError,
+  -- NonZero helpers
+  toCompactCoinNonZero,
+  unCoinNonZero,
+  toCoinNonZero,
+  fromCompactCoinNonZero,
+  compactCoinNonZero,
 )
 where
 
 import Cardano.HeapWords (HeapWords)
-import Cardano.Ledger.BaseTypes (Inject (..))
+import Cardano.Ledger.BaseTypes (
+  HasZero (..),
+  Inject (..),
+  NonZero,
+  unNonZero,
+  unsafeNonZero,
+ )
 import Cardano.Ledger.Binary (
   DecCBOR (..),
   Decoder,
@@ -190,3 +202,21 @@ instance UniformRange Coin where
 
 instance UniformRange (CompactForm Coin) where
   uniformRM (CompactCoin l, CompactCoin h) g = CompactCoin <$> uniformRM (l, h) g
+
+instance HasZero Coin where
+  isZero = (== Coin 0)
+
+toCompactCoinNonZero :: NonZero Coin -> Maybe (NonZero (CompactForm Coin))
+toCompactCoinNonZero = fmap unsafeNonZero . toCompact . unNonZero
+
+fromCompactCoinNonZero :: NonZero (CompactForm Coin) -> NonZero Coin
+fromCompactCoinNonZero = unsafeNonZero . fromCompact . unNonZero
+
+unCoinNonZero :: NonZero Coin -> NonZero Integer
+unCoinNonZero = unsafeNonZero . unCoin . unNonZero
+
+toCoinNonZero :: Integral a => NonZero a -> NonZero Coin
+toCoinNonZero = unsafeNonZero . Coin . toInteger . unNonZero
+
+compactCoinNonZero :: NonZero Word64 -> NonZero (CompactForm Coin)
+compactCoinNonZero = unsafeNonZero . CompactCoin . unNonZero

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -54,6 +54,7 @@ import Cardano.Ledger.BaseTypes (
   CertIx (..),
   DnsName,
   EpochInterval (..),
+  HasZero,
   Mismatch (..),
   Network (..),
   NonNegativeInterval,
@@ -73,6 +74,7 @@ import Cardano.Ledger.BaseTypes (
   textToDns,
   textToUrl,
  )
+import qualified Cardano.Ledger.BaseTypes as NZ
 import Cardano.Ledger.Binary (EncCBOR, Sized, mkSized)
 import Cardano.Ledger.CertState (
   Anchor (..),
@@ -547,6 +549,9 @@ instance Arbitrary DRep where
       , pure DRepAlwaysAbstain
       , pure DRepAlwaysNoConfidence
       ]
+
+instance (Arbitrary a, HasZero a) => Arbitrary (NZ.NonZero a) where
+  arbitrary = arbitrary `suchThatMap` NZ.nonZero
 
 -- | Used for testing UMap operations
 genValidTuples ::

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Utils.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Utils.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -13,6 +14,7 @@ import Cardano.Ledger.BaseTypes (
   EpochSize (..),
   Globals (..),
   Network (..),
+  knownNonZeroBounded,
   mkActiveSlotCoeff,
  )
 import Cardano.Ledger.Core
@@ -32,7 +34,7 @@ testGlobals =
     , slotsPerKESPeriod = 20
     , stabilityWindow = 33
     , randomnessStabilisationWindow = 33
-    , securityParameter = 10
+    , securityParameter = knownNonZeroBounded @10
     , maxKESEvo = 10
     , quorum = 5
     , maxLovelaceSupply = 45 * 1000 * 1000 * 1000 * 1000 * 1000

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
@@ -256,3 +256,6 @@ deriving instance (Era era, ToExpr (Script era)) => ToExpr (ScriptsProvided era)
 instance ToExpr (TxOut era) => ToExpr (UTxO era)
 
 instance ToExpr TxOutSource
+
+instance ToExpr a => ToExpr (NonZero a) where
+  toExpr x = App "NonZero" [toExpr $ unNonZero x]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Basic.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Basic.hs
@@ -66,7 +66,7 @@ import Test.Cardano.Ledger.Allegra.Arbitrary ()
 import Test.Cardano.Ledger.Alonzo.Arbitrary ()
 import Test.Cardano.Ledger.Generic.PrettyCore (PrettyA (..))
 import Test.Cardano.Ledger.Generic.Proof (Reflect (..))
-import Test.QuickCheck hiding (Args, Fun, forAll)
+import Test.QuickCheck hiding (Args, Fun, NonZero, forAll)
 
 -- ============================================================================
 -- Making Intervals based on Ratios, These can fail, so be careful using them.

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -174,7 +174,7 @@ import Test.Cardano.Ledger.Core.Utils
 import Test.Cardano.Ledger.Shelley.Utils
 import Test.Cardano.Ledger.TreeDiff (ToExpr)
 import Test.Cardano.Slotting.Numeric ()
-import Test.QuickCheck hiding (Args, Fun, forAll)
+import Test.QuickCheck hiding (Args, Fun, NonZero, forAll)
 
 -- ==========================================================
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Vars.hs
@@ -25,6 +25,10 @@ import Cardano.Ledger.BaseTypes (
   SlotNo (..),
   StrictMaybe (..),
   UnitInterval,
+  knownNonZero,
+  mulNonZero,
+  toIntegerNonZero,
+  (%.),
  )
 import qualified Cardano.Ledger.BaseTypes as Base (EpochInterval (..), Globals (..))
 import Cardano.Ledger.CertState (
@@ -109,7 +113,6 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict (maybeToStrictMaybe, strictMaybeToMaybe)
 import qualified Data.OMap.Strict as OMap
-import Data.Ratio ((%))
 import qualified Data.Sequence.Strict as SS
 import Data.Set (Set)
 import qualified Data.VMap as VMap
@@ -1847,7 +1850,7 @@ initPulser proof utx credDRepMap poold credDRepStateMap epoch commstate enactsta
       pp = def & ppProtocolVersionL .~ protocolVersion proof
       IStake stakeDistr _ = updateStakeDistribution pp mempty mempty (utx ^. utxoFL proof)
    in DRepPulser
-        (max 1 (ceiling (toInteger umapSize % (8 * toInteger k))))
+        (max 1 (ceiling (toInteger umapSize %. (knownNonZero @8 `mulNonZero` toIntegerNonZero k))))
         umap
         0
         stakeDistr

--- a/libs/constrained-generators/src/Constrained/Base.hs
+++ b/libs/constrained-generators/src/Constrained/Base.hs
@@ -5104,7 +5104,7 @@ instance BaseUniverse fn => Functions (IntFn fn) fn where
     | HOLE :? Value i :> Nil <- ctx =
         case spec of
           TypeSpec ts cant ->
-            subtractSpec @fn i ts <> notMemberSpec (catMaybes $ map (safeSubtract @fn i) cant)
+            subtractSpec @fn i ts <> notMemberSpec (mapMaybe (safeSubtract @fn i) cant)
           MemberSpec es ->
             memberSpecList
               (nub $ mapMaybe (safeSubtract @fn i) (NE.toList es))


### PR DESCRIPTION
# Description

This PR adds the `NonZero` module and gets rid of unsafe division (or at least makes the error explicit).

closes #4696

# Checklist

- [ ] Commits in meaningful sequence and with useful messages
- [x] Tests added or updated when needed
- [x] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
