### PR TITLE
Remove old tests already implemented in `Alonzo.Imp.UtxowSpec.Valid`

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoValidTxUTXOW.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoValidTxUTXOW.hs
@@ -14,21 +14,16 @@
 
 module Test.Cardano.Ledger.Examples.AlonzoValidTxUTXOW (tests, mkSingleRedeemer) where
 
-import Cardano.Ledger.Address (RewardAccount (..))
-import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
 import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
 import Cardano.Ledger.Alonzo.TxWits (Redeemers (..))
 import Cardano.Ledger.BaseTypes (
-  Network (..),
   ProtVer (..),
-  StrictMaybe (..),
   TxIx,
   mkTxIxPartial,
   natVersion,
  )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Credential (Credential (..), StakeCredential)
-import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..))
 import Cardano.Ledger.Plutus.Data (Data (..), hashData)
 import Cardano.Ledger.Plutus.Language (Language (..))
 import Cardano.Ledger.Shelley.Core
@@ -38,8 +33,7 @@ import Cardano.Ledger.Shelley.LedgerState (
  )
 import Cardano.Ledger.State
 import Cardano.Ledger.TxIn (TxIn (..))
-import Cardano.Ledger.Val (Val (..), inject, (<+>))
-import Cardano.Slotting.Slot (SlotNo (..))
+import Cardano.Ledger.Val (inject)
 import Control.State.Transition.Extended hiding (Assertion)
 import Data.Default (Default (..))
 import Data.List.NonEmpty (NonEmpty)
