### PR TITLE
Add `CanGetUTxO` and `CanSetUTxO` type classes

### DIFF
--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/ChainTrace.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/ChainTrace.hs
@@ -27,7 +27,6 @@ import Cardano.Ledger.Plutus.Evaluate (PlutusWithContext (..), ScriptResult (..)
 import Cardano.Ledger.Plutus.Language (plutusFromRunnable)
 import Cardano.Ledger.Shelley.LedgerState hiding (circulation)
 import Cardano.Ledger.Slot (EpochSize (..))
-import Cardano.Ledger.UTxO (UTxO (..))
 import Cardano.Slotting.EpochInfo (fixedEpochInfo)
 import Cardano.Slotting.Time (SystemStart (..), mkSlotLength)
 import Control.State.Transition

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -94,8 +94,8 @@ import Cardano.Ledger.Shelley.LedgerState (
   LedgerState (..),
   UTxOState (..),
   asTreasuryL,
+  utxoL,
   utxosGovStateL,
-  utxosUtxoL,
  )
 import Cardano.Ledger.Shelley.Rules (
   LedgerEnv (..),
@@ -407,7 +407,7 @@ ledgerTransition = do
                       }
                   )
 
-        let totalRefScriptSize = txNonDistinctRefScriptsSize (utxoState ^. utxosUtxoL) tx
+        let totalRefScriptSize = txNonDistinctRefScriptsSize (utxoState ^. utxoL) tx
         totalRefScriptSize
           <= maxRefScriptSizePerTx
             ?! ConwayTxRefScriptsSizeTooBig

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -209,9 +209,9 @@ import Cardano.Ledger.Shelley.LedgerState (
   newEpochStateGovStateL,
   produced,
   unifiedL,
+  utxoL,
   utxosGovStateL,
   utxosStakeDistrL,
-  utxosUtxoL,
   vsCommitteeStateL,
   vsDRepsL,
  )
@@ -1761,7 +1761,7 @@ logConwayTxBalance ::
 logConwayTxBalance tx = do
   pp <- getsPParams id
   certState <- getsNES $ nesEsL . esLStateL . lsCertStateL
-  utxo <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosUtxoL
+  utxo <- getsNES utxoL
   logString $ showConwayTxBalance pp certState utxo tx
 
 submitBootstrapAwareFailingVote ::

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.16.0.0
 
+* Deprecated `utxosUtxoL`
+* Added `CanGetUTxO` and `CanSetUTxO` instances for `EpochState`, `UTxOState`, `NewEpochState`, `LedgerState` 
 * Made the fields of predicate failures and environments lazy
 * Changed the type of `sgSecurityParam` to `NonZero Word64`
 * Following functions now expect a `NonZero Word64` security parameter:

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -10,6 +10,12 @@
 -- as state transformations on a ledger state ('LedgerState'),
 -- as specified in /A Simplified Formal Specification of a UTxO Ledger/.
 module Cardano.Ledger.Shelley.LedgerState (
+  -- * UTxO
+  UTxO (..),
+  CanGetUTxO (..),
+  CanSetUTxO (..),
+
+  -- * Others to organize
   AccountState (..),
   CertState (..),
   DState (..),
@@ -159,3 +165,4 @@ import Cardano.Ledger.Shelley.PParams (pvCanFollow)
 import Cardano.Ledger.Shelley.RewardUpdate
 import Cardano.Ledger.Shelley.Rules.Ppup (ShelleyGovState (..))
 import Cardano.Ledger.Shelley.UTxO (consumed, produced)
+import Cardano.Ledger.UTxO (CanGetUTxO (..), CanSetUTxO (..), UTxO (..))

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
@@ -68,7 +68,7 @@ import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.PoolRank (NonMyopic (..))
 import Cardano.Ledger.Shelley.RewardUpdate (PulsingRewUpdate (..))
 import Cardano.Ledger.UMap (UMap (..))
-import Cardano.Ledger.UTxO (UTxO (..))
+import Cardano.Ledger.UTxO (CanGetUTxO (..), CanSetUTxO (..), UTxO (..))
 import Control.DeepSeq (NFData)
 import Control.Monad.State.Strict (evalStateT)
 import Control.Monad.Trans (MonadTrans (lift))
@@ -129,6 +129,11 @@ data EpochState era = EpochState
   -- See https://github.com/intersectmbo/cardano-ledger/releases/latest/download/pool-ranking.pdf
   }
   deriving (Generic)
