### PR TITLE
Remove `era` type parameter from `MemoBytes`

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 1.7.0.0
 
+* Add `Era era` constraint to `NoThunks` instance for `TimeLock`
+* Remove `Era era` constraint from:
+  * `getRequireSignatureTimelock`
+  * `getRequireAllOfTimelock`
+  * `getRequireAnyOfTimelock`
+  * `getRequireMOfTimelock`
+  * `getTimeStartTimelock`
+  * `getTimeExpireTimelock`
 * Add `MemPack` instance for `Timelock`
 * Remove deprecated `AuxiliaryData` type synonym
 * Deprecate `Allegra` type synonym

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody/Internal.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody/Internal.hs
@@ -131,7 +131,7 @@ import Cardano.Ledger.MemoBytes (
   getMemoRawType,
   getMemoSafeHash,
   lensMemoRawType,
-  mkMemoized,
+  mkMemoizedEra,
  )
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..), Update (..))
 import Cardano.Ledger.Shelley.TxBody (getShelleyGenesisKeyHashCountTxBody)
@@ -215,12 +215,12 @@ deriving instance
   (Era era, Show (TxOut era), Show (TxCert era), Show (PParamsUpdate era)) =>
   Show (AlonzoTxBodyRaw era)
 
-newtype AlonzoTxBody era = TxBodyConstr (MemoBytes AlonzoTxBodyRaw era)
+newtype AlonzoTxBody era = TxBodyConstr (MemoBytes (AlonzoTxBodyRaw era))
   deriving (ToCBOR, Generic)
   deriving newtype (SafeToHash)
 
-instance Memoized AlonzoTxBody where
-  type RawType AlonzoTxBody = AlonzoTxBodyRaw
+instance Memoized (AlonzoTxBody era) where
+  type RawType (AlonzoTxBody era) = AlonzoTxBodyRaw era
 
 data AlonzoTxBodyUpgradeError
   = -- | The TxBody contains a protocol parameter update that attempts to update
@@ -233,24 +233,26 @@ instance EraTxBody AlonzoEra where
   type TxBody AlonzoEra = AlonzoTxBody AlonzoEra
   type TxBodyUpgradeError AlonzoEra = AlonzoTxBodyUpgradeError
 
-  mkBasicTxBody = mkMemoized emptyAlonzoTxBodyRaw
+  mkBasicTxBody = mkMemoizedEra @AlonzoEra emptyAlonzoTxBodyRaw
 
   inputsTxBodyL =
