### PR TITLE
Invert mempool

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -19,7 +20,7 @@ import Cardano.Ledger.Allegra.Translation ()
 import Cardano.Ledger.Allegra.Tx ()
 import Cardano.Ledger.Allegra.TxSeq ()
 import Cardano.Ledger.Allegra.UTxO ()
-import Cardano.Ledger.Shelley.API (ApplyBlock, ApplyTx)
+import Cardano.Ledger.Shelley.API
 
 type Allegra = AllegraEra
 
@@ -29,6 +30,7 @@ type Allegra = AllegraEra
 -- Mempool instances
 --------------------------------------------------------------------------------
 
-instance ApplyTx AllegraEra
+instance ApplyTx AllegraEra where
+  applyTxValidation = ruleApplyTxValidation @"LEDGER"
 
 instance ApplyBlock AllegraEra

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.0.0
 
+* Remove `reapplyAlonzoTx` as no longer needed.
 * Add `TxInfoResult` data family, `mkTxInfoResult` and `lookupTxInfoResult` to `EraPlutusContext`
 * Add `lookupTxInfoResultImpossible` helper
 * Add `TxInfoResult era` parameter to `toPlutusWithContext` and `mkPlutusWithContext`

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -91,7 +91,6 @@ library
     deepseq,
     mempack,
     microlens,
-    mtl,
     nothunks,
     plutus-ledger-api >=1.37,
     set-algebra >=1.0,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -14,7 +14,6 @@ module Cardano.Ledger.Alonzo (
   AlonzoTxBody,
   AlonzoScript,
   AlonzoTxAuxData,
-  reapplyAlonzoTx,
 )
 where
 
@@ -30,15 +29,9 @@ import Cardano.Ledger.Alonzo.TxAuxData (AlonzoTxAuxData)
 import Cardano.Ledger.Alonzo.TxBody (AlonzoTxBody, AlonzoTxOut)
 import Cardano.Ledger.Alonzo.TxWits ()
 import Cardano.Ledger.Alonzo.UTxO ()
-import Cardano.Ledger.Core
 import Cardano.Ledger.Mary.Value (MaryValue)
 import Cardano.Ledger.Plutus.Data ()
-import Cardano.Ledger.Rules.ValidationMode (applySTSNonStatic)
 import Cardano.Ledger.Shelley.API
-import Control.Arrow (left)
-import Control.Monad.Except (MonadError, liftEither)
-import Control.Monad.Reader (runReader)
-import Control.State.Transition.Extended (TRC (TRC))
 
 type Alonzo = AlonzoEra
 
@@ -46,23 +39,7 @@ type Alonzo = AlonzoEra
 
 -- =====================================================
 
-reapplyAlonzoTx ::
-  forall era m.
-  (ApplyTx era, MonadError (ApplyTxError era) m) =>
-  Globals ->
-  MempoolEnv era ->
-  MempoolState era ->
-  Validated (Tx era) ->
-  m (MempoolState era)
-reapplyAlonzoTx globals env state vtx =
-  let res =
-        flip runReader globals
-          . applySTSNonStatic
-            @(EraRule "LEDGER" era)
-          $ TRC (env, state, extractTx vtx)
-   in liftEither . left ApplyTxError $ res
-
 instance ApplyTx AlonzoEra where
-  reapplyTx = reapplyAlonzoTx
+  applyTxValidation = ruleApplyTxValidation @"LEDGER"
 
 instance ApplyBlock AlonzoEra

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledger.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledger.hs
@@ -127,7 +127,7 @@ ledgerTransition ::
   ) =>
   TransitionRule (someLEDGER era)
 ledgerTransition = do
-  TRC (LedgerEnv slot mbCurEpochNo txIx pp account _, LedgerState utxoSt certState, tx) <-
+  TRC (LedgerEnv slot mbCurEpochNo txIx pp account, LedgerState utxoSt certState, tx) <-
     judgmentContext
   let txBody = tx ^. bodyTxL
 

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
@@ -71,7 +71,6 @@ instance
     LedgerEnv (SlotNo 0) Nothing minBound
       <$> genEraPParams @era geConstants
       <*> genAccountState geConstants
-      <*> pure False
 
   sigGen genenv env state = genTx genenv env state
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -14,7 +15,6 @@ module Cardano.Ledger.Babbage (
 )
 where
 
-import Cardano.Ledger.Alonzo (reapplyAlonzoTx)
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..))
 import Cardano.Ledger.Alonzo.TxAuxData (AlonzoTxAuxData (..))
 import Cardano.Ledger.Babbage.Era (BabbageEra)
@@ -33,6 +33,6 @@ type Babbage = BabbageEra
 -- =====================================================
 
 instance ApplyTx BabbageEra where
-  reapplyTx = reapplyAlonzoTx
+  applyTxValidation = ruleApplyTxValidation @"LEDGER"
 
 instance ApplyBlock BabbageEra

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.19.0.0
 
+* Remove `ConwayMempoolPredFailure` and `ConwayMempoolEvent`
+* Switch to `MEMPOOL` rule to be the entry point for `ApplyTx` instead of `LEDGER` and invert their
+  ivocation.
 * Added `ToCBOR` and `FromCBOR` instances for `DefaultVote`.
 * Made the fields of predicate failures and environments lazy
 * Add `MemPack` instance for `PlutusScript ConwayEra`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -180,6 +180,7 @@ library testlib
     plutus-ledger-api,
     prettyprinter,
     small-steps >=1.1,
+    text,
 
 executable huddle-cddl
   main-is: Main.hs

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -10,7 +11,6 @@ module Cardano.Ledger.Conway (
 )
 where
 
-import Cardano.Ledger.Alonzo (reapplyAlonzoTx)
 import Cardano.Ledger.Babbage.TxBody ()
 import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Conway.Governance (RunConwayRatify (..))
@@ -30,7 +30,7 @@ type Conway = ConwayEra
 -- =====================================================
 
 instance ApplyTx ConwayEra where
-  reapplyTx = reapplyAlonzoTx
+  applyTxValidation = ruleApplyTxValidation @"MEMPOOL"
 
 instance ApplyBlock ConwayEra
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -361,7 +361,7 @@ ledgerTransition ::
   TransitionRule (someLEDGER era)
 ledgerTransition = do
   TRC
