### PR TITLE
Pin Cabal version in Haddocks to GitHub Pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
       id: setup-haskell
       with:
         ghc-version: "9.2.8"
-        cabal-version: latest
+        cabal-version: "3.12"
 
     - name: Install system dependencies
       uses: input-output-hk/actions/base@latest


### PR DESCRIPTION
# Description

This fixes an error, "haddocks/cardano-data:testlib/*.haddock: openBinaryFile: does not exist" that has been persistent in CI since 2 Jan. On or before that date, ghcup's definition of Cabal's `latest` changed from `3.12` to `3.14`. Pinning to `3.12` restores the previous behaviour. This is a different version from the one used in the Haskell CI workflow (`3.14`) but I don't expect that will make any significant difference to the generated haddocks.

We can investigate the root cause separately. It's possible to reproduce the problem locally using `3.14`.

Closes #4840

# Checklist

- [x] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
