### PR TITLE
Fixed a flaky test

### DIFF
--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Regression.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Regression.hs
@@ -84,6 +84,7 @@ spec = describe "Regression" $ do
   describe "ImpTest" $
     withImpInit @(LedgerSpec ConwayEra) $
       it "InsufficientCollateral is not encoded with negative coin #4198" $ do
+        modifyPParams $ ppCoinsPerUTxOByteL .~ CoinPerByte (Coin 4310)
         collateralAddress <- freshKeyAddr_
         stakingKeyHash <- freshKeyHash @'Staking
         let


### PR DESCRIPTION
# Description

This test sometimes failed if the `ppCoinsPerUTxOByte` parameter happened to be set to a bad value. This PR sets the parameter to a fixed value to get rid of this flakiness.

closes #4885

# Checklist

- [ ] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
