### PR TITLE
Add missing cbor round trip tests 

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### `testlib`
 
+* Add `genNonEmptyTxDats` and `genNonEmptyRedeemers` to `Arbitrary`
 * Renamed:
   * `impLookupPlutusScriptMaybe` -> `impLookupPlutusScript`
   * `impGetScriptContextMaybe` -> `impLookupScriptContext`

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -143,7 +143,7 @@ library testlib
     QuickCheck,
     base,
     bytestring,
-    cardano-data,
+    cardano-data:{cardano-data, testlib},
     cardano-ledger-allegra,
     cardano-ledger-alonzo,
     cardano-ledger-binary,

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
@@ -23,6 +23,8 @@ module Test.Cardano.Ledger.Alonzo.Arbitrary (
   genEraLanguage,
   genAlonzoScript,
   genNativeScript,
+  genNonEmptyRedeemers,
+  genNonEmptyTxDats,
   genPlutusScript,
   genScripts,
   genValidCostModel,
@@ -86,6 +88,7 @@ import Data.Text (pack)
 import Data.Word
 import Generic.Random (genericArbitraryU)
 import Numeric.Natural (Natural)
+import Test.Cardano.Data (genNonEmptyMap)
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Arbitrary (
   genValidAndUnknownCostModels,
@@ -108,6 +111,10 @@ instance
   Arbitrary (Redeemers era)
   where
   arbitrary = Redeemers <$> arbitrary
+
+genNonEmptyRedeemers ::
+  (AlonzoEraScript era, Arbitrary (PlutusPurpose AsIx era)) => Gen (Redeemers era)
+genNonEmptyRedeemers = Redeemers <$> genNonEmptyMap arbitrary arbitrary
 
 instance
   ( Era era
@@ -135,6 +142,9 @@ genScripts = Map.fromElems (hashScript @era) <$> (arbitrary :: Gen [Script era])
 
 instance Era era => Arbitrary (TxDats era) where
   arbitrary = TxDats . Map.fromElems @[] hashData <$> arbitrary
+
+genNonEmptyTxDats :: Era era => Gen (TxDats era)
+genNonEmptyTxDats = TxDats . Map.fromElems @[] hashData <$> listOf1 arbitrary
 
 instance
   ( EraTxOut era

--- a/eras/babbage/impl/cddl-files/babbage.cddl
+++ b/eras/babbage/impl/cddl-files/babbage.cddl
@@ -228,6 +228,11 @@ network_id = 0 / 1
 
 nonnegative_interval = #6.30([uint, positive_int])
 
+operational_cert = [hot_vkey : $kes_vkey
+                   , sequence_number : uint .size 8
+                   , kes_period : uint
+                   , sigma : $signature]
+
 plutus_data = constr<plutus_data>
                / {* plutus_data => plutus_data}
                / [* plutus_data]
@@ -512,13 +517,6 @@ move_instantaneous_rewards_cert = (6, move_instantaneous_reward)
 ; dns_name: An SRV DNS record
 ; 
 multi_host_name = (2, dns_name)
-
-;  kes_vkey: hot_vkey
-;      uint: sequence_number
-;      uint: key_period
-; signature: sigma
-; 
-operational_cert = ($kes_vkey, uint, uint, $signature)
 
 ;         pool_keyhash: operator
 ;                 coin: pledge

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/CDDL.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/CDDL.hs
@@ -27,6 +27,7 @@ import Test.Cardano.Ledger.Alonzo.CDDL hiding (
   major_protocol_version,
   multiasset,
   next_major_protocol_version,
+  operational_cert,
   plutus_data,
   plutus_script,
   proposed_protocol_parameter_updates,
@@ -106,6 +107,16 @@ next_major_protocol_version = 9
 
 major_protocol_version :: Rule
 major_protocol_version = "major_protocol_version" =:= (1 :: Integer) ... next_major_protocol_version
+
+operational_cert :: Rule
+operational_cert =
+  "operational_cert"
+    =:= arr
+      [ "hot_vkey" ==> kes_vkey
+      , "sequence_number" ==> (VUInt `sized` (8 :: Word64))
+      , "kes_period" ==> VUInt
+      , "sigma" ==> signature
+      ]
 
 protocol_version :: Rule
 protocol_version = "protocol_version" =:= arr [a major_protocol_version, a VUInt]

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/RoundTrip.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/RoundTrip.hs
@@ -12,6 +12,10 @@ module Test.Cardano.Ledger.Conway.Binary.RoundTrip (
   roundTripConwayEraTypesSpec,
 ) where
 
+import Cardano.Ledger.Alonzo.Scripts (
+  AlonzoEraScript (..),
+  AsIx (..),
+ )
 import Cardano.Ledger.BaseTypes (StrictMaybe)
 import Cardano.Ledger.Binary (DecCBOR)
 import Cardano.Ledger.Compactible
@@ -32,6 +36,7 @@ roundTripConwayCommonSpec ::
   , EraGov era
   , EraStake era
   , EraCertState era
+  , AlonzoEraScript era
   , StashedAVVMAddresses era ~ ()
   , Arbitrary (Tx era)
   , Arbitrary (TxBody era)
@@ -43,6 +48,7 @@ roundTripConwayCommonSpec ::
   , Arbitrary (CompactForm (Value era))
   , Arbitrary (Script era)
   , Arbitrary (GovState era)
+  , Arbitrary (PlutusPurpose AsIx era)
   , Arbitrary (PParams era)
   , Arbitrary (PParamsUpdate era)
   , Arbitrary (PParamsHKD StrictMaybe era)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/CDDL.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/CDDL.hs
@@ -38,7 +38,6 @@ import Test.Cardano.Ledger.Babbage.CDDL hiding (
   native_script,
   next_major_protocol_version,
   nonempty_set,
-  operational_cert,
   plutus_v1_script,
   plutus_v2_script,
   pool_metadata,
@@ -135,16 +134,6 @@ header_body =
       , "block_body_hash" ==> hash32
       , a operational_cert
       , a protocol_version
-      ]
-
-operational_cert :: Rule
-operational_cert =
-  "operational_cert"
-    =:= arr
-      [ "hot_vkey" ==> kes_vkey
-      , "sequence_number" ==> (VUInt `sized` (8 :: Word64))
-      , "kes_period" ==> VUInt
-      , "sigma" ==> signature
       ]
 
 protocol_version :: Rule

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Cuddle.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Cuddle.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Test.Cardano.Ledger.Binary.Cuddle (
+  CuddleData,
   huddleDecoderEquivalenceSpec,
   specWithHuddle,
   huddleRoundTripCborSpec,

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary/RoundTrip.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary/RoundTrip.hs
@@ -38,7 +38,6 @@ import Cardano.Ledger.Binary
 import Cardano.Ledger.CertState
 import Cardano.Ledger.Compactible
 import Cardano.Ledger.Core
-import Cardano.Ledger.Keys.Bootstrap
 import Cardano.Ledger.State
 import Control.State.Transition.Extended (STS (..))
 import Data.Typeable
@@ -234,8 +233,6 @@ roundTripCoreEraTypesSpec = do
         (eraProtVerHigh @era)
     roundTripShareEraSpec @era @(CertState era)
   describe "Core State Types" $ do
-    roundTripAnnEraSpec @era @BootstrapWitness
-    roundTripEraSpec @era @BootstrapWitness
     roundTripShareEraSpec @era @SnapShots
     roundTripShareEraTypeSpec @era @DState
     roundTripShareEraTypeSpec @era @PState

--- a/libs/cardano-protocol-tpraos/CHANGELOG.md
+++ b/libs/cardano-protocol-tpraos/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### `testlib`
 
+* Add `RoundTrip` module with `roundTripBlockSpec`
 * Add `genAllIssuerKeys`
 * Add `Arbitrary` instances for `KESKeyPair` and `VRFKeyPair`
 * Move `VRFNatVal` from `cardano-ledger-shelley-test` in here.

--- a/libs/cardano-protocol-tpraos/CHANGELOG.md
+++ b/libs/cardano-protocol-tpraos/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.4.0.0
 
+* Add `DecCBOR` instance for `OCert`
 * Add `DecCBOR` instance for `BHeader`
 * Converted `CertState` to a type family
 * Made the fields of predicate failures and environments lazy

--- a/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
+++ b/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
@@ -61,6 +61,7 @@ library
 
 library testlib
   exposed-modules:
+    Test.Cardano.Protocol.Binary.RoundTrip
     Test.Cardano.Protocol.Crypto.KES
     Test.Cardano.Protocol.Crypto.VRF
     Test.Cardano.Protocol.Crypto.VRF.Fake

--- a/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
+++ b/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
@@ -125,3 +125,4 @@ test-suite tests
     cardano-ledger-mary:{cardano-ledger-mary, testlib},
     cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
     cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib},
+    cuddle,

--- a/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
+++ b/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
@@ -61,6 +61,7 @@ library
 
 library testlib
   exposed-modules:
+    Test.Cardano.Protocol.Binary.Cddl
     Test.Cardano.Protocol.Binary.RoundTrip
     Test.Cardano.Protocol.Crypto.KES
     Test.Cardano.Protocol.Crypto.VRF
@@ -84,6 +85,7 @@ library testlib
     base,
     bytestring,
     cardano-crypto-class >=2.1.1,
+    cardano-ledger-babbage,
     cardano-ledger-binary:{cardano-ledger-binary, testlib},
     cardano-ledger-core:{cardano-ledger-core, testlib},
     cardano-ledger-shelley:testlib,

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/OCert.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/OCert.hs
@@ -94,6 +94,7 @@ data OCert c = OCert
   }
   deriving (Generic)
   deriving (EncCBOR) via (CBORGroup (OCert c))
+  deriving (DecCBOR) via (CBORGroup (OCert c))
 
 deriving instance Crypto c => Eq (OCert c)
 

--- a/libs/cardano-protocol-tpraos/test/Main.hs
+++ b/libs/cardano-protocol-tpraos/test/Main.hs
@@ -1,8 +1,19 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
 module Main where
 
+import Cardano.Ledger.Allegra (AllegraEra)
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Mary (MaryEra)
+import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Protocol.Crypto (StandardCrypto)
+import Cardano.Protocol.TPraos.BHeader (BHeader)
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Protocol.Binary.BinarySpec as Binary
 import qualified Test.Cardano.Protocol.Binary.CddlSpec as Cddl
+import Test.Cardano.Protocol.Binary.RoundTrip
+import Test.Cardano.Protocol.TPraos.Arbitrary ()
 
 main :: IO ()
 main =
@@ -10,3 +21,8 @@ main =
     describe "TPraos" $ do
       Cddl.spec
       Binary.spec
+      describe "RoundTrip" $ do
+        roundTripBlockSpec @(BHeader StandardCrypto) @ShelleyEra
+        roundTripBlockSpec @(BHeader StandardCrypto) @AllegraEra
+        roundTripBlockSpec @(BHeader StandardCrypto) @MaryEra
+        roundTripBlockSpec @(BHeader StandardCrypto) @AlonzoEra

--- a/libs/cardano-protocol-tpraos/test/Test/Cardano/Protocol/Binary/CddlSpec.hs
+++ b/libs/cardano-protocol-tpraos/test/Test/Cardano/Protocol/Binary/CddlSpec.hs
@@ -1,46 +1,50 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Cardano.Protocol.Binary.CddlSpec (spec) where
 
+import Cardano.Ledger.Allegra (AllegraEra)
+import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Binary.Group (CBORGroup)
 import Cardano.Ledger.Core
-import Cardano.Ledger.Shelley
-import Cardano.Protocol.Crypto
+import Cardano.Ledger.Mary (MaryEra)
+import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Protocol.Crypto (StandardCrypto)
 import Cardano.Protocol.TPraos.BHeader (BHBody, BHeader)
 import Cardano.Protocol.TPraos.OCert (OCert)
 import qualified Data.ByteString.Lazy as BSL
-import Test.Cardano.Ledger.Binary.Cddl (
-  beforeAllCddlFile,
-  cddlDecoderEquivalenceSpec,
-  cddlRoundTripAnnCborSpec,
-  cddlRoundTripCborSpec,
- )
-import Test.Cardano.Ledger.Binary.Cuddle
+import Test.Cardano.Ledger.Allegra.Binary.Cddl (readAllegraCddlFiles)
+import Test.Cardano.Ledger.Alonzo.Binary.Cddl (readAlonzoCddlFiles)
+import Test.Cardano.Ledger.Binary.Cddl (beforeAllCddlFile, cddlRoundTripCborSpec)
 import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Mary.Binary.Cddl (readMaryCddlFiles)
 import Test.Cardano.Ledger.Shelley.Binary.Cddl (readShelleyCddlFiles)
-import Test.Cardano.Ledger.Shelley.CDDL (shelleyCDDL)
+import Test.Cardano.Protocol.Binary.Cddl (cddlEraSpec)
 
 spec :: Spec
 spec =
   describe "CDDL" $ do
     let n = 3
     specForEra @ShelleyEra readShelleyCddlFiles n
+    specForEra @AllegraEra readAllegraCddlFiles n
+    specForEra @MaryEra readMaryCddlFiles n
+    specForEra @AlonzoEra readAlonzoCddlFiles n
 
-specForEra :: forall era. Era era => IO [BSL.ByteString] -> Int -> Spec
+specForEra ::
+  forall era.
+  (Era era, AtMostEra AlonzoEra era) =>
+  IO [BSL.ByteString] ->
+  Int ->
+  Spec
 specForEra readCddlFiles n = do
   describe (eraName @era) $ do
-    let v = eraProtVerLow @era
-    beforeAllCddlFile n readCddlFiles $ do
-      cddlRoundTripAnnCborSpec @(BHeader StandardCrypto) v "header"
-      cddlRoundTripCborSpec @(BHeader StandardCrypto) v "header"
-      cddlRoundTripCborSpec @(BHBody StandardCrypto) v "header_body"
-      cddlRoundTripCborSpec @(CBORGroup (OCert StandardCrypto)) v "[ operational_cert ]"
-      -- TODO: add Huddle round trip tests
-      describe "DecCBOR instances equivalence via CDDL" $ do
-        cddlDecoderEquivalenceSpec @(BHeader StandardCrypto) v "header"
-    describe "DecCBOR instances equivalence via CDDL - Huddle" $ do
-      specWithHuddle shelleyCDDL 100 $ do
-        huddleDecoderEquivalenceSpec @(BHeader StandardCrypto) v "header"
+    -- TODO: add Huddle round trip tests
+    describe "Ruby-based" $
+      beforeAllCddlFile n readCddlFiles $ do
+        cddlBlockSpec @era @StandardCrypto @BHeader @BHBody
+        cddlRoundTripCborSpec @(CBORGroup (OCert StandardCrypto))
+          (eraProtVerLow @era)
+          "[ operational_cert ]"

--- a/libs/cardano-protocol-tpraos/testlib/Test/Cardano/Protocol/Binary/Cddl.hs
+++ b/libs/cardano-protocol-tpraos/testlib/Test/Cardano/Protocol/Binary/Cddl.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Protocol.Binary.Cddl (
+  cddlEraSpec,
+  postBabbageCddlSpec,
+) where
+
+import Cardano.Ledger.Babbage (BabbageEra)
+import Cardano.Ledger.Binary (Annotator, DecCBOR, EncCBOR)
+import Cardano.Ledger.Core
+import Cardano.Protocol.Crypto (StandardCrypto)
+import Cardano.Protocol.TPraos.OCert (OCert)
+import Test.Cardano.Ledger.Binary.Cddl (
+  CddlData,
+  cddlDecoderEquivalenceSpec,
+  cddlRoundTripAnnCborSpec,
+  cddlRoundTripCborSpec,
+ )
+import Test.Cardano.Ledger.Common
+
+cddlBlockSpec ::
+  forall era c bh bhbody.
+  ( Era era
+  , Eq (bh c)
+  , Show (bh c)
+  , DecCBOR (bh c)
+  , EncCBOR (bh c)
+  , DecCBOR (Annotator (bh c))
+  , Eq (bhbody c)
+  , Show (bhbody c)
+  , DecCBOR (bhbody c)
+  , EncCBOR (bhbody c)
+  ) =>
+  SpecWith CddlData
+cddlBlockSpec = do
+  let v = eraProtVerLow @era
+  cddlRoundTripCborSpec @(bh c) v "header"
+  cddlRoundTripAnnCborSpec @(bh c) v "header"
+  cddlRoundTripCborSpec @(bhbody c) v "header_body"
+  describe "DecCBOR instances equivalence via CDDL" $ do
+    cddlDecoderEquivalenceSpec @(bh c) v "header"
+
+-- To be used in Consensus with the appropriate new header types
+praosBlockCddlSpec ::
+  forall era c bh bhbody.
+  ( Era era
+  , AtLeastEra BabbageEra era
+  , Eq (bh c)
+  , Show (bh c)
+  , DecCBOR (bh c)
+  , EncCBOR (bh c)
+  , DecCBOR (Annotator (bh c))
+  , Eq (bhbody c)
+  , Show (bhbody c)
+  , DecCBOR (bhbody c)
+  , EncCBOR (bhbody c)
+  ) =>
+  SpecWith CddlData
+praosBlockCddlSpec = do
+  let v = eraProtVerLow @era
+  cddlBlockSpec @era @c @bh @bhbody
+  cddlRoundTripCborSpec @(OCert StandardCrypto) v "operational_cert"

--- a/libs/cardano-protocol-tpraos/testlib/Test/Cardano/Protocol/Binary/RoundTrip.hs
+++ b/libs/cardano-protocol-tpraos/testlib/Test/Cardano/Protocol/Binary/RoundTrip.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Protocol.Binary.RoundTrip (roundTripBlockSpec) where
+
+import Cardano.Ledger.Binary (Annotator, DecCBOR)
+import Cardano.Ledger.Block (Block)
+import Cardano.Ledger.Core
+import Data.Typeable
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Core.Binary.RoundTrip
+import Test.Cardano.Protocol.TPraos.Arbitrary ()
+
+roundTripBlockSpec ::
+  forall h era.
+  ( Eq h
+  , Show h
+  , DecCBOR h
+  , DecCBOR (Annotator h)
+  , EraSegWits era
+  , DecCBOR (TxSeq era)
+  , Arbitrary (Block h era)
+  ) =>
+  Spec
+roundTripBlockSpec =
+  prop (show (typeRep $ Proxy @(Block h era))) $ do
+    withMaxSuccess 3 $ do
+      conjoin
+        [ roundTripEraExpectation @era @(Block h era)
+        , roundTripAnnEraExpectation @era @(Block h era)
+        ]


### PR DESCRIPTION
# Description
In this PR I'm adding: 
*  roundtrip tests for:  TxDats, Remeemers 
*  cbor roundtrip tests for Block for eras [Shelley .. Alonzo]
*  cddl roundtrip tests for BHeader and BHBody for eras [Allegra  ..  Alonzo]
*  huddle roundtrip tests BHeader and BHBody for eras [Allegra. .. Alonzo]
* functions that test cddl and huddle roundtrip tests for Babbage era and beyond, to be called by Consensus

Also, removing a duplicated roundtrip check.

Also, i have discovered that the cddl for babbage for bheader is incorrent: the operational certificate is serialized like in conway, and not like in Shelley-Alonzo, so  I have fixed the cddl for babbage. 

Below is an example of  why what we have in master is wrong: 

1. A cbor representation of BHeader in [Shelley..Alonzo]: 
```
[[
	[8640, 172836,  ; block_number, slot
	h'..',    		; block_number, slot
	h'..',    		; issuer_vkey
	h'..',    		; vrf_vkey
	[h'..', h'..'], ; nonce_vrf
	[h'..', h'..'], ; leader_vrf
	4,  			; block_body_size
	h'..',			; block_body_hash
	h'..', 0, 0, h'..', 7, 2  ;operational certificate & prot version
]]
```

2. A cbor representation of BHeader starting with Babbage: 
```
[[
	89439, 1912624, ; block_number, slot
	h'..', 			; block_number, slot
	h'..',			; issuer_vkey
	h'..', 			; vrf_vkey
	[h'..', h'..'], ; vrf_result
	4,				; block_body_size
	h'..', 			; block_body_hash
	[h'..', 0, 13, h'..'], ; operational_cert
	[8, 0]			
]]
```

The change I made to babbage cddl is aligning the definition to the actual deserialization. 

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
