### PR TITLE
Add `ToCBOR`/`FromCBOR` instances for `Genesis` config types

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Add `ToCBOR` and `FromCBOR` instance for `ConwayGenesis`
 * Switch `ctbrCerts` to use `TxCert` instead of `ConwayTxCert`
 * Add `DecCBOR` instance for `ConwayTxBody`
 * Converted `CertState` to a type family

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Genesis.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Genesis.hs
@@ -53,6 +53,24 @@ data ConwayGenesis = ConwayGenesis
   }
   deriving (Eq, Generic, Show)
 
+instance EncCBOR ConwayGenesis where
+  encCBOR x@(ConwayGenesis _ _ _ _ _) =
+    let ConwayGenesis {..} = x
+     in encode $ Rec ConwayGenesis
+       !> To cgUpgradePParams
+       !> To cgConstitution
+       !> To cgCommittee
+       !> To cgDelegs
+       !> To cgInitialDReps
+
+instance DecCBOR ConwayGenesis where
+  decCBOR = decode $ RecD ConwayGenesis
+    <! From
+    <! From
+    <! From
+    <! From
+    <! From
+
 cgDelegsL :: Lens' ConwayGenesis (ListMap (Credential 'Staking) Delegatee)
 cgDelegsL = lens cgDelegs (\x y -> x {cgDelegs = y})
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Add `ToCBOR` and `FromCBOR` instance for `FromByronTranslationContext`
 * Add `auxDataSeqDecoder`
 * Remove `constructMetadata`
 * Remove `getProposedPPUpdates` as no longer relevant

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
@@ -13,8 +13,16 @@ module Cardano.Ledger.Shelley.Translation (
 )
 where
 
-import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
-import Cardano.Ledger.Binary.Coders (Encode (..), encode, (!>), decode, Decode (..), (<!))
+import Cardano.Ledger.Binary (
+  DecCBOR (..),
+  EncCBOR (..),
+  FromCBOR (..),
+  ToCBOR (..),
+  shelleyProtVer,
+  toPlainDecoder,
+  toPlainEncoding,
+ )
+import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
 import Cardano.Ledger.Core (PParams, TranslationContext, emptyPParams)
 import Cardano.Ledger.Keys
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
@@ -33,22 +41,28 @@ data FromByronTranslationContext = FromByronTranslationContext
   }
   deriving (Eq, Show, Generic)
 
-instance EncCBOR FromByronTranslationContext where
-  encCBOR x@(FromByronTranslationContext _ _ _) =
+instance ToCBOR FromByronTranslationContext where
+  toCBOR x@(FromByronTranslationContext _ _ _) =
     let FromByronTranslationContext {..} = x
-     in encode $
-          Rec FromByronTranslationContext
-            !> To fbtcGenDelegs
-            !> To fbtcProtocolParams
-            !> To fbtcMaxLovelaceSupply
+     in toPlainEncoding shelleyProtVer $
+          encode $
+            Rec FromByronTranslationContext
+              !> To fbtcGenDelegs
+              !> To fbtcProtocolParams
+              !> To fbtcMaxLovelaceSupply
 
-instance DecCBOR FromByronTranslationContext where
-  decCBOR =
-    decode $
-      RecD FromByronTranslationContext
-        <! From
-        <! From
-        <! From
+instance FromCBOR FromByronTranslationContext where
+  fromCBOR =
+    toPlainDecoder Nothing shelleyProtVer $
+      decode $
+        RecD FromByronTranslationContext
+          <! From
+          <! From
+          <! From
+
+instance EncCBOR FromByronTranslationContext
+
+instance DecCBOR FromByronTranslationContext
 
 -- | Trivial FromByronTranslationContext value, for use in cases where we do not need
 -- to translate from Byron to Shelley.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -12,6 +13,8 @@ module Cardano.Ledger.Shelley.Translation (
 )
 where
 
+import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
+import Cardano.Ledger.Binary.Coders (Encode (..), encode, (!>), decode, Decode (..), (<!))
 import Cardano.Ledger.Core (PParams, TranslationContext, emptyPParams)
 import Cardano.Ledger.Keys
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
@@ -29,6 +32,23 @@ data FromByronTranslationContext = FromByronTranslationContext
   , fbtcMaxLovelaceSupply :: !Word64
   }
   deriving (Eq, Show, Generic)
+
+instance EncCBOR FromByronTranslationContext where
+  encCBOR x@(FromByronTranslationContext _ _ _) =
+    let FromByronTranslationContext {..} = x
+     in encode $
+          Rec FromByronTranslationContext
+            !> To fbtcGenDelegs
+            !> To fbtcProtocolParams
+            !> To fbtcMaxLovelaceSupply
+
+instance DecCBOR FromByronTranslationContext where
+  decCBOR =
+    decode $
+      RecD FromByronTranslationContext
+        <! From
+        <! From
+        <! From
 
 -- | Trivial FromByronTranslationContext value, for use in cases where we do not need
 -- to translate from Byron to Shelley.

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.6.0.0
 
