### PR TITLE
Generate a proper `pmHash` in `Arbitrary PoolMetadata`

### DIFF
--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -127,6 +127,7 @@ import Cardano.Ledger.UTxO (UTxO (..))
 import Control.Monad (replicateM)
 import Control.Monad.Identity (Identity)
 import Control.Monad.Trans.Fail.String (errorFail)
+import qualified Data.ByteString
 import Data.GenValidity
 import Data.Int (Int64)
 import Data.Map.Strict (Map)
@@ -482,7 +483,7 @@ instance Arbitrary PoolParams where
       <*> arbitrary
 
 instance Arbitrary PoolMetadata where
-  arbitrary = PoolMetadata <$> arbitrary <*> arbitrary
+  arbitrary = PoolMetadata <$> arbitrary <*> (Data.ByteString.pack <$> vectorOf 32 (choose (0, 255)))
 
 instance Arbitrary StakePoolRelay where
   arbitrary = genericArbitraryU


### PR DESCRIPTION
# Description

Other libraries (e.g. [txpipe/pallas](https://github.com/txpipe/pallas)) expect the [`pmHash` field in `PoolMetadata`](https://github.com/michalrus/cardano-ledger/blob/0279c818f23fbb0409407eec12b48d76867b4d6c/libs/cardano-ledger-core/src/Cardano/Ledger/PoolParams.hs#L73) to be 32 bytes long.

It seems it's always 32 bytes long in runtime.

We (Blockfrost) are using the `Arbitrary` instances to test our Rust code, but the one for `PoolMetadata` uses just `arbitrary :: Gen ByteString`, which often results in empty `ByteString`s, which breaks Pallas.

It's not a blocker, since we have this patch in our own worktree, but it would be good to get it in the upstream eventually:
* [input-output-hk/testgen-hs/blob/…/nix/cardano-ledger-core--Arbitrary-PoolMetadata.diff](https://github.com/input-output-hk/testgen-hs/blob/d8b08921cdcf47ea834acbc64b538fb7ff8d8cec/nix/cardano-ledger-core--Arbitrary-PoolMetadata.diff)

## Proposed solution

Instead of `arbitrary`, use `(Data.ByteString.pack <$> vectorOf 32 (choose (0, 255)))`.

# Checklist

- [x] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
