### PR TITLE
Change `ApplyBlock` interface

### DIFF
--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 1.16.0.0
 
+* Remove redundant supercalss constraints for `ApplyBlock`
+* Add `applyBlockEither`, `applyBlockEitherNoEvents`, `applyBlockNoValidaton`, `applyTickNoEvents`.
+* Add `applyBlock` and `applyTick` to `ApplyBlock` type class.
+* Remove `applyBlockOpts` (in favor of `applyBlockEither`), `reapplyBlock` (in favor of
+  `applyBlockNoValidation`)  and `applyTickOpts` (in favor `applyTick`).
+* Disable validation level for `applyTick`
 * Add `DecCBOR` instances for:
   * `ShelleyTxWits`
   * `ShelleyTxAuxData`

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -118,7 +118,7 @@ library
     nothunks,
     quiet,
     set-algebra >=1.0,
-    small-steps >=1.1,
+    small-steps >=1.1.1,
     text,
     time,
     transformers,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Block.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Block.hs
@@ -303,7 +303,7 @@ tickChainState
         ChainDepState {csProtocol, csTickn} =
           tickChainDepState testGlobals lv isNewEpoch cds
         PrtclState ocertIssue evNonce candNonce = csProtocol
-        nes' = applyTick testGlobals chainNes slotNo
+        nes' = applyTickNoEvents testGlobals chainNes slotNo
      in ChainState
           { chainNes = nes'
           , chainOCertIssue = ocertIssue

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
@@ -387,7 +387,6 @@ potsSumIncreaseWithdrawalsPerTx SourceSignalTarget {source = chainSt, signal = b
 potsSumIncreaseByRewardsPerTx ::
   forall era ledger.
   ( ChainProperty era
-  , EraSegWits era
   , TestingLedger era ledger
   ) =>
   SourceSignalTarget (CHAIN era) ->
@@ -495,7 +494,6 @@ preserveBalanceRestricted ::
   forall era ledger.
   ( ChainProperty era
   , TestingLedger era ledger
-  , EraSegWits era
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -553,7 +551,6 @@ preserveOutputsTx SourceSignalTarget {source = chainSt, signal = block} =
 canRestrictUTxO ::
   forall era ledger.
   ( ChainProperty era
-  , EraSegWits era
   , TestingLedger era ledger
   ) =>
   SourceSignalTarget (CHAIN era) ->

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
@@ -124,7 +124,6 @@ relevantCasesAreCovered n =
 relevantCasesAreCoveredForTrace ::
   forall era.
   ( ChainProperty era
-  , EraSegWits era
   , ShelleyEraTxBody era
   ) =>
   Trace (CHAIN era) ->

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/IncrementalStake.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/IncrementalStake.hs
@@ -94,7 +94,7 @@ incrStakeComputationTest =
 
 incrStakeComp ::
   forall era ledger.
-  (EraSegWits era, ChainProperty era, TestingLedger era ledger) =>
+  (ChainProperty era, TestingLedger era ledger) =>
   SourceSignalTarget (CHAIN era) ->
   Property
 incrStakeComp SourceSignalTarget {source = chainSt, signal = block} =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -88,7 +88,6 @@ tests =
 -- retirement.
 poolRetirement ::
   ( ChainProperty era
-  , EraSegWits era
   , ShelleyEraTxBody era
   ) =>
   SourceSignalTarget (CHAIN era) ->
@@ -106,7 +105,6 @@ poolRetirement SourceSignalTarget {source = chainSt, signal = block} =
 -- in the retiring map.
 poolRegistration ::
   ( ChainProperty era
-  , EraSegWits era
   , ShelleyEraTxBody era
   ) =>
   SourceSignalTarget (CHAIN era) ->
@@ -121,7 +119,6 @@ poolRegistration (SourceSignalTarget {source = chainSt, signal = block}) =
 -- POOL` transition.
 poolStateIsInternallyConsistent ::
   ( ChainProperty era
-  , EraSegWits era
   , ShelleyEraTxBody era
   ) =>
   SourceSignalTarget (CHAIN era) ->

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -141,7 +141,6 @@ shortChainTrace constants f = withMaxSuccess 100 $ forAllChainTrace @era 10 cons
 ledgerTraceFromBlock ::
   forall era ledger.
   ( ChainProperty era
-  , EraSegWits era
   , TestingLedger era ledger
   ) =>
   ChainState era ->
@@ -161,7 +160,6 @@ ledgerTraceFromBlock chainSt block =
 ledgerTraceFromBlockWithRestrictedUTxO ::
   forall era ledger.
   ( ChainProperty era
-  , EraSegWits era
   , TestingLedger era ledger
   ) =>
   ChainState era ->
@@ -185,7 +183,6 @@ poolTraceFromBlock ::
   forall era.
   ( ChainProperty era
   , ShelleyEraTxBody era
-  , EraSegWits era
   ) =>
   ChainState era ->
   Block (BHeader MockCrypto) era ->
@@ -210,7 +207,6 @@ delegTraceFromBlock ::
   forall era.
   ( ChainProperty era
   , ShelleyEraTxBody era
-  , EraSegWits era
   ) =>
   ChainState era ->
   Block (BHeader MockCrypto) era ->
@@ -244,8 +240,7 @@ delegTraceFromBlock chainSt block =
 -- transactions with the LEDGERS rule)
 ledgerTraceBase ::
   forall era.
-  ( EraSegWits era
-  , GetLedgerView era
+  ( GetLedgerView era
   , ApplyBlock era
   ) =>
   ChainState era ->

--- a/libs/small-steps/CHANGELOG.md
+++ b/libs/small-steps/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `small-steps`
 
-## 1.1.0.2
+## 1.1.1.0
 
-*
+* Add `STSResult` and `applySTSOptsResult`
 
 ## 1.1.0.1
 

--- a/libs/small-steps/small-steps.cabal
+++ b/libs/small-steps/small-steps.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: small-steps
-version: 1.1.0.1
+version: 1.1.1.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK


### PR DESCRIPTION
# Description

This PR:
* adds functionality for producing the result of STS that does not change the resulting type because of events option.
* Removes ability to customize assertion policy, since that is only needed for tests
* removes bunch of redundant superclass constraints from `ApplyBlock`
* It also disables validation for `applyTICK`, since `TICK` can't fail anyways.

# Checklist

- [x] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [x] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
