### PR TITLE
Add type parameter to KeySpace and GenEnv

### DIFF
--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -52,7 +52,7 @@ library
     cardano-ledger-mary >=1.4,
     cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.14,
     cardano-ledger-shelley-ma-test >=1.2,
-    cardano-ledger-shelley-test >=1.4.1,
+    cardano-ledger-shelley-test >=1.6,
     cardano-protocol-tpraos >=1.0,
     cardano-slotting,
     cardano-strict-containers,

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -252,7 +252,7 @@ okAsCollateral utxo inputx =
   maybe False vKeyLockedAdaOnly $ Map.lookup inputx (unUTxO utxo)
 
 genAlonzoTxBody ::
-  GenEnv AlonzoEra ->
+  GenEnv c AlonzoEra ->
   UTxO AlonzoEra ->
   PParams AlonzoEra ->
   SlotNo ->

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
@@ -28,6 +28,7 @@ import Cardano.Ledger.Shelley.Rules (
   UtxoEnv,
  )
 import Cardano.Ledger.State (EraUTxO)
+import Cardano.Protocol.Crypto (Crypto)
 import Cardano.Slotting.Slot (SlotNo (..))
 import Control.Monad.Trans.Reader (runReaderT)
 import Control.State.Transition
@@ -66,8 +67,9 @@ instance
   , Tx era ~ AlonzoTx era
   , ProtVerAtMost era 8
   , EraCertState era
+  , Crypto c
   ) =>
-  TQC.HasTrace (AlonzoLEDGER era) (GenEnv era)
+  TQC.HasTrace (AlonzoLEDGER era) (GenEnv c era)
   where
   envGen GenEnv {geConstants} =
     LedgerEnv (SlotNo 0) Nothing minBound

--- a/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
+++ b/eras/babbage/test-suite/cardano-ledger-babbage-test.cabal
@@ -43,7 +43,7 @@ library
     cardano-ledger-mary >=1.4,
     cardano-ledger-shelley >=1.16,
     cardano-ledger-shelley-ma-test >=1.1,
-    cardano-ledger-shelley-test >=1.1,
+    cardano-ledger-shelley-test >=1.6,
     cardano-slotting,
     cardano-strict-containers,
     containers,

--- a/eras/conway/test-suite/cardano-ledger-conway-test.cabal
+++ b/eras/conway/test-suite/cardano-ledger-conway-test.cabal
@@ -39,7 +39,7 @@ library
     cardano-ledger-mary >=1.4,
     cardano-ledger-shelley >=1.16,
     cardano-ledger-shelley-ma-test >=1.1,
-    cardano-ledger-shelley-test >=1.1,
+    cardano-ledger-shelley-test >=1.6,
     cardano-strict-containers,
     containers,
     data-default,

--- a/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
+++ b/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
@@ -51,7 +51,7 @@ library
     cardano-ledger-core:{cardano-ledger-core, testlib} >=1.17,
     cardano-ledger-mary:{cardano-ledger-mary, testlib} ^>=1.8,
     cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.12,
-    cardano-ledger-shelley-test >=1.1,
+    cardano-ledger-shelley-test >=1.6,
     cardano-slotting,
     cardano-strict-containers,
     containers,

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/MaryEraGen.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/MaryEraGen.hs
@@ -106,7 +106,7 @@ genAuxiliaryData Constants {frequencyTxWithMetadata} =
     ]
 
 -- | Carefully crafted to apply in any Era where Value is MaryValue
-maryGenesisValue :: GenEnv era -> Gen MaryValue
+maryGenesisValue :: GenEnv c era -> Gen MaryValue
 maryGenesisValue (GenEnv _ _ Constants {minGenesisOutputVal, maxGenesisOutputVal}) =
   Val.inject . Coin <$> exponential minGenesisOutputVal maxGenesisOutputVal
 

--- a/eras/shelley/test-suite/CHANGELOG.md
+++ b/eras/shelley/test-suite/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.6.0.0
 
+* Add crypto type-parameter to `KeySpace` and `GenEnv` #4908
 * Add `DecCBOR` instance for `LaxBlock`
 * Add `genCoreNodeKeys` and `genIssuerKeys`
 * Move `VRFNatVal` into `cardano-protocol-tpraos:testlib`

