### PR TITLE
Remove no longer needed workarounds

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
@@ -506,10 +506,12 @@ transTxBodyWithdrawals :: EraTxBody era => TxBody era -> PV3.Map PV3.Credential 
 transTxBodyWithdrawals txBody =
   transMap transRewardAccount transCoinToLovelace (unWithdrawals $ txBody ^. withdrawalsTxBodyL)
 
--- | In version 9, a bug in `RegTxCert` and `UnRegTxCert` pattern definitions
--- was causing the deposit in `RegDepositTxCert` and `UnRegDepositTxCert` to be omitted.
--- We need to keep this behavior for version 9, so, now that the bug in the patterns has been fixed,
--- we are explicitly omitting the deposit in these cases.
+-- | In protocol version 9, a bug in `RegTxCert` and `UnRegTxCert` pattern definitions was causing
+-- the deposit in `RegDepositTxCert` and `UnRegDepositTxCert` to be omitted.  We need to keep this
+-- behavior for version 9, so, now that the bug in the patterns has been fixed, we are explicitly
+-- omitting the deposit in these cases. It has been confirmed that this buggy behavior for protocol
+-- version 9 has been exercised on Mainnet, therefore this conditional translation can never be
+-- removed for Conway era (#4863)
 transTxCert :: ConwayEraTxCert era => ProtVer -> TxCert era -> PV3.TxCert
 transTxCert pv = \case
   RegPoolTxCert PoolParams {ppId, ppVrf} ->

--- a/eras/mary/impl/test/Test/Cardano/Ledger/Mary/ValueSpec.hs
+++ b/eras/mary/impl/test/Test/Cardano/Ledger/Mary/ValueSpec.hs
@@ -24,7 +24,6 @@ import Test.Cardano.Data
 import Test.Cardano.Ledger.Binary.RoundTrip (
   roundTripCborExpectation,
   roundTripCborFailureExpectation,
-  roundTripCborRangeExpectation,
   roundTripCborRangeFailureExpectation,
  )
 import Test.Cardano.Ledger.Common
@@ -47,10 +46,8 @@ spec = do
     context "Coin" $ do
       prop "Non-negative Coin succeeds for all eras" $
         \(NonNegative i) -> roundTripCborExpectation (Coin i)
-      prop "Negative Coin succeeds for pre-Conway" $
-        \(Negative i) -> roundTripCborRangeExpectation minBound (natVersion @8) (Coin i)
-      prop "Negative Coin fails to deserialise for Conway" $
-        \(Negative i) -> roundTripCborRangeFailureExpectation (natVersion @9) (natVersion @9) (Coin i)
+      prop "Negative Coin fails to deserialise for all eras" $
+        \(Negative i) -> roundTripCborRangeFailureExpectation (natVersion @0) maxBound (Coin i)
     context "MultiAsset" $ do
       prop "Non-zero-valued MultiAsset succeeds for all eras" $
         roundTripCborExpectation @MultiAsset

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
@@ -47,10 +47,7 @@ import Cardano.Ledger.Binary (
   EncCBOR (..),
   FromCBOR (..),
   ToCBOR,
-  decodeInteger,
   decodeWord64,
-  ifDecoderVersionAtLeast,
-  natVersion,
  )
 import qualified Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Compactible
@@ -89,12 +86,7 @@ newtype Coin = Coin {unCoin :: Integer}
 instance FromCBOR Coin where
   fromCBOR = Coin . toInteger <$> Plain.decodeWord64
 
-instance DecCBOR Coin where
-  decCBOR =
-    ifDecoderVersionAtLeast
-      (natVersion @9)
-      (Coin . fromIntegral <$> decodeWord64)
-      (Coin <$> decodeInteger)
+instance DecCBOR Coin
 
 newtype DeltaCoin = DeltaCoin Integer
   deriving (Eq, Ord, Generic, Enum, NoThunks, HeapWords)


### PR DESCRIPTION
# Description

This PR removes conditional decoding workarounds that where set in place in order to preserve the behavior of decoders, until we are in newer eras where fix is permanent:
* Removes the `IgnoreSigOrd`, which, until Alonzo, preserved the behavior of older `Ord` instance for `WitVKey`. Fixes #4902
* Remove conditional decoding for `Coin`, which until Conway era allowed negative coin in a couple of obscure places.
* Adds a comment about inability to remove buggy translation of certificated in plutus context for protocol version 9. Fixes #4863

This change has been verified to have no affect on mainnet, preview and preprod. Therefore removal of those hacks can now be safely removed.

# Checklist

- [x] Commits in meaningful sequence and with useful messages
- [x] Tests added or updated when needed
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes<br>
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary<br>
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
