### PR TITLE
Add roundtrip test functions skipping comparison with FlatTerm-decoded

### DIFF
--- a/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Failure.hs
+++ b/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Failure.hs
@@ -56,7 +56,7 @@ prop_shouldFailMapWithDupKeys :: Property
 prop_shouldFailMapWithDupKeys =
   forAllBlind genDuplicateAssocListEncoding $
     \mapEncoding ->
-      let trip = Trip id (decCBOR @(Map Int Int)) (dropCBOR (Proxy @(Map Int Int)))
+      let trip = Trip id (decCBOR @(Map Int Int)) (dropCBOR (Proxy @(Map Int Int))) True
        in property $ embedTripRangeFailureExpectation trip (natVersion @9) maxBound mapEncoding
 
 -- | Starting in version 9, do not accept duplicates in CBOR sets
@@ -64,7 +64,7 @@ prop_shouldFailSetWithDupKeys :: Property
 prop_shouldFailSetWithDupKeys =
   forAllBlind genDuplicateListEncoding $
     \setEncoding ->
-      let trip = Trip id (decCBOR @(Set Int)) (dropCBOR (Proxy @(Set Int)))
+      let trip = Trip id (decCBOR @(Set Int)) (dropCBOR (Proxy @(Set Int))) True
        in property $ embedTripRangeFailureExpectation trip (natVersion @9) maxBound setEncoding
 
 spec :: Spec

--- a/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Success.hs
+++ b/libs/cardano-ledger-binary/test/Test/Cardano/Ledger/Binary/Success.hs
@@ -37,10 +37,10 @@ prop_setWithNoDuplicatesAndTag :: Property
 prop_setWithNoDuplicatesAndTag =
   forAllBlind genUniqueListEncoding $
     \(s, setEncoder) ->
-      let trip = Trip id (decCBOR @(Set.Set Int)) (dropCBOR (Proxy @(Set.Set Int)))
+      let trip = Trip id (decCBOR @(Set.Set Int)) (dropCBOR (Proxy @(Set.Set Int))) True
        in property $
             forM_ [(natVersion @9) .. maxBound] $
-              \v -> embedTripExpectation v v trip (\s' _ -> (s' `shouldBe` s)) setEncoder
+              \v -> embedTripExpectation v v trip (\s' _ -> s' `shouldBe` s) setEncoder
 
 spec :: Spec
 spec = do

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary/RoundTrip.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary/RoundTrip.hs
@@ -17,6 +17,7 @@ module Test.Cardano.Ledger.Core.Binary.RoundTrip (
 
   -- * Spec
   roundTripEraSpec,
+  roundTripEraNoFlatTermCompSpec,
   roundTripAnnEraSpec,
   roundTripEraTypeSpec,
   roundTripAnnEraTypeSpec,
@@ -56,6 +57,13 @@ roundTripEraSpec ::
 roundTripEraSpec =
   prop (show (typeRep $ Proxy @t)) $ roundTripEraExpectation @era @t
 
+roundTripEraNoFlatTermCompSpec ::
+  forall era t.
+  (Era era, Show t, Eq t, EncCBOR t, DecCBOR t, Arbitrary t, HasCallStack) =>
+  Spec
+roundTripEraNoFlatTermCompSpec =
+  prop (show (typeRep $ Proxy @t)) $ roundTripEraExpectationInternal @era @t False
+
 -- | Roundtrip CBOR testing for types and type families that implement
 -- EncCBOR/DecCBOR. Requires TypeApplication of an @@era@
 roundTripEraExpectation ::
@@ -64,7 +72,16 @@ roundTripEraExpectation ::
   t ->
   Expectation
 roundTripEraExpectation =
-  roundTripCborRangeExpectation (eraProtVerLow @era) (eraProtVerHigh @era)
+  roundTripEraExpectationInternal @era @t True
+
+roundTripEraExpectationInternal ::
+  forall era t.
+  (Era era, Show t, Eq t, EncCBOR t, DecCBOR t, HasCallStack) =>
+  Bool ->
+  t ->
+  Expectation
+roundTripEraExpectationInternal noFlatTermCompare =
+  roundTripCborRangeExpectation noFlatTermCompare (eraProtVerLow @era) (eraProtVerHigh @era)
 
 -- | QuickCheck property spec that uses `roundTripAnnEraExpectation`
 roundTripAnnEraSpec ::


### PR DESCRIPTION
# Description

This is an attempt to allow for more relaxed cbor roundtrip checks, namely:  optionally skipping the comparison of the initial value with the value obtained by decoding the `FlatTerm`.  For types that are memoized, this check doesn't succeed (and it's also  already skipped roundtrip functions for `Annotator` types) . 
Since we'll have `DecCBOR` instances for types for which atm we only have `DecCBOR (Annotator)` instances  (memoized),  if we can't skip this check, then we can't have roundtrip checks for them. 


PR is a draft, and missing comments and changelog entries, because it's just a proposal - I'm not too happy about polluting the Roundtrip space with another dimension. 
I would be happy  to implement a more elegant solution, or maybe better names. 


<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