--- a/eras/shelley/test-suite/bench/BenchValidation.hs
+++ b/eras/shelley/test-suite/bench/BenchValidation.hs
@@ -74,7 +74,7 @@ instance NFData (ValidateInput era) where
 validateInput ::
   ( EraGen era
   , EraRule "LEDGERS" era ~ API.ShelleyLEDGERS era
-  , QC.HasTrace (API.ShelleyLEDGERS era) (GenEnv era)
+  , QC.HasTrace (API.ShelleyLEDGERS era) (GenEnv MockCrypto era)
   , API.ApplyBlock era
   , GetLedgerView era
   , MinLEDGER_STS era
@@ -86,7 +86,7 @@ validateInput utxoSize = genValidateInput utxoSize
 genValidateInput ::
   ( EraGen era
   , EraRule "LEDGERS" era ~ API.ShelleyLEDGERS era
-  , QC.HasTrace (API.ShelleyLEDGERS era) (GenEnv era)
+  , QC.HasTrace (API.ShelleyLEDGERS era) (GenEnv MockCrypto era)
   , API.ApplyBlock era
   , GetLedgerView era
   , MinLEDGER_STS era
@@ -169,7 +169,7 @@ genUpdateInputs ::
   , MinLEDGER_STS era
   , GetLedgerView era
   , EraRule "LEDGERS" era ~ API.ShelleyLEDGERS era
-  , QC.HasTrace (API.ShelleyLEDGERS era) (GenEnv era)
+  , QC.HasTrace (API.ShelleyLEDGERS era) (GenEnv MockCrypto era)
   , API.ApplyBlock era
   ) =>
   Int ->

--- a/eras/shelley/test-suite/bench/Cardano/Ledger/Shelley/Bench/Gen.hs
+++ b/eras/shelley/test-suite/bench/Cardano/Ledger/Shelley/Bench/Gen.hs
@@ -62,7 +62,7 @@ genChainState ::
   , EraGov era
   ) =>
   Int ->
-  GenEnv era ->
+  GenEnv MockCrypto era ->
   IO (ChainState era)
 genChainState n ge =
   let cs =
@@ -86,10 +86,10 @@ genBlock ::
   , MinLEDGER_STS era
   , GetLedgerView era
   , EraRule "LEDGERS" era ~ ShelleyLEDGERS era
-  , QC.HasTrace (ShelleyLEDGERS era) (GenEnv era)
+  , QC.HasTrace (ShelleyLEDGERS era) (GenEnv MockCrypto era)
   , ApplyBlock era
   ) =>
-  GenEnv era ->
+  GenEnv MockCrypto era ->
   ChainState era ->
   IO (Block (BHeader MockCrypto) era)
 genBlock ge cs = generate $ GenBlock.genBlock ge cs
@@ -116,7 +116,7 @@ genTriple ::
   ) =>
   Proxy era ->
   Int ->
-  IO (GenEnv era, ChainState era, GenEnv era -> IO (ShelleyTx era))
+  IO (GenEnv MockCrypto era, ChainState era, GenEnv MockCrypto era -> IO (ShelleyTx era))
 genTriple proxy n = do
   let ge = genEnv proxy defaultConstants
   cs <- genChainState n ge

--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -165,7 +165,7 @@ test-suite cardano-ledger-shelley-test
     cardano-ledger-byron,
     cardano-ledger-core:{cardano-ledger-core, testlib},
     cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
-    cardano-ledger-shelley-test >=1.6,
+    cardano-ledger-shelley-test,
     cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib},
     cardano-slotting,
     cardano-strict-containers,

--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -165,7 +165,7 @@ test-suite cardano-ledger-shelley-test
     cardano-ledger-byron,
     cardano-ledger-core:{cardano-ledger-core, testlib},
     cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
-    cardano-ledger-shelley-test >=1.1,
+    cardano-ledger-shelley-test >=1.6,
     cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib},
     cardano-slotting,
     cardano-strict-containers,

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
@@ -148,7 +148,7 @@ type MinUTXO_STS era =
 class Show (TxOut era) => MinGenTxout era where
   calcEraMinUTxO :: TxOut era -> PParams era -> Coin
   addValToTxOut :: Value era -> TxOut era -> TxOut era
-  genEraTxOut :: GenEnv era -> Gen (Value era) -> [Addr] -> Gen [TxOut era]
+  genEraTxOut :: GenEnv c era -> Gen (Value era) -> [Addr] -> Gen [TxOut era]
 
 -- ======================================================================================
 -- The EraGen class. Generally one method for each type family in Cardano.Ledger.Core
@@ -167,7 +167,7 @@ class
   EraGen era
   where
   -- | Generate a genesis value for the Era
-  genGenesisValue :: GenEnv era -> Gen (Value era)
+  genGenesisValue :: GenEnv c era -> Gen (Value era)
 
   -- | A list of three-phase scripts that can be chosen for payment when building a transaction
   genEraTwoPhase3Arg :: [TwoPhase3ArgInfo era]
@@ -181,7 +181,7 @@ class
   -- and a list of additional scripts for eras that sometimes require
   -- additional script witnessing.
   genEraTxBody ::
-    GenEnv era ->
+    GenEnv c era ->
     UTxO era ->
     PParams era ->
     SlotNo ->
@@ -270,7 +270,7 @@ class
 someKeyPairs :: Constants -> (Int, Int) -> Gen KeyPairs
 someKeyPairs c range = take <$> choose range <*> shuffle (keyPairs c)
 
-genUtxo0 :: forall era. EraGen era => GenEnv era -> Gen (UTxO era)
+genUtxo0 :: forall era c. EraGen era => GenEnv c era -> Gen (UTxO era)
 genUtxo0 ge@(GenEnv _ _ c@Constants {minGenesisUTxOouts, maxGenesisUTxOouts}) = do
   let range = (minGenesisUTxOouts `div` 2, maxGenesisUTxOouts `div` 2)
   genesisKeys <- someKeyPairs c range

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Presets.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Presets.hs
@@ -50,11 +50,13 @@ import Test.Cardano.Protocol.TPraos.Create (genAllIssuerKeys)
 -- | Example generator environment, consisting of default constants and an
 -- corresponding keyspace.
 genEnv ::
