### PR TITLE
Upgrade `cborg` dependency

### DIFF
--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.6.0.0
 
+* Add `DecCBOR` instance for `Annotated a ByteString`
+* Add `originalBytesExpectedFailureMessage` needed for testing
 * Add `decodeListLikeWithCountT`
 * Add `internMap`, `internSet`, ` internsFromSet`
 * Add `DecShareCBOR` for  `Set`

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -60,7 +60,7 @@ library
     cardano-crypto-praos >=2.2,
     cardano-slotting >=0.2,
     cardano-strict-containers >=0.1.2,
-    cborg >=0.2.9,
+    cborg >=0.2.10,
     containers,
     data-fix,
     deepseq,

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Annotated.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Annotated.hs
@@ -95,6 +95,9 @@ instance ToJSON b => ToJSON (Annotated b a) where
 instance FromJSON b => FromJSON (Annotated b ()) where
   parseJSON j = flip Annotated () <$> parseJSON j
 
+instance DecCBOR a => DecCBOR (Annotated a BSL.ByteString) where
+  decCBOR = decodeAnnotated decCBOR
+
 -- | A decoder for a value paired with an annotation specifying the start and end
 -- of the consumed bytes.
 annotatedDecoder :: Decoder s a -> Decoder s (Annotated a ByteSpan)

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
@@ -18,6 +18,7 @@ module Cardano.Ledger.Binary.Decoding.Decoder (
   withPlainDecoder,
   enforceDecoderVersion,
   getOriginalBytes,
+  originalBytesExpectedFailureMessage,
   DecoderError (..),
   C.ByteOffset,
   ByteArray (..),
@@ -340,8 +341,14 @@ getOriginalBytes :: Decoder s BSL.ByteString
 getOriginalBytes =
   Decoder $ \maybeBytes _ ->
     case maybeBytes of
-      Nothing -> fail "Decoder was expected to provide the original ByteString"
+      Nothing -> fail originalBytesExpectedFailureMessage
       Just bsl -> pure bsl
+
+-- | This is the message that will be reported by `getOriginalBytes` when original bytes are not
+-- provided. It is defined as a separate biding for testing.
+originalBytesExpectedFailureMessage :: String
+originalBytesExpectedFailureMessage =
+  "Decoder was expected to provide the original ByteString"
 
 --------------------------------------------------------------------------------
 -- Working with current decoder version

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/RoundTrip.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/RoundTrip.hs
@@ -524,12 +524,8 @@ embedTripLabelExtra lbl encVersion decVersion (Trip encoder decoder dropper) s =
               let flatTerm = CBOR.toFlatTerm encoding
                   plainDecoder = toPlainDecoder (Just encodedBytes) decVersion decoder
                in case CBOR.fromFlatTerm plainDecoder flatTerm of
-                    Left _err ->
-                      -- Until we switch to a release of cborg that includes a fix for this issue:
-                      -- https://github.com/well-typed/cborg/issues/324
-                      -- We can't rely on FlatTerm decoding
-                      -- Left $ mkFailure (Just $ "fromFlatTerm error:" <> err) Nothing Nothing
-                      Right (val, encoding, encodedBytes)
+                    Left err ->
+                      Left $ mkFailure (Just $ "fromFlatTerm error:" <> err) Nothing Nothing
                     Right valFromFlatTerm
                       | val /= valFromFlatTerm ->
                           let errMsg =
@@ -542,10 +538,9 @@ embedTripLabelExtra lbl encVersion decVersion (Trip encoder decoder dropper) s =
                                   ++ "FlatTerm for the type is not valid"
                            in Left $ mkFailure (Just errMsg) Nothing Nothing
                       | otherwise -> Right (val, encoding, encodedBytes)
-          --  else Left $ mkFailure Nothing Nothing
           | Just err <- mDropperError -> Left $ mkFailure Nothing (Just err) Nothing
         Left err ->
-          -- In case of failure we only record dropper error if it differs from the
+          -- In case of failure we only record dropper error iff it differs from the
           -- decoder failure:
           let mErr = do
                 dropperError <- mDropperError


### PR DESCRIPTION
# Description

This PR improves rountrip tests:
* Adds `DecCBOR` instance for `Annotated a ByteString`
* Uses `cborg` library without a bug that allows us using `FlatTerm` for ensuring validity of our decoders
* Prevents roundtrip testing through `FlatTerm`, whenever a type depends on availability of original bytes.

# Checklist

- [x] Commits in meaningful sequence and with useful messages
- [x] Tests added or updated when needed
- [x] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
