### PR TITLE
Enable Imp conformance for `GOV`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -24,8 +24,8 @@ source-repository-package
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `MAlonzo-code` BEFORE MERGE!
   subdir: generated
-  --sha256: sha256-MSQpX5wkb/LfgGw5sHl5g0DeHVAZF7oNxlM1sUOEB3Q=
-  tag: 9ea3e2123e89538fa89ce633db0652650f7291dc
+  --sha256: sha256-vrxKI3I1kwt+XiHk+UAWm49veRPTWkVPOvwNzVxuFs8=
+  tag: 9b706ae8c332d5ad10def54aa51d4a66836df363
 
 -- NOTE: If you would like to update the above, look for the `MAlonzo-code`
 -- branch in the `formal-ledger-specifications` repo and copy the SHA of

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Gov.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Gov.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,13 +11,11 @@
 
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Gov () where
 
-import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Conway (ConwayEra)
-import Cardano.Ledger.Conway.Core
+import Cardano.Ledger.Conway.Core (EraPParams (..))
 import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Conway.Rules
-import Cardano.Ledger.TxIn (TxId)
-import Lens.Micro
+import Lens.Micro ((&), (.~), (^.))
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base ()
@@ -25,21 +24,12 @@ import Test.Cardano.Ledger.Conway.Arbitrary ()
 import Test.Cardano.Ledger.Imp.Common
 
 instance
-  Inject
-    (TxId, Proposals ConwayEra, EnactState ConwayEra)
-    (EnactState ConwayEra)
-  where
-  inject (_, _, x) = x
-
-instance
   ( NFData (SpecRep (ConwayGovPredFailure ConwayEra))
   , IsConwayUniv fn
   ) =>
   ExecSpecRule fn "GOV" ConwayEra
   where
-  type
-    ExecContext fn "GOV" ConwayEra =
-      (TxId, ProposalsSplit, EnactState ConwayEra)
+  type ExecContext fn "GOV" ConwayEra = EnactState ConwayEra
 
   environmentSpec _ = govEnvSpec
 
@@ -47,28 +37,17 @@ instance
 
   signalSpec _ = govProceduresSpec
 
-  genExecContext = do
-    txId <- arbitrary
-    proposalsSplit <- genProposalsSplit 50
-    enactState <- arbitrary
-    pure
-      ( txId
-      , proposalsSplit
-      , enactState
-      )
-
   runAgdaRule env st sig = unComputationResult $ Agda.govStep env st sig
 
-  translateInputs env@GovEnv {gePParams} st sig (txId, _proposalsSplit, enactState) = do
+  translateInputs env@GovEnv {gePParams} st sig enactState = do
     agdaEnv <- expectRight $ runSpecTransM ctx $ toSpecRep env
     agdaSt <- expectRight $ runSpecTransM ctx $ toSpecRep st
     agdaSig <- expectRight $ runSpecTransM ctx $ toSpecRep sig
     pure (agdaEnv, agdaSt, agdaSig)
     where
       ctx =
-        ( txId
-        , st
-        , enactState
-            & ensPrevGovActionIdsL .~ toPrevGovActionIds (st ^. pRootsL)
-            & ensProtVerL .~ (gePParams ^. ppProtocolVersionL)
-        )
+        enactState
+          & ensPrevGovActionIdsL
+            .~ toPrevGovActionIds (st ^. pRootsL)
+          & ensProtVerL
+            .~ (gePParams ^. ppProtocolVersionL)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Gov.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Gov.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -13,11 +14,14 @@
 module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Gov () where
 
 import Cardano.Ledger.BaseTypes
-import Cardano.Ledger.CertState (CertState)
+import Cardano.Ledger.CertState (CertState, certDStateL, dsUnifiedL)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Conway.Rules
+import Cardano.Ledger.UMap (umElemsL)
 import Data.Functor.Identity (Identity)
+import qualified Data.Map.Strict as Map
+import Lens.Micro ((^.))
 import qualified Lib as Agda
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
@@ -36,6 +40,7 @@ instance
 
   toSpecRep GovEnv {..} = do
     enactState <- askCtx @(EnactState era)
+    let rewardAccounts = Map.keysSet $ geCertState ^. certDStateL . dsUnifiedL . umElemsL
     Agda.MkGovEnv
       <$> toSpecRep geTxId
       <*> toSpecRep geEpoch
@@ -43,6 +48,7 @@ instance
       <*> toSpecRep gePPolicy
       <*> toSpecRep enactState
       <*> toSpecRep geCertState
+      <*> toSpecRep rewardAccounts
 
 instance
   ( EraPParams era

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
@@ -156,7 +156,7 @@ spec =
           describe "DELEG" Deleg.spec
           describe "ENACT" Enact.spec
           xdescribe "EPOCH" Epoch.spec
-          xdescribe "GOV" Gov.spec
+          describe "GOV" Gov.spec
           describe "GOVCERT" GovCert.spec
           -- LEDGER tests pending on the dRep delegations cleanup in the spec:
           -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/635


### PR DESCRIPTION
# Description

This PR bumps the spec SRP to enable Imp conformance tests for `GOV`. I updated some of the translations and also got rid of some unused code in the `GOV` exec context.

This gets us closer to closing #4770

# Checklist

- [ ] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