-    ( LedgerEnv slot mbCurEpochNo _txIx pp account _mempool
+    ( LedgerEnv slot mbCurEpochNo _txIx pp account
       , LedgerState utxoState certState
       , tx
       ) <-

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -55,7 +55,6 @@ import Cardano.Ledger.Conway.Era (
   ConwayEra,
   ConwayGOV,
   ConwayLEDGER,
-  ConwayMEMPOOL,
   ConwayUTXOW,
  )
 import Cardano.Ledger.Conway.Governance (
@@ -81,7 +80,6 @@ import Cardano.Ledger.Conway.Rules.Gov (
   GovSignal (..),
  )
 import Cardano.Ledger.Conway.Rules.GovCert (ConwayGovCertPredFailure)
-import Cardano.Ledger.Conway.Rules.Mempool (ConwayMempoolEvent (..), ConwayMempoolPredFailure (..))
 import Cardano.Ledger.Conway.Rules.Utxo (ConwayUtxoPredFailure)
 import Cardano.Ledger.Conway.Rules.Utxos (ConwayUtxosPredFailure)
 import Cardano.Ledger.Conway.Rules.Utxow (ConwayUtxowPredFailure)
@@ -114,7 +112,7 @@ import Cardano.Ledger.State (EraUTxO (..))
 import Cardano.Ledger.UMap (UView (..))
 import qualified Cardano.Ledger.UMap as UMap
 import Control.DeepSeq (NFData)
-import Control.Monad (unless, void, when)
+import Control.Monad (unless)
 import Control.State.Transition.Extended (
   Embed (..),
   STS (..),
@@ -210,9 +208,6 @@ instance InjectRuleFailure "LEDGER" ConwayGovCertPredFailure ConwayEra where
 instance InjectRuleFailure "LEDGER" ConwayGovPredFailure ConwayEra where
   injectFailure = ConwayGovFailure
 
-instance InjectRuleFailure "LEDGER" ConwayMempoolPredFailure ConwayEra where
-  injectFailure (ConwayMempoolPredFailure t) = ConwayMempoolFailure t
-
 deriving instance
   ( Era era
   , Eq (PredicateFailure (EraRule "UTXOW" era))
@@ -286,14 +281,12 @@ data ConwayLedgerEvent era
   = UtxowEvent (Event (EraRule "UTXOW" era))
   | CertsEvent (Event (EraRule "CERTS" era))
   | GovEvent (Event (EraRule "GOV" era))
-  | MempoolEvent (Event (EraRule "MEMPOOL" era))
   deriving (Generic)
 
 deriving instance
   ( Eq (Event (EraRule "CERTS" era))
   , Eq (Event (EraRule "UTXOW" era))
   , Eq (Event (EraRule "GOV" era))
-  , Eq (Event (EraRule "MEMPOOL" era))
   ) =>
   Eq (ConwayLedgerEvent era)
 
@@ -301,7 +294,6 @@ instance
   ( NFData (Event (EraRule "CERTS" era))
   , NFData (Event (EraRule "UTXOW" era))
   , NFData (Event (EraRule "GOV" era))
-  , NFData (Event (EraRule "MEMPOOL" era))
   ) =>
   NFData (ConwayLedgerEvent era)
 
@@ -313,19 +305,15 @@ instance
   , Embed (EraRule "UTXOW" era) (ConwayLEDGER era)
   , Embed (EraRule "GOV" era) (ConwayLEDGER era)
   , Embed (EraRule "CERTS" era) (ConwayLEDGER era)
-  , Embed (EraRule "MEMPOOL" era) (ConwayLEDGER era)
   , State (EraRule "UTXOW" era) ~ UTxOState era
   , State (EraRule "CERTS" era) ~ CertState era
   , State (EraRule "GOV" era) ~ Proposals era
-  , State (EraRule "MEMPOOL" era) ~ LedgerState era
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , Environment (EraRule "CERTS" era) ~ CertsEnv era
   , Environment (EraRule "GOV" era) ~ GovEnv era
-  , Environment (EraRule "MEMPOOL" era) ~ LedgerEnv era
   , Signal (EraRule "UTXOW" era) ~ Tx era
   , Signal (EraRule "CERTS" era) ~ Seq (TxCert era)
   , Signal (EraRule "GOV" era) ~ GovSignal era
-  , Signal (EraRule "MEMPOOL" era) ~ Tx era
   ) =>
   STS (ConwayLEDGER era)
   where
@@ -358,35 +346,26 @@ ledgerTransition ::
   , Embed (EraRule "UTXOW" era) (someLEDGER era)
   , Embed (EraRule "GOV" era) (someLEDGER era)
   , Embed (EraRule "CERTS" era) (someLEDGER era)
-  , Embed (EraRule "MEMPOOL" era) (someLEDGER era)
   , State (EraRule "UTXOW" era) ~ UTxOState era
   , State (EraRule "CERTS" era) ~ CertState era
   , State (EraRule "GOV" era) ~ Proposals era
-  , State (EraRule "MEMPOOL" era) ~ LedgerState era
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , Environment (EraRule "GOV" era) ~ GovEnv era
   , Environment (EraRule "CERTS" era) ~ CertsEnv era
-  , Environment (EraRule "MEMPOOL" era) ~ LedgerEnv era
   , Signal (EraRule "UTXOW" era) ~ Tx era
   , Signal (EraRule "CERTS" era) ~ Seq (TxCert era)
   , Signal (EraRule "GOV" era) ~ GovSignal era
-  , Signal (EraRule "MEMPOOL" era) ~ Tx era
   , BaseM (someLEDGER era) ~ ShelleyBase
   , STS (someLEDGER era)
   ) =>
   TransitionRule (someLEDGER era)
 ledgerTransition = do
   TRC
-    ( le@(LedgerEnv slot mbCurEpochNo _txIx pp account mempool)
-      , ls@(LedgerState utxoState certState)
+    ( LedgerEnv slot mbCurEpochNo _txIx pp account _mempool
+      , LedgerState utxoState certState
       , tx
       ) <-
     judgmentContext
-
-  when mempool $
-    void $
-      trans @(EraRule "MEMPOOL" era) $
-        TRC (le, ls, tx)
 
   curEpochNo <- maybe (liftSTS $ epochFromSlot slot) pure mbCurEpochNo
 
@@ -531,7 +510,6 @@ instance
   ( Embed (EraRule "UTXOW" era) (ConwayLEDGER era)
   , Embed (EraRule "CERTS" era) (ConwayLEDGER era)
   , Embed (EraRule "GOV" era) (ConwayLEDGER era)
-  , Embed (EraRule "MEMPOOL" era) (ConwayLEDGER era)
   , ConwayEraGov era
   , AlonzoEraTx era
   , ConwayEraTxBody era
@@ -540,15 +518,12 @@ instance
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , Environment (EraRule "CERTS" era) ~ CertsEnv era
   , Environment (EraRule "GOV" era) ~ GovEnv era
-  , Environment (EraRule "MEMPOOL" era) ~ LedgerEnv era
   , Signal (EraRule "UTXOW" era) ~ Tx era
   , Signal (EraRule "CERTS" era) ~ Seq (TxCert era)
   , Signal (EraRule "GOV" era) ~ GovSignal era
-  , Signal (EraRule "MEMPOOL" era) ~ Tx era
   , State (EraRule "UTXOW" era) ~ UTxOState era
   , State (EraRule "CERTS" era) ~ CertState era
   , State (EraRule "GOV" era) ~ Proposals era
-  , State (EraRule "MEMPOOL" era) ~ LedgerState era
   , EraRule "GOV" era ~ ConwayGOV era
   , PredicateFailure (EraRule "LEDGER" era) ~ ConwayLedgerPredFailure era
   , Event (EraRule "LEDGER" era) ~ ConwayLedgerEvent era
@@ -585,16 +560,3 @@ instance
   where
   wrapFailed = ConwayCertsFailure . CertFailure . DelegFailure
   wrapEvent = CertsEvent . CertEvent . DelegEvent
-
-instance
-  ( EraTx era
-  , ConwayEraGov era
-  , ConwayEraTxBody era
-  , EraRule "MEMPOOL" era ~ ConwayMEMPOOL era
-  , PredicateFailure (EraRule "MEMPOOL" era) ~ ConwayMempoolPredFailure era
-  , Event (EraRule "MEMPOOL" era) ~ ConwayMempoolEvent era
-  ) =>
-  Embed (ConwayMEMPOOL era) (ConwayLEDGER era)
-  where
-  wrapFailed (ConwayMempoolPredFailure t) = ConwayMempoolFailure t
-  wrapEvent = MempoolEvent

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -226,9 +226,6 @@ instance
   where
   arbitrary = genericArbitraryU
 
-instance Arbitrary (ConwayMempoolPredFailure era) where
-  arbitrary = genericArbitraryU
-
 instance
   ( EraTxOut era
   , Arbitrary (Value era)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/RoundTrip.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/RoundTrip.hs
@@ -84,7 +84,6 @@ instance RuleListEra ConwayEra where
        , "GOV"
        , "LEDGER"
        , "LEDGERS"
-       , "MEMPOOL"
        , "POOL"
        , "UTXO"
        , "UTXOS"

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -28,7 +28,6 @@ import Cardano.Ledger.Conway.Rules (
   ConwayHardForkEvent,
   ConwayLedgerEvent,
   ConwayLedgerPredFailure,
-  ConwayMempoolEvent,
   ConwayNewEpochEvent,
  )
 import Cardano.Ledger.Conway.TxInfo (ConwayContextError)
@@ -85,7 +84,6 @@ spec ::
   , InjectRuleEvent "TICK" ConwayEpochEvent era
   , Event (EraRule "EPOCH" era) ~ ConwayEpochEvent era
   , Event (EraRule "NEWEPOCH" era) ~ ConwayNewEpochEvent era
-  , Event (EraRule "MEMPOOL" era) ~ ConwayMempoolEvent era
   , Event (EraRule "LEDGERS" era) ~ ShelleyLedgersEvent era
   , Event (EraRule "LEDGER" era) ~ ConwayLedgerEvent era
   , Event (EraRule "HARDFORK" era) ~ ConwayHardForkEvent era
@@ -127,7 +125,6 @@ conwaySpec ::
   , InjectRuleEvent "TICK" ConwayEpochEvent era
   , Event (EraRule "EPOCH" era) ~ ConwayEpochEvent era
   , Event (EraRule "NEWEPOCH" era) ~ ConwayNewEpochEvent era
-  , Event (EraRule "MEMPOOL" era) ~ ConwayMempoolEvent era
   , Event (EraRule "LEDGERS" era) ~ ShelleyLedgersEvent era
   , Event (EraRule "LEDGER" era) ~ ConwayLedgerEvent era
   , Event (EraRule "HARDFORK" era) ~ ConwayHardForkEvent era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -16,7 +16,7 @@ import Cardano.Ledger.Alonzo.Rules (
  )
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure, BabbageUtxowPredFailure)
 import Cardano.Ledger.Babbage.TxInfo (BabbageContextError)
-import Cardano.Ledger.BaseTypes (Inject, ShelleyBase)
+import Cardano.Ledger.BaseTypes (Inject)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Rules (
   ConwayBbodyPredFailure,
@@ -26,20 +26,16 @@ import Cardano.Ledger.Conway.Rules (
   ConwayGovCertPredFailure,
   ConwayGovPredFailure,
   ConwayHardForkEvent,
-  ConwayLedgerEvent,
   ConwayLedgerPredFailure,
   ConwayNewEpochEvent,
  )
 import Cardano.Ledger.Conway.TxInfo (ConwayContextError)
 import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
 import Cardano.Ledger.Shelley.Rules (
-  ShelleyLedgersEnv,
-  ShelleyLedgersEvent,
   ShelleyUtxoPredFailure,
   ShelleyUtxowPredFailure,
  )
 import Control.State.Transition.Extended
-import Data.Sequence (Seq)
 import Data.Typeable (Typeable)
 import qualified Test.Cardano.Ledger.Babbage.Imp as BabbageImp
 import qualified Test.Cardano.Ledger.Conway.Imp.BbodySpec as Bbody
@@ -84,13 +80,7 @@ spec ::
   , InjectRuleEvent "TICK" ConwayEpochEvent era
   , Event (EraRule "EPOCH" era) ~ ConwayEpochEvent era
   , Event (EraRule "NEWEPOCH" era) ~ ConwayNewEpochEvent era
-  , Event (EraRule "LEDGERS" era) ~ ShelleyLedgersEvent era
-  , Event (EraRule "LEDGER" era) ~ ConwayLedgerEvent era
   , Event (EraRule "HARDFORK" era) ~ ConwayHardForkEvent era
-  , BaseM (EraRule "LEDGERS" era) ~ ShelleyBase
-  , Environment (EraRule "LEDGERS" era) ~ ShelleyLedgersEnv era
-  , Signal (EraRule "LEDGERS" era) ~ Seq (Tx era)
-  , STS (EraRule "LEDGERS" era)
   , ApplyTx era
   , NFData (Event (EraRule "ENACT" era))
   , ToExpr (Event (EraRule "ENACT" era))
@@ -125,13 +115,7 @@ conwaySpec ::
   , InjectRuleEvent "TICK" ConwayEpochEvent era
   , Event (EraRule "EPOCH" era) ~ ConwayEpochEvent era
   , Event (EraRule "NEWEPOCH" era) ~ ConwayNewEpochEvent era
-  , Event (EraRule "LEDGERS" era) ~ ShelleyLedgersEvent era
-  , Event (EraRule "LEDGER" era) ~ ConwayLedgerEvent era
   , Event (EraRule "HARDFORK" era) ~ ConwayHardForkEvent era
-  , BaseM (EraRule "LEDGERS" era) ~ ShelleyBase
-  , Environment (EraRule "LEDGERS" era) ~ ShelleyLedgersEnv era
-  , Signal (EraRule "LEDGERS" era) ~ Seq (Tx era)
-  , STS (EraRule "LEDGERS" era)
   , ApplyTx era
   , NFData (Event (EraRule "ENACT" era))
   , ToExpr (Event (EraRule "ENACT" era))

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
@@ -16,7 +16,6 @@ import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Conway.Rules (
   ConwayLedgerEvent (..),
   ConwayLedgerPredFailure (..),
-  ConwayMempoolEvent (..),
   maxRefScriptSizePerTx,
  )
 import Cardano.Ledger.Credential (Credential (..))
@@ -44,7 +43,6 @@ spec ::
   forall era.
   ( ConwayEraImp era
   , InjectRuleFailure "LEDGER" ConwayLedgerPredFailure era
-  , Event (EraRule "MEMPOOL" era) ~ ConwayMempoolEvent era
   , BaseM (EraRule "LEDGERS" era) ~ ShelleyBase
   , Environment (EraRule "LEDGERS" era) ~ ShelleyLedgersEnv era
   , Signal (EraRule "LEDGERS" era) ~ Seq.Seq (Tx era)
@@ -235,7 +233,7 @@ spec = do
           (LedgersEnv slotNo epochNo pp account)
           ls
           (Seq.singleton tx)
-      let mempoolEvents = [ev | LedgerEvent ev@(MempoolEvent (ConwayMempoolEvent _)) <- evs]
+      let mempoolEvents = [ev | LedgerEvent ev <- evs]
       mempoolEvents `shouldBeExpr` []
 
     it "Mempool events should be emitted via `applyTx` with `mkMempoolEnv`" $ do
@@ -256,7 +254,7 @@ spec = do
         Left e ->
           assertFailure $ "Unexpected failure while applyingTx: " <> show tx <> ": " <> show e
         Right (_, evs) ->
-          length [ev | ev@(MempoolEvent (ConwayMempoolEvent _)) <- evs] `shouldBe` 1
+          length [ev | ev <- evs] `shouldBe` 1
 
     it "Unelected Committee voting" $ whenPostBootstrap $ do
       globals <- use impGlobalsL

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -14,21 +15,18 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Conway.Rules (
-  ConwayLedgerEvent (..),
   ConwayLedgerPredFailure (..),
   maxRefScriptSizePerTx,
  )
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.DRep
 import Cardano.Ledger.Plutus (SLanguage (..), hashPlutusScript)
-import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..), applyTx, mkMempoolEnv)
+import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..), ApplyTxError (..), applyTx, mkMempoolEnv)
 import qualified Cardano.Ledger.Shelley.HardForks as HF (bootstrapPhase)
 import Cardano.Ledger.Shelley.LedgerState
-import Cardano.Ledger.Shelley.Rules (ShelleyLedgersEnv (..), ShelleyLedgersEvent (..))
-import Control.State.Transition.Extended
 import qualified Data.Map.Strict as Map
-import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
+import qualified Data.Text as T
 import Lens.Micro ((&), (.~), (^.))
 import Lens.Micro.Mtl (use)
 import Test.Cardano.Ledger.Conway.ImpTest
@@ -43,12 +41,6 @@ spec ::
   forall era.
   ( ConwayEraImp era
   , InjectRuleFailure "LEDGER" ConwayLedgerPredFailure era
-  , BaseM (EraRule "LEDGERS" era) ~ ShelleyBase
-  , Environment (EraRule "LEDGERS" era) ~ ShelleyLedgersEnv era
-  , Signal (EraRule "LEDGERS" era) ~ Seq.Seq (Tx era)
-  , Event (EraRule "LEDGERS" era) ~ ShelleyLedgersEvent era
-  , Event (EraRule "LEDGER" era) ~ ConwayLedgerEvent era
-  , STS (EraRule "LEDGERS" era)
   , ApplyTx era
   ) =>
   SpecWith (ImpInit (LedgerSpec era))
@@ -219,43 +211,7 @@ spec = do
       mkBasicTx $
         mkBasicTxBody & withdrawalsTxBodyL .~ Withdrawals [(ra, mempty)]
 
-  describe "Mempool events" $ do
-    it "No Mempool events should be emitted via LEDGERS rules " $ do
-      nes <- use impNESL
-      slotNo <- use impLastTickG
-      let ls = nes ^. nesEsL . esLStateL
-          pp = nes ^. nesEsL . curPParamsEpochStateL
-          account = nes ^. nesEsL . esAccountStateL
-          epochNo = nes ^. nesELL
-      tx <- fixupTx $ mkBasicTx mkBasicTxBody
-      Right (_, evs) <-
-        tryRunImpRule @"LEDGERS"
-          (LedgersEnv slotNo epochNo pp account)
-          ls
-          (Seq.singleton tx)
-      let mempoolEvents = [ev | LedgerEvent ev <- evs]
-      mempoolEvents `shouldBeExpr` []
-
-    it "Mempool events should be emitted via `applyTx` with `mkMempoolEnv`" $ do
-      globals <- use impGlobalsL
-      slotNo <- use impLastTickG
-      nes <- use impNESL
-      let ls = nes ^. nesEsL . esLStateL
-
-      let mempoolEnv = mkMempoolEnv nes slotNo
-      tx <- fixupTx $ mkBasicTx mkBasicTxBody
-      let stsOpts =
-            ApplySTSOpts
-              { asoAssertions = AssertionsAll
-              , asoValidation = ValidateAll
-              , asoEvents = EPReturn
-              }
-      case applyTxOpts stsOpts globals mempoolEnv ls tx of
-        Left e ->
-          assertFailure $ "Unexpected failure while applyingTx: " <> show tx <> ": " <> show e
-        Right (_, evs) ->
-          length [ev | ev <- evs] `shouldBe` 1
-
+  describe "Mempool" $ do
     it "Unelected Committee voting" $ whenPostBootstrap $ do
       globals <- use impGlobalsL
       slotNo <- use impLastTickG
@@ -291,6 +247,10 @@ spec = do
                   )
 
       case applyTx globals mempoolEnv ls tx of
-        Left _ -> pure ()
+        Left err ->
+          let expectedFailure =
+                ConwayMempoolFailure $
+                  "Unelected committee members are not allowed to cast votes: " <> T.pack (show (pure @[] ccHot))
+           in err `shouldBe` ApplyTxError @era (pure (injectFailure expectedFailure))
         Right _ -> assertFailure $ "Expected failure due to an unallowed vote: " <> show tx
       withNoFixup $ submitTx_ tx

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
@@ -290,5 +290,3 @@ instance
   , ToExpr (Tx era)
   ) =>
   ToExpr (CertsEnv era)
