### PR TITLE
Made predicate failure and environment fields lazy

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.7.0.0
 
+* Made the fields of predicate failures and environments lazy
 * Add `Era era` constraint to `NoThunks` instance for `TimeLock`
 * Remove `Era era` constraint from:
   * `getRequireSignatureTimelock`

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
@@ -70,29 +70,29 @@ import Validation
 -- ==========================================================
 
 data AllegraUtxoPredFailure era
-  = BadInputsUTxO !(Set TxIn) -- The bad transaction inputs
+  = BadInputsUTxO (Set TxIn) -- The bad transaction inputs
   | OutsideValidityIntervalUTxO
-      !ValidityInterval -- transaction's validity interval
-      !SlotNo -- current slot
-  | MaxTxSizeUTxO !(Mismatch 'RelLTEQ Integer)
+      ValidityInterval -- transaction's validity interval
+      SlotNo -- current slot
+  | MaxTxSizeUTxO (Mismatch 'RelLTEQ Integer)
   | InputSetEmptyUTxO
-  | FeeTooSmallUTxO !(Mismatch 'RelGTEQ Coin)
-  | ValueNotConservedUTxO !(Mismatch 'RelEQ (Value era)) -- Consumed, then produced
+  | FeeTooSmallUTxO (Mismatch 'RelGTEQ Coin)
+  | ValueNotConservedUTxO (Mismatch 'RelEQ (Value era)) -- Consumed, then produced
   | WrongNetwork
-      !Network -- the expected network id
-      !(Set Addr) -- the set of addresses with incorrect network IDs
+      Network -- the expected network id
+      (Set Addr) -- the set of addresses with incorrect network IDs
   | WrongNetworkWithdrawal
-      !Network -- the expected network id
-      !(Set RewardAccount) -- the set of reward addresses with incorrect network IDs
+      Network -- the expected network id
+      (Set RewardAccount) -- the set of reward addresses with incorrect network IDs
   | OutputTooSmallUTxO
-      ![TxOut era] -- list of supplied transaction outputs that are too small
+      [TxOut era] -- list of supplied transaction outputs that are too small
   | UpdateFailure (EraRuleFailure "PPUP" era) -- Subtransition Failures
   | OutputBootAddrAttrsTooBig
-      ![TxOut era] -- list of supplied bad transaction outputs
+      [TxOut era] -- list of supplied bad transaction outputs
   | -- Kept for backwards compatibility: no longer used because the `MultiAsset` type of mint doesn't allow for this possibility
     TriesToForgeADA -- TODO: remove
   | OutputTooBigUTxO
-      ![TxOut era] -- list of supplied bad transaction outputs
+      [TxOut era] -- list of supplied bad transaction outputs
   deriving (Generic)
 
 type instance EraRuleFailure "UTXO" AllegraEra = AllegraUtxoPredFailure AllegraEra

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.0.0
 
+* Made the fields of predicate failures and environments lazy
 * Add `MemPack` instance for `Addr28Extra`, `DataHash32`, `AlonzoTxOut` and `PlutusScript AlonzoEra`
 * Deprecate `hashAlonzoTxAuxData`
 * Stop re-exporting deprecated `AuxiliaryDataHash` from `Cardano.Ledger.Alonzo.TxAuxData`

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
@@ -81,7 +81,7 @@ import NoThunks.Class (NoThunks (..))
 
 data AlonzoBbodyPredFailure era
   = ShelleyInAlonzoBbodyPredFailure (ShelleyBbodyPredFailure era)
-  | TooManyExUnits !(Mismatch 'RelLTEQ ExUnits)
+  | TooManyExUnits (Mismatch 'RelLTEQ ExUnits)
   deriving (Generic)
 
 newtype AlonzoBbodyEvent era

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -119,58 +119,58 @@ import Validation
 data AlonzoUtxoPredFailure era
   = -- | The bad transaction inputs
     BadInputsUTxO
-      !(Set TxIn)
+      (Set TxIn)
   | OutsideValidityIntervalUTxO
       -- | transaction's validity interval
-      !ValidityInterval
+      ValidityInterval
       -- | current slot
-      !SlotNo
-  | MaxTxSizeUTxO !(Mismatch 'RelLTEQ Integer)
+      SlotNo
+  | MaxTxSizeUTxO (Mismatch 'RelLTEQ Integer)
   | InputSetEmptyUTxO
-  | FeeTooSmallUTxO !(Mismatch 'RelGTEQ Coin)
-  | ValueNotConservedUTxO !(Mismatch 'RelEQ (Value era))
+  | FeeTooSmallUTxO (Mismatch 'RelGTEQ Coin)
+  | ValueNotConservedUTxO (Mismatch 'RelEQ (Value era))
   | -- | the set of addresses with incorrect network IDs
     WrongNetwork
       -- | the expected network id
-      !Network
+      Network
       -- | the set of addresses with incorrect network IDs
-      !(Set Addr)
+      (Set Addr)
   | WrongNetworkWithdrawal
       -- | the expected network id
-      !Network
+      Network
       -- | the set of reward addresses with incorrect network IDs
-      !(Set RewardAccount)
+      (Set RewardAccount)
   | -- | list of supplied transaction outputs that are too small
     OutputTooSmallUTxO
-      ![TxOut era]
+      [TxOut era]
   | -- | Subtransition Failures
     UtxosFailure (PredicateFailure (EraRule "UTXOS" era))
   | -- | list of supplied bad transaction outputs
     OutputBootAddrAttrsTooBig
-      ![TxOut era]
+      [TxOut era]
   | -- Kept for backwards compatibility: no longer used because the `MultiAsset` type of mint doesn't allow for this possibility
     TriesToForgeADA
   | -- | list of supplied bad transaction output triples (actualSize,PParameterMaxValue,TxOut)
     OutputTooBigUTxO
-      ![(Integer, Integer, TxOut era)]
+      [(Integer, Integer, TxOut era)]
   | InsufficientCollateral
       -- | balance computed
-      !DeltaCoin
+      DeltaCoin
       -- | the required collateral for the given fee
-      !Coin
+      Coin
   | -- | The UTxO entries which have the wrong kind of script
     ScriptsNotPaidUTxO
-      !(UTxO era)
-  | ExUnitsTooBigUTxO !(Mismatch 'RelLTEQ ExUnits)
+      (UTxO era)
+  | ExUnitsTooBigUTxO (Mismatch 'RelLTEQ ExUnits)
   | -- | The inputs marked for use as fees contain non-ADA tokens
-    CollateralContainsNonADA !(Value era)
+    CollateralContainsNonADA (Value era)
   | -- | Wrong Network ID in body
-    WrongNetworkInTxBody !(Mismatch 'RelEQ Network)
+    WrongNetworkInTxBody (Mismatch 'RelEQ Network)
   | -- | slot number outside consensus forecast range
     OutsideForecast
-      !SlotNo
+      SlotNo
   | -- | There are too many collateral inputs
-    TooManyCollateralInputs !(Mismatch 'RelLTEQ Natural)
+    TooManyCollateralInputs (Mismatch 'RelLTEQ Natural)
   | NoCollateralInputs
   deriving (Generic)
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -92,26 +92,26 @@ import Validation
 -- | The Predicate failure type in the Alonzo Era. It embeds the Predicate
 --   failure type of the Shelley Era, as they share some failure modes.
 data AlonzoUtxowPredFailure era
-  = ShelleyInAlonzoUtxowPredFailure !(ShelleyUtxowPredFailure era)
+  = ShelleyInAlonzoUtxowPredFailure (ShelleyUtxowPredFailure era)
   | -- | List of scripts for which no redeemers were supplied
     MissingRedeemers
-      ![(PlutusPurpose AsItem era, ScriptHash)]
+      [(PlutusPurpose AsItem era, ScriptHash)]
   | MissingRequiredDatums
       -- TODO: Make this NonEmpty #4066
 
       -- | Set of missing data hashes
-      !(Set DataHash)
+      (Set DataHash)
       -- | Set of received data hashes
-      !(Set DataHash)
+      (Set DataHash)
   | NotAllowedSupplementalDatums
       -- TODO: Make this NonEmpty #4066
 
       -- | Set of unallowed data hashes
-      !(Set DataHash)
+      (Set DataHash)
       -- | Set of acceptable supplemental data hashes
-      !(Set DataHash)
+      (Set DataHash)
   | PPViewHashesDontMatch
-      !(Mismatch 'RelEQ (StrictMaybe ScriptIntegrityHash))
+      (Mismatch 'RelEQ (StrictMaybe ScriptIntegrityHash))
   | -- | Set of witnesses which were needed and not supplied
     MissingRequiredSigners -- TODO: remove once in Conway. It is now redundant. See #3972
       (Set (KeyHash 'Witness))
@@ -121,7 +121,7 @@ data AlonzoUtxowPredFailure era
       (Set TxIn)
   | -- | List of redeemers not needed
     ExtraRedeemers
-      ![PlutusPurpose AsIx era]
+      [PlutusPurpose AsIx era]
   deriving (Generic)
 
 type instance EraRuleFailure "UTXOW" AlonzoEra = AlonzoUtxowPredFailure AlonzoEra

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.11.0.0
 
+* Made the fields of predicate failures and environments lazy
 * Add `MemPack` instance for `BabbageTxOut` and `PlutusScript BabbageEra`
 * Deprecate `Babbage` type synonym
 * Remove crypto parametrization from `BabbageEra`

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -108,20 +108,20 @@ import Validation (Validation, failureIf, failureUnless)
 
 -- | Predicate failure for the Babbage Era
 data BabbageUtxoPredFailure era
-  = AlonzoInBabbageUtxoPredFailure !(AlonzoUtxoPredFailure era) -- Inherited from Alonzo
+  = AlonzoInBabbageUtxoPredFailure (AlonzoUtxoPredFailure era) -- Inherited from Alonzo
   | -- | The collateral is not equivalent to the total collateral asserted by the transaction
     IncorrectTotalCollateralField
       -- | collateral provided
-      !DeltaCoin
+      DeltaCoin
       -- | collateral amount declared in transaction body
-      !Coin
+      Coin
   | -- | list of supplied transaction outputs that are too small,
     -- together with the minimum value for the given output.
     BabbageOutputTooSmallUTxO
-      ![(TxOut era, Coin)]
+      [(TxOut era, Coin)]
   | -- | TxIns that appear in both inputs and reference inputs
     BabbageNonDisjointRefInputs
-      !(NonEmpty TxIn)
+      (NonEmpty TxIn)
   deriving (Generic)
 
 type instance EraRuleFailure "UTXO" BabbageEra = BabbageUtxoPredFailure BabbageEra

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -92,15 +92,15 @@ import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
 import Validation (failureUnless)
 
 data BabbageUtxowPredFailure era
-  = AlonzoInBabbageUtxowPredFailure !(AlonzoUtxowPredFailure era) -- TODO: embed and translate
+  = AlonzoInBabbageUtxowPredFailure (AlonzoUtxowPredFailure era) -- TODO: embed and translate
   | -- | Embed UTXO rule failures
-    UtxoFailure !(PredicateFailure (EraRule "UTXO" era))
+    UtxoFailure (PredicateFailure (EraRule "UTXO" era))
   | -- | the set of malformed script witnesses
     MalformedScriptWitnesses
-      !(Set ScriptHash)
+      (Set ScriptHash)
   | -- | the set of malformed script witnesses
     MalformedReferenceScripts
-      !(Set ScriptHash)
+      (Set ScriptHash)
   deriving (Generic)
 
 type instance EraRuleFailure "UTXOW" BabbageEra = BabbageUtxowPredFailure BabbageEra

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Made the fields of predicate failures and environments lazy
 * Add `MemPack` instance for `PlutusScript ConwayEra`
 * Deprecate `Conway` type synonym
 * Remove crypto parametrization from `ConwayEra`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Internal.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Internal.hs
@@ -561,14 +561,14 @@ ratifySignalL = lens unRatifySignal (\x y -> x {unRatifySignal = y})
 instance EraPParams era => NFData (RatifySignal era)
 
 data RatifyEnv era = RatifyEnv
-  { reStakeDistr :: (Map (Credential 'Staking) (CompactForm Coin))
+  { reStakeDistr :: Map (Credential 'Staking) (CompactForm Coin)
   , reStakePoolDistr :: PoolDistr
-  , reDRepDistr :: (Map DRep (CompactForm Coin))
-  , reDRepState :: (Map (Credential 'DRepRole) DRepState)
+  , reDRepDistr :: Map DRep (CompactForm Coin)
+  , reDRepState :: Map (Credential 'DRepRole) DRepState
   , reCurrentEpoch :: EpochNo
-  , reCommitteeState :: (CommitteeState era)
-  , reDelegatees :: (Map (Credential 'Staking) DRep)
-  , rePoolParams :: (Map (KeyHash 'StakePool) PoolParams)
+  , reCommitteeState :: CommitteeState era
+  , reDelegatees :: Map (Credential 'Staking) DRep
+  , rePoolParams :: Map (KeyHash 'StakePool) PoolParams
   }
   deriving (Generic)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Internal.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Internal.hs
@@ -561,14 +561,14 @@ ratifySignalL = lens unRatifySignal (\x y -> x {unRatifySignal = y})
 instance EraPParams era => NFData (RatifySignal era)
 
 data RatifyEnv era = RatifyEnv
-  { reStakeDistr :: !(Map (Credential 'Staking) (CompactForm Coin))
-  , reStakePoolDistr :: !PoolDistr
-  , reDRepDistr :: !(Map DRep (CompactForm Coin))
-  , reDRepState :: !(Map (Credential 'DRepRole) DRepState)
-  , reCurrentEpoch :: !EpochNo
-  , reCommitteeState :: !(CommitteeState era)
-  , reDelegatees :: !(Map (Credential 'Staking) DRep)
-  , rePoolParams :: !(Map (KeyHash 'StakePool) PoolParams)
+  { reStakeDistr :: (Map (Credential 'Staking) (CompactForm Coin))
+  , reStakePoolDistr :: PoolDistr
+  , reDRepDistr :: (Map DRep (CompactForm Coin))
+  , reDRepState :: (Map (Credential 'DRepRole) DRepState)
+  , reCurrentEpoch :: EpochNo
+  , reCommitteeState :: (CommitteeState era)
+  , reDelegatees :: (Map (Credential 'Staking) DRep)
+  , rePoolParams :: (Map (KeyHash 'StakePool) PoolParams)
   }
   deriving (Generic)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
@@ -91,12 +91,12 @@ maxRefScriptSizePerBlock :: Int
 maxRefScriptSizePerBlock = 1024 * 1024 -- 1MiB
 
 data ConwayBbodyPredFailure era
-  = WrongBlockBodySizeBBODY !(Mismatch 'RelEQ Int)
-  | InvalidBodyHashBBODY !(Mismatch 'RelEQ (Hash HASH EraIndependentBlockBody))
+  = WrongBlockBodySizeBBODY (Mismatch 'RelEQ Int)
+  | InvalidBodyHashBBODY (Mismatch 'RelEQ (Hash HASH EraIndependentBlockBody))
   | -- | LEDGERS rule subtransition Failures
-    LedgersFailure !(PredicateFailure (EraRule "LEDGERS" era))
-  | TooManyExUnits !(Mismatch 'RelLTEQ ExUnits)
-  | BodyRefScriptsSizeTooBig !(Mismatch 'RelLTEQ Int)
+    LedgersFailure (PredicateFailure (EraRule "LEDGERS" era))
+  | TooManyExUnits (Mismatch 'RelLTEQ ExUnits)
+  | BodyRefScriptsSizeTooBig (Mismatch 'RelLTEQ Int)
   deriving (Generic)
 
 deriving instance

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
@@ -76,7 +76,7 @@ import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 
 data CertEnv era = CertEnv
-  { cePParams :: (PParams era)
+  { cePParams :: PParams era
   , ceCurrentEpoch :: EpochNo
   -- ^ Lazy on purpose, because not all certificates need to know the current EpochNo
   , ceCurrentCommittee :: StrictMaybe (Committee era)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
@@ -76,7 +76,7 @@ import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 
 data CertEnv era = CertEnv
-  { cePParams :: !(PParams era)
+  { cePParams :: (PParams era)
   , ceCurrentEpoch :: EpochNo
   -- ^ Lazy on purpose, because not all certificates need to know the current EpochNo
   , ceCurrentCommittee :: StrictMaybe (Committee era)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
@@ -86,8 +86,8 @@ import Lens.Micro
 import NoThunks.Class (NoThunks (..))
 
 data CertsEnv era = CertsEnv
-  { certsTx :: (Tx era)
-  , certsPParams :: (PParams era)
+  { certsTx :: Tx era
+  , certsPParams :: PParams era
   , certsCurrentEpoch :: EpochNo
   -- ^ Lazy on purpose, because not all certificates need to know the current EpochNo
   , certsCurrentCommittee :: StrictMaybe (Committee era)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
@@ -113,9 +113,9 @@ instance (EraPParams era, NFData (Tx era)) => NFData (CertsEnv era)
 data ConwayCertsPredFailure era
   = -- | Withdrawals that are missing or do not withdrawal the entire amount
     WithdrawalsNotInRewardsCERTS
-      !(Map.Map RewardAccount Coin)
+      (Map.Map RewardAccount Coin)
   | -- | CERT rule subtransition Failures
-    CertFailure !(PredicateFailure (EraRule "CERT" era))
+    CertFailure (PredicateFailure (EraRule "CERT" era))
   deriving (Generic)
 
 type instance EraRuleFailure "CERTS" ConwayEra = ConwayCertsPredFailure ConwayEra

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
@@ -86,8 +86,8 @@ import Lens.Micro
 import NoThunks.Class (NoThunks (..))
 
 data CertsEnv era = CertsEnv
-  { certsTx :: !(Tx era)
-  , certsPParams :: !(PParams era)
+  { certsTx :: (Tx era)
+  , certsPParams :: (PParams era)
   , certsCurrentEpoch :: EpochNo
   -- ^ Lazy on purpose, because not all certificates need to know the current EpochNo
   , certsCurrentCommittee :: StrictMaybe (Committee era)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -139,9 +139,9 @@ import Validation (failureUnless)
 data GovEnv era = GovEnv
   { geTxId :: TxId
   , geEpoch :: EpochNo
-  , gePParams :: (PParams era)
-  , gePPolicy :: (StrictMaybe ScriptHash)
-  , geCertState :: (CertState era)
+  , gePParams :: PParams era
+  , gePPolicy :: StrictMaybe ScriptHash
+  , geCertState :: CertState era
   }
   deriving (Generic)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -137,11 +137,11 @@ import NoThunks.Class (NoThunks (..))
 import Validation (failureUnless)
 
 data GovEnv era = GovEnv
-  { geTxId :: !TxId
-  , geEpoch :: !EpochNo
-  , gePParams :: !(PParams era)
-  , gePPolicy :: !(StrictMaybe ScriptHash)
-  , geCertState :: !(CertState era)
+  { geTxId :: TxId
+  , geEpoch :: EpochNo
+  , gePParams :: (PParams era)
+  , gePPolicy :: (StrictMaybe ScriptHash)
+  , geCertState :: (CertState era)
   }
   deriving (Generic)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -165,11 +165,11 @@ data ConwayGovPredFailure era
   | MalformedProposal (GovAction era)
   | ProposalProcedureNetworkIdMismatch RewardAccount Network
   | TreasuryWithdrawalsNetworkIdMismatch (Set.Set RewardAccount) Network
-  | ProposalDepositIncorrect !(Mismatch 'RelEQ Coin)
+  | ProposalDepositIncorrect (Mismatch 'RelEQ Coin)
   | -- | Some governance actions are not allowed to be voted on by certain types of
     -- Voters. This failure lists all governance action ids with their respective voters
     -- that are not allowed to vote on those governance actions.
-    DisallowedVoters !(NonEmpty (Voter, GovActionId))
+    DisallowedVoters (NonEmpty (Voter, GovActionId))
   | ConflictingCommitteeUpdate
       -- | Credentials that are mentioned as members to be both removed and added
       (Set.Set (Credential 'ColdCommitteeRole))
@@ -182,7 +182,7 @@ data ConwayGovPredFailure era
       -- | The PrevGovActionId of the HardForkInitiation that fails
       (StrictMaybe (GovPurposeId 'HardForkPurpose era))
       -- | Its protocol version and the protocal version of the previous gov-action pointed to by the proposal
-      !(Mismatch 'RelGT ProtVer)
+      (Mismatch 'RelGT ProtVer)
   | InvalidPolicyHash
       -- | The policy script hash in the proposal
       (StrictMaybe ScriptHash)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
@@ -114,15 +114,15 @@ deriving instance EraPParams era => Show (ConwayGovCertEnv era)
 deriving instance EraPParams era => Eq (ConwayGovCertEnv era)
 
 data ConwayGovCertPredFailure era
-  = ConwayDRepAlreadyRegistered !(Credential 'DRepRole)
-  | ConwayDRepNotRegistered !(Credential 'DRepRole)
-  | ConwayDRepIncorrectDeposit !(Mismatch 'RelEQ Coin)
-  | ConwayCommitteeHasPreviouslyResigned !(Credential 'ColdCommitteeRole)
-  | ConwayDRepIncorrectRefund !(Mismatch 'RelEQ Coin)
+  = ConwayDRepAlreadyRegistered (Credential 'DRepRole)
+  | ConwayDRepNotRegistered (Credential 'DRepRole)
+  | ConwayDRepIncorrectDeposit (Mismatch 'RelEQ Coin)
+  | ConwayCommitteeHasPreviouslyResigned (Credential 'ColdCommitteeRole)
+  | ConwayDRepIncorrectRefund (Mismatch 'RelEQ Coin)
   | -- | Predicate failure whenever an update to an unknown committee member is
     -- attempted. Current Constitutional Committee and all available proposals will be
     -- searched before reporting this predicate failure.
-    ConwayCommitteeIsUnknown !(Credential 'ColdCommitteeRole)
+    ConwayCommitteeIsUnknown (Credential 'ColdCommitteeRole)
   deriving (Show, Eq, Generic)
 
 type instance EraRuleFailure "GOVCERT" ConwayEra = ConwayGovCertPredFailure ConwayEra

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
@@ -88,7 +88,7 @@ import Lens.Micro ((&), (.~), (^.))
 import NoThunks.Class (NoThunks (..))
 
 data ConwayGovCertEnv era = ConwayGovCertEnv
-  { cgcePParams :: (PParams era)
+  { cgcePParams :: PParams era
   , cgceCurrentEpoch :: EpochNo
   -- ^ Lazy on purpose, because not all certificates need to know the current EpochNo
   , cgceCurrentCommittee :: StrictMaybe (Committee era)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
@@ -88,7 +88,7 @@ import Lens.Micro ((&), (.~), (^.))
 import NoThunks.Class (NoThunks (..))
 
 data ConwayGovCertEnv era = ConwayGovCertEnv
-  { cgcePParams :: !(PParams era)
+  { cgcePParams :: (PParams era)
   , cgceCurrentEpoch :: EpochNo
   -- ^ Lazy on purpose, because not all certificates need to know the current EpochNo
   , cgceCurrentCommittee :: StrictMaybe (Committee era)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -85,74 +85,74 @@ data ConwayUtxoPredFailure era
     UtxosFailure (PredicateFailure (EraRule "UTXOS" era))
   | -- | The bad transaction inputs
     BadInputsUTxO
-      !(Set TxIn)
+      (Set TxIn)
   | OutsideValidityIntervalUTxO
       -- | transaction's validity interval
-      !ValidityInterval
+      ValidityInterval
       -- | current slot
-      !SlotNo
+      SlotNo
   | MaxTxSizeUTxO
-      !(Mismatch 'RelLTEQ Integer)
+      (Mismatch 'RelLTEQ Integer)
   | InputSetEmptyUTxO
   | FeeTooSmallUTxO
-      !(Mismatch 'RelGTEQ Coin) -- The values are serialised in reverse order
+      (Mismatch 'RelGTEQ Coin) -- The values are serialised in reverse order
   | ValueNotConservedUTxO
-      !(Mismatch 'RelEQ (Value era)) -- Serialise consumed first, then produced
+      (Mismatch 'RelEQ (Value era)) -- Serialise consumed first, then produced
   | -- | the set of addresses with incorrect network IDs
     WrongNetwork
       -- | the expected network id
-      !Network
+      Network
       -- | the set of addresses with incorrect network IDs
-      !(Set Addr)
+      (Set Addr)
   | WrongNetworkWithdrawal
       -- | the expected network id
-      !Network
+      Network
       -- | the set of reward addresses with incorrect network IDs
-      !(Set RewardAccount)
+      (Set RewardAccount)
   | -- | list of supplied transaction outputs that are too small
     OutputTooSmallUTxO
-      ![TxOut era]
+      [TxOut era]
   | -- | list of supplied bad transaction outputs
     OutputBootAddrAttrsTooBig
-      ![TxOut era]
+      [TxOut era]
   | -- | list of supplied bad transaction output triples (actualSize,PParameterMaxValue,TxOut)
     OutputTooBigUTxO
-      ![(Int, Int, TxOut era)]
+      [(Int, Int, TxOut era)]
   | InsufficientCollateral
       -- | balance computed
-      !DeltaCoin
+      DeltaCoin
       -- | the required collateral for the given fee
-      !Coin
+      Coin
   | -- | The UTxO entries which have the wrong kind of script
     ScriptsNotPaidUTxO
-      !(UTxO era)
+      (UTxO era)
   | ExUnitsTooBigUTxO
-      !(Mismatch 'RelLTEQ ExUnits) -- The values are serialised in reverse order
+      (Mismatch 'RelLTEQ ExUnits) -- The values are serialised in reverse order
   | -- | The inputs marked for use as fees contain non-ADA tokens
-    CollateralContainsNonADA !(Value era)
+    CollateralContainsNonADA (Value era)
   | -- | Wrong Network ID in body
     WrongNetworkInTxBody
-      !(Mismatch 'RelEQ Network) -- The values are serialised in reverse order
+      (Mismatch 'RelEQ Network) -- The values are serialised in reverse order
   | -- | slot number outside consensus forecast range
     OutsideForecast
-      !SlotNo
+      SlotNo
   | -- | There are too many collateral inputs
     TooManyCollateralInputs
-      !(Mismatch 'RelLTEQ Natural) -- The values are serialised in reverse order
+      (Mismatch 'RelLTEQ Natural) -- The values are serialised in reverse order
   | NoCollateralInputs
   | -- | The collateral is not equivalent to the total collateral asserted by the transaction
     IncorrectTotalCollateralField
       -- | collateral provided
-      !DeltaCoin
+      DeltaCoin
       -- | collateral amount declared in transaction body
-      !Coin
+      Coin
   | -- | list of supplied transaction outputs that are too small,
     -- together with the minimum value for the given output.
     BabbageOutputTooSmallUTxO
-      ![(TxOut era, Coin)]
+      [(TxOut era, Coin)]
   | -- | TxIns that appear in both inputs and reference inputs
     BabbageNonDisjointRefInputs
-      !(NonEmpty TxIn)
+      (NonEmpty TxIn)
   deriving (Generic)
 
 type instance EraRuleFailure "UTXO" ConwayEra = ConwayUtxoPredFailure ConwayEra

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
@@ -73,60 +73,60 @@ import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
 data ConwayUtxowPredFailure era
   = UtxoFailure (PredicateFailure (EraRule "UTXO" era))
   | InvalidWitnessesUTXOW
-      ![VKey 'Witness]
+      [VKey 'Witness]
   | -- | witnesses which failed in verifiedWits function
     MissingVKeyWitnessesUTXOW
       -- | witnesses which were needed and not supplied
-      !(Set (KeyHash 'Witness))
+      (Set (KeyHash 'Witness))
   | -- | missing scripts
     MissingScriptWitnessesUTXOW
-      !(Set ScriptHash)
+      (Set ScriptHash)
   | -- | failed scripts
     ScriptWitnessNotValidatingUTXOW
-      !(Set ScriptHash)
+      (Set ScriptHash)
   | -- | hash of the full metadata
     MissingTxBodyMetadataHash
-      !TxAuxDataHash
+      TxAuxDataHash
   | -- | hash of the metadata included in the transaction body
     MissingTxMetadata
-      !TxAuxDataHash
+      TxAuxDataHash
   | ConflictingMetadataHash
-      !(Mismatch 'RelEQ TxAuxDataHash)
+      (Mismatch 'RelEQ TxAuxDataHash)
   | -- | Contains out of range values (string`s too long)
     InvalidMetadata
   | -- | extraneous scripts
     ExtraneousScriptWitnessesUTXOW
-      !(Set ScriptHash)
+      (Set ScriptHash)
   | MissingRedeemers
-      ![(PlutusPurpose AsItem era, ScriptHash)]
+      [(PlutusPurpose AsItem era, ScriptHash)]
   | MissingRequiredDatums
       -- TODO: Make this NonEmpty #4066
 
       -- | Set of missing data hashes
-      !(Set DataHash)
+      (Set DataHash)
       -- | Set of received data hashes
-      !(Set DataHash)
+      (Set DataHash)
   | NotAllowedSupplementalDatums
       -- TODO: Make this NonEmpty #4066
 
       -- | Set of unallowed data hashes.
-      !(Set DataHash)
+      (Set DataHash)
       -- | Set of acceptable supplemental data hashes
-      !(Set DataHash)
+      (Set DataHash)
   | PPViewHashesDontMatch
-      !(Mismatch 'RelEQ (StrictMaybe ScriptIntegrityHash))
+      (Mismatch 'RelEQ (StrictMaybe ScriptIntegrityHash))
   | -- | Set of transaction inputs that are TwoPhase scripts, and should have a DataHash but don't
     UnspendableUTxONoDatumHash
       -- TODO: Make this NonEmpty #4066
       (Set TxIn)
   | -- | List of redeemers not needed
-    ExtraRedeemers ![PlutusPurpose AsIx era]
+    ExtraRedeemers [PlutusPurpose AsIx era]
   | -- | Embed UTXO rule failures
     MalformedScriptWitnesses
-      !(Set ScriptHash)
+      (Set ScriptHash)
   | -- | the set of malformed script witnesses
     MalformedReferenceScripts
-      !(Set ScriptHash)
+      (Set ScriptHash)
   deriving (Generic)
 
 type instance EraRuleFailure "UTXOW" ConwayEra = ConwayUtxowPredFailure ConwayEra

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Made the fields of predicate failures and environments lazy
 * Changed the type of `sgSecurityParam` to `NonZero Word64`
 * Following functions now expect a `NonZero Word64` security parameter:
   * `startStep`

--- a/eras/shelley/impl/src/Cardano/Ledger/Chain.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Chain.hs
@@ -48,14 +48,14 @@ pparamsToChainChecksPParams pp =
 
 data ChainPredicateFailure
   = HeaderSizeTooLargeCHAIN
-      !Int -- Header Size
-      !Word16 -- Max Header Size
+      Int -- Header Size
+      Word16 -- Max Header Size
   | BlockSizeTooLargeCHAIN
-      !Word32 -- Block Size
-      !Word32 -- Max Block Size
+      Word32 -- Block Size
+      Word32 -- Max Block Size
   | ObsoleteNodeCHAIN
-      !Version -- protocol version used
-      !Version -- max protocol version
+      Version -- protocol version used
+      Version -- max protocol version
   deriving (Generic, Show, Eq, Ord)
 
 instance NoThunks ChainPredicateFailure

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
@@ -98,34 +98,34 @@ instance NFData (PParams era) => NFData (DelegEnv era)
 
 data ShelleyDelegPredFailure era
   = StakeKeyAlreadyRegisteredDELEG
-      !(Credential 'Staking) -- Credential which is already registered
+      (Credential 'Staking) -- Credential which is already registered
   | StakeKeyNotRegisteredDELEG
-      !(Credential 'Staking) -- Credential which is not registered
+      (Credential 'Staking) -- Credential which is not registered
   | StakeKeyNonZeroAccountBalanceDELEG
-      !Coin -- The remaining reward account balance
+      Coin -- The remaining reward account balance
   | StakeDelegationImpossibleDELEG
-      !(Credential 'Staking) -- Credential that is not registered
+      (Credential 'Staking) -- Credential that is not registered
   | WrongCertificateTypeDELEG -- The TxCertPool constructor should not be used by this transition
   | GenesisKeyNotInMappingDELEG
-      !(KeyHash 'Genesis) -- Unknown Genesis KeyHash
+      (KeyHash 'Genesis) -- Unknown Genesis KeyHash
   | DuplicateGenesisDelegateDELEG
-      !(KeyHash 'GenesisDelegate) -- Keyhash which is already delegated to
+      (KeyHash 'GenesisDelegate) -- Keyhash which is already delegated to
   | InsufficientForInstantaneousRewardsDELEG
-      !MIRPot -- which pot the rewards are to be drawn from, treasury or reserves
-      !(Mismatch 'RelLTEQ Coin)
+      MIRPot -- which pot the rewards are to be drawn from, treasury or reserves
+      (Mismatch 'RelLTEQ Coin)
   | MIRCertificateTooLateinEpochDELEG
-      !(Mismatch 'RelLT SlotNo)
+      (Mismatch 'RelLT SlotNo)
   | DuplicateGenesisVRFDELEG
-      !(VRFVerKeyHash 'GenDelegVRF) -- VRF KeyHash which is already delegated to
+      (VRFVerKeyHash 'GenDelegVRF) -- VRF KeyHash which is already delegated to
   | MIRTransferNotCurrentlyAllowed
   | MIRNegativesNotCurrentlyAllowed
   | InsufficientForTransferDELEG
-      !MIRPot -- which pot the rewards are to be drawn from, treasury or reserves
-      !(Mismatch 'RelLTEQ Coin)
+      MIRPot -- which pot the rewards are to be drawn from, treasury or reserves
+      (Mismatch 'RelLTEQ Coin)
   | MIRProducesNegativeUpdate
   | MIRNegativeTransfer
-      !MIRPot -- which pot the rewards are to be drawn from, treasury or reserves
-      !Coin -- amount attempted to transfer
+      MIRPot -- which pot the rewards are to be drawn from, treasury or reserves
+      Coin -- amount attempted to transfer
   deriving (Show, Eq, Generic)
 
 type instance EraRuleFailure "DELEG" ShelleyEra = ShelleyDelegPredFailure ShelleyEra

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
@@ -81,12 +81,12 @@ import Lens.Micro ((^.))
 import NoThunks.Class (NoThunks (..))
 
 data DelegEnv era = DelegEnv
-  { slotNo :: !SlotNo
+  { slotNo :: SlotNo
   , deCurEpochNo :: EpochNo
   -- ^ Lazy on purpose, because not all certificates need to know the current EpochNo
-  , ptr_ :: !Ptr
-  , acnt_ :: !AccountState
-  , ppDE :: !(PParams era) -- The protocol parameters are only used for the HardFork mechanism
+  , ptr_ :: Ptr
+  , acnt_ :: AccountState
+  , ppDE :: (PParams era) -- The protocol parameters are only used for the HardFork mechanism
   }
   deriving (Generic)
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
@@ -86,7 +86,7 @@ data DelegEnv era = DelegEnv
   -- ^ Lazy on purpose, because not all certificates need to know the current EpochNo
   , ptr_ :: Ptr
   , acnt_ :: AccountState
-  , ppDE :: (PParams era) -- The protocol parameters are only used for the HardFork mechanism
+  , ppDE :: PParams era -- The protocol parameters are only used for the HardFork mechanism
   }
   deriving (Generic)
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
@@ -99,13 +99,13 @@ import NoThunks.Class (NoThunks (..))
 import Validation (failureUnless)
 
 data DelegsEnv era = DelegsEnv
-  { delegsSlotNo :: !SlotNo
+  { delegsSlotNo :: SlotNo
   , delegsEpochNo :: EpochNo
   -- ^ Lazy on purpose, because not all certificates need to know the current EpochNo
-  , delegsIx :: !TxIx
-  , delegspp :: !(PParams era)
-  , delegsTx :: !(Tx era)
-  , delegsAccount :: !AccountState
+  , delegsIx :: TxIx
+  , delegspp :: (PParams era)
+  , delegsTx :: (Tx era)
+  , delegsAccount :: AccountState
   }
 
 deriving stock instance

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
@@ -117,12 +117,12 @@ deriving stock instance
 data ShelleyDelegsPredFailure era
   = -- | Target pool which is not registered
     DelegateeNotRegisteredDELEG
-      !(KeyHash 'StakePool)
+      (KeyHash 'StakePool)
   | -- | Withdrawals that are missing or do not withdrawal the entire amount
     WithdrawalsNotInRewardsDELEGS
-      !(Map RewardAccount Coin)
+      (Map RewardAccount Coin)
   | -- | Subtransition Failures
-    DelplFailure !(PredicateFailure (EraRule "DELPL" era))
+    DelplFailure (PredicateFailure (EraRule "DELPL" era))
   deriving (Generic)
 
 type instance EraRuleFailure "DELEGS" ShelleyEra = ShelleyDelegsPredFailure ShelleyEra

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
@@ -103,8 +103,8 @@ data DelegsEnv era = DelegsEnv
   , delegsEpochNo :: EpochNo
   -- ^ Lazy on purpose, because not all certificates need to know the current EpochNo
   , delegsIx :: TxIx
-  , delegspp :: (PParams era)
-  , delegsTx :: (Tx era)
+  , delegspp :: PParams era
+  , delegsTx :: Tx era
   , delegsAccount :: AccountState
   }
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
@@ -91,9 +91,9 @@ import NoThunks.Class (NoThunks (..))
 
 data LedgerEnv era = LedgerEnv
   { ledgerSlotNo :: SlotNo
-  , ledgerEpochNo :: (Maybe EpochNo)
+  , ledgerEpochNo :: Maybe EpochNo
   , ledgerIx :: TxIx
-  , ledgerPp :: (PParams era)
+  , ledgerPp :: PParams era
   , ledgerAccount :: AccountState
   , ledgerMempool :: Bool
   }

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
@@ -90,12 +90,12 @@ import NoThunks.Class (NoThunks (..))
 -- ========================================================
 
 data LedgerEnv era = LedgerEnv
-  { ledgerSlotNo :: !SlotNo
-  , ledgerEpochNo :: !(Maybe EpochNo)
-  , ledgerIx :: !TxIx
-  , ledgerPp :: !(PParams era)
-  , ledgerAccount :: !AccountState
-  , ledgerMempool :: !Bool
+  { ledgerSlotNo :: SlotNo
+  , ledgerEpochNo :: (Maybe EpochNo)
+  , ledgerIx :: TxIx
+  , ledgerPp :: (PParams era)
+  , ledgerAccount :: AccountState
+  , ledgerMempool :: Bool
   }
   deriving (Generic)
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/NewEpoch.hs
@@ -54,7 +54,7 @@ import NoThunks.Class (NoThunks (..))
 data ShelleyNewEpochPredFailure era
   = EpochFailure (PredicateFailure (EraRule "EPOCH" era)) -- Subtransition Failures
   | CorruptRewardUpdate
-      !RewardUpdate -- The reward update which violates an invariant
+      RewardUpdate -- The reward update which violates an invariant
   | MirFailure (PredicateFailure (EraRule "MIR" era)) -- Subtransition Failures
   deriving (Generic)
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Newpp.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Newpp.hs
@@ -45,8 +45,8 @@ data ShelleyNewppState era
   = NewppState (PParams era) (ShelleyGovState era)
 
 data NewppEnv era = NewppEnv
-  { neCertState :: (CertState era)
-  , neUTxOState :: (UTxOState era)
+  { neCertState :: CertState era
+  , neUTxOState :: UTxOState era
   }
 
 instance

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Newpp.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Newpp.hs
@@ -45,8 +45,8 @@ data ShelleyNewppState era
   = NewppState (PParams era) (ShelleyGovState era)
 
 data NewppEnv era = NewppEnv
-  { neCertState :: !(CertState era)
-  , neUTxOState :: !(UTxOState era)
+  { neCertState :: (CertState era)
+  , neUTxOState :: (UTxOState era)
   }
 
 instance

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -90,18 +90,18 @@ instance NFData (PParams era) => NFData (PoolEnv era)
 
 data ShelleyPoolPredFailure era
   = StakePoolNotRegisteredOnKeyPOOL
-      !(KeyHash 'StakePool) -- KeyHash which cannot be retired since it is not registered
+      (KeyHash 'StakePool) -- KeyHash which cannot be retired since it is not registered
   | StakePoolRetirementWrongEpochPOOL
-      !(Mismatch 'RelGT EpochNo)
-      !(Mismatch 'RelLTEQ EpochNo)
+      (Mismatch 'RelGT EpochNo)
+      (Mismatch 'RelLTEQ EpochNo)
   | StakePoolCostTooLowPOOL
-      !(Mismatch 'RelGTEQ Coin)
+      (Mismatch 'RelGTEQ Coin)
   | WrongNetworkPOOL
-      !(Mismatch 'RelEQ Network)
-      !(KeyHash 'StakePool) -- Stake Pool ID
+      (Mismatch 'RelEQ Network)
+      (KeyHash 'StakePool) -- Stake Pool ID
   | PoolMedataHashTooBig
-      !(KeyHash 'StakePool) -- Stake Pool ID
-      !Int -- Size of the metadata hash
+      (KeyHash 'StakePool) -- Stake Pool ID
+      Int -- Size of the metadata hash
   deriving (Eq, Show, Generic)
 
 type instance EraRuleFailure "POOL" ShelleyEra = ShelleyPoolPredFailure ShelleyEra

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -72,7 +72,7 @@ import Lens.Micro ((^.))
 import NoThunks.Class (NoThunks (..))
 
 data PoolEnv era
-  = PoolEnv !EpochNo !(PParams era)
+  = PoolEnv EpochNo (PParams era)
   deriving (Generic)
 
 instance EraPParams era => EncCBOR (PoolEnv era) where

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ppup.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ppup.hs
@@ -90,23 +90,23 @@ data ShelleyPpupPredFailure era
     --  `mismatchSupplied` ~ key hashes which were a part of the update.
     --  `mismatchExpected` ~ key hashes of the genesis keys.
     NonGenesisUpdatePPUP
-      !(Mismatch 'RelSubset (Set (KeyHash 'Genesis)))
+      (Mismatch 'RelSubset (Set (KeyHash 'Genesis)))
   | -- | An update was proposed for the wrong epoch.
     --  The first 'EpochNo' is the current epoch.
     --  The second 'EpochNo' is the epoch listed in the update.
     --  The last parameter indicates if the update was intended
     --  for the current or the next epoch.
     PPUpdateWrongEpoch
-      !EpochNo
-      !EpochNo
-      !VotingPeriod
+      EpochNo
+      EpochNo
+      VotingPeriod
   | -- | An update was proposed which contains an invalid protocol version.
     --  New protocol versions must either increase the major
     --  number by exactly one and set the minor version to zero,
     --  or keep the major version the same and increase the minor
     --  version by exactly one.
     PVCannotFollowPPUP
-      !ProtVer
+      ProtVer
   deriving (Show, Eq, Generic)
 
 type instance EraRuleFailure "PPUP" ShelleyEra = ShelleyPpupPredFailure ShelleyEra

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Rupd.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Rupd.hs
@@ -74,7 +74,7 @@ import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 
 data RupdEnv era
-  = RupdEnv !BlocksMade !(EpochState era)
+  = RupdEnv BlocksMade (EpochState era)
 
 data ShelleyRupdPredFailure era -- No predicate failures
   deriving (Show, Eq, Generic)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Snap.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Snap.hs
@@ -69,7 +69,7 @@ deriving instance Eq (SnapEvent era)
 
 instance NFData (SnapEvent era)
 
-data SnapEnv era = SnapEnv !(LedgerState era) !(PParams era)
+data SnapEnv era = SnapEnv (LedgerState era) (PParams era)
 
 instance EraTxOut era => STS (ShelleySNAP era) where
   type State (ShelleySNAP era) = SnapShots

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -170,27 +170,27 @@ instance (Era era, NFData (Event (EraRule "PPUP" era)), NFData (TxOut era)) => N
 
 data ShelleyUtxoPredFailure era
   = BadInputsUTxO
-      !(Set TxIn) -- The bad transaction inputs
+      (Set TxIn) -- The bad transaction inputs
   | ExpiredUTxO
-      !(Mismatch 'RelLTEQ SlotNo)
+      (Mismatch 'RelLTEQ SlotNo)
   | MaxTxSizeUTxO
-      !(Mismatch 'RelLTEQ Integer)
+      (Mismatch 'RelLTEQ Integer)
   | InputSetEmptyUTxO
   | FeeTooSmallUTxO
-      !(Mismatch 'RelGTEQ Coin)
+      (Mismatch 'RelGTEQ Coin)
   | ValueNotConservedUTxO
-      !(Mismatch 'RelEQ (Value era))
+      (Mismatch 'RelEQ (Value era))
   | WrongNetwork
-      !Network -- the expected network id
-      !(Set Addr) -- the set of addresses with incorrect network IDs
+      Network -- the expected network id
+      (Set Addr) -- the set of addresses with incorrect network IDs
   | WrongNetworkWithdrawal
-      !Network -- the expected network id
-      !(Set RewardAccount) -- the set of reward addresses with incorrect network IDs
+      Network -- the expected network id
+      (Set RewardAccount) -- the set of reward addresses with incorrect network IDs
   | OutputTooSmallUTxO
-      ![TxOut era] -- list of supplied transaction outputs that are too small
+      [TxOut era] -- list of supplied transaction outputs that are too small
   | UpdateFailure (EraRuleFailure "PPUP" era) -- Subtransition Failures
   | OutputBootAddrAttrsTooBig
-      ![TxOut era] -- list of supplied bad transaction outputs
+      [TxOut era] -- list of supplied bad transaction outputs
   deriving (Generic)
 
 type instance EraRuleFailure "UTXO" ShelleyEra = ShelleyUtxoPredFailure ShelleyEra

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
@@ -113,26 +113,26 @@ import Validation
 
 data ShelleyUtxowPredFailure era
   = InvalidWitnessesUTXOW
-      ![VKey 'Witness]
+      [VKey 'Witness]
   | -- witnesses which failed in verifiedWits function
     MissingVKeyWitnessesUTXOW
-      !(Set (KeyHash 'Witness)) -- witnesses which were needed and not supplied
+      (Set (KeyHash 'Witness)) -- witnesses which were needed and not supplied
   | MissingScriptWitnessesUTXOW
-      !(Set ScriptHash) -- missing scripts
+      (Set ScriptHash) -- missing scripts
   | ScriptWitnessNotValidatingUTXOW
-      !(Set ScriptHash) -- failed scripts
+      (Set ScriptHash) -- failed scripts
   | UtxoFailure (PredicateFailure (EraRule "UTXO" era))
   | MIRInsufficientGenesisSigsUTXOW (Set (KeyHash 'Witness))
   | MissingTxBodyMetadataHash
-      !TxAuxDataHash -- hash of the full metadata
+      TxAuxDataHash -- hash of the full metadata
   | MissingTxMetadata
-      !TxAuxDataHash -- hash of the metadata included in the transaction body
+      TxAuxDataHash -- hash of the metadata included in the transaction body
   | ConflictingMetadataHash
-      !(Mismatch 'RelEQ TxAuxDataHash)
+      (Mismatch 'RelEQ TxAuxDataHash)
   | -- Contains out of range values (strings too long)
     InvalidMetadata
   | ExtraneousScriptWitnessesUTXOW
-      !(Set ScriptHash) -- extraneous scripts
+      (Set ScriptHash) -- extraneous scripts
   deriving (Generic)
 
 type instance EraRuleFailure "UTXOW" ShelleyEra = ShelleyUtxowPredFailure ShelleyEra

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -793,7 +793,7 @@ data ImpTestEnv era = ImpTestEnv
       LedgerState era ->
       Tx era ->
       BaseImpM ()
-  , iteCborRoundTripFailures :: !Bool
+  , iteCborRoundTripFailures :: Bool
   -- ^ Expect failures in CBOR round trip serialization tests for predicate failures
   }
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
@@ -150,12 +150,12 @@ chainStateNesL :: Lens' (ChainState era) (NewEpochState era)
 chainStateNesL = lens chainNes $ \x y -> x {chainNes = y}
 
 data TestChainPredicateFailure era
-  = RealChainPredicateFailure !ChainPredicateFailure
-  | BbodyFailure !(PredicateFailure (EraRule "BBODY" era)) -- Subtransition Failures
-  | TickFailure !(PredicateFailure (EraRule "TICK" era)) -- Subtransition Failures
-  | TicknFailure !(PredicateFailure (EraRule "TICKN" era)) -- Subtransition Failures
-  | PrtclFailure !(PredicateFailure (PRTCL MockCrypto)) -- Subtransition Failures
-  | PrtclSeqFailure !PrtlSeqFailure -- Subtransition Failures
+  = RealChainPredicateFailure ChainPredicateFailure
+  | BbodyFailure (PredicateFailure (EraRule "BBODY" era)) -- Subtransition Failures
+  | TickFailure (PredicateFailure (EraRule "TICK" era)) -- Subtransition Failures
+  | TicknFailure (PredicateFailure (EraRule "TICKN" era)) -- Subtransition Failures
+  | PrtclFailure (PredicateFailure (PRTCL MockCrypto)) -- Subtransition Failures
+  | PrtclSeqFailure PrtlSeqFailure -- Subtransition Failures
   deriving (Generic)
 
 data ChainEvent era

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -1180,9 +1180,9 @@ instance SpecTranslate ctx (EpochExecEnv era) where
 
 -- | This type is used as the Env only in the Agda Spec
 data ConwayExecEnactEnv era = ConwayExecEnactEnv
-  { ceeeGid :: !GovActionId
-  , ceeeTreasury :: !Coin
-  , ceeeEpoch :: !EpochNo
+  { ceeeGid :: GovActionId
+  , ceeeTreasury :: Coin
+  , ceeeEpoch :: EpochNo
   }
   deriving (Generic, Eq, Show)
 

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx/Gen.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx/Gen.hs
@@ -57,10 +57,10 @@ applyTxMempoolEnv pp =
     }
 
 data ApplyTxEnv era = ApplyTxEnv
-  { ateGlobals :: !Globals
-  , ateMempoolEnv :: !(MempoolEnv era)
-  , ateState :: !(LedgerState era)
-  , ateTx :: !(Tx era)
+  { ateGlobals :: Globals
+  , ateMempoolEnv :: (MempoolEnv era)
+  , ateState :: (LedgerState era)
+  , ateTx :: (Tx era)
   }
   deriving (Generic)
 

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx/Gen.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx/Gen.hs
@@ -58,9 +58,9 @@ applyTxMempoolEnv pp =
 
 data ApplyTxEnv era = ApplyTxEnv
   { ateGlobals :: Globals
-  , ateMempoolEnv :: (MempoolEnv era)
-  , ateState :: (LedgerState era)
-  , ateTx :: (Tx era)
+  , ateMempoolEnv :: MempoolEnv era
+  , ateState :: LedgerState era
+  , ateTx :: Tx era
   }
   deriving (Generic)
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
@@ -212,7 +212,7 @@ data GenSize = GenSize
   deriving (Show)
 
 data GenEnv era = GenEnv
-  { gePParams :: (PParams era)
+  { gePParams :: PParams era
   , geSize :: GenSize
   }
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
@@ -212,8 +212,8 @@ data GenSize = GenSize
   deriving (Show)
 
 data GenEnv era = GenEnv
-  { gePParams :: !(PParams era)
-  , geSize :: !GenSize
+  { gePParams :: (PParams era)
+  , geSize :: GenSize
   }
 
 data GenState era = GenState

--- a/libs/cardano-protocol-tpraos/CHANGELOG.md
+++ b/libs/cardano-protocol-tpraos/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.4.0.0
 
+* Made the fields of predicate failures and environments lazy
 * Move `Crypto` and `StandardCrypto` definitions from `cardano-ledger-core` into new
   `Cardano.Protocol.Crypto` module.
 * Remove crypto parametrization from types:

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/OCert.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/OCert.hs
@@ -61,8 +61,8 @@ import NoThunks.Class (NoThunks (..))
 import Quiet
 
 data OCertEnv = OCertEnv
-  { ocertEnvStPools :: (Set (KeyHash 'StakePool))
-  , ocertEnvGenDelegs :: (Set (KeyHash 'GenesisDelegate))
+  { ocertEnvStPools :: Set (KeyHash 'StakePool)
+  , ocertEnvGenDelegs :: Set (KeyHash 'GenesisDelegate)
   }
   deriving (Show, Eq)
 

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/OCert.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/OCert.hs
@@ -61,8 +61,8 @@ import NoThunks.Class (NoThunks (..))
 import Quiet
 
 data OCertEnv = OCertEnv
-  { ocertEnvStPools :: !(Set (KeyHash 'StakePool))
-  , ocertEnvGenDelegs :: !(Set (KeyHash 'GenesisDelegate))
+  { ocertEnvStPools :: (Set (KeyHash 'StakePool))
+  , ocertEnvGenDelegs :: (Set (KeyHash 'GenesisDelegate))
   }
   deriving (Show, Eq)
 

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/OCert.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/OCert.hs
@@ -32,25 +32,25 @@ data OCERT c
 
 data OcertPredicateFailure
   = KESBeforeStartOCERT
-      !KESPeriod -- OCert Start KES Period
-      !KESPeriod -- Current KES Period
+      KESPeriod -- OCert Start KES Period
+      KESPeriod -- Current KES Period
   | KESAfterEndOCERT
-      !KESPeriod -- Current KES Period
-      !KESPeriod -- OCert Start KES Period
-      !Word64 -- Max KES Key Evolutions
+      KESPeriod -- Current KES Period
+      KESPeriod -- OCert Start KES Period
+      Word64 -- Max KES Key Evolutions
   | CounterTooSmallOCERT
-      !Word64 -- last KES counter used
-      !Word64 -- current KES counter
+      Word64 -- last KES counter used
+      Word64 -- current KES counter
   | InvalidSignatureOCERT
-      !Word64 -- OCert counter
-      !KESPeriod -- OCert KES period
+      Word64 -- OCert counter
+      KESPeriod -- OCert KES period
   | InvalidKesSignatureOCERT
-      !Word -- current KES Period
-      !Word -- KES start period
-      !Word -- expected KES evolutions
-      !String -- error message given by Consensus Layer
+      Word -- current KES Period
+      Word -- KES start period
+      Word -- expected KES evolutions
+      String -- error message given by Consensus Layer
   | NoCounterForKeyHashOCERT
-      !(KeyHash 'BlockIssuer) -- stake pool key hash
+      (KeyHash 'BlockIssuer) -- stake pool key hash
   deriving (Show, Eq, Generic)
 
 instance NoThunks OcertPredicateFailure

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Overlay.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Overlay.hs
@@ -98,36 +98,36 @@ instance NoThunks OverlayEnv
 
 data OverlayPredicateFailure c
   = VRFKeyUnknown
-      !(KeyHash 'StakePool) -- unknown VRF keyhash (not registered)
+      (KeyHash 'StakePool) -- unknown VRF keyhash (not registered)
   | VRFKeyWrongVRFKey
-      !(KeyHash 'StakePool) -- KeyHash of block issuer
-      !(VRFVerKeyHash 'StakePoolVRF) -- VRF KeyHash registered with stake pool
-      !(VRFVerKeyHash 'BlockIssuerVRF) -- VRF KeyHash from Header
+      (KeyHash 'StakePool) -- KeyHash of block issuer
+      (VRFVerKeyHash 'StakePoolVRF) -- VRF KeyHash registered with stake pool
+      (VRFVerKeyHash 'BlockIssuerVRF) -- VRF KeyHash from Header
   | VRFKeyBadNonce
-      !Nonce -- Nonce constant to distinguish VRF nonce values
-      !SlotNo -- Slot used for VRF calculation
-      !Nonce -- Epoch nonce used for VRF calculation
-      !(VRF.CertifiedVRF (VRF c) Nonce) -- VRF calculated nonce value
+      Nonce -- Nonce constant to distinguish VRF nonce values
+      SlotNo -- Slot used for VRF calculation
+      Nonce -- Epoch nonce used for VRF calculation
+      (VRF.CertifiedVRF (VRF c) Nonce) -- VRF calculated nonce value
   | VRFKeyBadLeaderValue
-      !Nonce -- Leader constant to distinguish VRF leader values
-      !SlotNo -- Slot used for VRF calculation
-      !Nonce -- Epoch nonce used for VRF calculation
-      !(VRF.CertifiedVRF (VRF c) Nonce) -- VRF calculated leader value
+      Nonce -- Leader constant to distinguish VRF leader values
+      SlotNo -- Slot used for VRF calculation
+      Nonce -- Epoch nonce used for VRF calculation
+      (VRF.CertifiedVRF (VRF c) Nonce) -- VRF calculated leader value
   | VRFLeaderValueTooBig
-      !(VRF.OutputVRF (VRF c)) -- VRF Leader value
-      !Rational -- stake pool's relative stake
-      !ActiveSlotCoeff -- Praos active slot coefficient value
+      (VRF.OutputVRF (VRF c)) -- VRF Leader value
+      Rational -- stake pool's relative stake
+      ActiveSlotCoeff -- Praos active slot coefficient value
   | NotActiveSlotOVERLAY
-      !SlotNo -- Slot which is supposed to be silent
+      SlotNo -- Slot which is supposed to be silent
   | WrongGenesisColdKeyOVERLAY
-      !(KeyHash 'BlockIssuer) -- KeyHash of block issuer
-      !(KeyHash 'GenesisDelegate) -- KeyHash genesis delegate keyhash assigned to this slot
+      (KeyHash 'BlockIssuer) -- KeyHash of block issuer
+      (KeyHash 'GenesisDelegate) -- KeyHash genesis delegate keyhash assigned to this slot
   | WrongGenesisVRFKeyOVERLAY
-      !(KeyHash 'BlockIssuer) -- KeyHash of block issuer
-      !(VRFVerKeyHash 'GenDelegVRF) -- VRF KeyHash registered with genesis delegation
-      !(VRFVerKeyHash 'BlockIssuerVRF) -- VRF KeyHash from Header
+      (KeyHash 'BlockIssuer) -- KeyHash of block issuer
+      (VRFVerKeyHash 'GenDelegVRF) -- VRF KeyHash registered with genesis delegation
+      (VRFVerKeyHash 'BlockIssuerVRF) -- VRF KeyHash from Header
   | UnknownGenesisKeyOVERLAY
-      !(KeyHash 'Genesis) -- KeyHash which does not correspond to o genesis node
+      (KeyHash 'Genesis) -- KeyHash which does not correspond to o genesis node
   | OcertFailure (PredicateFailure (OCERT c)) -- Subtransition Failures
   deriving (Generic)
 


### PR DESCRIPTION
# Description

I made all the fields in predicate failure constructors lazy using [ast-grep](https://github.com/ast-grep/ast-grep).

Here are the rules I applied:
```yaml
id: lazy-predfailures
language: Haskell
rule:
  kind: strict_field
  inside:
    kind: data_type
    stopBy: end
    has:
      field: name
      regex: '.*Pred.*Failure'
  has:
    field: type
    pattern: $TYPE
fix: ' $TYPE'
```
```yaml
id: lazy-environments
language: Haskell
rule:
  kind: strict_field
  inside:
    kind: data_type
    stopBy: end
    has:
      field: name
      regex: '.*Env$'
  has:
    field: type
    pattern: $TYPE
fix: ' $TYPE'
```

and this one for cleaning up redundant parentheses from field types:
```yaml
id: remove-extra-parens
language: Haskell
rule:
  kind: field
  all:
  - has:
      field: name
      pattern: $NAME
  - has:
      field: type
      pattern: ($TYPE)
fix: '$NAME :: $TYPE'
```

closes #4848

# Checklist

- [x] Commits in meaningful sequence and with useful messages
- [x] Tests added or updated when needed
- [x] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