-  forall era.
-  EraGen era =>
+  forall era c.
+  ( EraGen era
+  , Crypto c
+  ) =>
   Proxy era ->
   Constants ->
-  GenEnv era
+  GenEnv c era
 genEnv _ constants =
   GenEnv
     (keySpace constants)
@@ -77,10 +79,12 @@ scriptSpace scripts3 scripts2 =
 
 -- | Example keyspace for use in generators
 keySpace ::
-  forall era.
-  EraGen era =>
+  forall era c.
+  ( EraGen era
+  , Crypto c
+  ) =>
   Constants ->
-  KeySpace era
+  KeySpace c era
 keySpace c =
   KeySpace
     (coreNodeKeys c)

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Chain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Chain.hs
@@ -53,6 +53,7 @@ import Data.Proxy (Proxy (..))
 import Lens.Micro ((&), (.~), (^.))
 import Lens.Micro.Extras (view)
 import Numeric.Natural (Natural)
+import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (MockCrypto)
 import Test.Cardano.Ledger.Shelley.Generator.Block (genBlock)
 import Test.Cardano.Ledger.Shelley.Generator.Core (GenEnv (..))
 import Test.Cardano.Ledger.Shelley.Generator.EraGen (
@@ -102,9 +103,9 @@ instance
   , Environment (EraRule "TICK" era) ~ ()
   , State (EraRule "TICK" era) ~ NewEpochState era
   , Signal (EraRule "TICK" era) ~ SlotNo
-  , QC.HasTrace (EraRule "LEDGERS" era) (GenEnv era)
+  , QC.HasTrace (EraRule "LEDGERS" era) (GenEnv MockCrypto era)
   ) =>
-  HasTrace (CHAIN era) (GenEnv era)
+  HasTrace (CHAIN era) (GenEnv MockCrypto era)
   where
   envGen _ = pure ()
 
@@ -127,11 +128,11 @@ lastByronHeaderHash _ = HashHeader $ mkHash 0
 -- To achieve this we (1) use 'IRC CHAIN' (the "initial rule context") instead of simply 'Chain Env'
 -- and (2) always return Right (since this function does not raise predicate failures).
 mkGenesisChainState ::
-  forall era a.
+  forall era a c.
   ( EraGen era
   , EraGov era
   ) =>
-  GenEnv era ->
+  GenEnv c era ->
   IRC (CHAIN era) ->
   Gen (Either a (ChainState era))
 mkGenesisChainState ge@(GenEnv _ _ constants) (IRC _slotNo) = do

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/TxCert.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/TxCert.hs
@@ -37,6 +37,7 @@ import Cardano.Ledger.Shelley.API (
   ShelleyDELPL,
  )
 import Cardano.Ledger.Shelley.Rules (ShelleyDelplEvent, ShelleyDelplPredFailure)
+import Cardano.Protocol.Crypto (Crypto)
 import Control.Monad.Trans.Reader (runReaderT)
 import Control.State.Transition (
   BaseM,
@@ -161,8 +162,9 @@ instance
   , Signal (Core.EraRule "DELPL" era) ~ TxCert era
   , ProtVerAtMost era 8
   , EraCertState era
+  , Crypto c
   ) =>
-  QC.HasTrace (CERTS era) (GenEnv era)
+  QC.HasTrace (CERTS era) (GenEnv c era)
   where
   envGen _ = error "HasTrace CERTS - envGen not required"
 
@@ -190,14 +192,15 @@ instance
 -- | Generate certificates and also return the associated witnesses and
 -- deposits and refunds required.
 genTxCerts ::
-  forall era.
+  forall era c.
   ( EraGen era
   , Embed (Core.EraRule "DELPL" era) (CERTS era)
   , Environment (Core.EraRule "DELPL" era) ~ DelplEnv era
   , State (Core.EraRule "DELPL" era) ~ CertState era
   , Signal (Core.EraRule "DELPL" era) ~ TxCert era
+  , Crypto c
   ) =>
-  GenEnv era ->
+  GenEnv c era ->
   Core.PParams era ->
   CertState era ->
   SlotNo ->

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/TxCert.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/TxCert.hs
@@ -43,7 +43,7 @@ import Cardano.Ledger.Shelley.LedgerState (
  )
 import Cardano.Ledger.Slot (EpochNo (EpochNo), SlotNo)
 import qualified Cardano.Ledger.UMap as UM
-import Cardano.Protocol.Crypto (hashVerKeyVRF)
+import Cardano.Protocol.Crypto (Crypto, hashVerKeyVRF)
 import Control.Monad (replicateM)
 import Control.SetAlgebra (dom, domain, eval, (∈))
 import Data.Foldable (fold)
@@ -97,10 +97,10 @@ deriving instance (Era era, Show (Script era)) => Show (CertCred era)
 -- Note: we register keys and pools more often than deregistering/retiring them,
 -- and we generate more delegations than registrations of keys/pools.
 genTxCert ::