-
-instance ToExpr (ConwayMempoolEvent era)

--- a/eras/mary/impl/src/Cardano/Ledger/Mary.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -31,6 +32,7 @@ type Mary = MaryEra
 
 {-# DEPRECATED Mary "In favor of `MaryEra`" #-}
 
-instance ApplyTx MaryEra
+instance ApplyTx MaryEra where
+  applyTxValidation = ruleApplyTxValidation @"LEDGER"
 
 instance ApplyBlock MaryEra

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Allegra/ScriptTranslation.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Allegra/ScriptTranslation.hs
@@ -64,7 +64,6 @@ testScriptPostTranslation =
               minBound
               emptyPParams
               (S.AccountState (S.Coin 0) (S.Coin 0))
-              False
           utxoStShelley = def {S.utxosUtxo = utxo}
           utxoStAllegra = fromRight . runExcept $ translateEra @AllegraEra NoGenesis utxoStShelley
           txb =

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
@@ -95,7 +95,7 @@ pp =
     & ppMinUTxOValueL .~ Coin 100
 
 ledgerEnv :: SlotNo -> LedgerEnv MaryEra
-ledgerEnv s = LedgerEnv s Nothing minBound pp (AccountState (Coin 0) (Coin 0)) False
+ledgerEnv s = LedgerEnv s Nothing minBound pp (AccountState (Coin 0) (Coin 0))
 
 feeEx :: Coin
 feeEx = Coin 3

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## 1.16.0.0
 
+* Restrict the monad of `applyTx` and `reapllyTx` to `Either` from abstract `MonadError`
+* Remove `applyTxOpts` in favor of new `applyTxValidation` function in `ApplyTx`
+* Move `reapplyTx` outside of the `ApplyTx` type class.
+* Add helper `ruleApplyTxValidation` that is used to implement `applyTxValidation`
 * Remove the no longer necessary `ledgerMempool` field
 * Fix `NFData` instance for `LedgerEnv`
 * Move `AccountState` to `Cardano.Ledger.State`
 * Deprecated `RewardAccounts`
 * Deprecated `utxosUtxoL`
-* Added `CanGetUTxO` and `CanSetUTxO` instances for `EpochState`, `UTxOState`, `NewEpochState`, `LedgerState` 
+* Added `CanGetUTxO` and `CanSetUTxO` instances for `EpochState`, `UTxOState`, `NewEpochState`, `LedgerState`
 * Made the fields of predicate failures and environments lazy
 * Changed the type of `sgSecurityParam` to `NonZero Word64`
 * Following functions now expect a `NonZero Word64` security parameter:

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.16.0.0
 
+* Remove the no longer necessary `ledgerMempool` field
+* Fix `NFData` instance for `LedgerEnv`
 * Move `AccountState` to `Cardano.Ledger.State`
 * Deprecated `RewardAccounts`
 * Deprecated `utxosUtxoL`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -192,7 +192,6 @@ mkMempoolEnv
       , Ledger.ledgerIx = minBound
       , Ledger.ledgerPp = nesEs ^. curPParamsEpochStateL
       , Ledger.ledgerAccount = LedgerState.esAccountState nesEs
-      , Ledger.ledgerMempool = True
       }
 
 -- | Construct a mempool state from the wider ledger state.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -44,9 +44,6 @@ import Cardano.Ledger.Binary (
   EncCBOR (..),
   FromCBOR (..),
   ToCBOR (..),
-  encodeFoldableAsIndefLenList,
-  ifEncodingVersionAtLeast,
-  natVersion,
  )
 import Cardano.Ledger.Core
 import Cardano.Ledger.Rules.ValidationMode (lblStatic)
