### PR TITLE
Add required CBOR instances for NonZero

### DIFF
--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes/NonZero.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes/NonZero.hs
@@ -38,7 +38,7 @@ module Cardano.Ledger.BaseTypes.NonZero (
   (%?),
 ) where
 
-import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR)
+import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR, FromCBOR (..), ToCBOR (..))
 import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON (..), ToJSON)
 import Data.Maybe (fromMaybe)
@@ -76,7 +76,7 @@ type WithinBounds n a = (MinBound a <= n, n <= MaxBound a)
 
 newtype NonZero a = NonZero {unNonZero :: a}
   deriving (Eq, Ord, Show, NoThunks, NFData)
-  deriving newtype (EncCBOR, ToJSON)
+  deriving newtype (EncCBOR, ToCBOR, ToJSON)
 
 class HasZero a where
   isZero :: a -> Bool
@@ -102,6 +102,9 @@ instance HasZero a => HasZero (Ratio a) where
 
 instance (Typeable a, DecCBOR a, HasZero a) => DecCBOR (NonZero a) where
   decCBOR = decCBOR >>= nonZeroM
+
+instance (HasZero a, FromCBOR a) => FromCBOR (NonZero a) where
+  fromCBOR = nonZeroM =<< fromCBOR
 
 instance (FromJSON a, HasZero a) => FromJSON (NonZero a) where
   parseJSON v = parseJSON v >>= nonZeroM


### PR DESCRIPTION
# Description

This is in support of `cardano-node 10.3` release.

- [x] Make sure `CBOR` instances exist for `NonZero`

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] ~~Tests added or updated when needed.~~
- [ ] ~~`CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).~~
- [ ] ~~Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).~~
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
