### PR TITLE
Add `Imp` fixup for collateral return txout

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -12,6 +12,10 @@
 * Deprecate `Alonzo` type synonym
 * Remove crypto parametrization from `AlonzoEra`
 
+### `testlib`
+
+* Expose `alonzoFixupFees`
+
 ## 1.12.0.0
 
 * Remove deprecated `lookupPlutusScript`

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -38,6 +38,7 @@ module Test.Cardano.Ledger.Alonzo.ImpTest (
   fixupRedeemers,
   fixupRedeemerIndices,
   fixupScriptWits,
+  alonzoFixupFees,
 ) where
 
 import Cardano.Ledger.Address (Addr (..))

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Deprecate `Babbage` type synonym
 * Remove crypto parametrization from `BabbageEra`
 
+### `testlib`
+
+* Add `babbageFixupTx`
+
 ## 1.10.1.0
 
 * Use `Mismatch` to clarify predicate failures. #4711

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
@@ -11,6 +11,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Babbage.ImpTest (
+  babbageFixupTx,
   module Test.Cardano.Ledger.Alonzo.ImpTest,
   produceRefScript,
   produceRefScripts,
@@ -21,13 +22,14 @@ import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Plutus.Language (Language (..), SLanguage (..))
 import Cardano.Ledger.Shelley.LedgerState (curPParamsEpochStateL, nesEsL)
-import Cardano.Ledger.Tools (setMinCoinTxOut)
+import Cardano.Ledger.Tools (ensureMinCoinTxOut, setMinCoinTxOut)
 import Cardano.Ledger.TxIn (TxIn, mkTxInPartial)
-import Control.Monad (forM)
+import Control.Monad (forM, (>=>))
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Sequence.Strict as SSeq
-import Lens.Micro ((&), (.~), (<>~))
+import GHC.Stack (HasCallStack)
+import Lens.Micro
 import Test.Cardano.Ledger.Alonzo.ImpTest
 import Test.Cardano.Ledger.Babbage.TreeDiff ()
 import Test.Cardano.Ledger.Plutus (testingCostModels)
@@ -37,7 +39,40 @@ instance ShelleyEraImp BabbageEra where
     defaultInitNewEpochState
       (nesEsL . curPParamsEpochStateL . ppCostModelsL <>~ testingCostModels [PlutusV2])
   impSatisfyNativeScript = impAllegraSatisfyNativeScript
-  fixupTx = alonzoFixupTx
+  fixupTx = babbageFixupTx
+
+babbageFixupTx ::
+  ( HasCallStack
+  , AlonzoEraImp era
+  , BabbageEraTxBody era
+  ) =>
+  Tx era ->
+  ImpTestM era (Tx era)
+babbageFixupTx =
+  addNativeScriptTxWits
+    >=> fixupAuxDataHash
+    >=> addCollateralInput
+    >=> addRootTxIn
+    >=> fixupScriptWits
+    >=> fixupOutputDatums
+    >=> fixupDatums
+    >=> fixupRedeemerIndices
+    >=> fixupTxOuts
+    >=> fixupCollateralReturn
+    >=> alonzoFixupFees
+    >=> fixupRedeemers
+    >=> fixupPPHash
+    >=> updateAddrTxWits
+
+fixupCollateralReturn ::
+  ( ShelleyEraImp era
+  , BabbageEraTxBody era
+  ) =>
+  Tx era ->
+  ImpTestM era (Tx era)
+fixupCollateralReturn tx = do
+  pp <- getsNES $ nesEsL . curPParamsEpochStateL
+  pure $ tx & bodyTxL . collateralReturnTxBodyL %~ fmap (ensureMinCoinTxOut pp)
 
 instance ShelleyEraImp BabbageEra => MaryEraImp BabbageEra
 

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -317,7 +317,7 @@ instance ShelleyEraImp ConwayEra where
 
   modifyPParams = conwayModifyPParams
 
-  fixupTx = alonzoFixupTx
+  fixupTx = babbageFixupTx
 
 instance MaryEraImp ConwayEra
 


### PR DESCRIPTION
# Description

The fixup in Imp tests for txouts doesn't include the collateral return txout. This causes intermittent test failures.

The PR adds the necessary fixup, thus closing  https://github.com/IntersectMBO/cardano-ledger/issues/4885 

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
