### PR TITLE
Add `genIssuerKeys` that can be used in consensus

### DIFF
--- a/eras/shelley/test-suite/CHANGELOG.md
+++ b/eras/shelley/test-suite/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.6.0.0
 
+* Add `genCoreNodeKeys` and `genIssuerKeys`
 * Move `VRFNatVal` into `cardano-protocol-tpraos:testlib`
 * Account for removal of crypto parametrization
 * Remove crypto parametrization from `PoolSetUpArgs`, `PoolInfo`, `RewardUpdateOld`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Move `Cardano.Ledger.SnapShots` module contents into `Cardano.Ledger.State` and deprecated the former
 * Move `Cardano.Ledger.UTxO` module contents into `Cardano.Ledger.State` and deprecated the former
 * Add `CanGetUTxO` and `CanSetUTxO` type classes
-* Add `CanGetUTxO` and `CanSetUTxO` instances for `UTxO` 
+* Add `CanGetUTxO` and `CanSetUTxO` instances for `UTxO`
 * Add `DecShareCBOR` instances for `DRep` and `DRepState`
 * Added `ToPlutusData` instance for `NonZero`
 * `maxpool'` now expects `nOpt` to be a `NonZero Word16`
@@ -99,6 +99,7 @@
 
 ### `testlib`
 
+* Add `runGen`
 * Added `Arbitrary` and `ToExpr` instances for `NonZero`
 * Deprecate `genBadPtr`, `genAddrBadPtr` and `genCompactAddrBadPtr`
 * Remove crypto parametrization from types: `KeyPair` and `KeyPairs`

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Common.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Common.hs
@@ -4,6 +4,7 @@ module Test.Cardano.Ledger.Common (
   ledgerTestMainWith,
   ledgerHspecConfig,
   NFData,
+  runGen,
 
   -- * Expr
   ToExpr (..),
@@ -63,6 +64,8 @@ import Test.Hspec.Runner
 import Test.ImpSpec (ansiDocToString, impSpecConfig, impSpecMainWithConfig)
 import Test.ImpSpec.Expectations
 import Test.QuickCheck as X
+import Test.QuickCheck.Gen (Gen (..))
+import Test.QuickCheck.Random (mkQCGen)
 import UnliftIO.Exception (evaluateDeep)
 
 infix 1 `shouldBeExpr`
@@ -110,3 +113,13 @@ shouldBeLeftExpr e x = expectLeftExpr e >>= (`shouldBeExpr` x)
 -- | Same as `Test.QuickCheck.discard` but outputs a debug trace message
 tracedDiscard :: String -> a
 tracedDiscard message = (if False then Debug.trace $ "\nDiscarded trace: " ++ message else id) discard
+
+runGen ::
+  -- | Seed
+  Int ->
+  -- | Size
+  Int ->
+  -- | Generator to run.
+  Gen a ->
+  a
+runGen seed size gen = unGen gen (mkQCGen seed) size

--- a/libs/cardano-protocol-tpraos/CHANGELOG.md
+++ b/libs/cardano-protocol-tpraos/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### `testlib`
 
+* Add `genAllIssuerKeys`
+* Add `Arbitrary` instances for `KESKeyPair` and `VRFKeyPair`
 * Move `VRFNatVal` from `cardano-ledger-shelley-test` in here.
 * Change type of `kesSignKey` in `KESKeyPair` and result of `evolveKESUntil` from `SignKeyKES` to `UnsoundPureSignKeyKES`
 

--- a/libs/cardano-protocol-tpraos/testlib/Test/Cardano/Protocol/Crypto/KES.hs
+++ b/libs/cardano-protocol-tpraos/testlib/Test/Cardano/Protocol/Crypto/KES.hs
@@ -1,14 +1,26 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Test.Cardano.Protocol.Crypto.KES (
   KESKeyPair (..),
 ) where
 
+import Cardano.Crypto.KES (
+  UnsoundPureKESAlgorithm (..),
+  seedSizeKES,
+  unsoundPureDeriveVerKeyKES,
+  unsoundPureGenKeyKES,
+ )
 import qualified Cardano.Crypto.KES.Class as KES
+import Cardano.Crypto.Seed
 import Cardano.Protocol.Crypto
+import Data.Proxy
+import Test.Cardano.Ledger.Binary.Arbitrary (genByteString)
+import Test.Cardano.Ledger.Common
 
 data KESKeyPair c = KESKeyPair
   { kesSignKey :: !(KES.UnsoundPureSignKeyKES (KES c))
@@ -19,3 +31,20 @@ instance Show (KES.VerKeyKES (KES c)) => Show (KESKeyPair c) where
   show (KESKeyPair _ vk) =
     -- showing `SignKeyKES` is impossible for security reasons.
     "KESKeyPair <SignKeyKES> " <> show vk
+
+-- TODO: upstream into `cardano-base`
+
+-- | Generate a `Seed` with specified number of bytes, which can only be positive.
+genSeedN :: HasCallStack => Int -> Gen Seed
+genSeedN n
+  | n >= 1 = mkSeedFromBytes <$> genByteString n
+  | otherwise = error $ "Seed cannot be empty. Supplied " ++ show n ++ " for the size of the seed"
+
+instance Crypto c => Arbitrary (KESKeyPair c) where
+  arbitrary = do
+    signKey <- unsoundPureGenKeyKES <$> genSeedN (fromIntegral (seedSizeKES (Proxy @(KES c))))
+    pure $
+      KESKeyPair
+        { kesSignKey = signKey
+        , kesVerKey = unsoundPureDeriveVerKeyKES signKey
+        }

--- a/libs/cardano-protocol-tpraos/testlib/Test/Cardano/Protocol/Crypto/VRF.hs
+++ b/libs/cardano-protocol-tpraos/testlib/Test/Cardano/Protocol/Crypto/VRF.hs
@@ -9,6 +9,7 @@ module Test.Cardano.Protocol.Crypto.VRF (
 
 import qualified Cardano.Crypto.VRF.Class as VRF
 import Cardano.Protocol.Crypto
+import Test.Cardano.Ledger.Common
 
 data VRFKeyPair c = VRFKeyPair
   { vrfSignKey :: !(VRF.SignKeyVRF (VRF c))
@@ -17,3 +18,12 @@ data VRFKeyPair c = VRFKeyPair
 
 deriving instance
   (Show (VRF.SignKeyVRF (VRF c)), Show (VRF.VerKeyVRF (VRF c))) => Show (VRFKeyPair c)
+
+instance (Crypto c, Arbitrary (VRF.SignKeyVRF (VRF c))) => Arbitrary (VRFKeyPair c) where
+  arbitrary = do
+    signKey <- arbitrary
+    pure $
+      VRFKeyPair
+        { vrfSignKey = signKey
+        , vrfVerKey = VRF.deriveVerKeyVRF signKey
+        }


### PR DESCRIPTION
# Description

This PR makes few test functions polymorphic in crypto, since consensus relies on it.

# Checklist

- [x] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [x] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
