### PR TITLE
Move rewards withdrawal logic to `LEDGER` and bump spec

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,13 +10,13 @@ repository cardano-haskell-packages
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
-source-repository-package
-  type: git
-  location: https://github.com/IntersectMBO/formal-ledger-specifications.git
-  subdir: generated
+ -- source-repository-package
+ --   type: git
+ --   location: https://github.com/IntersectMBO/formal-ledger-specifications.git
+ --   subdir: generated
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `MAlonzo-code` BEFORE MERGE!
-  tag: ab84ceae725d27b8bb8e8e19b0162a824bbe9c0b
+ --   tag: ab84ceae725d27b8bb8e8e19b0162a824bbe9c0b
 
 -- NOTE: If you would like to update the above,
 -- see CONTRIBUTING.md#to-update-the-referenced-agda-ledger-spec
@@ -25,6 +25,7 @@ index-state:
   , cardano-haskell-packages 2025-01-08T16:35:32Z
 
 packages:
+  /nix/store/2d2czjxwq2x9n79ljhgbzhasf65j8vad-hs-src-0.1/haskell/Ledger
   -- == Byron era ==
   -- byron-spec-chain:
   -- byron-spec-ledger:

--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
   subdir: generated
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `MAlonzo-code` BEFORE MERGE!
-  tag: 9b706ae8c332d5ad10def54aa51d4a66836df363
+  tag: ab84ceae725d27b8bb8e8e19b0162a824bbe9c0b
 
 -- NOTE: If you would like to update the above,
 -- see CONTRIBUTING.md#to-update-the-referenced-agda-ledger-spec

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Mempool.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Mempool.hs
@@ -28,7 +28,7 @@ import Cardano.Ledger.Conway.Governance (
   authorizedElectedHotCommitteeCredentials,
   unVotingProcedures,
  )
-import Cardano.Ledger.Conway.Rules.Certs (CertsEnv)
+import Cardano.Ledger.Conway.Rules.Certs (CertsEnv, ConwayCertsPredFailure)
 import Cardano.Ledger.Conway.Rules.Gov (GovEnv, GovSignal)
 import Cardano.Ledger.Conway.Rules.Ledger (ConwayLedgerEvent, ConwayLedgerPredFailure (..))
 import Cardano.Ledger.Conway.State
@@ -139,6 +139,7 @@ instance
   , Signal (EraRule "GOV" era) ~ GovSignal era
   , Signal (EraRule "UTXOW" era) ~ Tx era
   , EraCertState era
+  , PredicateFailure (EraRule "CERTS" era) ~ ConwayCertsPredFailure era
   ) =>
   Embed (ConwayLEDGER era) (ConwayMEMPOOL era)
   where

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/DelegSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/DelegSpec.hs
@@ -210,7 +210,7 @@ spec = do
       submitAndExpireProposalToMakeReward otherStakeCred
       getReward otherStakeCred `shouldReturn` govActionDeposit
       unRegTxCert <- genUnRegTxCert stakeCred
-      submitTx_ . mkBasicTx $
+      impAnn "Deregister staking credential and withdraw" . submitTx_ . mkBasicTx $
         mkBasicTxBody
           & certsTxBodyL
             .~ SSeq.fromList [unRegTxCert]

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovCertSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovCertSpec.hs
@@ -1,21 +1,24 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE NumericUnderscores #-}
 
 module Test.Cardano.Ledger.Conway.Imp.GovCertSpec (spec) where
 
 import Cardano.Ledger.BaseTypes (EpochInterval (..), Mismatch (..))
+import Cardano.Ledger.CertState (DRep (..), EraCertState (..), dsUnifiedL)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Rules (ConwayGovCertPredFailure (..), ConwayGovPredFailure (..))
 import Cardano.Ledger.Credential (Credential (..))
-import Cardano.Ledger.Shelley.LedgerState (curPParamsEpochStateL, nesEsL, esLStateL, lsCertStateL)
+import Cardano.Ledger.Shelley.LedgerState (curPParamsEpochStateL, esLStateL, lsCertStateL, nesEsL)
+import Cardano.Ledger.UMap (umElemDRep, umElemsL)
 import Cardano.Ledger.Val (Val (..))
+import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict (StrictMaybe (..))
 import qualified Data.Sequence.Strict as SSeq
 import Lens.Micro ((&), (.~))
@@ -23,9 +26,6 @@ import Test.Cardano.Ledger.Conway.Arbitrary ()
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Core.Rational (IsRatio (..))
 import Test.Cardano.Ledger.Imp.Common
-import Cardano.Ledger.CertState (DRep(..), EraCertState (..), dsUnifiedL)
-import Cardano.Ledger.UMap (umElemsL, umElemDRep)
-import qualified Data.Map.Strict as Map
 
 spec ::
   forall era.

--- a/flake.lock
+++ b/flake.lock
@@ -204,11 +204,11 @@
     "formal-ledger-specifications": {
       "flake": false,
       "locked": {
-        "lastModified": 1739273763,
-        "narHash": "sha256-vrxKI3I1kwt+XiHk+UAWm49veRPTWkVPOvwNzVxuFs8=",
+        "lastModified": 1740746070,
+        "narHash": "sha256-IUvFEirar2BSXQThHkxH/56Q8fzU4EaA8jRVYJXJRyA=",
         "owner": "IntersectMBO",
         "repo": "formal-ledger-specifications",
-        "rev": "9b706ae8c332d5ad10def54aa51d4a66836df363",
+        "rev": "ab84ceae725d27b8bb8e8e19b0162a824bbe9c0b",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
@@ -160,7 +160,7 @@ spec =
           describe "GOVCERT" GovCert.spec
           -- LEDGER tests pending on the dRep delegations cleanup in the spec:
           -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/635
-          xdescribe "LEDGER" Ledger.spec
+          describe "LEDGER" Ledger.spec
           xdescribe "RATIFY" Ratify.spec
           xdescribe "UTXO" Utxo.spec
           xdescribe "UTXOS" Utxos.spec

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
@@ -155,7 +155,7 @@ spec =
           describe "CERTS" Certs.spec
           describe "DELEG" Deleg.spec
           describe "ENACT" Enact.spec
-          xdescribe "EPOCH" Epoch.spec
+          describe "EPOCH" Epoch.spec
           describe "GOV" Gov.spec
           describe "GOVCERT" GovCert.spec
           -- LEDGER tests pending on the dRep delegations cleanup in the spec:


### PR DESCRIPTION
# Description

This PR moves the rewards withdrawal logic to `LEDGER` and gets rid of an ugly workaround in conformance testing.

related https://github.com/IntersectMBO/formal-ledger-specifications/pull/710
close #4932

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
