### PR TITLE
Improve `TxSeq` decoders

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxSeq/Internal.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxSeq/Internal.hs
@@ -52,7 +52,7 @@ import Data.ByteString (ByteString)
 import Data.ByteString.Builder (shortByteString, toLazyByteString)
 import qualified Data.ByteString.Lazy as BSL
 import Data.Coerce (coerce)
-import qualified Data.Map.Strict as Map
+import qualified Data.IntMap as IntMap
 import Data.Maybe.Strict (maybeToStrictMaybe, strictMaybeToMaybe)
 import Data.Monoid (All (..))
 import Data.Proxy (Proxy (..))
@@ -193,7 +193,7 @@ instance AlonzoEraTx era => DecCBOR (Annotator (AlonzoTxSeq era)) where
       do
         auxDataMap <- decCBOR
         unless
-          (getAll (Map.foldMapWithKey (\k _ -> All (inRange k)) auxDataMap))
+          (getAll (IntMap.foldMapWithKey (\k _ -> All (inRange k)) auxDataMap))
           ( fail
               ( "Some Auxiliarydata index is not in the range: 0 .. "
                   ++ show (bodiesLength - 1)
@@ -249,7 +249,7 @@ instance
         inRange x = (0 <= x) && (x <= (bodiesLength - 1))
         witsLength = length wits
     unless
-      (getAll (Map.foldMapWithKey (\k _ -> All (inRange k)) auxDataMap))
+      (getAll (IntMap.foldMapWithKey (\k _ -> All (inRange k)) auxDataMap))
       ( fail
           ( "Some Auxiliarydata index is not in the range: 0 .. "
               ++ show (bodiesLength - 1)

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.16.0.0
 
+* Add `auxDataSeqDecoder`
+* Remove `constructMetadata`
 * Remove `getProposedPPUpdates` as no longer relevant
 * Remove `proposalsL` and `futureProposalsL` as unused
 * Remove redundant supercalss constraints for `ApplyBlock`
@@ -16,7 +18,6 @@
   * `ShelleyTxBody`
   * `ShelleyTx`
   * `ShelleyTxSeq`
-* Add `indexLookupSeq`
 * Add `segWitTx`
 * Rename `segwitTx` to `segWitAnnTx`
 * Converted `CertState` to a type family

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.6.0.0
 
+* Add `DecCBOR` instance for `Data.IntMap`
+* Add `decodeIntMap`
 * Add `ToCBOR` instance for `PV1.Data`
 * Add `DecCBOR` instance for `Annotated a ByteString`
 * Add `originalBytesExpectedFailureMessage` needed for testing

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs
@@ -66,6 +66,7 @@ import Data.ByteString.Short.Internal (ShortByteString(SBS))
 import Data.Fixed (Fixed (..))
 import Data.IP (IPv4, IPv6)
 import Data.Int (Int16, Int32, Int64, Int8)
+import qualified Data.IntMap as IntMap
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
 import qualified Data.Maybe.Strict as SMaybe
@@ -404,6 +405,10 @@ instance (Ord a, DecCBOR a) => DecCBOR (Set.Set a) where
 
 instance (Ord k, DecCBOR k, DecCBOR v) => DecCBOR (Map.Map k v) where
   decCBOR = decodeMap decCBOR decCBOR
+  {-# INLINE decCBOR #-}
+
+instance DecCBOR v => DecCBOR (IntMap.IntMap v) where
+  decCBOR = decodeIntMap decCBOR
   {-# INLINE decCBOR #-}
 
 instance


### PR DESCRIPTION
# Description

Changes the decoders of the `TxAuxData` within `TxSeq` to deserialize as `IntMap` instead of `Map Int` 

Closes https://github.com/IntersectMBO/cardano-ledger/issues/4900

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages
- [ ] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