-    lensMemoRawType atbrInputs (\txBodyRaw inputs_ -> txBodyRaw {atbrInputs = inputs_})
+    lensMemoRawType @AlonzoEra atbrInputs $
+      \txBodyRaw inputs_ -> txBodyRaw {atbrInputs = inputs_}
   {-# INLINEABLE inputsTxBodyL #-}
 
   outputsTxBodyL =
-    lensMemoRawType atbrOutputs (\txBodyRaw outputs_ -> txBodyRaw {atbrOutputs = outputs_})
+    lensMemoRawType @AlonzoEra atbrOutputs $
+      \txBodyRaw outputs_ -> txBodyRaw {atbrOutputs = outputs_}
   {-# INLINEABLE outputsTxBodyL #-}
 
   feeTxBodyL =
-    lensMemoRawType atbrTxFee (\txBodyRaw fee_ -> txBodyRaw {atbrTxFee = fee_})
+    lensMemoRawType @AlonzoEra atbrTxFee $
+      \txBodyRaw fee_ -> txBodyRaw {atbrTxFee = fee_}
   {-# INLINEABLE feeTxBodyL #-}
 
   auxDataHashTxBodyL =
-    lensMemoRawType
-      atbrAuxDataHash
-      (\txBodyRaw auxDataHash -> txBodyRaw {atbrAuxDataHash = auxDataHash})
+    lensMemoRawType @AlonzoEra atbrAuxDataHash $
+      \txBodyRaw auxDataHash -> txBodyRaw {atbrAuxDataHash = auxDataHash}
   {-# INLINEABLE auxDataHashTxBodyL #-}
 
   spendableInputsTxBodyF = allInputsTxBodyF
@@ -261,13 +263,13 @@ instance EraTxBody AlonzoEra where
   {-# INLINEABLE allInputsTxBodyF #-}
 
   withdrawalsTxBodyL =
-    lensMemoRawType
-      atbrWithdrawals
-      (\txBodyRaw withdrawals_ -> txBodyRaw {atbrWithdrawals = withdrawals_})
+    lensMemoRawType @AlonzoEra atbrWithdrawals $
+      \txBodyRaw withdrawals_ -> txBodyRaw {atbrWithdrawals = withdrawals_}
   {-# INLINEABLE withdrawalsTxBodyL #-}
 
   certsTxBodyL =
-    lensMemoRawType atbrCerts (\txBodyRaw certs_ -> txBodyRaw {atbrCerts = certs_})
+    lensMemoRawType @AlonzoEra atbrCerts $
+      \txBodyRaw certs_ -> txBodyRaw {atbrCerts = certs_}
   {-# INLINEABLE certsTxBodyL #-}
 
   getGenesisKeyHashCountTxBody = getShelleyGenesisKeyHashCountTxBody
@@ -330,17 +332,20 @@ instance ShelleyEraTxBody AlonzoEra where
   ttlTxBodyL = notSupportedInThisEraL
 
   updateTxBodyL =
-    lensMemoRawType atbrUpdate (\txBodyRaw update_ -> txBodyRaw {atbrUpdate = update_})
+    lensMemoRawType @AlonzoEra atbrUpdate $
+      \txBodyRaw update_ -> txBodyRaw {atbrUpdate = update_}
   {-# INLINEABLE updateTxBodyL #-}
 
 instance AllegraEraTxBody AlonzoEra where
   vldtTxBodyL =
-    lensMemoRawType atbrValidityInterval (\txBodyRaw vldt_ -> txBodyRaw {atbrValidityInterval = vldt_})
+    lensMemoRawType @AlonzoEra atbrValidityInterval $
+      \txBodyRaw vldt_ -> txBodyRaw {atbrValidityInterval = vldt_}
   {-# INLINEABLE vldtTxBodyL #-}
 
 instance MaryEraTxBody AlonzoEra where
   mintTxBodyL =
-    lensMemoRawType atbrMint (\txBodyRaw mint_ -> txBodyRaw {atbrMint = mint_})
+    lensMemoRawType @AlonzoEra atbrMint $
+      \txBodyRaw mint_ -> txBodyRaw {atbrMint = mint_}
   {-# INLINEABLE mintTxBodyL #-}
 
   mintValueTxBodyF = mintTxBodyL . to (MaryValue mempty)
@@ -351,23 +356,23 @@ instance MaryEraTxBody AlonzoEra where
 
 instance AlonzoEraTxBody AlonzoEra where
   collateralInputsTxBodyL =
-    lensMemoRawType atbrCollateral (\txBodyRaw collateral_ -> txBodyRaw {atbrCollateral = collateral_})
+    lensMemoRawType @AlonzoEra atbrCollateral $
+      \txBodyRaw collateral_ -> txBodyRaw {atbrCollateral = collateral_}
   {-# INLINEABLE collateralInputsTxBodyL #-}
 
   reqSignerHashesTxBodyL =
-    lensMemoRawType
-      atbrReqSignerHashes
-      (\txBodyRaw reqSignerHashes_ -> txBodyRaw {atbrReqSignerHashes = reqSignerHashes_})
+    lensMemoRawType @AlonzoEra atbrReqSignerHashes $
+      \txBodyRaw reqSignerHashes_ -> txBodyRaw {atbrReqSignerHashes = reqSignerHashes_}
   {-# INLINEABLE reqSignerHashesTxBodyL #-}
 
   scriptIntegrityHashTxBodyL =
-    lensMemoRawType
-      atbrScriptIntegrityHash
-      (\txBodyRaw scriptIntegrityHash_ -> txBodyRaw {atbrScriptIntegrityHash = scriptIntegrityHash_})
+    lensMemoRawType @AlonzoEra atbrScriptIntegrityHash $
+      \txBodyRaw scriptIntegrityHash_ -> txBodyRaw {atbrScriptIntegrityHash = scriptIntegrityHash_}
   {-# INLINEABLE scriptIntegrityHashTxBodyL #-}
 
   networkIdTxBodyL =
-    lensMemoRawType atbrTxNetworkId (\txBodyRaw networkId -> txBodyRaw {atbrTxNetworkId = networkId})
+    lensMemoRawType @AlonzoEra atbrTxNetworkId $
+      \txBodyRaw networkId -> txBodyRaw {atbrTxNetworkId = networkId}
   {-# INLINEABLE networkIdTxBodyL #-}
 
   redeemerPointer = alonzoRedeemerPointer
@@ -391,12 +396,13 @@ deriving instance
   Show (AlonzoTxBody era)
 
 deriving via
-  (Mem AlonzoTxBodyRaw era)
+  Mem (AlonzoTxBodyRaw era)
   instance
     (Era era, DecCBOR (TxOut era), DecCBOR (TxCert era), DecCBOR (PParamsUpdate era)) =>
     DecCBOR (Annotator (AlonzoTxBody era))
 
 pattern AlonzoTxBody ::
+  forall era.
   (EraTxOut era, EraTxCert era) =>
   Set TxIn ->
   Set TxIn ->
@@ -459,7 +465,7 @@ pattern AlonzoTxBody
       scriptIntegrityHash
       auxDataHash
       txNetworkId =
-        mkMemoized $
+        mkMemoizedEra @era $
           AlonzoTxBodyRaw
             { atbrInputs = inputs
             , atbrCollateral = collateral
@@ -478,7 +484,7 @@ pattern AlonzoTxBody
 
 {-# COMPLETE AlonzoTxBody #-}
 
-type instance MemoHashIndex AlonzoTxBodyRaw = EraIndependentTxBody
+type instance MemoHashIndex (AlonzoTxBodyRaw era) = EraIndependentTxBody
 
 instance HashAnnotated (AlonzoTxBody era) EraIndependentTxBody where
   hashAnnotated = getMemoSafeHash

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Remove `Era era` constraint from `sizeShelleyTxF` and `wireSizeShelleyTxF`
 * Add `MemPack` instance `ShelleyTxOut`
 * Deprecate `hashShelleyTxAuxData`
 * Stop re-exporting `ScriptHash` from `Cardano.Ledger.Shelley.Scripts`. Import it instead from `Cardano.Ledger.Hashes`.

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## 1.17.0.0
 
+* Add `byteCountMemoBytes`, `packMemoBytesM` and `unpackMemoBytesM` to `MemoBytes` module
 * Require `MemPack` instance for `TxOut` and `CompactForm (Value era)` for `EraTxOut` type class.
 * Add `decodeMemoBytes`
 * Add `MemPack` instance for `CompactAddr`, `TxIx`, `TxId`, `TxIn`, `CompactForm Coin`,
-  `KeyHash`, `ScriptHash`, `Credential`, `SafeHash`, `MemoBytes`, `Plutus`, `PlutusBinary`, `BinaryData` and `Datum`
+  `KeyHash`, `ScriptHash`, `Credential`, `SafeHash`, `Plutus`, `PlutusBinary`, `BinaryData` and `Datum`
 * Add `DecShareCBOR` instance for `TxIn`
 * Add `fromCborRigorousBothAddr`
 * Add `SlotNo32` and use it in `Ptr` definition

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## 1.17.0.0
 
+* Remove `era` type parameter from `MemoBytes` type
+* Remove `Era era` constraint from:
+  * `Memo` pattern
+  * `decodeMemoBytes`
+  * `DecCBOR (Annotator (MemoBytes t))` instance
+  * `DecCBOR (MemoBytes t)` instance
+  * `memoBytes`
+  * `mkMemoized`
+  * `lensMemoRawType`
+  * `Data` pattern
+  * `dataToBinaryData`
+* Introduce `mkMemoizedEra` and `memoBytesEra`
+* Add `Version` parameter to:
+  * `memoBytes`
+  * `mkMemoized`
+  * `lensMemoRawType`
+* Remove `era` type parameter from `Mem` type
+* Reduce the kind of `MemoHashIndex` type family parameter to a concrete type
+* Reduce the kind of `RawType` type to a concrete type
 * Add `byteCountMemoBytes`, `packMemoBytesM` and `unpackMemoBytesM` to `MemoBytes` module
 * Require `MemPack` instance for `TxOut` and `CompactForm (Value era)` for `EraTxOut` type class.
 * Add `decodeMemoBytes`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes.hs
@@ -31,6 +31,11 @@ module Cardano.Ledger.MemoBytes (
   lensMemoRawType,
   getterMemoRawType,
 
+  -- * MemoBytes MemPack definitions
+  byteCountMemoBytes,
+  packMemoBytesM,
+  unpackMemoBytesM,
+
   -- * Raw equality
   EqRaw (..),
 )

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes.hs
@@ -12,6 +12,7 @@ module Cardano.Ledger.MemoBytes (
   getMemoBytesType,
   getMemoBytesHash,
   memoBytes,
+  memoBytesEra,
   shorten,
   showMemo,
   printMemo,
@@ -22,6 +23,7 @@ module Cardano.Ledger.MemoBytes (
   -- * Memoized
   Memoized (RawType),
   mkMemoized,
+  mkMemoizedEra,
   decodeMemoized,
   getMemoSafeHash,
   getMemoRawType,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes/Internal.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DeriveAnyClass #-}
@@ -35,6 +36,7 @@ module Cardano.Ledger.MemoBytes.Internal (
   getMemoBytesType,
   getMemoBytesHash,
   memoBytes,
+  memoBytesEra,
   shorten,
   showMemo,
   printMemo,
@@ -45,6 +47,7 @@ module Cardano.Ledger.MemoBytes.Internal (
   -- * Memoized
   Memoized (RawType),
   mkMemoized,
+  mkMemoizedEra,
   decodeMemoized,
   getMemoSafeHash,
   getMemoRawType,
@@ -71,6 +74,7 @@ import Cardano.Ledger.Binary (
   DecCBOR (decCBOR),
   Decoder,
   EncCBOR,
+  Version,
   decodeAnnotated,
   decodeFullAnnotator,
   serialize,
@@ -104,15 +108,15 @@ import Prelude hiding (span)
 --   that were used to transmit it. Important since hashes are computed
 --   from the serialization of a type, and EncCBOR instances do not have unique
 --   serializations.
-data MemoBytes t era = Memo'
-  { mbRawType :: !(t era)
+data MemoBytes t = Memo'
+  { mbRawType :: !t
   , mbBytes :: ShortByteString
   , mbHash :: SafeHash (MemoHashIndex t)
   }
   deriving (Generic)
-  deriving (NoThunks) via AllowThunksIn '["mbBytes", "mbHash"] (MemoBytes t era)
+  deriving (NoThunks) via AllowThunksIn '["mbBytes", "mbHash"] (MemoBytes t)
 
-pattern Memo :: Era era => t era -> ShortByteString -> MemoBytes t era
+pattern Memo :: t -> ShortByteString -> MemoBytes t
 pattern Memo memoType memoBytes <-
   Memo' memoType memoBytes _
   where
@@ -120,54 +124,53 @@ pattern Memo memoType memoBytes <-
 
 {-# COMPLETE Memo #-}
 
-byteCountMemoBytes :: MemoBytes t era -> Int
+byteCountMemoBytes :: MemoBytes t -> Int
 byteCountMemoBytes = packedByteCount . mbBytes
 
-packMemoBytesM :: MemoBytes t era -> Pack s ()
+packMemoBytesM :: MemoBytes t -> Pack s ()
 packMemoBytesM = packM . mbBytes
 
 unpackMemoBytesM ::
-  forall era t b.
-  (Era era, DecCBOR (Annotator (t era)), Typeable t, Buffer b) =>
-  Unpack b (MemoBytes t era)
-unpackMemoBytesM = unpackM >>= decodeMemoBytes
+  forall t b.
+  (Typeable t, DecCBOR (Annotator t), Buffer b) =>
+  Version ->
+  Unpack b (MemoBytes t)
+unpackMemoBytesM v = unpackM >>= decodeMemoBytes v
 
 decodeMemoBytes ::
-  forall t era m.
-  (Typeable t, Era era, DecCBOR (Annotator (t era)), MonadFail m) =>
-  ByteString ->
-  m (MemoBytes t era)
-decodeMemoBytes bs =
+  forall t m.
+  (Typeable t, DecCBOR (Annotator t), MonadFail m) => Version -> ByteString -> m (MemoBytes t)
+decodeMemoBytes v bs =
   either (fail . show) pure $
     decodeFullAnnotator
-      (eraProtVerLow @era)
+      v
       (T.pack (show (typeRep (Proxy @t))))
       decCBOR
       (BSL.fromStrict bs)
 
-type family MemoHashIndex (t :: Type -> Type) :: Type
+type family MemoHashIndex (t :: Type) :: Type
 
-deriving instance NFData (t era) => NFData (MemoBytes t era)
+deriving instance NFData t => NFData (MemoBytes t)
 
-instance (Typeable t, Typeable era) => Plain.ToCBOR (MemoBytes t era) where
+instance Typeable t => Plain.ToCBOR (MemoBytes t) where
   toCBOR (Memo' _ bytes _hash) = Plain.encodePreEncoded (fromShort bytes)
 
 instance
-  (Typeable t, DecCBOR (Annotator (t era)), Era era) =>
-  DecCBOR (Annotator (MemoBytes t era))
+  (Typeable t, DecCBOR (Annotator t)) =>
+  DecCBOR (Annotator (MemoBytes t))
   where
   decCBOR = do
     (Annotator getT, Annotator getBytes) <- withSlice decCBOR
     pure (Annotator (\fullbytes -> mkMemoBytes (getT fullbytes) (getBytes fullbytes)))
 
-instance (Typeable t, DecCBOR (t era), Era era) => DecCBOR (MemoBytes t era) where
+instance DecCBOR t => DecCBOR (MemoBytes t) where
   decCBOR = decodeMemoized decCBOR
 
 -- | Both binary representation and Haskell types are compared.
-instance Eq (t era) => Eq (MemoBytes t era) where
+instance Eq t => Eq (MemoBytes t) where
   x == y = mbBytes x == mbBytes y && mbRawType x == mbRawType y
 
-instance Show (t era) => Show (MemoBytes t era) where
+instance Show t => Show (MemoBytes t) where
   show (Memo' y _ h) =
     show y
       <> " ("
@@ -176,7 +179,7 @@ instance Show (t era) => Show (MemoBytes t era) where
       <> show h
       <> ")"
 
-instance SafeToHash (MemoBytes t era) where
+instance SafeToHash (MemoBytes t) where
   originalBytes = fromShort . mbBytes
   originalBytesSize = SBS.length . mbBytes
 
@@ -185,11 +188,11 @@ shorten :: BSL.ByteString -> ShortByteString
 shorten x = toShort (toStrict x)
 
 -- | Useful when deriving DecCBOR(Annotator T)
--- deriving via (Mem T) instance (Era era) => DecCBOR (Annotator T)
-type Mem t era = Annotator (MemoBytes t era)
+-- deriving via (Mem T) instance DecCBOR (Annotator T)
+type Mem t = Annotator (MemoBytes t)
 
 -- | Smart constructor
-mkMemoBytes :: forall era t. t era -> BSL.ByteString -> MemoBytes t era
+mkMemoBytes :: forall t. t -> BSL.ByteString -> MemoBytes t
 mkMemoBytes t bsl =
   Memo'
     t
@@ -200,109 +203,116 @@ mkMemoBytes t bsl =
 
 -- | Turn a MemoBytes into a string, Showing both its internal structure and its original bytes.
 --   Useful since the Show instance of MemoBytes does not display the original bytes.
-showMemo :: Show (t era) => MemoBytes t era -> String
+showMemo :: Show t => MemoBytes t -> String
 showMemo (Memo' t b _) = "(Memo " ++ show t ++ "  " ++ show b ++ ")"
 
-printMemo :: Show (t era) => MemoBytes t era -> IO ()
+printMemo :: Show t => MemoBytes t -> IO ()
 printMemo x = putStrLn (showMemo x)
 
 -- | Create MemoBytes from its CBOR encoding
-memoBytes :: forall era w t. Era era => Encode w (t era) -> MemoBytes t era
-memoBytes t = mkMemoBytes (runE t) (serialize (eraProtVerLow @era) (encode t))
+memoBytes :: Version -> Encode w t -> MemoBytes t
+memoBytes v t = mkMemoBytes (runE t) (serialize v (encode t))
+
+memoBytesEra :: forall era w t. Era era => Encode w t -> MemoBytes t
+memoBytesEra = memoBytes (eraProtVerLow @era)
 
 -- | Helper function. Converts a short bytestring to a lazy bytestring.
 shortToLazy :: ShortByteString -> BSL.ByteString
 shortToLazy = fromStrict . fromShort
 
 -- | Returns true if the contents of the MemoBytes are equal
-contentsEq :: Eq (t era) => MemoBytes t era -> MemoBytes t era -> Bool
+contentsEq :: Eq t => MemoBytes t -> MemoBytes t -> Bool
 contentsEq x y = mbRawType x == mbRawType y
 
 -- | Extract the inner type of the MemoBytes
-getMemoBytesType :: MemoBytes t era -> t era
+getMemoBytesType :: MemoBytes t -> t
 getMemoBytesType = mbRawType
 
 -- | Extract the hash value of the binary representation of the MemoBytes
-getMemoBytesHash :: MemoBytes t era -> SafeHash (MemoHashIndex t)
+getMemoBytesHash :: MemoBytes t -> SafeHash (MemoHashIndex t)
 getMemoBytesHash = mbHash
 
 -- | Class that relates the actual type with its raw and byte representations
 class Memoized t where
-  type RawType t = (r :: Type -> Type) | r -> t
+  type RawType t = (r :: Type) | r -> t
 
   -- | This is a coercion from the memoized type to the MemoBytes. This implementation
   -- cannot be changed since `getMemoBytes` is not exported, therefore it will only work
   -- on newtypes around `MemoBytes`
-  getMemoBytes :: t era -> MemoBytes (RawType t) era
+  getMemoBytes :: t -> MemoBytes (RawType t)
   default getMemoBytes ::
-    Coercible (t era) (MemoBytes (RawType t) era) =>
-    t era ->
-    MemoBytes (RawType t) era
+    Coercible t (MemoBytes (RawType t)) =>
+    t ->
+    MemoBytes (RawType t)
   getMemoBytes = coerce
 
   -- | This is a coercion from the MemoBytes to the momoized type. This implementation
   -- cannot be changed since `warpMemoBytes` is not exported, therefore it will only work
   -- on newtypes around `MemoBytes`
-  wrapMemoBytes :: MemoBytes (RawType t) era -> t era
+  wrapMemoBytes :: MemoBytes (RawType t) -> t
   default wrapMemoBytes ::
-    Coercible (MemoBytes (RawType t) era) (t era) =>
-    MemoBytes (RawType t) era ->
-    t era
+    Coercible (MemoBytes (RawType t)) t =>
+    MemoBytes (RawType t) ->
+    t
   wrapMemoBytes = coerce
 
 -- | Construct memoized type from the raw type using its EncCBOR instance
-mkMemoized :: forall era t. (Era era, EncCBOR (RawType t era), Memoized t) => RawType t era -> t era
-mkMemoized rawType = wrapMemoBytes (mkMemoBytes rawType (serialize (eraProtVerLow @era) rawType))
+mkMemoized :: forall t. (EncCBOR (RawType t), Memoized t) => Version -> RawType t -> t
+mkMemoized v rawType = wrapMemoBytes (mkMemoBytes rawType (serialize v rawType))
 
-decodeMemoized :: Decoder s (t era) -> Decoder s (MemoBytes t era)
+mkMemoizedEra :: forall era t. (Era era, EncCBOR (RawType t), Memoized t) => RawType t -> t
+mkMemoizedEra = mkMemoized (eraProtVerLow @era)
+
+decodeMemoized :: Decoder s t -> Decoder s (MemoBytes t)
 decodeMemoized rawTypeDecoder = do
   Annotated rawType lazyBytes <- decodeAnnotated rawTypeDecoder
   pure $ mkMemoBytes rawType lazyBytes
 
 -- | Extract memoized SafeHash
-getMemoSafeHash :: Memoized t => t era -> SafeHash (MemoHashIndex (RawType t))
+getMemoSafeHash :: Memoized t => t -> SafeHash (MemoHashIndex (RawType t))
 getMemoSafeHash t = mbHash (getMemoBytes t)
 
 -- | Extract the raw type from the memoized version
-getMemoRawType :: Memoized t => t era -> RawType t era
+getMemoRawType :: Memoized t => t -> RawType t
 getMemoRawType t = mbRawType (getMemoBytes t)
 
 -- | Extract the raw bytes from the memoized version
-getMemoRawBytes :: Memoized t => t era -> ShortByteString
+getMemoRawBytes :: Memoized t => t -> ShortByteString
 getMemoRawBytes t = mbBytes (getMemoBytes t)
 
 -- | This is a helper function that operates on raw types of two memoized types.
 zipMemoRawType ::
   (Memoized t1, Memoized t2) =>
-  (RawType t1 era -> RawType t2 era -> a) ->
-  t1 era ->
-  t2 era ->
+  (RawType t1 -> RawType t2 -> a) ->
+  t1 ->
+  t2 ->
   a
 zipMemoRawType f x y = f (getMemoRawType x) (getMemoRawType y)
 
 eqRawType ::
-  forall t era.
-  (Memoized t, Eq (RawType t era)) =>
-  t era ->
-  t era ->
+  forall t.
+  (Memoized t, Eq (RawType t)) =>
+  t ->
+  t ->
   Bool
 eqRawType = zipMemoRawType @t (==)
 
 -- | This is a helper Lens creator for any Memoized type.
 lensMemoRawType ::
-  (Era era, EncCBOR (RawType t era), Memoized t) =>
-  (RawType t era -> a) ->
-  (RawType t era -> b -> RawType t era) ->
-  Lens (t era) (t era) a b
+  forall era t a b.
+  (Era era, EncCBOR (RawType t), Memoized t) =>
+  (RawType t -> a) ->
+  (RawType t -> b -> RawType t) ->
+  Lens t t a b
 lensMemoRawType getter setter =
-  lens (getter . getMemoRawType) (\t v -> mkMemoized $ setter (getMemoRawType t) v)
+  lens (getter . getMemoRawType) (\t b -> mkMemoizedEra @era $ setter (getMemoRawType t) b)
 {-# INLINEABLE lensMemoRawType #-}
 
 -- | This is a helper SimpleGetter creator for any Memoized type
 getterMemoRawType ::
   Memoized t =>
-  (RawType t era -> a) ->
-  SimpleGetter (t era) a
+  (RawType t -> a) ->
+  SimpleGetter t a
 getterMemoRawType getter =
   to (getter . getMemoRawType)
 {-# INLINEABLE getterMemoRawType #-}
@@ -311,5 +321,5 @@ getterMemoRawType getter =
 -- potentially memoized binary representation of the type.
 class EqRaw a where
   eqRaw :: a -> a -> Bool
-  default eqRaw :: (a ~ t era, Memoized t, Eq (RawType t era)) => a -> a -> Bool
+  default eqRaw :: (a ~ t, Memoized t, Eq (RawType t)) => a -> a -> Bool
   eqRaw = eqRawType

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
@@ -86,7 +86,7 @@ instance ToExpr PlutusBinary
 instance ToExpr Language
 
 -- MemoBytes
-instance ToExpr (t era) => ToExpr (MemoBytes t era)
+instance ToExpr t => ToExpr (MemoBytes t)
 
 -- Core
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -445,7 +445,7 @@ instance IsConwayUniv fn => HasSpec fn PV1.Data where
 instance Era era => HasSimpleRep (Data era) where
   type SimpleRep (Data era) = PV1.Data
   toSimpleRep = getPlutusData
-  fromSimpleRep = mkMemoized . PlutusData
+  fromSimpleRep = mkMemoizedEra @era . PlutusData
 instance (IsConwayUniv fn, Era era) => HasSpec fn (Data era)
 
 instance Era era => HasSimpleRep (BinaryData era) where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Universes.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Universes.hs
@@ -214,12 +214,11 @@ bootWitness hash bootaddrs byronuniv = List.foldl' accum Set.empty bootaddrs
 -- Datums
 
 -- | The universe of non-empty Datums. i.e. There are no NoDatum Datums in this list
-genDatums ::
-  Era era => UnivSize -> Int -> Map DataHash (Data era) -> Gen [Datum era]
+genDatums :: UnivSize -> Int -> Map DataHash (Data era) -> Gen [Datum era]
 genDatums sizes n datauniv = vectorOf n (genDatum sizes datauniv)
 
 -- | Only generate non-empty Datums. I.e. There are no NoDatum Datums generated.
-genDatum :: Era era => UnivSize -> Map DataHash (Data era) -> Gen (Datum era)
+genDatum :: UnivSize -> Map DataHash (Data era) -> Gen (Datum era)
 genDatum UnivSize {usDatumFreq} datauniv =
   frequency
     [ (1, DatumHash . fst <$> genFromMap ["from genDatums DatumHash case"] datauniv)


### PR DESCRIPTION
# Description

`MemoBytes` type no long needs the `era` parameter, following the removal of crypto parameterization. 
This PR is removing this type parameter from `MemoBytes` and making the necessary adjustments at the usage site. 

Closes https://github.com/IntersectMBO/cardano-ledger/issues/4842


<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
