### PR TITLE
Improve `mkAddr` and `mkCred` interface

### DIFF
--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Invalid.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Invalid.hs
@@ -9,7 +9,6 @@
 
 module Test.Cardano.Ledger.Alonzo.Imp.UtxowSpec.Invalid (spec) where
 
-import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Allegra.Scripts (AllegraEraScript (..))
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Core
@@ -20,7 +19,7 @@ import Cardano.Ledger.Alonzo.Rules (
  )
 import Cardano.Ledger.Alonzo.Scripts (eraLanguages)
 import Cardano.Ledger.Alonzo.TxWits (Redeemers (..), TxDats (..), unRedeemers)
-import Cardano.Ledger.BaseTypes (Mismatch (..), Network (..), StrictMaybe (..), natVersion)
+import Cardano.Ledger.BaseTypes (Mismatch (..), StrictMaybe (..), natVersion)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import Cardano.Ledger.Keys (asWitness, witVKeyHash)
@@ -139,10 +138,9 @@ spec = describe "Invalid transactions" $ do
             testHashMismatch SNothing
 
         it "UnspendableUTxONoDatumHash" $ do
-          let scriptHash = redeemerSameAsDatumHash
-
           txIn <- impAnn "Produce script at a txout with a missing datahash" $ do
-            let addr = Addr Testnet (ScriptHashObj scriptHash) StakeRefNull
+            let scriptHash = redeemerSameAsDatumHash
+            let addr = mkAddr scriptHash StakeRefNull
             let tx =
                   mkBasicTx mkBasicTxBody
                     & bodyTxL . outputsTxBodyL .~ [mkBasicTxOut addr mempty]

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Examples/Consensus.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Examples/Consensus.hs
@@ -99,7 +99,7 @@ exampleTxBodyAlonzo =
     (Set.fromList [mkTxInPartial (TxId (mkDummySafeHash 2)) 1]) -- collateral
     ( StrictSeq.fromList
         [ AlonzoTxOut
-            (mkAddr (SLE.examplePayKey, SLE.exampleStakeKey))
+            (mkAddr SLE.examplePayKey SLE.exampleStakeKey)
             (SLE.exampleMultiAssetValue 2)
             (SJust $ mkDummySafeHash 1) -- outputs
         ]

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Examples/Consensus.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Examples/Consensus.hs
@@ -94,7 +94,7 @@ ledgerExamplesBabbage =
 collateralOutput :: BabbageTxOut BabbageEra
 collateralOutput =
   BabbageTxOut
-    (mkAddr (SLE.examplePayKey, SLE.exampleStakeKey))
+    (mkAddr SLE.examplePayKey SLE.exampleStakeKey)
     (MaryValue (Coin 8675309) mempty)
     NoDatum
     SNothing
@@ -108,7 +108,7 @@ exampleTxBodyBabbage =
     ( StrictSeq.fromList
         [ mkSized (eraProtVerHigh @BabbageEra) $
             BabbageTxOut
-              (mkAddr (SLE.examplePayKey, SLE.exampleStakeKey))
+              (mkAddr SLE.examplePayKey SLE.exampleStakeKey)
               (MarySLE.exampleMultiAssetValue 2)
               (Datum $ dataToBinaryData datumExample) -- inline datum
               (SJust $ alwaysSucceeds @'PlutusV2 3) -- reference script

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### `testlib`
 
+* Add `sendCoinTo_` and `sendValueTo_`
 * Add `genRegTxCert` and `genUnRegTxCert`. #4830
 * Add `Arbitrary` instance for `ConwayBbodyPredFailure` and `ConwayMempoolPredFailure`
 

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Regression.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Regression.hs
@@ -21,16 +21,7 @@ import Cardano.Ledger.Binary (
  )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
-import Cardano.Ledger.Conway.Core (
-  BabbageEraTxBody (..),
-  EraTx (..),
-  EraTxBody (..),
-  EraTxOut (..),
-  EraTxWits (..),
-  coinTxOutL,
-  eraProtVerLow,
-  txIdTx,
- )
+import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Rules (
   ConwayLedgerPredFailure (..),
   ConwayUtxoPredFailure (..),
@@ -43,7 +34,6 @@ import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
 import Lens.Micro ((%~), (&), (.~))
 import Test.Cardano.Ledger.Conway.ImpTest
-import Test.Cardano.Ledger.Core.KeyPair (mkScriptAddr)
 import Test.Cardano.Ledger.Imp.Common
 import Test.Cardano.Ledger.Plutus.Examples (redeemerSameAsDatum)
 
@@ -95,11 +85,11 @@ spec = describe "Regression" $ do
     withImpInit @(LedgerSpec ConwayEra) $
       it "InsufficientCollateral is not encoded with negative coin #4198" $ do
         collateralAddress <- freshKeyAddr_
-        (_, skp) <- freshKeyPair
+        stakingKeyHash <- freshKeyHash @'Staking
         let
           plutusVersion = SPlutusV2
           scriptHash = hashPlutusScript $ redeemerSameAsDatum plutusVersion
-          lockScriptAddress = mkScriptAddr scriptHash skp
+          lockScriptAddress = mkAddr scriptHash stakingKeyHash
         collateralReturnAddr <- freshKeyAddr_
         lockedTx <-
           submitTxAnn @ConwayEra "Script locked tx" $
@@ -110,7 +100,7 @@ spec = describe "Regression" $ do
                   , mkBasicTxOut collateralAddress mempty
                   ]
               & bodyTxL . collateralReturnTxBodyL
-                .~ SJust (mkBasicTxOut collateralReturnAddr . inject $ Coin 849070)
+                .~ SJust (mkBasicTxOut collateralReturnAddr . inject $ Coin 862000)
         let
           modifyRootCoin = coinTxOutL .~ Coin 989482376
           modifyRootTxOut (x SSeq.:<| SSeq.Empty) =

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/RatifySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/RatifySpec.hs
@@ -7,7 +7,6 @@
 
 module Test.Cardano.Ledger.Conway.Imp.RatifySpec (spec) where
 
-import Cardano.Ledger.Address
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Conway.Core
@@ -628,7 +627,7 @@ votingSpec =
           -- Bump up the UTxO delegated
           -- to barely make the threshold (65 %! 100)
           stakingKP1 <- lookupKeyPair stakingKH1
-          _ <- sendCoinTo (mkAddr (paymentKP1, stakingKP1)) (inject $ Coin 858_000_000)
+          sendCoinTo_ (mkAddr paymentKP1 stakingKP1) (inject $ Coin 858_000_000)
           passNEpochs 2
           -- The same vote should now successfully ratify the proposal
           getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)
@@ -929,10 +928,7 @@ votingSpec =
           getLastEnactedCommittee `shouldReturn` SNothing
           -- Bump up the UTxO delegated
           -- to barely make the threshold (51 %! 100)
-          _ <-
-            sendCoinTo
-              (Addr Testnet delegatorCPayment1 (StakeRefBase delegatorCStaking1))
-              (Coin 40_900_000)
+          sendCoinTo_ (mkAddr delegatorCPayment1 delegatorCStaking1) (Coin 40_900_000)
           passNEpochs 2
           -- The same vote should now successfully ratify the proposal
           getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxoSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxoSpec.hs
@@ -35,7 +35,6 @@ import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
 import Lens.Micro ((&), (.~), (^.))
 import Test.Cardano.Ledger.Conway.ImpTest
-import Test.Cardano.Ledger.Core.KeyPair (mkScriptAddr)
 import Test.Cardano.Ledger.Core.Rational ((%!))
 import Test.Cardano.Ledger.Core.Utils (txInAt)
 import Test.Cardano.Ledger.Imp.Common
@@ -149,11 +148,11 @@ spec =
       _ <- impAddNativeScript script
       pure script
 
-    addScriptAddr :: HasCallStack => NativeScript era -> ImpTestM era Addr
+    addScriptAddr :: NativeScript era -> ImpTestM era Addr
     addScriptAddr script = do
-      kpStaking1 <- lookupKeyPair =<< freshKeyHash
       scriptHash <- impAddNativeScript script
-      pure $ mkScriptAddr scriptHash kpStaking1
+      stakingKeyHash <- freshKeyHash @'Staking
+      pure $ mkAddr scriptHash stakingKeyHash
 
     scriptSize :: Script era -> Int
     scriptSize = \case

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxosSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxosSpec.hs
@@ -40,7 +40,6 @@ import qualified Data.Set as Set
 import Lens.Micro
 import qualified PlutusLedgerApi.V1 as P1
 import Test.Cardano.Ledger.Conway.ImpTest
-import Test.Cardano.Ledger.Core.KeyPair (mkAddr)
 import Test.Cardano.Ledger.Imp.Common
 import Test.Cardano.Ledger.Plutus (testingCostModels)
 import Test.Cardano.Ledger.Plutus.Examples (
@@ -629,7 +628,7 @@ scriptLockedTxOut ::
   TxOut era
 scriptLockedTxOut shSpending =
   mkBasicTxOut
-    (Addr Testnet (ScriptHashObj shSpending) StakeRefNull)
+    (mkAddr shSpending StakeRefNull)
     mempty
     & dataHashTxOutL .~ SJust (hashData @era $ Data spendDatum)
 
@@ -640,11 +639,10 @@ mkRefTxOut ::
   ScriptHash ->
   ImpTestM era (TxOut era)
 mkRefTxOut sh = do
-  kpPayment <- lookupKeyPair =<< freshKeyHash
-  kpStaking <- lookupKeyPair =<< freshKeyHash
+  addr <- freshKeyAddr_
   let mbyPlutusScript = impLookupPlutusScriptMaybe sh
   pure $
-    mkBasicTxOut (mkAddr (kpPayment, kpStaking)) mempty
+    mkBasicTxOut addr mempty
       & referenceScriptTxOutL .~ maybeToStrictMaybe (fromPlutusScript <$> mbyPlutusScript)
 
 setupRefTx ::

--- a/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
+++ b/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
@@ -110,7 +110,7 @@ ledgerExamplesConway =
 collateralOutput :: BabbageTxOut ConwayEra
 collateralOutput =
   BabbageTxOut
-    (mkAddr (SLE.examplePayKey, SLE.exampleStakeKey))
+    (mkAddr SLE.examplePayKey SLE.exampleStakeKey)
     (MaryValue (Coin 8675309) mempty)
     NoDatum
     SNothing
@@ -130,7 +130,7 @@ exampleTxBodyConway =
     ( StrictSeq.fromList
         [ mkSized (eraProtVerHigh @ConwayEra) $
             BabbageTxOut
-              (mkAddr (SLE.examplePayKey, SLE.exampleStakeKey))
+              (mkAddr SLE.examplePayKey SLE.exampleStakeKey)
               (MarySLE.exampleMultiAssetValue 2)
               (Datum $ dataToBinaryData datumExample) -- inline datum
               (SJust $ alwaysSucceeds @'PlutusV2 3) -- reference script

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/Allegra/Examples/Consensus.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/Allegra/Examples/Consensus.hs
@@ -46,7 +46,7 @@ exampleAllegraTxBody value =
   mkBasicTxBody
     & inputsTxBodyL .~ exampleTxIns
     & outputsTxBodyL
-      .~ StrictSeq.singleton (mkBasicTxOut (mkAddr (examplePayKey, exampleStakeKey)) value)
+      .~ StrictSeq.singleton (mkBasicTxOut (mkAddr examplePayKey exampleStakeKey) value)
     & certsTxBodyL .~ exampleCerts
     & withdrawalsTxBodyL .~ exampleWithdrawals
     & feeTxBodyL .~ Coin 3

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/Cast.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/Cast.hs
@@ -39,7 +39,7 @@ aliceStake = KeyPair vk sk
 
 -- | Alice's base address
 aliceAddr :: Addr
-aliceAddr = mkAddr (alicePay, aliceStake)
+aliceAddr = mkAddr alicePay aliceStake
 
 -- | Bob's payment key pair
 bobPay :: KeyPair 'Payment
@@ -55,7 +55,7 @@ bobStake = KeyPair vk sk
 
 -- | Bob's address
 bobAddr :: Addr
-bobAddr = mkAddr (bobPay, bobStake)
+bobAddr = mkAddr bobPay bobStake
 
 -- Carl's payment key pair
 carlPay :: KeyPair 'Payment
@@ -71,7 +71,7 @@ carlStake = KeyPair vk sk
 
 -- | Carl's address
 carlAddr :: Addr
-carlAddr = mkAddr (carlPay, carlStake)
+carlAddr = mkAddr carlPay carlStake
 
 -- | Daria's payment key pair
 dariaPay :: KeyPair 'Payment
@@ -87,4 +87,4 @@ dariaStake = KeyPair vk sk
 
 -- | Daria's address
 dariaAddr :: Addr
-dariaAddr = mkAddr (dariaPay, dariaStake)
+dariaAddr = mkAddr dariaPay dariaStake

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/UtxowSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/UtxowSpec.hs
@@ -12,7 +12,7 @@ import Cardano.Ledger.Address (Addr (..), BootstrapAddress (..))
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
-import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
+import Cardano.Ledger.Credential (StakeReference (..))
 import Cardano.Ledger.Keys (asWitness, witVKeyHash)
 import Cardano.Ledger.Keys.Bootstrap
 import Cardano.Ledger.Shelley.Rules (ShelleyUtxowPredFailure (..))
@@ -60,8 +60,8 @@ spec = describe "UTXOW" $ do
       submitFailingTx txBad [injectFailure $ InvalidWitnessesUTXOW [aliceVKey]]
 
   it "MissingVKeyWitnessesUTXOW" $ do
-    aliceKh <- freshKeyHash
-    txIn <- sendCoinTo (Addr Testnet (KeyHashObj aliceKh) StakeRefNull) mempty
+    aliceKh <- freshKeyHash @'Payment
+    txIn <- sendCoinTo (mkAddr aliceKh StakeRefNull) mempty
     let tx = mkBasicTx $ mkBasicTxBody & inputsTxBodyL <>~ [txIn]
     let isAliceWitness wit = witVKeyHash wit == asWitness aliceKh
     withPostFixup (pure . (witsTxL . addrTxWitsL %~ Set.filter (not . isAliceWitness))) $

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/UnitTests/IncrementalStakeTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/UnitTests/IncrementalStakeTest.hs
@@ -6,8 +6,6 @@
 
 module Test.Cardano.Ledger.Shelley.UnitTests.IncrementalStakeTest (spec) where
 
-import Cardano.Ledger.Address (Addr (..))
-import Cardano.Ledger.BaseTypes (Network (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Core (EraTxOut, emptyPParams, mkCoinTxOut)
@@ -32,13 +30,10 @@ import qualified Data.VMap as VMap
 import Lens.Micro
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Arbitrary ()
+import Test.Cardano.Ledger.Core.KeyPair (mkAddr)
 
 ppIdL :: Lens' PoolParams (KeyHash 'StakePool)
 ppIdL = lens ppId (\x y -> x {ppId = y})
-
-address :: Credential 'Payment -> Maybe (Credential 'Staking) -> Addr
-address pc Nothing = Addr Testnet pc StakeRefNull
-address pc (Just sc) = Addr Testnet pc (StakeRefBase sc)
 
 arbitraryLens :: Arbitrary a => Lens' a b -> b -> Gen a
 arbitraryLens l b = do a <- arbitrary; pure (a & l .~ b)
@@ -56,10 +51,10 @@ stakeDistrIncludesRewards = do
 
   (tomRD, johnRD, annRD, ronRD, maryRD) <- arbitrary @(TupleN 5 RDPair)
 
-  let tomAddr = address tomPay Nothing -- Nothing means tomAddr does not have a StakeReference
-      johnAddr = address johnPay (Just john)
-      annAddr = address annPay (Just ann)
-      ronAddr = address ronPay (Just ron)
+  let tomAddr = mkAddr tomPay StakeRefNull
+      johnAddr = mkAddr johnPay john
+      annAddr = mkAddr annPay ann
+      ronAddr = mkAddr ronPay ron
       -- maryAddr is omitted on purpose. Mary will not have a UTxO entry
 
       rewards :: Map (Credential 'Staking) RDPair

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/BenchmarkFunctions.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/BenchmarkFunctions.hs
@@ -103,7 +103,7 @@ alicePay = KeyPair vk sk
     (sk, vk) = mkKeyPair (RawSeed 0 0 0 0 0)
 
 aliceAddr :: Addr
-aliceAddr = mkAddr (alicePay, aliceStake)
+aliceAddr = mkAddr alicePay aliceStake
 
 -- ==========================================================
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Cast.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Cast.hs
@@ -49,7 +49,6 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Credential (
   Credential (..),
   Ptr (..),
-  StakeReference (..),
  )
 import Cardano.Ledger.Keys (
   KeyRole (..),
@@ -68,7 +67,7 @@ import qualified Data.List.NonEmpty as NE
 import Data.Maybe (fromJust)
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
-import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..), mkAddr)
+import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..), mkAddr, mkCredential)
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (MockCrypto)
 import Test.Cardano.Ledger.Shelley.Generator.Core (
   AllIssuerKeys (..),
@@ -107,19 +106,19 @@ alicePoolKeys =
 
 -- | Alice's base address
 aliceAddr :: Addr
-aliceAddr = mkAddr (alicePay, aliceStake)
+aliceAddr = mkAddr alicePay aliceStake
 
 -- | Alice's payment credential
 alicePHK :: Credential 'Payment
-alicePHK = (KeyHashObj . hashKey . vKey) alicePay
+alicePHK = mkCredential alicePay
 
 -- | Alice's stake credential
 aliceSHK :: Credential 'Staking
-aliceSHK = (KeyHashObj . hashKey . vKey) aliceStake
+aliceSHK = mkCredential aliceStake
 
 -- | Alice's base address
 alicePtrAddr :: Addr
-alicePtrAddr = Addr Testnet alicePHK (StakeRefPtr $ Ptr 10 minBound minBound)
+alicePtrAddr = mkAddr alicePHK (Ptr 10 minBound minBound)
 
 -- | Alice's stake pool parameters
 alicePoolParams :: PoolParams
@@ -159,11 +158,11 @@ bobStake = KeyPair vk sk
 
 -- | Bob's address
 bobAddr :: Addr
-bobAddr = mkAddr (bobPay, bobStake)
+bobAddr = mkAddr bobPay bobStake
 
 -- | Bob's stake credential
 bobSHK :: Credential 'Staking
-bobSHK = (KeyHashObj . hashKey . vKey) bobStake
+bobSHK = mkCredential bobStake
 
 -- | Bob's stake pool keys (cold keys, VRF keys, hot KES keys)
 bobPoolKeys :: AllIssuerKeys MockCrypto 'StakePool
@@ -209,11 +208,11 @@ carlStake = KeyPair vk sk
 
 -- | Carl's address
 carlAddr :: Addr
-carlAddr = mkAddr (carlPay, carlStake)
+carlAddr = mkAddr carlPay carlStake
 
 -- | Carl's stake credential
 carlSHK :: Credential 'Staking
-carlSHK = (KeyHashObj . hashKey . vKey) carlStake
+carlSHK = mkCredential carlStake
 
 -- | Daria's payment key pair
 dariaPay :: KeyPair 'Payment
@@ -229,8 +228,8 @@ dariaStake = KeyPair vk sk
 
 -- | Daria's address
 dariaAddr :: Addr
-dariaAddr = mkAddr (dariaPay, dariaStake)
+dariaAddr = mkAddr dariaPay dariaStake
 
 -- | Daria's stake credential
 dariaSHK :: Credential 'Staking
-dariaSHK = (KeyHashObj . hashKey . vKey) dariaStake
+dariaSHK = mkCredential dariaStake

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
@@ -419,7 +419,7 @@ exampleTxBodyShelley =
   ShelleyTxBody
     exampleTxIns
     ( StrictSeq.fromList
-        [ ShelleyTxOut (mkAddr (examplePayKey, exampleStakeKey)) (Coin 100000)
+        [ ShelleyTxOut (mkAddr examplePayKey exampleStakeKey) (Coin 100000)
         ]
     )
     exampleCerts

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Core.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Core.hs
@@ -39,7 +39,7 @@ module Test.Cardano.Ledger.Shelley.Generator.Core (
   increasingProbabilityAt,
   pickStakeKey,
   mkAddr,
-  mkCred,
+  mkCredential,
   mkBlock,
   mkBlockFakeVRF,
   mkOCert,
@@ -93,7 +93,7 @@ import Data.Maybe (fromMaybe)
 import Data.Word (Word64)
 import Numeric.Natural (Natural)
 import qualified PlutusLedgerApi.V1 as PV1
-import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..), KeyPairs, mkAddr, mkCred, vKey)
+import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..), KeyPairs, mkAddr, mkCredential, vKey)
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (MockCrypto)
 import Test.Cardano.Ledger.Shelley.Constants (Constants (..))
 import Test.Cardano.Ledger.Shelley.Generator.ScriptClass (

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/TxCert.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/TxCert.hs
@@ -60,7 +60,7 @@ import Test.Cardano.Ledger.Shelley.Generator.Core (
   KeySpace (..),
   genInteger,
   genWord64,
-  mkCred,
+  mkCredential,
   tooLateInEpoch,
  )
 import Test.Cardano.Ledger.Shelley.Generator.EraGen (EraGen)
@@ -171,7 +171,7 @@ genRegKeyCert
               (_payKey, stakeKey) <- QC.elements availableKeys
               pure $
                 Just
-                  ( RegTxCert (mkCred stakeKey)
+                  ( RegTxCert (mkCredential stakeKey)
                   , NoCred
                   )
         )
@@ -191,7 +191,7 @@ genRegKeyCert
     where
       scriptToCred' = ScriptHashObj . hashScript @era
       notRegistered k = UM.notMember k (rewards delegSt)
-      availableKeys = filter (notRegistered . mkCred . snd) keys
+      availableKeys = filter (notRegistered . mkCredential . snd) keys
       availableScripts = filter (notRegistered . scriptToCred' . snd) scripts
 
 -- | Generate a DeRegKey certificate along with the staking credential, which is
@@ -212,7 +212,7 @@ genDeRegKeyCert Constants {frequencyKeyCredDeReg, frequencyScriptCredDeReg} keys
           [] -> pure Nothing
           _ -> do
             (_payKey, stakeKey) <- QC.elements availableKeys
-            pure $ Just (UnRegTxCert (mkCred stakeKey), StakeCred stakeKey)
+            pure $ Just (UnRegTxCert (mkCredential stakeKey), StakeCred stakeKey)
       )
     ,
       ( frequencyScriptCredDeReg
@@ -233,7 +233,7 @@ genDeRegKeyCert Constants {frequencyKeyCredDeReg, frequencyScriptCredDeReg} keys
     availableKeys =
       filter
         ( \(_, k) ->
-            let cred = mkCred k
+            let cred = mkCredential k
              in ((&&) <$> registered <*> zeroRewards) cred
         )
         keys
@@ -294,14 +294,14 @@ genDelegation
       scriptToCred' = ScriptHashObj . hashScript @era
       mkCert (_, delegatorKey) poolKey = Just (cert, StakeCred delegatorKey)
         where
-          cert = DelegStakeTxCert (mkCred delegatorKey) poolKey
+          cert = DelegStakeTxCert (mkCredential delegatorKey) poolKey
       mkCertFromScript (s, delegatorScript) poolKey =
         Just (scriptCert, ScriptCred (s, delegatorScript))
         where
           scriptCert =
             DelegStakeTxCert (scriptToCred' delegatorScript) poolKey
       registeredDelegate k = UM.member k (rewards (certDState dpState))
-      availableDelegates = filter (registeredDelegate . mkCred . snd) keys
+      availableDelegates = filter (registeredDelegate . mkCredential . snd) keys
       availableDelegatesScripts =
         filter (registeredDelegate . scriptToCred' . snd) scripts
       registeredPools = psStakePoolParams (certPState dpState)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
@@ -131,7 +131,7 @@ alicePoolParams =
     }
 
 aliceAddr :: Addr
-aliceAddr = mkAddr (alicePay, aliceStake)
+aliceAddr = mkAddr alicePay aliceStake
 
 bobPay :: KeyPair 'Payment
 bobPay = KeyPair vk sk
@@ -147,7 +147,7 @@ bobSHK :: Credential 'Staking
 bobSHK = KeyHashObj . hashKey $ vKey bobStake
 
 bobAddr :: Addr
-bobAddr = mkAddr (bobPay, bobStake)
+bobAddr = mkAddr bobPay bobStake
 
 carlPay :: KeyPair 'Payment
 carlPay = KeyPair vk sk

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -99,6 +99,11 @@
 
 ### `testlib`
 
+* Re-export `KeyPair`, `mkAddr` and `mkCredential` from `Test.Cardano.Ledger.Imp.Common`
+* Add `MakeStakeReference` and `MakeCredential`
+* Deprecate `mkCred` in favor of `mkCredential` from `MakeCredential`
+* Change `mkAddr` to accept two polymorphic arguments instead of a tuple of keypairs
+* Deprecate `mkScriptAddr`
 * Add `runGen`
 * Added `Arbitrary` and `ToExpr` instances for `NonZero`
 * Deprecate `genBadPtr`, `genAddrBadPtr` and `genCompactAddrBadPtr`

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Imp/Common.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Imp/Common.hs
@@ -7,6 +7,12 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Imp.Common (
+  -- * Ledger
+  KeyPair (..),
+  mkAddr,
+  mkCredential,
+
+  -- * Re-exports
   module X,
   io,
 
@@ -123,6 +129,7 @@ import Test.Cardano.Ledger.Common as X hiding (
   variant,
   vectorOf,
  )
+import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..), mkAddr, mkCredential)
 import Test.ImpSpec (modifyImpInit, withImpInit)
 import Test.ImpSpec.Expectations.Lifted
 import Test.ImpSpec.Random (

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/EpochBoundary.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/EpochBoundary.hs
@@ -6,8 +6,7 @@
 -- | Benchmarks for things which happen on an epoch boundary.
 module Bench.Cardano.Ledger.EpochBoundary where
 
-import Cardano.Ledger.Address (Addr (Addr), compactAddr)
-import Cardano.Ledger.BaseTypes (Network (Testnet))
+import Cardano.Ledger.Address (compactAddr)
 import Cardano.Ledger.Coin (Coin (Coin))
 import Cardano.Ledger.Compactible (Compactible (toCompact))
 import Cardano.Ledger.Core
@@ -17,7 +16,7 @@ import Cardano.Ledger.Credential (
   Ptr (..),
   SlotNo32 (..),
   StakeCredential,
-  StakeReference (StakeRefBase, StakeRefNull, StakeRefPtr),
+  StakeReference (StakeRefNull),
  )
 import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
@@ -35,6 +34,7 @@ import Data.Maybe (fromJust)
 import Data.Proxy
 import Data.Word (Word64)
 import Test.Cardano.Ledger.Binary.Random (mkDummyHash)
+import Test.Cardano.Ledger.Core.KeyPair (mkAddr)
 import Test.Cardano.Ledger.Shelley.Rules.IncrementalStake (aggregateUtxoCoinByCredential)
 
 type TestEra = MaryEra
@@ -56,15 +56,13 @@ txIns = [minBound ..] <&> TxIn txId
 txOutUnstaked :: TxOut TestEra
 txOutUnstaked =
   TxOutCompact @TestEra
-    (compactAddr $ Addr Testnet payCred StakeRefNull)
+    (compactAddr $ mkAddr payCred StakeRefNull)
     (fromJust . toCompact . Val.inject $ Coin 1000)
 
 -- | Generate TxOuts for each stake credential.
 txOutsFromCreds :: [StakeCredential] -> [TxOut TestEra]
 txOutsFromCreds creds =
-  [ TxOutCompact
-      (compactAddr $ Addr Testnet payCred (StakeRefBase cred))
-      coinVal
+  [ TxOutCompact (compactAddr $ mkAddr payCred cred) coinVal
   | cred <- creds
   ]
   where
@@ -72,9 +70,7 @@ txOutsFromCreds creds =
 
 txOutsFromPtrs :: [Ptr] -> [TxOut TestEra]
 txOutsFromPtrs ptrs =
-  [ TxOutCompact
-      (compactAddr $ Addr Testnet payCred (StakeRefPtr ptr))
-      coinVal
+  [ TxOutCompact (compactAddr $ mkAddr payCred ptr) coinVal
   | ptr <- ptrs
   ]
   where

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -237,7 +237,7 @@ benchmark bench
     cardano-ledger-alonzo-test,
     cardano-ledger-binary:{cardano-ledger-binary, testlib},
     cardano-ledger-conway,
-    cardano-ledger-core,
+    cardano-ledger-core:{cardano-ledger-core, testlib},
     cardano-ledger-mary:{cardano-ledger-mary, testlib},
     cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
     cardano-ledger-shelley-ma-test,

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
@@ -15,7 +15,7 @@
 module Test.Cardano.Ledger.Examples.AlonzoBBODY (tests) where
 
 import Cardano.Crypto.Hash.Class (sizeHash)
-import Cardano.Ledger.Address (Addr (..), RewardAccount (..))
+import Cardano.Ledger.Address (RewardAccount (..))
 import Cardano.Ledger.Alonzo.Rules (AlonzoBbodyPredFailure (..))
 import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
 import Cardano.Ledger.Alonzo.TxWits (Redeemers (..))
@@ -37,7 +37,6 @@ import qualified Cardano.Ledger.Conway.Rules as Conway (
 import Cardano.Ledger.Credential (
   Credential (..),
   StakeCredential,
-  StakeReference (..),
  )
 import Cardano.Ledger.Keys (coerceKeyRole)
 import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..))
@@ -77,7 +76,7 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (fromJust)
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified PlutusLedgerApi.V1 as PV1
-import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..), mkWitnessVKey)
+import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..), mkAddr, mkWitnessVKey)
 import Test.Cardano.Ledger.Examples.AlonzoValidTxUTXOW (mkSingleRedeemer)
 import Test.Cardano.Ledger.Examples.STSTestUtils (
   alwaysFailsHash,
@@ -114,6 +113,7 @@ import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (MockCrypto)
 import Test.Cardano.Ledger.Shelley.Utils (
   RawSeed (..),
   mkKeyPair,
+  mkKeyPair',
   mkVRFKeyPair,
  )
 import Test.Cardano.Protocol.TPraos.Create (VRFKeyPair (..))
@@ -632,11 +632,8 @@ testBBodyState pf =
           , DHash' [hashData $ anotherDatum @era]
           ]
       timelockOut = newTxOut pf [Address $ timelockAddr, Amount (inject $ Coin 1)]
-      timelockAddr = Addr Testnet pCred sCred
+      timelockAddr = mkAddr timelockHash $ mkKeyPair' @'Staking (RawSeed 0 0 0 0 2)
         where
-          (_ssk, svk) = mkKeyPair (RawSeed 0 0 0 0 2)
-          pCred = ScriptHashObj timelockHash
-          sCred = StakeRefBase . KeyHashObj . hashKey $ svk
           timelockHash = hashScript @era $ fromNativeScript $ allOf [matchkey 1, after 100] pf
       -- This output is unspendable since it is locked by a plutus script,
       -- but has no datum hash.

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
@@ -845,7 +845,7 @@ initialLedgerState gstate = LedgerState utxostate dpstate
 -- Generators of inter-related items
 
 -- Adds to the gsKeys
-genKeyHash :: GenRS era (KeyHash kr)
+genKeyHash :: forall kr era. GenRS era (KeyHash kr)
 genKeyHash = do
   keyPair <- lift arbitrary
   let keyHash = hashKey $ vKey keyPair
@@ -1017,7 +1017,7 @@ genPlutusScript proof tag = do
 -- Adds to both gsKeys and gsScripts and gsPlutusScript
 -- via genKeyHash and genScript
 genCredential ::
-  forall era kr. Reflect era => PlutusPurposeTag -> GenRS era (Credential kr)
+  forall kr era. Reflect era => PlutusPurposeTag -> GenRS era (Credential kr)
 genCredential tag =
   frequencyT
     [ (35, KeyHashObj <$> genKeyHash')

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
@@ -55,7 +55,6 @@ import Cardano.Ledger.Shelley.API (
   PoolParams (..),
   RewardAccount (..),
   ShelleyDelegCert (..),
-  StakeReference (..),
   Withdrawals (..),
  )
 import Cardano.Ledger.Shelley.Scripts (
@@ -100,7 +99,7 @@ import Lens.Micro ((^.))
 import Lens.Micro.Extras (view)
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
 import Test.Cardano.Ledger.Babbage.Serialisation.Generators ()
-import Test.Cardano.Ledger.Core.KeyPair (mkWitnessVKey)
+import Test.Cardano.Ledger.Core.KeyPair (mkAddr, mkWitnessVKey)
 import Test.Cardano.Ledger.Generic.Fields hiding (Mint)
 import qualified Test.Cardano.Ledger.Generic.Fields as Generic (TxBodyField (Mint))
 import Test.Cardano.Ledger.Generic.Functions
@@ -396,16 +395,16 @@ redeemerWitnessMaker proof tag listWithCred =
 --   As we generate this we add to the gsKeys field of the GenState.
 genNoScriptRecipient :: GenRS era Addr
 genNoScriptRecipient = do
-  paymentCred <- KeyHashObj <$> genKeyHash
-  stakeCred <- StakeRefBase . KeyHashObj <$> genKeyHash
-  pure (Addr Testnet paymentCred stakeCred)
+  paymentCred <- genKeyHash @'Payment
+  stakeCred <- genKeyHash @'Staking
+  pure (mkAddr paymentCred stakeCred)
 
 -- | Sometimes generates new Credentials, and some times reuses old ones
 genRecipient :: Reflect era => GenRS era Addr
 genRecipient = do
-  paymentCred <- genCredential Spending
-  stakeCred <- genCredential Certifying
-  pure (Addr Testnet paymentCred (StakeRefBase stakeCred))
+  paymentCred <- genCredential @'Payment Spending
+  stakeCred <- genCredential @'Staking Rewarding
+  pure (mkAddr paymentCred stakeCred)
 
 genDatum :: Era era => GenRS era (Data era)
 genDatum = snd <$> genDatumWithHash


### PR DESCRIPTION
# Description

There are a bunch of places throughout the test suite that create addresses and credentials. This change unifies construction into a single abstract interface.

# Checklist

- [x] Commits in meaningful sequence and with useful messages
- [x] Tests added or updated when needed
- [x] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