-  forall era.
-  (EraGen era, ProtVerAtMost era 8, EraCertState era) =>
+  forall era c.
+  (EraGen era, ProtVerAtMost era 8, EraCertState era, Crypto c) =>
   Constants ->
-  KeySpace era ->
+  KeySpace c era ->
   PParams era ->
   AccountState ->
   CertState era ->
@@ -313,11 +313,12 @@ genDelegation
       availablePools = Set.toList $ domain registeredPools
 
 genGenesisDelegation ::
-  (Era era, ShelleyEraTxCert era, ProtVerAtMost era 8, EraCertState era) =>
+  forall era c.
+  (Era era, ShelleyEraTxCert era, ProtVerAtMost era 8, EraCertState era, Crypto c) =>
   -- | Core nodes
-  [(GenesisKeyPair MockCrypto, AllIssuerKeys MockCrypto 'GenesisDelegate)] ->
+  [(GenesisKeyPair c, AllIssuerKeys c 'GenesisDelegate)] ->
   -- | All potential genesis delegate keys
-  [AllIssuerKeys MockCrypto 'GenesisDelegate] ->
+  [AllIssuerKeys c 'GenesisDelegate] ->
   CertState era ->
   Gen (Maybe (TxCert era, CertCred era))
 genGenesisDelegation coreNodes delegateKeys dpState =
@@ -337,7 +338,7 @@ genGenesisDelegation coreNodes delegateKeys dpState =
         ( GenesisDelegTxCert
             (hashVKey gkey)
             (hashVKey key)
-            (hashVerKeyVRF @MockCrypto vrf)
+            (hashVerKeyVRF @c vrf)
         , CoreKeyCred [gkey]
         )
     GenDelegs genDelegs_ = dpState ^. certDStateL . dsGenDelegsL
@@ -354,8 +355,10 @@ genGenesisDelegation coreNodes delegateKeys dpState =
 
 -- | Generate PoolParams and the key witness.
 genStakePool ::
+  forall c.
+  Crypto c =>
   -- | Available keys for stake pool registration
-  [AllIssuerKeys MockCrypto 'StakePool] ->
+  [AllIssuerKeys c 'StakePool] ->
   -- | KeyPairs containing staking keys to act as owners/reward account
   KeyPairs ->
   -- | Minimum pool cost Protocol Param
@@ -377,7 +380,7 @@ genStakePool poolKeys skeys (Coin minPoolCost) =
     getAnyStakeKey :: KeyPairs -> Gen (VKey 'Staking)
     getAnyStakeKey keys = vKey . snd <$> QC.elements keys
     mkPoolParams ::
-      AllIssuerKeys MockCrypto 'StakePool ->
+      AllIssuerKeys c 'StakePool ->
       Coin ->
       Coin ->
       Natural ->
@@ -388,7 +391,7 @@ genStakePool poolKeys skeys (Coin minPoolCost) =
           pps =
             PoolParams
               (hashKey . vKey $ aikCold allPoolKeys)
-              (hashVerKeyVRF @MockCrypto . vrfVerKey $ aikVrf allPoolKeys)
+              (hashVerKeyVRF @c . vrfVerKey $ aikVrf allPoolKeys)
               pledge
               cost
               interval
@@ -400,8 +403,8 @@ genStakePool poolKeys skeys (Coin minPoolCost) =
 
 -- | Generate `RegPool` and the key witness.
 genRegPool ::
-  (Era era, EraTxCert era) =>
-  [AllIssuerKeys MockCrypto 'StakePool] ->
+  (Era era, EraTxCert era, Crypto c) =>
+  [AllIssuerKeys c 'StakePool] ->
   KeyPairs ->
   Coin ->
   Gen (Maybe (TxCert era, CertCred era))
@@ -419,7 +422,7 @@ genRegPool poolKeys keyPairs minPoolCost = do
 genRetirePool ::
   (EraPParams era, EraTxCert era) =>
   PParams era ->
-  [AllIssuerKeys MockCrypto 'StakePool] ->
+  [AllIssuerKeys c 'StakePool] ->
   PState era ->
   SlotNo ->
   Gen (Maybe (TxCert era, CertCred era))
@@ -457,7 +460,7 @@ genInstantaneousRewardsAccounts ::
   (EraPParams era, ShelleyEraTxCert era, ProtVerAtMost era 8) =>
   SlotNo ->
   -- | Index over the cold key hashes of all possible Genesis Delegates
-  Map (KeyHash 'GenesisDelegate) (AllIssuerKeys MockCrypto 'GenesisDelegate) ->
+  Map (KeyHash 'GenesisDelegate) (AllIssuerKeys c 'GenesisDelegate) ->
   PParams era ->
   AccountState ->
   DState era ->
@@ -507,7 +510,7 @@ genInstantaneousRewardsTransfer ::
   (EraPParams era, ShelleyEraTxCert era, ProtVerAtMost era 8) =>
   SlotNo ->
   -- | Index over the cold key hashes of all possible Genesis Delegates
-  Map (KeyHash 'GenesisDelegate) (AllIssuerKeys MockCrypto 'GenesisDelegate) ->
+  Map (KeyHash 'GenesisDelegate) (AllIssuerKeys c 'GenesisDelegate) ->
   PParams era ->
   AccountState ->
   DState era ->
@@ -544,7 +547,7 @@ genInstantaneousRewards ::
   (EraPParams era, ShelleyEraTxCert era, ProtVerAtMost era 8) =>
   SlotNo ->
   -- | Index over the cold key hashes of all possible Genesis Delegates
-  Map (KeyHash 'GenesisDelegate) (AllIssuerKeys MockCrypto 'GenesisDelegate) ->
+  Map (KeyHash 'GenesisDelegate) (AllIssuerKeys c 'GenesisDelegate) ->
   PParams era ->
   AccountState ->
   DState era ->

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Update.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Update.hs
@@ -320,8 +320,8 @@ genUpdate ::
   EraGen era =>
   Constants ->
   SlotNo ->
-  [(GenesisKeyPair MockCrypto, AllIssuerKeys MockCrypto 'GenesisDelegate)] ->
-  Map (KeyHash 'GenesisDelegate) (AllIssuerKeys MockCrypto 'GenesisDelegate) ->
+  [(GenesisKeyPair c, AllIssuerKeys c 'GenesisDelegate)] ->
+  Map (KeyHash 'GenesisDelegate) (AllIssuerKeys c 'GenesisDelegate) ->
   PParams era ->
   (UTxOState era, CertState era) ->
   Gen (Maybe (Update era), [KeyPair 'Witness])

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
@@ -29,6 +29,7 @@ import qualified Test.Control.State.Transition.Trace.Generator.QuickCheck as QC
 import qualified Test.Cardano.Ledger.Shelley.ByronTranslation as ByronTranslation (
   testGroupByronTranslation,
  )
+import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (MockCrypto)
 import qualified Test.Cardano.Ledger.Shelley.Rules.AdaPreservation as AdaPreservation
 import qualified Test.Cardano.Ledger.Shelley.Rules.ClassifyTraces as ClassifyTraces (
   onlyValidChainSignalsAreGenerated,
@@ -55,8 +56,8 @@ commonTests ::
   forall era ledger.
   ( EraGen era
   , ChainProperty era
-  , QC.HasTrace (CHAIN era) (GenEnv era)
-  , QC.HasTrace ledger (GenEnv era)
+  , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
+  , QC.HasTrace ledger (GenEnv MockCrypto era)
   , Embed (EraRule "DELEGS" era) ledger
   , Embed (EraRule "UTXOW" era) ledger
   , Environment ledger ~ LedgerEnv era

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
@@ -114,7 +114,7 @@ tests ::
   ( EraGen era
   , TestingLedger era ledger
   , ChainProperty era
-  , QC.HasTrace (CHAIN era) (GenEnv era)
+  , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
   , GovState era ~ ShelleyGovState era
   ) =>
   Int ->
@@ -130,7 +130,7 @@ adaPreservationProps ::
   ( EraGen era
   , TestingLedger era ledger
   , ChainProperty era
-  , QC.HasTrace (CHAIN era) (GenEnv era)
+  , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
   , GovState era ~ ShelleyGovState era
   ) =>
   Property

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
@@ -102,7 +102,7 @@ relevantCasesAreCovered ::
   forall era.
   ( EraGen era
   , ChainProperty era
-  , QC.HasTrace (CHAIN era) (GenEnv era)
+  , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
   ) =>
   Int ->
   TestTree
@@ -115,11 +115,16 @@ relevantCasesAreCovered n =
       let tl = 100
       checkCoverageWith stdConfidence {certainty = 1_000_000} $
         forAllBlind
-          (traceFromInitState @(CHAIN era) testGlobals tl (genEnv p defaultConstants) genesisChainSt)
+          ( traceFromInitState @(CHAIN era)
+              testGlobals
+              tl
+              (genEnv @era @MockCrypto p defaultConstants)
+              genesisChainSt
+          )
           relevantCasesAreCoveredForTrace
     p :: Proxy era
     p = Proxy
-    genesisChainSt = Just $ mkGenesisChainState (genEnv p defaultConstants)
+    genesisChainSt = Just $ mkGenesisChainState (genEnv @era @MockCrypto p defaultConstants)
 
 relevantCasesAreCoveredForTrace ::
   forall era.
@@ -298,7 +303,7 @@ hasMetadata tx = f (tx ^. bodyTxL . auxDataHashTxBodyL)
 onlyValidLedgerSignalsAreGenerated ::
   forall era ledger.
   ( EraGen era
-  , QC.HasTrace ledger (GenEnv era)
+  , QC.HasTrace ledger (GenEnv MockCrypto era)
   , QC.BaseEnv ledger ~ Globals
   , State ledger ~ LedgerState era
   , Show (Environment ledger)
@@ -319,7 +324,7 @@ onlyValidLedgerSignalsAreGenerated =
           genesisLedgerSt
     p :: Proxy era
     p = Proxy
-    ge = genEnv p defaultConstants
+    ge = genEnv @era @MockCrypto p defaultConstants
     genesisLedgerSt = Just $ mkGenesisLedgerState ge
 
 -- | Check that the abstract transaction size function
@@ -327,7 +332,7 @@ onlyValidLedgerSignalsAreGenerated =
 propAbstractSizeBoundsBytes ::
   forall era.
   ( EraGen era
-  , QC.HasTrace (ShelleyLEDGER era) (GenEnv era)
+  , QC.HasTrace (ShelleyLEDGER era) (GenEnv MockCrypto era)
   , EraGov era
   ) =>
   Property
@@ -337,7 +342,7 @@ propAbstractSizeBoundsBytes = property $ do
   forAllTraceFromInitState @(ShelleyLEDGER era)
     testGlobals
     tl
-    (genEnv p defaultConstants)
+    (genEnv @era @MockCrypto p defaultConstants)
     genesisLedgerSt
     $ \tr -> do
       let txs :: [Tx era]
@@ -346,14 +351,14 @@ propAbstractSizeBoundsBytes = property $ do
   where
     p :: Proxy era
     p = Proxy
-    genesisLedgerSt = Just $ mkGenesisLedgerState (genEnv p defaultConstants)
+    genesisLedgerSt = Just $ mkGenesisLedgerState (genEnv @era @MockCrypto p defaultConstants)
 
 -- | Check that the abstract transaction size function
 -- is not off by an acceptable order of magnitude.
 propAbstractSizeNotTooBig ::
   forall era.
   ( EraGen era
-  , QC.HasTrace (ShelleyLEDGER era) (GenEnv era)
+  , QC.HasTrace (ShelleyLEDGER era) (GenEnv MockCrypto era)
   , EraGov era
   ) =>
   Property
@@ -370,7 +375,7 @@ propAbstractSizeNotTooBig = property $ do
   forAllTraceFromInitState @(ShelleyLEDGER era)
     testGlobals
     tl
-    (genEnv p defaultConstants)
+    (genEnv @era @MockCrypto p defaultConstants)
     genesisLedgerSt
     $ \tr -> do
       let txs :: [Tx era]
@@ -379,12 +384,12 @@ propAbstractSizeNotTooBig = property $ do
   where
     p :: Proxy era
     p = Proxy
-    genesisLedgerSt = Just $ mkGenesisLedgerState (genEnv p defaultConstants)
+    genesisLedgerSt = Just $ mkGenesisLedgerState (genEnv @era @MockCrypto p defaultConstants)
 
 onlyValidChainSignalsAreGenerated ::
   forall era.
   ( EraGen era
-  , QC.HasTrace (CHAIN era) (GenEnv era)
+  , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
   , EraGov era
   ) =>
   TestTree
@@ -396,11 +401,11 @@ onlyValidChainSignalsAreGenerated =
         onlyValidSignalsAreGeneratedFromInitState @(CHAIN era)
           testGlobals
           100
-          (genEnv p defaultConstants)
+          (genEnv @era @MockCrypto p defaultConstants)
           genesisChainSt
     p :: Proxy era
     p = Proxy
-    genesisChainSt = Just (mkGenesisChainState (genEnv p defaultConstants))
+    genesisChainSt = Just (mkGenesisChainState (genEnv @era @MockCrypto p defaultConstants))
 
 -- | Counts the epochs spanned by this trace
 epochsInTrace :: forall era. [Block (BHeader MockCrypto) era] -> Int

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/CollisionFreeness.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/CollisionFreeness.hs
@@ -27,6 +27,7 @@ import Data.Proxy
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Lens.Micro hiding (ix)
+import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (MockCrypto)
 import Test.Cardano.Ledger.Shelley.Constants (defaultConstants)
 import Test.Cardano.Ledger.Shelley.Generator.Core (GenEnv)
 import Test.Cardano.Ledger.Shelley.Generator.EraGen (EraGen (..))
@@ -63,7 +64,7 @@ tests ::
   ( EraGen era
   , ChainProperty era
   , TestingLedger era ledger
-  , QC.HasTrace (CHAIN era) (GenEnv era)
+  , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
   ) =>
   TestTree
 tests =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Deleg.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Deleg.hs
@@ -32,6 +32,7 @@ import Data.Foldable as F (foldl')
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Lens.Micro.Extras (view)
+import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (MockCrypto)
 import Test.Cardano.Ledger.Shelley.Constants (defaultConstants)
 import Test.Cardano.Ledger.Shelley.Generator.Core (GenEnv)
 import Test.Cardano.Ledger.Shelley.Generator.EraGen (EraGen (..))
@@ -64,7 +65,7 @@ import Test.Tasty.QuickCheck (testProperty)
 tests ::
   forall era.
   ( EraGen era
-  , QC.HasTrace (CHAIN era) (GenEnv era)
+  , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
   , ChainProperty era
   ) =>
   TestTree

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Deposits.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Deposits.hs
@@ -47,6 +47,7 @@ import Test.Control.State.Transition.Trace (
 import qualified Test.Control.State.Transition.Trace.Generator.QuickCheck as QC
 
 import Test.Cardano.Ledger.Binary.TreeDiff (ansiDocToString, diffExpr)
+import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (MockCrypto)
 import Test.QuickCheck (
   Property,
   counterexample,
@@ -60,7 +61,7 @@ tests ::
   forall era.
   ( EraGen era
   , EraGov era
-  , QC.HasTrace (CHAIN era) (GenEnv era)
+  , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
   ) =>
   TestTree
 tests =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/IncrementalStake.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/IncrementalStake.hs
@@ -51,6 +51,7 @@ import qualified Data.Map.Strict as Map
 import Data.Proxy
 import qualified Data.VMap as VMap
 import Lens.Micro hiding (ix)
+import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (MockCrypto)
 import Test.Cardano.Ledger.Shelley.Constants (defaultConstants)
 import Test.Cardano.Ledger.Shelley.Generator.Core (GenEnv)
 import Test.Cardano.Ledger.Shelley.Generator.EraGen (EraGen (..))
@@ -79,7 +80,7 @@ incrStakeComputationTest ::
   ( EraGen era
   , TestingLedger era ledger
   , ChainProperty era
-  , QC.HasTrace (CHAIN era) (GenEnv era)
+  , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
   ) =>
   TestTree
 incrStakeComputationTest =
@@ -142,7 +143,7 @@ incrStakeComp SourceSignalTarget {source = chainSt, signal = block} =
 incrStakeComparisonTest ::
   forall era.
   ( EraGen era
-  , QC.HasTrace (CHAIN era) (GenEnv era)
+  , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
   , EraGov era
   ) =>
   Proxy era ->

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -50,6 +50,7 @@ import Test.Control.State.Transition.Trace (
 import qualified Test.Control.State.Transition.Trace.Generator.QuickCheck as QC
 import Test.QuickCheck (Property, conjoin, counterexample, (===))
 
+import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (MockCrypto)
 import Test.Cardano.Ledger.Shelley.Rules.TestChain (
   forAllChainTrace,
   poolTraceFromBlock,
@@ -71,7 +72,7 @@ tests ::
   forall era.
   ( EraGen era
   , ChainProperty era
-  , QC.HasTrace (CHAIN era) (GenEnv era)
+  , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
   ) =>
   TestTree
 tests =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/PoolReap.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/PoolReap.hs
@@ -38,6 +38,7 @@ import Cardano.Protocol.TPraos.BHeader (
 import Control.SetAlgebra (dom, eval, setSingleton, (∩), (⊆), (▷))
 import qualified Data.Set as Set
 import Lens.Micro ((^.))
+import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (MockCrypto)
 import Test.Cardano.Ledger.Shelley.Constants (defaultConstants)
 import Test.Cardano.Ledger.Shelley.Generator.Core (GenEnv)
 import Test.Cardano.Ledger.Shelley.Generator.EraGen (EraGen (..))
@@ -67,7 +68,7 @@ tests ::
   forall era.
   ( ChainProperty era
   , EraGen era
-  , QC.HasTrace (CHAIN era) (GenEnv era)
+  , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
   ) =>
   TestTree
 tests =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -125,7 +125,7 @@ type TestingLedger era ledger =
 shortChainTrace ::
   forall era.
   ( EraGen era
-  , QC.HasTrace (CHAIN era) (GenEnv era)
+  , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
   , EraGov era
   ) =>
   Constants ->
@@ -293,7 +293,7 @@ forAllChainTrace ::
   forall era prop.
   ( Testable prop
   , EraGen era
-  , QC.HasTrace (CHAIN era) (GenEnv era)
+  , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
   , EraGov era
   ) =>
   Word64 -> -- trace length
@@ -305,8 +305,8 @@ forAllChainTrace n constants prop =
     forAllTraceFromInitState
       testGlobals
       n
-      (Preset.genEnv p constants)
-      (Just $ mkGenesisChainState (Preset.genEnv p constants))
+      (Preset.genEnv @era @MockCrypto p constants)
+      (Just $ mkGenesisChainState (Preset.genEnv @era @MockCrypto p constants))
       prop
   where
     p :: Proxy era
@@ -317,8 +317,8 @@ forEachEpochTrace ::
   forall era prop.
   ( EraGen era
   , Testable prop
-  , QC.HasTrace (CHAIN era) (GenEnv era)
   , EraGov era
+  , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
   ) =>
   Int ->
   Word64 ->

--- a/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
+++ b/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
@@ -79,7 +79,7 @@ library
     cardano-ledger-core:testlib,
     cardano-ledger-executable-spec,
     cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
-    cardano-ledger-shelley-test >=1.6,
+    cardano-ledger-shelley-test,
     cardano-ledger-test,
     cardano-strict-containers,
     constrained-generators,

--- a/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
+++ b/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
@@ -79,7 +79,7 @@ library
     cardano-ledger-core:testlib,
     cardano-ledger-executable-spec,
     cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
-    cardano-ledger-shelley-test,
+    cardano-ledger-shelley-test >=1.6,
     cardano-ledger-test,
     cardano-strict-containers,
     constrained-generators,

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx.hs
@@ -38,6 +38,7 @@ import Data.Typeable (typeRep)
 import Test.Cardano.Ledger.Alonzo.AlonzoEraGen ()
 import Test.Cardano.Ledger.Alonzo.Trace ()
 import Test.Cardano.Ledger.MaryEraGen ()
+import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (MockCrypto)
 import Test.Cardano.Ledger.Shelley.Generator.Core (GenEnv)
 import Test.Cardano.Ledger.Shelley.Generator.EraGen (EraGen)
 import Test.Control.State.Transition.Trace.Generator.QuickCheck (BaseEnv, HasTrace)
@@ -59,7 +60,7 @@ benchmarkSeed = 24601
 benchWithGenState ::
   ( NFData a
   , EraGen era
-  , HasTrace (EraRule "LEDGER" era) (GenEnv era)
+  , HasTrace (EraRule "LEDGER" era) (GenEnv MockCrypto era)
   , BaseEnv (EraRule "LEDGER" era) ~ Globals
   , Signal (EraRule "LEDGER" era) ~ Tx era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
@@ -77,7 +78,7 @@ benchApplyTx ::
   forall era.
   ( EraGen era
   , ApplyTx era
-  , HasTrace (EraRule "LEDGER" era) (GenEnv era)
+  , HasTrace (EraRule "LEDGER" era) (GenEnv MockCrypto era)
   , BaseEnv (EraRule "LEDGER" era) ~ Globals
   , Signal (EraRule "LEDGER" era) ~ Tx era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
@@ -108,7 +109,7 @@ deserialiseTxEra ::
   forall era.
   ( EraGen era
   , BaseEnv (EraRule "LEDGER" era) ~ Globals
-  , HasTrace (EraRule "LEDGER" era) (GenEnv era)
+  , HasTrace (EraRule "LEDGER" era) (GenEnv MockCrypto era)
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , Signal (EraRule "LEDGER" era) ~ Tx era

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx/Gen.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx/Gen.hs
@@ -24,6 +24,7 @@ import Control.State.Transition (Environment, Signal, State)
 import Data.Proxy (Proxy)
 import GHC.Generics (Generic)
 import Test.Cardano.Ledger.AllegraEraGen ()
+import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (MockCrypto)
 import Test.Cardano.Ledger.Shelley.Constants (defaultConstants)
 import Test.Cardano.Ledger.Shelley.Generator.Core (GenEnv (..))
 import Test.Cardano.Ledger.Shelley.Generator.EraGen (EraGen)
@@ -70,7 +71,7 @@ instance NFData (ApplyTxEnv era) where
 generateApplyTxEnvForEra ::
   forall era.
   ( EraGen era
-  , HasTrace (EraRule "LEDGER" era) (GenEnv era)
+  , HasTrace (EraRule "LEDGER" era) (GenEnv MockCrypto era)
   , BaseEnv (EraRule "LEDGER" era) ~ Globals
   , Signal (EraRule "LEDGER" era) ~ Tx era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
@@ -81,7 +82,7 @@ generateApplyTxEnvForEra ::
   Int ->
   ApplyTxEnv era
 generateApplyTxEnvForEra eraProxy seed =
-  let ge = genEnv eraProxy defaultConstants
+  let ge = genEnv @era @MockCrypto eraProxy defaultConstants
       qcSeed = mkQCGen seed
       traceGen =
         traceFromInitState

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -143,7 +143,7 @@ library
     cardano-ledger-mary,
     cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
     cardano-ledger-shelley-ma-test,
-    cardano-ledger-shelley-test,
+    cardano-ledger-shelley-test >=1.6,
     cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib},
     cardano-slotting:{cardano-slotting, testlib},
     cardano-strict-containers,

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -143,7 +143,7 @@ library
     cardano-ledger-mary,
     cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
     cardano-ledger-shelley-ma-test,
-    cardano-ledger-shelley-test >=1.6,
+    cardano-ledger-shelley-test,
     cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib},
     cardano-slotting:{cardano-slotting, testlib},
     cardano-strict-containers,


### PR DESCRIPTION
# Description

Change:
- `KeySpace era` to `KeySpace c era`, and
- `GenEnv era` to `GenEnv c era`.
- Make the rest of the project compile, judiciously using `MockCrypto` to specialize where necessary.

Why:
The `test-suite` package from `cardano-ledger-shelley` exports some functions and data-types that are used by `ouroboros-consensus-cardano` package to write tests. These functions and data-types were monomorphic to `MockCrypto` from `cardano-ledger` while the ones from `ouroboros-consensus-cardano` need those to be monomorphic to `MockCrypto` from `ouroboros-consensus-cardano`. So we need to parameterize these data-types to make them reusable. This in another one of the many changes necessary to propogate the removal of the `EraCrypto` type-class from `cardano-ledger` into `ouroboros-consensus` and further downstream.

# Checklist

- [x] Commits in meaningful sequence and with useful messages
- [ ] ~~Tests added or updated when needed~~
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [ ] ~~Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).~~
- [x] Version bounds in `.cabal` files updated when necessary
      **NOTE: _If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] Code formatted (use `scripts/fourmolize.sh`)
- [x] Cabal files formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