+* Add to `Plain`:
+  * `assertTag`
+  * `decodeTagMaybe`
+  * `encodeRatioWithTag`,
 * Add `DecCBOR` instance for `Data.IntMap`
 * Add `decodeIntMap`
 * Add `ToCBOR` instance for `PV1.Data`

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
@@ -173,6 +173,7 @@ import Cardano.Ledger.Binary.Plain (
   showDecoderError,
   toCborError,
  )
+import qualified Cardano.Ledger.Binary.Plain as Plain (assertTag, decodeTagMaybe)
 import Cardano.Ledger.Binary.Version (Version, mkVersion64, natVersion)
 import Cardano.Slotting.Slot (WithOrigin, withOriginFromMaybe)
 import Codec.CBOR.ByteArray (ByteArray (..))
@@ -1204,11 +1205,7 @@ decodeIPv6 =
 --------------------------------------------------------------------------------
 
 decodeTagMaybe :: Decoder s (Maybe Word64)
-decodeTagMaybe =
-  peekTokenType >>= \case
-    C.TypeTag -> Just . fromIntegral <$> decodeTag
-    C.TypeTag64 -> Just <$> decodeTag64
-    _ -> pure Nothing
+decodeTagMaybe = fromPlainDecoder Plain.decodeTagMaybe
 {-# INLINE decodeTagMaybe #-}
 
 allowTag :: Word -> Decoder s ()
@@ -1221,14 +1218,7 @@ allowTag tagExpected = do
 {-# INLINE allowTag #-}
 
 assertTag :: Word -> Decoder s ()
-assertTag tagExpected = do
-  tagReceived <-
-    decodeTagMaybe >>= \case
-      Just tag -> pure tag
-      Nothing -> fail "Expected tag"
-  unless (tagReceived == (fromIntegral tagExpected :: Word64)) $
-    fail $
-      "Expecteg tag " <> show tagExpected <> " but got tag " <> show tagReceived
+assertTag = fromPlainDecoder . Plain.assertTag
 {-# INLINE assertTag #-}
 
 -- | Enforces that the input size is the same as the decoded one, failing in

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 1.17.0.0
 
+* Add `ToCBOR` and `FromCBOR` instances for:
+  * `BoundedRatio`
+  * `PositiveUnitInterval`
+  * `ActiveSlotCoeff`
+  * `Network`
+  * `NoGenesis`
 * Move `EraGov` to `Cardano.Ledger.State` from `cardano-ledger-shelley`
 * Add DecCBOR instances for:
   * `PlutusData`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Genesis.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Genesis.hs
@@ -7,6 +7,8 @@ module Cardano.Ledger.Genesis (
   NoGenesis (..),
 ) where
 
+import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
+import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode)
 import Cardano.Ledger.Core.Era (Era)
 import Data.Kind (Type)
 
@@ -16,3 +18,9 @@ class Era era => EraGenesis era where
 
 data NoGenesis era = NoGenesis
   deriving (Eq, Show)
+
+instance Era era => EncCBOR (NoGenesis era) where
+  encCBOR _ = encode $ Rec NoGenesis
+
+instance Era era => DecCBOR (NoGenesis era) where
+  decCBOR = decode $ RecD NoGenesis

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Genesis.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Genesis.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
@@ -7,8 +8,12 @@ module Cardano.Ledger.Genesis (
   NoGenesis (..),
 ) where
 
-import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
-import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode)
+import Cardano.Ledger.Binary (
+  DecCBOR (..),
+  EncCBOR (..),
+  FromCBOR (..),
+  ToCBOR (..),
+ )
 import Cardano.Ledger.Core.Era (Era)
 import Data.Kind (Type)
 
@@ -19,8 +24,12 @@ class Era era => EraGenesis era where
 data NoGenesis era = NoGenesis
   deriving (Eq, Show)
 
-instance Era era => EncCBOR (NoGenesis era) where
-  encCBOR _ = encode $ Rec NoGenesis
+instance Era era => ToCBOR (NoGenesis era) where
+  toCBOR _ = toCBOR ()
 
-instance Era era => DecCBOR (NoGenesis era) where
-  decCBOR = decode $ RecD NoGenesis
+instance Era era => FromCBOR (NoGenesis era) where
+  fromCBOR = NoGenesis <$ fromCBOR @()
+
+instance Era era => EncCBOR (NoGenesis era)
+
+instance Era era => DecCBOR (NoGenesis era)


### PR DESCRIPTION
# Description

Needed `FromCBOR` and `ToCBOR` instances for:

* FromByronTranslationContext
* NoGenesis {AllegraEra, MaryEra, BabbageEra}
* ConwayGenesis
* Network
* ActiveSlotCoeff

Closes https://github.com/IntersectMBO/cardano-ledger/issues/4893

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
