### PR TITLE
Remove bytestring from `Block` type 

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
@@ -193,7 +193,7 @@ alonzoBbodyTransition =
     >>= \( TRC
             ( BbodyEnv pp account
               , BbodyState ls b
-              , UnserialisedBlock bh txsSeq
+              , Block bh txsSeq
               )
           ) -> do
         let txs = txSeqTxns txsSeq

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
@@ -278,7 +278,7 @@ conwayBbodyTransition = do
     >>= \( TRC
             ( _
               , state@(BbodyState ls _)
-              , UnserialisedBlock _ txsSeq
+              , Block _ txsSeq
               )
           ) -> do
         let utxo = utxosUtxo (lsUTxOState ls)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/BbodySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/BbodySpec.hs
@@ -92,7 +92,7 @@ spec = describe "BBODY" $ do
       tryRunImpRule @"BBODY"
         (BbodyEnv pp account)
         (BbodyState ls (BlocksMade Map.empty))
-        (UnsafeUnserialisedBlock bhView txSeq)
+        (Block bhView txSeq)
     predFailures
       `shouldBe` NE.fromList
         [ injectFailure

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Bbody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Bbody.hs
@@ -179,7 +179,7 @@ bbodyTransition =
     >>= \( TRC
             ( BbodyEnv pp account
               , BbodyState ls b
-              , UnserialisedBlock bhview txsSeq
+              , Block bhview txsSeq
               )
           ) -> do
         let txs = fromTxSeq txsSeq

--- a/eras/shelley/test-suite/bench/BenchValidation.hs
+++ b/eras/shelley/test-suite/bench/BenchValidation.hs
@@ -94,7 +94,7 @@ benchValidate ::
   ValidateInput era ->
   IO (NewEpochState era)
 benchValidate (ValidateInput globals state (Block bh txs)) =
-  let block = UnsafeUnserialisedBlock (makeHeaderView bh) txs
+  let block = Block (makeHeaderView bh) txs
    in case API.applyBlockEitherNoEvents ValidateAll globals state block of
         Right x -> pure x
         Left x -> error (show x)
@@ -112,7 +112,7 @@ applyBlock ::
   Int ->
   Int
 applyBlock (ValidateInput globals state (Block bh txs)) n =
-  let block = UnsafeUnserialisedBlock (makeHeaderView bh) txs
+  let block = Block (makeHeaderView bh) txs
    in case API.applyBlockEitherNoEvents ValidateAll globals state block of
         Right x -> seq (rnf x) (n + 1)
         Left x -> error (show x)
@@ -122,7 +122,7 @@ benchreValidate ::
   ValidateInput era ->
   NewEpochState era
 benchreValidate (ValidateInput globals state (Block bh txs)) =
-  API.applyBlockNoValidaton globals state (UnsafeUnserialisedBlock (makeHeaderView bh) txs)
+  API.applyBlockNoValidaton globals state (Block (makeHeaderView bh) txs)
 
 -- ==============================================================
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
@@ -581,7 +581,7 @@ withdrawals ::
   EraGen era =>
   Block (BHeader MockCrypto) era ->
   Coin
-withdrawals (UnserialisedBlock _ txseq) =
+withdrawals (Block _ txseq) =
   F.foldl'
     ( \c tx ->
         let wdrls = unWithdrawals $ tx ^. bodyTxL . withdrawalsTxBodyL

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
@@ -301,7 +301,6 @@ chainTransition ::
   , State (EraRule "TICK" era) ~ NewEpochState era
   , Signal (EraRule "TICK" era) ~ SlotNo
   , Embed (PRTCL MockCrypto) (CHAIN era)
-  , EncCBORGroup (TxSeq era)
   , ProtVerAtMost era 6
   , State (EraRule "LEDGERS" era) ~ LedgerState era
   , EraGov era
@@ -370,10 +369,9 @@ chainTransition =
               , bh
               )
 
-        let thouShaltNot = error "A block with a header view should never be hashed"
         BbodyState ls' bcur' <-
           trans @(EraRule "BBODY" era) $
-            TRC (BbodyEnv pp' account, BbodyState ls bcur, Block' bhView txs thouShaltNot)
+            TRC (BbodyEnv pp' account, BbodyState ls bcur, Block bhView txs)
 
         let nes'' = updateNES nes' bcur' ls'
             bhb = bhbody bh

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
@@ -137,7 +137,7 @@ relevantCasesAreCoveredForTrace ::
   Property
 relevantCasesAreCoveredForTrace tr = do
   let blockTxs :: Block (BHeader MockCrypto) era -> [Tx era]
-      blockTxs (UnserialisedBlock _ txSeq) = toList (fromTxSeq @era txSeq)
+      blockTxs (Block _ txSeq) = toList (fromTxSeq @era txSeq)
       bs = traceSignals OldestFirst tr
       txs = concat (blockTxs <$> bs)
       certsByTx_ = certsByTx @era txs

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/PoolReap.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/PoolReap.hs
@@ -80,7 +80,7 @@ tests =
     poolState target = (chainNes target) ^. nesEsL . esLStateL . lsCertStateL . certPStateL
 
     removedAfterPoolreap_ :: SourceSignalTarget (CHAIN era) -> Property
-    removedAfterPoolreap_ (SourceSignalTarget {source, target, signal = (UnserialisedBlock bh _)}) =
+    removedAfterPoolreap_ (SourceSignalTarget {source, target, signal = (Block bh _)}) =
       let e = (epochFromSlotNo . bheaderSlotNo . bhbody) bh
        in removedAfterPoolreap (poolState source) (poolState target) e
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -254,7 +254,7 @@ ledgerTraceBase chainSt block =
   , txs
   )
   where
-    (UnserialisedBlock (BHeader bhb _) txSeq) = block
+    (Block (BHeader bhb _) txSeq) = block
     slot = bheaderSlotNo bhb
     tickedChainSt = tickChainState slot chainSt
     nes = (nesEs . chainNes) tickedChainSt

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
@@ -987,7 +987,7 @@ tests =
        in checkEncodingCBORAnnotated
             shelleyProtVer
             "empty_block"
-            (Block @C bh txns)
+            (Block @(BHeader MockCrypto) @C bh txns)
             ( (T $ TkListLen 4)
                 <> S bh
                 <> T (TkListLen 0 . TkListLen 0 . TkMapLen 0)
@@ -1048,7 +1048,7 @@ tests =
        in checkEncodingCBORAnnotated
             shelleyProtVer
             "rich_block"
-            (Block @C bh txns)
+            (Block @(BHeader MockCrypto) @C bh txns)
             ( (T $ TkListLen 4)
                 -- header
                 <> S bh

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.17.0.0
 
+* Replace `Block'` constructor with `Block`
+* Remove patterns: `Block`, `UnserialisedBlock` and `UnsafeUnserialisedBlock`
+* Add ` EncCBORGroup (TxSeq era)` and `EncCBOR h` constraints to `EncCBOR` and `ToCBOR` instances for `Block`
 * Add `BoootstrapWitnessRaw` type
 * Add `EraStake`, `CanGetInstantStake`,  `CanSetInstantStake` , `snapShotFromInstantStake`, `resolveActiveInstantStakeCredentials`
 * Add boolean argument to `fromCborRigorousBothAddr` for lenient `Ptr` decoding

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
@@ -705,7 +705,7 @@ coldKeys = KeyPair vk sk
 
 makeNaiveBlock ::
   forall era. EraSegWits era => [Tx era] -> Block BHeaderView era
-makeNaiveBlock txs = UnsafeUnserialisedBlock bhView txSeq
+makeNaiveBlock txs = Block bhView txSeq
   where
     bhView =
       BHeaderView

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Same.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Same.hs
@@ -247,7 +247,7 @@ instance
   Same era (ShelleyLedgerExamples era)
   where
   same proof x1 x2 = case (sleBlock x1, sleBlock x2) of
-    (Block' h1 a1 _, Block' h2 a2 _) ->
+    (Block h1 a1, Block h2 a2) ->
       sameWithDependency
         [ SomeM "Tx" (sameTx proof) (sleTx x1) (sleTx x2)
         , SomeM "TxSeq" (sameTxSeq proof) a1 a2

--- a/libs/cardano-protocol-tpraos/testlib/Test/Cardano/Protocol/Binary/RoundTrip.hs
+++ b/libs/cardano-protocol-tpraos/testlib/Test/Cardano/Protocol/Binary/RoundTrip.hs
@@ -6,7 +6,7 @@
 
 module Test.Cardano.Protocol.Binary.RoundTrip (roundTripBlockSpec) where
 
-import Cardano.Ledger.Binary (Annotator, DecCBOR)
+import Cardano.Ledger.Binary (Annotator, DecCBOR, EncCBOR)
 import Cardano.Ledger.Block (Block)
 import Cardano.Ledger.Core
 import Data.Typeable
@@ -20,6 +20,7 @@ roundTripBlockSpec ::
   , Show h
   , DecCBOR h
   , DecCBOR (Annotator h)
+  , EncCBOR h
   , EraSegWits era
   , DecCBOR (TxSeq era)
   , Arbitrary (Block h era)


### PR DESCRIPTION
# Description

Just block body and block header are important for hashing. 

Integrating this with consesus doesn't create non-trivial compilation problems: https://github.com/IntersectMBO/ouroboros-consensus/pull/1427


<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