+
+instance CanGetUTxO EpochState
+instance CanSetUTxO EpochState where
+  utxoL = (lens esLState $ \s ls -> s {esLState = ls}) . utxoL
+  {-# INLINE utxoL #-}
 
 deriving stock instance
   ( EraTxOut era
@@ -285,6 +290,11 @@ data UTxOState era = UTxOState
   }
   deriving (Generic)
 
+instance CanGetUTxO UTxOState
+instance CanSetUTxO UTxOState where
+  utxoL = lens utxosUtxo $ \s u -> s {utxosUtxo = u}
+  {-# INLINE utxoL #-}
+
 instance
   ( EraTxOut era
   , NFData (GovState era)
@@ -403,6 +413,11 @@ data NewEpochState era = NewEpochState
   }
   deriving (Generic)
 
+instance CanGetUTxO NewEpochState
+instance CanSetUTxO NewEpochState where
+  utxoL = (lens nesEs $ \s es -> s {nesEs = es}) . utxoL
+  {-# INLINE utxoL #-}
+
 type family StashedAVVMAddresses era where
   StashedAVVMAddresses ShelleyEra = UTxO ShelleyEra
   StashedAVVMAddresses _ = ()
@@ -489,6 +504,11 @@ data LedgerState era = LedgerState
   , lsCertState :: !(CertState era)
   }
   deriving (Generic)
+
+instance CanGetUTxO LedgerState
+instance CanSetUTxO LedgerState where
+  utxoL = (lens lsUTxOState $ \s us -> s {lsUTxOState = us}) . utxoL
+  {-# INLINE utxoL #-}
 
 deriving stock instance
   ( EraTxOut era
@@ -664,6 +684,7 @@ lsCertStateL = lens lsCertState (\x y -> x {lsCertState = y})
 
 utxosUtxoL :: Lens' (UTxOState era) (UTxO era)
 utxosUtxoL = lens utxosUtxo (\x y -> x {utxosUtxo = y})
+{-# DEPRECATED utxosUtxoL "In favor of `utxoL`" #-}
 
 utxosDepositedL :: Lens' (UTxOState era) Coin
 utxosDepositedL = lens utxosDeposited (\x y -> x {utxosDeposited = y})

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -80,7 +80,7 @@ import Cardano.Ledger.Shelley.TxBody (RewardAccount)
 import Cardano.Ledger.Shelley.UTxO (consumed, produced)
 import Cardano.Ledger.Slot (SlotNo)
 import Cardano.Ledger.TxIn (TxIn)
-import Cardano.Ledger.UTxO (EraUTxO (getMinFeeTxUtxo), UTxO (..), balance, txouts)
+import Cardano.Ledger.UTxO (CanSetUTxO (..), EraUTxO (getMinFeeTxUtxo), UTxO (..), balance, txouts)
 import Cardano.Ledger.Val ((<->))
 import qualified Cardano.Ledger.Val as Val
 import Control.DeepSeq
@@ -360,7 +360,8 @@ utxoInductive ::
   TransitionRule (EraRule "UTXO" era)
 utxoInductive = do
   TRC (UtxoEnv slot pp certState, utxos, tx) <- judgmentContext
-  let UTxOState utxo _ _ ppup _ _ = utxos
+  let utxo = utxos ^. utxoL
+      UTxOState _ _ _ ppup _ _ = utxos
       txBody = tx ^. bodyTxL
       outputs = txBody ^. outputsTxBodyL
       genDelegs = dsGenDelegs (certDState certState)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/EmptyBlock.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/EmptyBlock.hs
@@ -15,7 +15,6 @@ import Cardano.Ledger.Block (Block)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Slot (BlockNo (..), SlotNo (..))
-import Cardano.Ledger.UTxO (UTxO (..))
 import Cardano.Protocol.TPraos.BHeader (BHeader)
 import Cardano.Protocol.TPraos.OCert (KESPeriod (..))
 import Data.Default

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/GenesisDelegation.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/GenesisDelegation.hs
@@ -29,7 +29,6 @@ import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
 import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits, addrWits)
 import Cardano.Ledger.Slot (BlockNo (..), SlotNo (..))
 import Cardano.Ledger.TxIn (TxIn (..))
-import Cardano.Ledger.UTxO (UTxO (..))
 import Cardano.Ledger.Val ((<->))
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Protocol.Crypto (hashVerKeyVRF)

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
@@ -84,7 +84,7 @@ testImpConformance _globals impRuleResult env state signal = do
           , clecUtxoExecContext =
               UtxoExecContext
                 { uecTx = signal
-                , uecUTxO = state ^. lsUTxOStateL . utxosUtxoL
+                , uecUTxO = state ^. utxoL
                 , uecUtxoEnv =
                     UtxoEnv
                       { ueSlot = env ^. ledgerSlotNoL

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.17.0.0
 
+* Add `CanGetUTxO` and `CanSetUTxO` type classes
+* Add `CanGetUTxO` and `CanSetUTxO` instances for `UTxO` 
 * Add `DecShareCBOR` instances for `DRep` and `DRepState`
 * Added `ToPlutusData` instance for `NonZero`
 * `maxpool'` now expects `nOpt` to be a `NonZero Word16`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/UTxO.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/UTxO.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,6 +17,9 @@
 {-# LANGUAGE UndecidableSuperClasses #-}
 
 module Cardano.Ledger.UTxO (
+  CanGetUTxO (..),
+  CanSetUTxO (..),
+
   -- * Primitives
   UTxO (..),
   EraUTxO (..),
@@ -67,11 +71,24 @@ import Data.Monoid (Sum (..))
 import Data.Set (Set)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
-import Lens.Micro ((^.))
+import Lens.Micro (Lens', SimpleGetter, (^.))
 import NoThunks.Class (NoThunks (..))
 import Quiet (Quiet (Quiet))
 
 -- ===============================================
+
+class CanGetUTxO t where
+  utxoG :: SimpleGetter (t era) (UTxO era)
+  default utxoG :: CanSetUTxO t => SimpleGetter (t era) (UTxO era)
+  utxoG = utxoL
+  {-# INLINE utxoG #-}
+
+class CanGetUTxO t => CanSetUTxO t where
+  utxoL :: Lens' (t era) (UTxO era)
+
+instance CanGetUTxO UTxO
+instance CanSetUTxO UTxO where
+  utxoL = id
 
 -- | The unspent transaction outputs.
 newtype UTxO era = UTxO {unUTxO :: Map.Map TxIn (TxOut era)}

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -124,7 +124,6 @@ import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
 import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import Cardano.Ledger.UMap
-import Cardano.Ledger.UTxO
 import Cardano.Ledger.Val (Val)
 import Constrained hiding (Sized, Value)
 import Constrained qualified as C

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/WellFormed.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/WellFormed.hs
@@ -29,7 +29,6 @@ import Cardano.Ledger.EpochBoundary (SnapShot (..), SnapShots (..))
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
 import Cardano.Ledger.PoolParams (PoolParams (..))
 import Cardano.Ledger.Shelley.LedgerState
-import Cardano.Ledger.UTxO (UTxO (..))
 import Constrained hiding (Value)
 import Data.Map (Map)
 import Test.Cardano.Ledger.Constrained.Conway ()

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Lenses.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Lenses.hs
@@ -30,7 +30,6 @@ import Cardano.Ledger.UMap (
   unify,
  )
 import qualified Cardano.Ledger.UMap as UM
-import Cardano.Ledger.UTxO (UTxO (..))
 import Data.Foldable (Foldable (..))
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/TypeRep.hs
@@ -101,7 +101,6 @@ import Cardano.Ledger.Shelley.TxCert (ShelleyTxCert (..))
 import Cardano.Ledger.Shelley.UTxO (ShelleyScriptsNeeded (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import qualified Cardano.Ledger.UMap as UM
-import Cardano.Ledger.UTxO (UTxO (..))
 import Cardano.Ledger.Val (Val ((<+>)))
 import Control.Monad.Identity (Identity)
 import Data.ByteString (ByteString)

--- a/libs/ledger-state/src/Cardano/Ledger/State/Query.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/Query.hs
@@ -25,7 +25,6 @@ import Cardano.Ledger.State.Vector
 import qualified Cardano.Ledger.TxIn as TxIn
 import Cardano.Ledger.UMap (ptrMap, rewardMap, sPoolMap, unify)
 import qualified Cardano.Ledger.UMap as UM
-import qualified Cardano.Ledger.UTxO as Shelley
 import Conduit
 import Control.Foldl (Fold (..))
 import Control.Monad

--- a/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
@@ -30,7 +30,6 @@ import Cardano.Ledger.Shelley.PoolRank
 import Cardano.Ledger.TxIn
 import Cardano.Ledger.UMap (rewardMap, sPoolMap)
 import qualified Cardano.Ledger.UMap as UM (ptrMap)
-import Cardano.Ledger.UTxO
 import Conduit
 import Control.Exception (throwIO)
 import Control.Foldl (Fold (..))


### PR DESCRIPTION
# Description

This is the prototype of how we will deal with accessing and modifying the ledger using lenses

Feedback is welcome. Once this PR is merged we will apply the same approach to the rest of the ledger state components.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