@@ -48,7 +42,6 @@ import GHC.Stack
 import qualified PlutusLedgerApi.V1 as PV1
 import Test.Cardano.Ledger.Core.KeyPair (mkWitnessVKey)
 import Test.Cardano.Ledger.Examples.STSTestUtils (
-  alwaysFailsHash,
   alwaysSucceedsHash,
   initUTxO,
   mkGenesisTxIn,
@@ -57,8 +50,6 @@ import Test.Cardano.Ledger.Examples.STSTestUtils (
   someKeys,
   someScriptAddr,
   testUTXOW,
-  timelockScript,
-  timelockStakeCred,
   trustMeP,
  )
 import Test.Cardano.Ledger.Generic.Fields (
@@ -73,10 +64,9 @@ import Test.Cardano.Ledger.Generic.GenState (
   mkRedeemers,
   mkRedeemersFromTags,
  )
-import Test.Cardano.Ledger.Generic.Indexed (theKeyPair)
 import Test.Cardano.Ledger.Generic.PrettyCore ()
 import Test.Cardano.Ledger.Generic.Proof
-import Test.Cardano.Ledger.Generic.Scriptic (HasTokens (..), PostShelley, Scriptic (..))
+import Test.Cardano.Ledger.Generic.Scriptic (PostShelley, Scriptic (..))
 import Test.Cardano.Ledger.Generic.Updaters
 import Test.Cardano.Ledger.Plutus (zeroTestingCostModels)
 import Test.Tasty (TestTree, testGroup)
@@ -94,10 +84,8 @@ tests =
 alonzoUTXOWTests ::
   forall era.
   ( State (EraRule "UTXOW" era) ~ UTxOState era
-  , HasTokens era
   , Reflect era
   , PostShelley era -- MAYBE WE CAN REPLACE THIS BY GoodCrypto,
-  , Value era ~ MaryValue
   ) =>
   Proof era ->
   TestTree
@@ -106,52 +94,7 @@ alonzoUTXOWTests pf =
     (show pf ++ " UTXOW examples")
     [ testGroup
         "valid transactions"
-        [ testCase "validating SPEND script" $
-            testU
-              pf
-              (trustMeP pf True $ validatingTx pf)
-              (Right . validatingState $ pf)
-        , testCase "not validating SPEND script" $
-            testU
-              pf
-              (trustMeP pf False $ notValidatingTx pf)
-              (Right . notValidatingState $ pf)
-        , testCase "validating CERT script" $
-            testU
-              pf
-              (trustMeP pf True $ validatingWithCertTx pf)
-              (Right . validatingWithCertState $ pf)
-        , testCase "not validating CERT script" $
-            testU
-              pf
-              (trustMeP pf False $ notValidatingWithCertTx pf)
-              (Right . notValidatingWithCertState $ pf)
-        , testCase "validating WITHDRAWAL script" $
-            testU
-              pf
-              (trustMeP pf True $ validatingWithWithdrawalTx pf)
-              (Right . validatingWithWithdrawalState $ pf)
-        , testCase "not validating WITHDRAWAL script" $
-            testU
-              pf
-              (trustMeP pf False $ notValidatingTxWithWithdrawal pf)
-              (Right . notValidatingWithWithdrawalState $ pf)
-        , testCase "validating MINT script" $
-            testU
-              pf
-              (trustMeP pf True $ validatingWithMintTx pf)
-              (Right . validatingWithMintState $ pf)
-        , testCase "not validating MINT script" $
-            testU
-              pf
-              (trustMeP pf False $ notValidatingWithMintTx pf)
-              (Right . notValidatingWithMintState $ pf)
-        , testCase "validating scripts everywhere" $
-            testU
-              pf
-              (trustMeP pf True $ validatingManyScriptsTx pf)
-              (Right . validatingManyScriptsState $ pf)
-        , testCase "acceptable supplimentary datum" $
+        [ testCase "acceptable supplimentary datum" $
             testU
               pf
               (trustMeP pf True $ validatingSupplimentaryDatumTx pf)
@@ -171,586 +114,6 @@ alonzoUTXOWTests pf =
 
 -- =========================================================================
 -- ============================== DATA ========================================
-
--- =========================================================================
---  Example 1: Process a SPEND transaction with a succeeding Plutus script.
--- =========================================================================
-
-validatingTx ::
-  forall era.
-  ( Scriptic era
-  , EraTx era
-  ) =>
-  Proof era ->
-  Tx era
-validatingTx pf =
-  newTx
-    pf
-    [ Body (validatingBody pf)
-    , WitnessesI
-        [ AddrWits' [mkWitnessVKey (hashAnnotated (validatingBody pf)) (someKeys pf)]
-        , ScriptWits' [always 3 pf]
-        , DataWits' [Data (PV1.I 123)]
-        , RdmrWits $ validatingRedeemers pf
-        ]
-    ]
-
-validatingBody :: (Scriptic era, EraTxBody era) => Proof era -> TxBody era
-validatingBody pf =
-  newTxBody
-    pf
-    [ Inputs' [mkGenesisTxIn 1]
-    , Collateral' [mkGenesisTxIn 11]
-    , Outputs' [validatingTxOut pf]
-    , Txfee (Coin 5)
-    , WppHash
-        ( newScriptIntegrityHash
-            pf
-            (pp pf)
-            [PlutusV1]
-            (validatingRedeemers pf)
-            (mkTxDats (Data (PV1.I 123)))
-        )
-    ]
-
-validatingRedeemers :: Era era => Proof era -> Redeemers era
-validatingRedeemers proof = mkSingleRedeemer proof Spending (Data (PV1.I 42))
-
-validatingTxOut :: EraTxOut era => Proof era -> TxOut era
-validatingTxOut pf = newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 4995)]
-
-validatingState ::
-  forall era.
-  ( EraTxBody era
-  , PostShelley era
-  , EraStake era
-  , EraGov era
-  ) =>
-  Proof era ->
-  UTxOState era
-validatingState pf = smartUTxOState (pp pf) utxo (Coin 0) (Coin 5) def mempty
-  where
-    utxo = expectedUTxO' pf (ExpectSuccess (validatingBody pf) (validatingTxOut pf)) 1
-
--- ======================================================================
---  Example 2: Process a SPEND transaction with a failing Plutus script.
--- ======================================================================
-datumExample2 :: Era era => Data era
-datumExample2 = Data (PV1.I 0)
-
-notValidatingTx ::
-  ( Scriptic era
-  , EraTx era
-  ) =>
-  Proof era ->
-  Tx era
-notValidatingTx pf =
-  newTx
-    pf
-    [ Body body
-    , WitnessesI
-        [ AddrWits' [mkWitnessVKey (hashAnnotated body) (someKeys pf)]
-        , ScriptWits' [never 0 pf]
-        , DataWits' [datumExample2]
-        , RdmrWits redeemers
-        ]
-    ]
-  where
-    body =
-      newTxBody
-        pf
-        [ Inputs' [mkGenesisTxIn 2]
-        , Collateral' [mkGenesisTxIn 12]
-        , Outputs' [newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 2995)]]
-        , Txfee (Coin 5)
-        , WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] redeemers (mkTxDats datumExample2))
-        ]
-    redeemers = mkSingleRedeemer pf Spending (Data (PV1.I 1))
-
-notValidatingState ::
-  ( EraTxBody era
-  , PostShelley era
-  , EraStake era
-  , EraGov era
-  ) =>
-  Proof era ->
-  UTxOState era
-notValidatingState pf = smartUTxOState (pp pf) (expectedUTxO' pf ExpectFailure 2) (Coin 0) (Coin 5) def mempty
-
--- =========================================================================
---  Example 3: Process a CERT transaction with a succeeding Plutus script.
--- =========================================================================
-
-validatingWithCertTx ::
-  forall era.
-  ( Scriptic era
-  , EraTx era
-  , ShelleyEraTxCert era
-  ) =>
-  Proof era ->
-  Tx era
-validatingWithCertTx pf =
-  newTx
-    pf
-    [ Body (validatingWithCertBody pf)
-    , WitnessesI
-        [ AddrWits' [mkWitnessVKey (hashAnnotated (validatingWithCertBody pf)) (someKeys pf)]
-        , ScriptWits' [always 2 pf]
-        , RdmrWits $ validatingWithCertRedeemers pf
-        ]
-    ]
-
-validatingWithCertBody ::
-  (Scriptic era, EraTxBody era, ShelleyEraTxCert era) => Proof era -> TxBody era
-validatingWithCertBody pf =
-  newTxBody
-    pf
-    [ Inputs' [mkGenesisTxIn 3]
-    , Collateral' [mkGenesisTxIn 13]
-    , Outputs' [validatingWithCertTxOut pf]
-    , Certs' [UnRegTxCert (scriptStakeCredSuceed pf)]
-    , Txfee (Coin 5)
-    , WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] (validatingWithCertRedeemers pf) mempty)
-    ]
-
-validatingWithCertTxOut :: EraTxOut era => Proof era -> TxOut era
-validatingWithCertTxOut pf = newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 995)]
-
-validatingWithCertRedeemers :: Era era => Proof era -> Redeemers era
-validatingWithCertRedeemers proof = mkSingleRedeemer proof Certifying (Data (PV1.I 42))
-
-validatingWithCertState ::
-  ( EraTxBody era
-  , PostShelley era
-  , EraGov era
-  , EraStake era
-  , ShelleyEraTxCert era
-  ) =>
-  Proof era ->
-  UTxOState era
-validatingWithCertState pf = smartUTxOState (pp pf) utxo (Coin 0) (Coin 5) def mempty
-  where
-    utxo = expectedUTxO' pf (ExpectSuccess (validatingWithCertBody pf) (validatingWithCertTxOut pf)) 3
-
--- =====================================================================
---  Example 4: Process a CERT transaction with a failing Plutus script.
--- =====================================================================
-
-notValidatingWithCertTx ::
-  forall era.
-  ( Scriptic era
-  , EraTx era
-  , ShelleyEraTxCert era
-  ) =>
-  Proof era ->
-  Tx era
-notValidatingWithCertTx pf =
-  newTx
-    pf
-    [ Body body
-    , WitnessesI
-        [ AddrWits' [mkWitnessVKey (hashAnnotated body) (someKeys pf)]
-        , ScriptWits' [never 1 pf]
-        , RdmrWits redeemers
-        ]
-    ]
-  where
-    body =
-      newTxBody
-        pf
-        [ Inputs' [mkGenesisTxIn 4]
-        , Collateral' [mkGenesisTxIn 14]
-        , Outputs' [newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 995)]]
-        , Certs' [UnRegTxCert (scriptStakeCredFail pf)]
-        , Txfee (Coin 5)
-        , WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] redeemers mempty)
-        ]
-    redeemers = mkSingleRedeemer pf Certifying (Data (PV1.I 0))
-
-notValidatingWithCertState ::
-  ( EraTxBody era
-  , PostShelley era
-  , EraStake era
-  , EraGov era
-  ) =>
-  Proof era ->
-  UTxOState era
-notValidatingWithCertState pf =
-  smartUTxOState
-    (pp pf)
-    (expectedUTxO' pf ExpectFailure 4)
-    (Coin 0)
-    (Coin 5)
-    def
-    mempty
-
--- ==============================================================================
---  Example 5: Process a WITHDRAWAL transaction with a succeeding Plutus script.
--- ==============================================================================
-
-validatingWithWithdrawalTx ::
-  forall era.
-  ( Scriptic era
-  , EraTx era
-  ) =>
-  Proof era ->
-  Tx era
-validatingWithWithdrawalTx pf =
-  newTx
-    pf
-    [ Body (validatingWithWithdrawalBody pf)
-    , WitnessesI
-        [ AddrWits' [mkWitnessVKey (hashAnnotated (validatingWithWithdrawalBody pf)) (someKeys pf)]
-        , ScriptWits' [always 2 pf]
-        , RdmrWits $ validatingWithWithdrawalRedeemers pf
-        ]
-    ]
-
-validatingWithWithdrawalBody :: (EraTxBody era, Scriptic era) => Proof era -> TxBody era
-validatingWithWithdrawalBody pf =
-  newTxBody
-    pf
-    [ Inputs' [mkGenesisTxIn 5]
-    , Collateral' [mkGenesisTxIn 15]
-    , Outputs' [validatingWithWithdrawalTxOut pf]
-    , Txfee (Coin 5)
-    , Withdrawals'
-        ( Withdrawals $
-            Map.singleton
-              (RewardAccount Testnet (scriptStakeCredSuceed pf))
-              (Coin 1000)
-        )
-    , WppHash
-        ( newScriptIntegrityHash
-            pf
-            (pp pf)
-            [PlutusV1]
-            (validatingWithWithdrawalRedeemers pf)
-            mempty
-        )
-    ]
-
-validatingWithWithdrawalRedeemers :: Era era => Proof era -> Redeemers era
-validatingWithWithdrawalRedeemers pf = mkSingleRedeemer pf Rewarding (Data (PV1.I 42))
-
-validatingWithWithdrawalTxOut :: EraTxOut era => Proof era -> TxOut era
-validatingWithWithdrawalTxOut pf = newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 1995)]
-
-validatingWithWithdrawalState ::
-  (EraTxBody era, EraStake era, PostShelley era, EraGov era) =>
-  Proof era ->
-  UTxOState era
-validatingWithWithdrawalState pf =
-  smartUTxOState
-    (pp pf)
-    utxo
-    (Coin 0)
-    (Coin 5)
-    def
-    mempty
-  where
-    utxo =
-      expectedUTxO'
-        pf
-        (ExpectSuccess (validatingWithWithdrawalBody pf) (validatingWithWithdrawalTxOut pf))
-        5
-
--- ===========================================================================
---  Example 6: Process a WITHDRAWAL transaction with a failing Plutus script.
--- ===========================================================================
-
-notValidatingTxWithWithdrawal ::
-  forall era.
-  ( Scriptic era
-  , EraTx era
-  ) =>
-  Proof era ->
-  Tx era
-notValidatingTxWithWithdrawal pf =
-  newTx
-    pf
-    [ Body body
-    , WitnessesI
-        [ AddrWits' [mkWitnessVKey (hashAnnotated body) (someKeys pf)]
-        , ScriptWits' [never 1 pf]
-        , RdmrWits redeemers
-        ]
-    ]
-  where
-    body =
-      newTxBody
-        pf
-        [ Inputs' [mkGenesisTxIn 6]
-        , Collateral' [mkGenesisTxIn 16]
-        , Outputs' [newTxOut pf [Address (someAddr pf), Amount (inject $ Coin 1995)]]
-        , Txfee (Coin 5)
-        , Withdrawals'
-            ( Withdrawals $
-                Map.singleton
-                  (RewardAccount Testnet (scriptStakeCredFail pf))
-                  (Coin 1000)
-            )
-        , WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] redeemers mempty)
-        ]
-    redeemers = mkSingleRedeemer pf Rewarding (Data (PV1.I 0))
-
-notValidatingWithWithdrawalState ::
-  (EraTxBody era, EraStake era, PostShelley era, EraGov era) =>
-  Proof era ->
-  UTxOState era
-notValidatingWithWithdrawalState pf =
-  smartUTxOState
-    (pp pf)
-    (expectedUTxO' pf ExpectFailure 6)
-    (Coin 0)
-    (Coin 5)
-    def
-    mempty
-
--- =============================================================================
---  Example 7: Process a MINT transaction with a succeeding Plutus script.
--- =============================================================================
-
-validatingWithMintTx ::
-  forall era.
-  ( Scriptic era
-  , HasTokens era
-  , EraTx era
-  , Value era ~ MaryValue
-  ) =>
-  Proof era ->
-  Tx era
-validatingWithMintTx pf =
-  newTx
-    pf
-    [ Body (validatingWithMintBody pf)
-    , WitnessesI
-        [ AddrWits' [mkWitnessVKey (hashAnnotated (validatingWithMintBody pf)) (someKeys pf)]
-        , ScriptWits' [always 2 pf]
-        , RdmrWits $ validatingWithMintRedeemers pf
-        ]
-    ]
-
-validatingWithMintBody ::
-  (HasTokens era, EraTxBody era, Scriptic era, Value era ~ MaryValue) =>
-  Proof era ->
-  TxBody era
-validatingWithMintBody pf =
-  newTxBody
-    pf
-    [ Inputs' [mkGenesisTxIn 7]
-    , Collateral' [mkGenesisTxIn 17]
-    , Outputs' [validatingWithMintTxOut pf]
-    , Txfee (Coin 5)
-    , Mint (multiAsset pf)
-    , WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] (validatingWithMintRedeemers pf) mempty)
-    ]
-
-validatingWithMintRedeemers :: Era era => Proof era -> Redeemers era
-validatingWithMintRedeemers pf = mkSingleRedeemer pf Minting (Data (PV1.I 42))
-
-multiAsset :: forall era. (Scriptic era, HasTokens era) => Proof era -> MultiAsset
-multiAsset pf = forge @era 1 (always 2 pf)
-
-validatingWithMintTxOut ::
-  ( HasTokens era
-  , Scriptic era
-  , Value era ~ MaryValue
-  ) =>
-  Proof era ->
-  TxOut era
-validatingWithMintTxOut pf =
-  newTxOut pf [Address (someAddr pf), Amount (MaryValue mempty (multiAsset pf) <+> inject (Coin 995))]
-
-validatingWithMintState ::
-  forall era.
-  (PostShelley era, EraStake era, EraTxBody era, HasTokens era, Value era ~ MaryValue, EraGov era) =>
-  Proof era ->
-  UTxOState era
-validatingWithMintState pf =
-  smartUTxOState
-    (pp pf)
-    utxo
-    (Coin 0)
-    (Coin 5)
-    def
-    mempty
-  where
-    utxo = expectedUTxO' pf (ExpectSuccess (validatingWithMintBody pf) (validatingWithMintTxOut pf)) 7
-
--- ==============================================================================
---  Example 8: Process a MINT transaction with a failing Plutus script.
--- ==============================================================================
-
-notValidatingWithMintTx ::
-  forall era.
-  ( Scriptic era
-  , HasTokens era
-  , EraTx era
-  , Value era ~ MaryValue
-  ) =>
-  Proof era ->
-  Tx era
-notValidatingWithMintTx pf =
-  newTx
-    pf
-    [ Body body
-    , WitnessesI
-        [ AddrWits' [mkWitnessVKey (hashAnnotated body) (someKeys pf)]
-        , ScriptWits' [never 1 pf]
-        , RdmrWits redeemers
-        ]
-    ]
-  where
-    body =
-      newTxBody
-        pf
-        [ Inputs' [mkGenesisTxIn 8]
-        , Collateral' [mkGenesisTxIn 18]
-        , Outputs' [newTxOut pf [Address (someAddr pf), Amount (MaryValue mempty mint <+> inject (Coin 995))]]
-        , Txfee (Coin 5)
-        , Mint mint
-        , WppHash (newScriptIntegrityHash pf (pp pf) [PlutusV1] redeemers mempty)
-        ]
-    redeemers = mkSingleRedeemer pf Minting (Data (PV1.I 0))
-    mint = forge @era 1 (never 1 pf)
-
-notValidatingWithMintState ::
-  (EraTxBody era, PostShelley era, EraStake era, EraGov era) =>
-  Proof era ->
-  UTxOState era
-notValidatingWithMintState pf = smartUTxOState (pp pf) utxo (Coin 0) (Coin 5) def zero
-  where
-    utxo = expectedUTxO' pf ExpectFailure 8
-
--- ====================================================================================
---  Example 9: Process a transaction with a succeeding script in every place possible,
---  and also with succeeding timelock scripts.
--- ====================================================================================
-
-validatingManyScriptsTx ::
-  forall era.
-  ( PostShelley era
-  , HasTokens era
-  , EraTxBody era
-  , Value era ~ MaryValue
-  , ShelleyEraTxCert era
-  ) =>
-  Proof era ->
-  Tx era
-validatingManyScriptsTx pf =
-  newTx
-    pf
-    [ Body (validatingManyScriptsBody pf)
-    , WitnessesI
-        [ AddrWits' $
-            map
-              (mkWitnessVKey . hashAnnotated . validatingManyScriptsBody $ pf)
-              [someKeys pf, theKeyPair 1]
-        , ScriptWits'
-            [ always 2 pf
-            , always 3 pf
-            , timelockScript 0 pf
-            , timelockScript 1 pf
-            , timelockScript 2 pf
-            ]
-        , DataWits' [Data (PV1.I 123)]
-        , RdmrWits $ validatingManyScriptsRedeemers pf
-        ]
-    ]
-
-validatingManyScriptsBody ::
-  ( HasTokens era
-  , EraTxBody era
-  , PostShelley era
-  , Value era ~ MaryValue
-  , ShelleyEraTxCert era
-  ) =>
-  Proof era ->
-  TxBody era
-validatingManyScriptsBody pf =
-  newTxBody
-    pf
-    [ Inputs' [mkGenesisTxIn 1, mkGenesisTxIn 100]
-    , Collateral' [mkGenesisTxIn 11]
-    , Outputs' [validatingManyScriptsTxOut pf]
-    , Txfee (Coin 5)
-    , Certs'
-        [ UnRegTxCert (timelockStakeCred pf)
-        , UnRegTxCert (scriptStakeCredSuceed pf)
-        ]
-    , Withdrawals'
-        ( Withdrawals $
-            Map.fromList
-              [ (RewardAccount Testnet (scriptStakeCredSuceed pf), Coin 0)
-              , (RewardAccount Testnet (timelockStakeCred pf), Coin 0)
-              ]
-        )
-    , Mint (validatingManyScriptsMint pf)
-    , WppHash
-        ( newScriptIntegrityHash
-            pf
-            (pp pf)
-            [PlutusV1]
-            (validatingManyScriptsRedeemers pf)
-            (mkTxDats (Data (PV1.I 123)))
-        )
-    , Vldt (ValidityInterval SNothing (SJust $ SlotNo 1))
-    ]
-
-validatingManyScriptsRedeemers :: Era era => Proof era -> Redeemers era
-validatingManyScriptsRedeemers proof =
-  mkRedeemersFromTags
-    proof
-    [ ((Spending, 0), (Data (PV1.I 101), ExUnits 5000 5000))
-    , ((Certifying, 1), (Data (PV1.I 102), ExUnits 5000 5000))
-    , ((Rewarding, 0), (Data (PV1.I 103), ExUnits 5000 5000))
-    , ((Minting, 0), (Data (PV1.I 104), ExUnits 5000 5000))
-    ]
-
-validatingManyScriptsMint ::
-  forall era. (PostShelley era, HasTokens era) => Proof era -> MultiAsset
-validatingManyScriptsMint pf = forge @era 1 (always 2 pf) <> forge @era 1 (timelockScript 1 pf)
-
-validatingManyScriptsTxOut ::
-  (HasTokens era, PostShelley era, Value era ~ MaryValue) =>
-  Proof era ->
-  TxOut era
-validatingManyScriptsTxOut pf =
-  newTxOut
-    pf
-    [ Address (someAddr pf)
-    , Amount (MaryValue mempty (validatingManyScriptsMint pf) <+> inject (Coin 4996))
-    ]
-
-validatingManyScriptsState ::
-  forall era.
-  ( EraTxBody era
-  , PostShelley era
-  , HasTokens era
-  , Value era ~ MaryValue
-  , EraGov era
-  , EraStake era
-  , ShelleyEraTxCert era
-  ) =>
-  Proof era ->
-  UTxOState era
-validatingManyScriptsState pf =
-  smartUTxOState
-    (pp pf)
-    (UTxO utxo)
-    (Coin 0)
-    (Coin 5)
-    def
-    mempty
-  where
-    utxo =
-      Map.insert
-        (TxIn (txIdTxBody (validatingManyScriptsBody pf)) minBound)
-        (validatingManyScriptsTxOut pf)
-        $ Map.filterWithKey
-          (\k _ -> k /= mkGenesisTxIn 1 && k /= mkGenesisTxIn 100)
-          (unUTxO $ initUTxO pf)
 
 -- ====================================================================================
 --  Example 10: A transaction with an acceptable supplimentary datum
@@ -984,9 +347,6 @@ testU ::
   Either (NonEmpty (PredicateFailure (EraRule "UTXOW" era))) (State (EraRule "UTXOW" era)) ->
   Assertion
 testU pf = testUTXOW (UTXOW pf) (initUTxO pf) (pp pf)
-
-scriptStakeCredFail :: Scriptic era => Proof era -> StakeCredential
-scriptStakeCredFail pf = ScriptHashObj (alwaysFailsHash 1 pf)
 
 scriptStakeCredSuceed :: Scriptic era => Proof era -> StakeCredential
 scriptStakeCredSuceed pf = ScriptHashObj (alwaysSucceedsHash 2 pf)


### PR DESCRIPTION
# Description

These tests should have been removed a while ago

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
