### PR TITLE
Switch to using `TxCert` type family

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Switch `ctbrCerts` to use `TxCert` instead of `ConwayTxCert`
 * Add `DecCBOR` instance for `ConwayTxBody`
 * Converted `CertState` to a type family
 * Remove `ConwayMempoolPredFailure` and `ConwayMempoolEvent`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -544,6 +544,7 @@ instance
   , Arbitrary (Value era)
   , Arbitrary (Script era)
   , Arbitrary (PParamsUpdate era)
+  , Arbitrary (TxCert era)
   ) =>
   Arbitrary (ConwayTxBody era)
   where

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
@@ -165,11 +165,11 @@ instance
 
 -- TxBody
 instance
-  (EraPParams era, ToExpr (PParamsHKD StrictMaybe era), ToExpr (TxOut era)) =>
+  (EraPParams era, ToExpr (PParamsHKD StrictMaybe era), ToExpr (TxOut era), ToExpr (TxCert era)) =>
   ToExpr (ConwayTxBodyRaw era)
 
 instance
-  (EraPParams era, ToExpr (PParamsHKD StrictMaybe era), ToExpr (TxOut era)) =>
+  (EraPParams era, ToExpr (PParamsHKD StrictMaybe era), ToExpr (TxOut era), ToExpr (TxCert era)) =>
   ToExpr (ConwayTxBody era)
 
 -- Rules/Cert

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Same.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Same.hs
@@ -530,7 +530,7 @@ sameConwayTxBody
     , ("Outputs", eqVia (ppList (pcTxOut proof . sizedValue) . toList) o1 o2)
     , ("ColReturn", eqVia (ppStrictMaybe (pcTxOut proof . sizedValue)) cr1 cr2)
     , ("TotalCol", eqVia (ppStrictMaybe pcCoin) tc1 tc2)
-    , ("Certs", eqVia (ppList pcConwayTxCert . toList) c1 c2)
+    , ("Certs", eqVia (ppList (pcTxCert proof) . toList) c1 c2)
     , ("WDRL", eqVia (ppMap pcRewardAccount pcCoin) w1 w2)
     , ("Fee", eqVia pcCoin f1 f2)
     , ("ValidityInterval", eqVia ppValidityInterval v1 v2)


### PR DESCRIPTION

# Description

Instead of using the `ConwayTxCert` concrete type. This will be helpful when we start defining a new era.

Fixes #4899

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