@@ -201,26 +198,11 @@ deriving stock instance
   Show (PredicateFailure (EraRule "LEDGER" era)) =>
   Show (ApplyTxError era)
 
--- TODO: This instance can be switched back to a derived version, once we are officially
--- in the Conway era:
---
--- deriving newtype instance
---   ( Era era
---   , EncCBOR (PredicateFailure (EraRule "LEDGER" era))
---   ) =>
---   EncCBOR (ApplyTxError era)
-
-instance
+deriving newtype instance
   ( Era era
   , EncCBOR (PredicateFailure (EraRule "LEDGER" era))
   ) =>
   EncCBOR (ApplyTxError era)
-  where
-  encCBOR (ApplyTxError failures) =
-    ifEncodingVersionAtLeast
-      (natVersion @9)
-      (encCBOR failures)
-      (encodeFoldableAsIndefLenList encCBOR failures)
 
 deriving newtype instance
   ( Era era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,12 +17,14 @@
 -- mempool.
 module Cardano.Ledger.Shelley.API.Mempool (
   applyTx,
+  reapplyTx,
   ApplyTx (..),
   ApplyTxError (..),
   Validated,
   extractTx,
   coerceValidated,
   translateValidated,
+  ruleApplyTxValidation,
 
   -- * Exports for testing
   MempoolEnv,
@@ -46,6 +49,7 @@ import Cardano.Ledger.Binary (
   natVersion,
  )
 import Cardano.Ledger.Core
+import Cardano.Ledger.Rules.ValidationMode (lblStatic)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.Core (EraGov)
 import Cardano.Ledger.Shelley.LedgerState (NewEpochState, curPParamsEpochStateL)
@@ -54,11 +58,11 @@ import Cardano.Ledger.Shelley.Rules ()
 import Cardano.Ledger.Shelley.Rules.Ledger (LedgerEnv)
 import qualified Cardano.Ledger.Shelley.Rules.Ledger as Ledger
 import Cardano.Ledger.Slot (SlotNo)
-import Control.Arrow (ArrowChoice (right), left)
 import Control.DeepSeq (NFData)
-import Control.Monad.Except (Except, MonadError, liftEither)
+import Control.Monad.Except (Except)
 import Control.Monad.Trans.Reader (runReader)
 import Control.State.Transition.Extended
+import Data.Bifunctor (bimap)
 import Data.Coerce (Coercible, coerce)
 import Data.Functor ((<&>))
 import Data.List.NonEmpty (NonEmpty)
@@ -99,65 +103,50 @@ class
   , Eq (ApplyTxError era)
   , Show (ApplyTxError era)
   , Typeable (ApplyTxError era)
-  , STS (EraRule "LEDGER" era)
-  , BaseM (EraRule "LEDGER" era) ~ ShelleyBase
-  , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
-  , State (EraRule "LEDGER" era) ~ MempoolState era
-  , Signal (EraRule "LEDGER" era) ~ Tx era
   ) =>
   ApplyTx era
   where
   -- | Validate a transaction against a mempool state and for given STS options,
   -- and return the new mempool state, a "validated" 'TxInBlock' and,
   -- depending on the passed options, the emitted events.
-  applyTxOpts ::
-    forall ep m.
-    (MonadError (ApplyTxError era) m, EventReturnTypeRep ep) =>
-    ApplySTSOpts ep ->
+  applyTxValidation ::
+    ValidationPolicy ->
     Globals ->
     MempoolEnv era ->
     MempoolState era ->
     Tx era ->
-    m (EventReturnType ep (EraRule "LEDGER" era) (MempoolState era, Validated (Tx era)))
-  applyTxOpts opts globals env state tx =
-    let res =
-          flip runReader globals
-            . applySTSOptsEither @(EraRule "LEDGER" era) opts
-            $ TRC (env, state, tx)
-     in liftEither
-          . left ApplyTxError
-          . right
-            (mapEventReturn @ep @(EraRule "LEDGER" era) @(MempoolState era) (,Validated tx))
-          $ res
+    Either (ApplyTxError era) (MempoolState era, Validated (Tx era))
 
-  -- | Reapply a previously validated 'Tx'.
-  --
-  --   This applies the (validated) transaction to a new mempool state. It may
-  --   fail due to the mempool state changing (for example, a needed output
-  --   having already been spent). It should not fail due to any static check
-  --   (such as cryptographic checks).
-  --
-  --   Implementations of this function may optionally skip the performance of
-  --   any static checks. This is not required, but strongly encouraged since
-  --   this function will be called each time the mempool revalidates
-  --   transactions against a new mempool state.
-  reapplyTx ::
-    MonadError (ApplyTxError era) m =>
-    Globals ->
-    MempoolEnv era ->
-    MempoolState era ->
-    Validated (Tx era) ->
-    m (MempoolState era)
-  reapplyTx globals env state (Validated tx) =
-    let res =
-          flip runReader globals
-            . applySTS @(EraRule "LEDGER" era)
-            $ TRC (env, state, tx)
-     in liftEither
-          . left ApplyTxError
-          $ res
+ruleApplyTxValidation ::
+  forall rule era.
+  ( STS (EraRule rule era)
+  , BaseM (EraRule rule era) ~ ShelleyBase
+  , Environment (EraRule rule era) ~ LedgerEnv era
+  , State (EraRule rule era) ~ MempoolState era
+  , Signal (EraRule rule era) ~ Tx era
+  , PredicateFailure (EraRule rule era) ~ PredicateFailure (EraRule "LEDGER" era)
+  ) =>
+  ValidationPolicy ->
+  Globals ->
+  MempoolEnv era ->
+  MempoolState era ->
+  Tx era ->
+  Either (ApplyTxError era) (MempoolState era, Validated (Tx era))
+ruleApplyTxValidation validationPolicy globals env state tx =
+  let opts =
+        ApplySTSOpts
+          { asoAssertions = globalAssertionPolicy
+          , asoValidation = validationPolicy
+          , asoEvents = EPDiscard
+          }
+      result =
+        flip runReader globals
+          . applySTSOptsEither @(EraRule rule era) opts
+          $ TRC (env, state, tx)
+   in bimap ApplyTxError (,Validated tx) result
 
-instance ApplyTx ShelleyEra
+instance ApplyTx ShelleyEra where
+  applyTxValidation = ruleApplyTxValidation @"LEDGER"
 
 type MempoolEnv era = Ledger.LedgerEnv era
 
@@ -279,16 +268,26 @@ overNewEpochState f st = do
 -- 'TxInBlock' has had all checks run, and can now only fail due to checks
 -- which depend on the state; most notably, that UTxO inputs disappear.
 applyTx ::
-  (ApplyTx era, MonadError (ApplyTxError era) m) =>
+  ApplyTx era =>
   Globals ->
   MempoolEnv era ->
   MempoolState era ->
   Tx era ->
-  m (MempoolState era, Validated (Tx era))
-applyTx =
-  applyTxOpts $
-    ApplySTSOpts
-      { asoAssertions = globalAssertionPolicy
-      , asoValidation = ValidateAll
-      , asoEvents = EPDiscard
-      }
+  Either (ApplyTxError era) (MempoolState era, Validated (Tx era))
+applyTx = applyTxValidation ValidateAll
+
+-- | Reapply a previously validated 'Tx'.
+--
+--   This applies the (validated) transaction to a new mempool state. It may
+--   fail due to the mempool state changing (for example, a needed output
+--   having already been spent). It does not fail due to any static check
+--   (such as cryptographic checks).
+reapplyTx ::
+  ApplyTx era =>
+  Globals ->
+  MempoolEnv era ->
+  MempoolState era ->
+  Validated (Tx era) ->
+  Either (ApplyTxError era) (MempoolState era)
+reapplyTx globals env state (Validated tx) =
+  fst <$> applyTxValidation (ValidateSuchThat (notElem lblStatic)) globals env state tx

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
@@ -196,7 +196,7 @@ ledgersTransition = do
   foldM
     ( \ !ls' (ix, tx) ->
         trans @(EraRule "LEDGER" era) $
-          TRC (LedgerEnv slot (Just epochNo) ix pp account False, ls', tx)
+          TRC (LedgerEnv slot (Just epochNo) ix pp account, ls', tx)
     )
     ls
     $ zip [minBound ..]

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -658,7 +658,6 @@ impLedgerEnv nes = do
       , ledgerPp = nes ^. nesEsL . curPParamsEpochStateL
       , ledgerIx = TxIx 0
       , ledgerAccount = nes ^. nesEsL . esAccountStateL
-      , ledgerMempool = False
       }
 
 -- | Modify the previous PParams in the current state with the given function. For current

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/BenchmarkFunctions.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/BenchmarkFunctions.hs
@@ -141,7 +141,7 @@ ppsBench =
     & ppTauL .~ unsafeBoundRational 0.2
 
 ledgerEnv :: (EraPParams era, ProtVerAtMost era 4, ProtVerAtMost era 6) => LedgerEnv era
-ledgerEnv = LedgerEnv (SlotNo 0) Nothing minBound ppsBench (AccountState (Coin 0) (Coin 0)) False
+ledgerEnv = LedgerEnv (SlotNo 0) Nothing minBound ppsBench (AccountState (Coin 0) (Coin 0))
 
 testLEDGER ::
   LedgerState ShelleyEra ->

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Ledger.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Ledger.hs
@@ -98,7 +98,6 @@ instance
     LedgerEnv (SlotNo 0) Nothing minBound
       <$> genEraPParams @era geConstants
       <*> genAccountState geConstants
-      <*> pure False
 
   sigGen genenv env state = genTx genenv env state
 
@@ -148,7 +147,7 @@ instance
           TxIx ->
           Gen (LedgerState era, [Tx era])
         genAndApplyTx (ls', txs) txIx = do
-          let ledgerEnv = LedgerEnv slotNo (Just epochNo) txIx pParams reserves False
+          let ledgerEnv = LedgerEnv slotNo (Just epochNo) txIx pParams reserves
           tx <- genTx ge ledgerEnv ls'
 
           let res =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
@@ -148,7 +148,7 @@ genTx
         scriptspace
         constants
       )
-  (LedgerEnv slot _ txIx pparams reserves _)
+  (LedgerEnv slot _ txIx pparams reserves)
   (LedgerState utxoSt@(UTxOState utxo _ _ _ _ _) dpState) =
     do
       -------------------------------------------------------------------------

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -198,7 +198,7 @@ poolTraceFromBlock chainSt block =
     certs = concatMap (toList . view certsTxBodyL . view bodyTxL)
     poolCerts = mapMaybe getPoolCertTxCert (certs txs)
     poolEnv =
-      let (LedgerEnv sl _ _ pp _ _) = ledgerEnv
+      let LedgerEnv sl _ _ pp _ = ledgerEnv
        in PoolEnv (epochFromSlotNo sl) pp
     poolSt0 =
       certPState (lsCertState ledgerSt0)
@@ -223,7 +223,7 @@ delegTraceFromBlock chainSt block =
     certs = concatMap (reverse . toList . view certsTxBodyL . view bodyTxL)
     blockCerts = filter delegCert (certs txs)
     delegEnv =
-      let (LedgerEnv slot@(SlotNo slot64) _ txIx pp reserves _) = ledgerEnv
+      let LedgerEnv slot@(SlotNo slot64) _ txIx pp reserves = ledgerEnv
           dummyCertIx = minBound
           ptr = Ptr (SlotNo32 (fromIntegral slot64)) txIx dummyCertIx
        in DelegEnv slot (epochFromSlotNo slot) ptr reserves pp
@@ -251,7 +251,7 @@ ledgerTraceBase ::
   (ChainState era, LedgerEnv era, LedgerState era, [Tx era])
 ledgerTraceBase chainSt block =
   ( tickedChainSt
-  , LedgerEnv slot Nothing minBound pp_ (esAccountState nes) False
+  , LedgerEnv slot Nothing minBound pp_ (esAccountState nes)
   , esLState nes
   , txs
   )

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
@@ -332,7 +332,7 @@ addReward dp ra c = dp {certDState = ds {dsUnified = rewards'}}
 
 -- Any key deposit works in this test ^
 ledgerEnv :: LedgerEnv C
-ledgerEnv = LedgerEnv (SlotNo 0) Nothing minBound pp (AccountState (Coin 0) (Coin 0)) False
+ledgerEnv = LedgerEnv (SlotNo 0) Nothing minBound pp (AccountState (Coin 0) (Coin 0))
 
 testInvalidTx ::
   NonEmpty (PredicateFailure (ShelleyLEDGER C)) ->
@@ -493,7 +493,7 @@ testExpiredTx =
             , ttl = SlotNo 0
             , signers = [asWitness alicePay]
             }
-      ledgerEnv' = LedgerEnv (SlotNo 1) Nothing minBound pp (AccountState (Coin 0) (Coin 0)) False
+      ledgerEnv' = LedgerEnv (SlotNo 1) Nothing minBound pp (AccountState (Coin 0) (Coin 0))
    in testLEDGER ledgerState tx ledgerEnv' (Left errs)
 
 testInvalidWintess :: Assertion

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
@@ -127,7 +127,7 @@ instance
 
   environmentSpec ConwayLedgerExecContext {..} =
     let UtxoExecContext {..} = clecUtxoExecContext
-     in constrained' $ \slotNo _ _txIx pp _acntSt _mempool ->
+     in constrained' $ \slotNo _ _txIx pp _acntSt ->
           [ assert $ pp ==. lit (uePParams uecUtxoEnv)
           , assert $ slotNo ==. lit (ueSlot uecUtxoEnv)
           ]

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.17.0.0
 
+* Remove `applySTSValidateSuchThat` and `applySTSNonStatic` as redundant.
 * Move `AccountState` to `Cardano.Ledger.State` from `cardano-ledger-shelley`
 * Move `Cardano.Ledger.PoolDistr` module contents into `Cardano.Ledger.State` and deprecated the former
 * Move `Cardano.Ledger.SnapShots` module contents into `Cardano.Ledger.State` and deprecated the former

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Rules/ValidationMode.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Rules/ValidationMode.hs
@@ -19,8 +19,6 @@ module Cardano.Ledger.Rules.ValidationMode (
   (?!#),
   (?!#:),
   failBecauseS,
-  applySTSNonStatic,
-  applySTSValidateSuchThat,
 
   -- * Interface for independent Tests
   Inject (..),
@@ -36,22 +34,6 @@ import Control.State.Transition.Extended
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import Validation
-
-applySTSValidateSuchThat ::
-  forall s m rtype.
-  (STS s, RuleTypeRep rtype, m ~ BaseM s) =>
-  ([Label] -> Bool) ->
-  RuleContext rtype s ->
-  m (Either (NonEmpty (PredicateFailure s)) (State s))
-applySTSValidateSuchThat cond =
-  applySTSOptsEither opts
-  where
-    opts =
-      ApplySTSOpts
-        { asoAssertions = AssertionsOff
-        , asoValidation = ValidateSuchThat cond
-        , asoEvents = EPDiscard
-        }
 
 --------------------------------------------------------------------------------
 -- Static checks
@@ -95,14 +77,6 @@ infix 1 ?!#:
 -- | Fail, if static checks are enabled.
 failBecauseS :: PredicateFailure sts -> Rule sts ctx ()
 failBecauseS = (False ?!#)
-
--- | Apply an STS system and do not validate any static checks.
-applySTSNonStatic ::
-  forall s m rtype.
-  (STS s, RuleTypeRep rtype, m ~ BaseM s) =>
-  RuleContext rtype s ->
-  m (Either (NonEmpty (PredicateFailure s)) (State s))
-applySTSNonStatic = applySTSValidateSuchThat (notElem lblStatic)
 
 -- ===========================================================
 

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx.hs
@@ -79,6 +79,9 @@ benchApplyTx ::
   , ApplyTx era
   , HasTrace (EraRule "LEDGER" era) (GenEnv era)
   , BaseEnv (EraRule "LEDGER" era) ~ Globals
+  , Signal (EraRule "LEDGER" era) ~ Tx era
+  , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
+  , State (EraRule "LEDGER" era) ~ LedgerState era
   , EraGov era
   ) =>
   Proxy era ->

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx/Gen.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx/Gen.hs
@@ -53,7 +53,6 @@ applyTxMempoolEnv pp =
     , ledgerIx = minBound
     , ledgerPp = pp
     , ledgerAccount = AccountState (Coin 45000000000) (Coin 45000000000)
-    , ledgerMempool = False
     }
 
 data ApplyTxEnv era = ApplyTxEnv

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Tx.hs
@@ -893,7 +893,7 @@ gone = do
   (PParamsF _ pp) <- monadTyped (findVar (unVar (pparams proof)) env)
   accntState <- monadTyped (runTarget env accountStateT)
   utxo1 <- monadTyped (findVar (unVar (utxo proof)) env)
-  let lenv = LedgerEnv slot Nothing txIx pp accntState False
+  let lenv = LedgerEnv slot Nothing txIx pp accntState
   -- putStrLn (show (pcTx Babbage tx))
   pure $ case applySTSByProof proof (TRC (lenv, ledgerstate, tx)) of
     Right _ledgerState' -> do
@@ -1002,7 +1002,7 @@ oneTest sizes proof = do
   (PParamsF _ pp) <- monadTyped (runTerm env2 (pparams proof))
   accntState <- monadTyped (runTarget env2 accountStateT)
   txIx <- arbitrary
-  let lenv = LedgerEnv slot Nothing txIx pp accntState False
+  let lenv = LedgerEnv slot Nothing txIx pp accntState
   case applySTSByProof proof (TRC (lenv, ledgerstate, tx)) of
     Right ledgerState' -> pure (totalAda ledgerState' === totalAda ledgerstate)
     Left errs -> do

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/SimpleTx.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Trace/SimpleTx.hs
@@ -104,7 +104,7 @@ getSTSLedgerEnv proof txIx env = do
   slot <- runTerm env currentSlot
   (PParamsF _ pp) <- runTerm env (pparams proof)
   accntState <- runTarget env accountStateT
-  pure (LedgerEnv slot Nothing txIx pp accntState False, ledgerstate)
+  pure (LedgerEnv slot Nothing txIx pp accntState, ledgerstate)
 
 -- ====================================================================
 -- Picking things that have no Plutus Scripts inside. To make very

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/STSTestUtils.hs
@@ -322,7 +322,7 @@ runLEDGER ::
   Tx era ->
   Either (NonEmpty (PredicateFailure (EraRule "LEDGER" era))) (State (EraRule "LEDGER" era))
 runLEDGER wit@(LEDGER proof) state pparams tx =
-  let env = LedgerEnv (SlotNo 0) Nothing minBound pparams def False
+  let env = LedgerEnv (SlotNo 0) Nothing minBound pparams def
    in case proof of
         Conway -> runSTS' wit (TRC (env, state, tx))
         Babbage -> runSTS' wit (TRC (env, state, tx))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -3629,10 +3629,10 @@ instance Reflect era => PrettyA (LedgerEnv era) where
     ppRecord
       "LedgerEnv"
       [ ("slot no", prettyA ledgerSlotNo)
+      , ("epoch no", ppMaybe prettyA ledgerEpochNo)
       , ("ix", prettyA (txIxToInt ledgerIx))
       , ("pparams", prettyA ledgerPp)
       , ("account", prettyA ledgerAccount)
-      , ("mempool", prettyA ledgerMempool)
       ]
 
 instance Reflect era => PrettyA (UtxoEnv era) where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -88,27 +88,27 @@ import Test.Tasty (TestTree, defaultMain, testGroup)
 genTxAndUTXOState ::
   Reflect era => Proof era -> GenSize -> Gen (TRC (EraRule "UTXOW" era), GenState era)
 genTxAndUTXOState proof@Conway gsize = do
-  (Box _ (TRC (LedgerEnv slotNo _ _ pp _ _, ledgerState, vtx)) genState) <-
+  (Box _ (TRC (LedgerEnv slotNo _ _ pp _, ledgerState, vtx)) genState) <-
     genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 genTxAndUTXOState proof@Babbage gsize = do
-  (Box _ (TRC (LedgerEnv slotNo _ _ pp _ _, ledgerState, vtx)) genState) <-
+  (Box _ (TRC (LedgerEnv slotNo _ _ pp _, ledgerState, vtx)) genState) <-
     genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 genTxAndUTXOState proof@Alonzo gsize = do
-  (Box _ (TRC (LedgerEnv slotNo _ _ pp _ _, ledgerState, vtx)) genState) <-
+  (Box _ (TRC (LedgerEnv slotNo _ _ pp _, ledgerState, vtx)) genState) <-
     genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 genTxAndUTXOState proof@Mary gsize = do
-  (Box _ (TRC (LedgerEnv slotNo _ _ pp _ _, ledgerState, vtx)) genState) <-
+  (Box _ (TRC (LedgerEnv slotNo _ _ pp _, ledgerState, vtx)) genState) <-
     genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 genTxAndUTXOState proof@Allegra gsize = do
-  (Box _ (TRC (LedgerEnv slotNo _ _ pp _ _, ledgerState, vtx)) genState) <-
+  (Box _ (TRC (LedgerEnv slotNo _ _ pp _, ledgerState, vtx)) genState) <-
     genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 genTxAndUTXOState proof@Shelley gsize = do
-  (Box _ (TRC (LedgerEnv slotNo _ _ pp _ _, ledgerState, vtx)) genState) <-
+  (Box _ (TRC (LedgerEnv slotNo _ _ pp _, ledgerState, vtx)) genState) <-
     genTxAndLEDGERState proof gsize
   pure (TRC (UtxoEnv slotNo pp def, lsUTxOState ledgerState, vtx), genState)
 
@@ -143,7 +143,7 @@ genTxAndLEDGERState proof sizes = do
         model <- gets gsModel
         pp <- gets (gePParams . gsGenEnv)
         let ledgerState = extract @(LedgerState era) model
-            ledgerEnv = LedgerEnv slotNo Nothing txIx pp (AccountState (Coin 0) (Coin 0)) False
+            ledgerEnv = LedgerEnv slotNo Nothing txIx pp (AccountState (Coin 0) (Coin 0))
         pure $ TRC (ledgerEnv, ledgerState, tx)
   (trc, genstate) <- runGenRS proof sizes (initStableFields >> genT)
   pure (Box proof trc genstate)


### PR DESCRIPTION
# Description

Draft because still needs changelogs and related imp tests fixed.

This PR provides a different approach to #4880

Resolves #4864

Besides that it also improves the `ApplyTx` interface:
* Abstracts it to be used with any rule, not just `"LEDGER"`
* Switching to `Either` instead of polymorphic `MonadError` in order to improve performance. GHC is not good at optimizing mtl style, it is better to be monomorphic when possible. There isn't really any reason for it to be MonadError
* Moves `reapplyTx` outside of the class, since there is no reason to have different implementation between eras. Even though there is no change in behavior of `reapplyTx` with respect to older eras, `ApplyTx` can only ever be only used with current era, so there is even no danger in affecting behavior of previous eras.
* Simplifies `EncCBOR` instance for `ApplyTxError`

Also contains removal of some the no longer necessary functions.


# Checklist

- [x] Commits in meaningful sequence and with useful messages
- [x] Tests added or updated when needed
- [x] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
