### PR TITLE
Remove redundant bytes memoization from `WitVKey` and `BootstrapWitness`

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
@@ -218,7 +218,7 @@ shelleyEqTxWitsRaw :: EraTxWits era => TxWits era -> TxWits era -> Bool
 shelleyEqTxWitsRaw txWits1 txWits2 =
   txWits1 ^. addrTxWitsL == txWits2 ^. addrTxWitsL
     && liftEq eqRaw (txWits1 ^. scriptTxWitsL) (txWits2 ^. scriptTxWitsL)
-    && liftEq eqRaw (txWits1 ^. bootAddrTxWitsL) (txWits2 ^. bootAddrTxWitsL)
+    && txWits1 ^. bootAddrTxWitsL == txWits2 ^. bootAddrTxWitsL
 
 instance EraScript era => DecCBOR (Annotator (ShelleyTxWitsRaw era)) where
   decCBOR = decodeWits

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
@@ -216,7 +216,7 @@ pattern ShelleyTxWits {addrWits, scriptWits, bootWits} <-
 
 shelleyEqTxWitsRaw :: EraTxWits era => TxWits era -> TxWits era -> Bool
 shelleyEqTxWitsRaw txWits1 txWits2 =
-  liftEq eqRaw (txWits1 ^. addrTxWitsL) (txWits2 ^. addrTxWitsL)
+  txWits1 ^. addrTxWitsL == txWits2 ^. addrTxWitsL
     && liftEq eqRaw (txWits1 ^. scriptTxWitsL) (txWits2 ^. scriptTxWitsL)
     && liftEq eqRaw (txWits1 ^. bootAddrTxWitsL) (txWits2 ^. bootAddrTxWitsL)
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## 1.11.0.0
 
+* Remove `witVKeyBytes`
 * Converted `CertState` to a type family
 * Expose new `TxAuxDataHash` and deprecate old `AuxiliaryDataHash`
 * Stop re-exporting `Crypto` and `StandardCrypto`, since they have been moved to `cardano-protocol-tpraos`

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Wits.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Wits.hs
@@ -9,7 +9,6 @@ module Cardano.Ledger.Api.Tx.Wits (
 
   -- *** WitVKey
   WitVKey (WitVKey),
-  witVKeyBytes,
   witVKeyHash,
 
   -- ** Byron address witness
@@ -64,4 +63,4 @@ import Cardano.Ledger.Conway.Scripts (ConwayPlutusPurpose (..))
 import Cardano.Ledger.Core (EraTxWits (..), hashScriptTxWitsL)
 import Cardano.Ledger.Keys (KeyRole (Witness))
 import Cardano.Ledger.Keys.Bootstrap (BootstrapWitness)
-import Cardano.Ledger.Keys.WitVKey (WitVKey (WitVKey), witVKeyBytes, witVKeyHash)
+import Cardano.Ledger.Keys.WitVKey (WitVKey (WitVKey), witVKeyHash)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -90,7 +90,6 @@ import Control.Monad.Except (MonadError (..))
 import Control.State.Transition.Extended (STS (..))
 import Data.Bifunctor (Bifunctor (..))
 import Data.Bitraversable (bimapM)
-import Data.Data (Typeable)
 import Data.Default (Default (..))
 import Data.Foldable (Foldable (..))
 import Data.List (sortOn)
@@ -460,7 +459,7 @@ instance DSIGNAlgorithm v => SpecTranslate ctx (SignedDSIGN v a) where
 
   toSpecRep (SignedDSIGN x) = pure $ signatureToInteger x
 
-instance Typeable k => SpecTranslate ctx (WitVKey k) where
+instance SpecTranslate ctx (WitVKey k) where
   type SpecRep (WitVKey k) = (SpecRep (VKey k), Integer)
 
   toSpecRep (WitVKey vk sk) = toSpecRep (vk, sk)

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## 1.18.0.0
 
+* Remove `witVKeyBytes` and `eqWitVKeyRaw`
+* Remove `EqRaw` instance for `WitVKey`
 * Replace `Block'` constructor with `Block`
 * Remove patterns: `Block`, `UnserialisedBlock` and `UnsafeUnserialisedBlock`
 * Add ` EncCBORGroup (TxSeq era)` and `EncCBOR h` constraints to `EncCBOR` and `ToCBOR` instances for `Block`
 
 ## 1.17.0.0
 
+* Remove `eqBootstrapWitnessRaw` and `BootstrapWitnessRaw`
+* Rename `bwSig` to `bwSignature` for `BootstrapWitness`
 * Add `BoootstrapWitnessRaw` type
 * Add `EraStake`, `CanGetInstantStake`,  `CanSetInstantStake` , `snapShotFromInstantStake`, `resolveActiveInstantStakeCredentials`
 * Add boolean argument to `fromCborRigorousBothAddr` for lenient `Ptr` decoding

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.18.0.0
 
+* Remove `eqBootstrapWitnessRaw` and `BootstrapWitnessRaw`
+* Rename `bwSig` to `bwSignature` for `BootstrapWitness`
 * Remove `witVKeyBytes` and `eqWitVKeyRaw`
 * Remove `EqRaw` instance for `WitVKey`
 * Replace `Block'` constructor with `Block`
@@ -10,8 +12,6 @@
 
 ## 1.17.0.0
 
-* Remove `eqBootstrapWitnessRaw` and `BootstrapWitnessRaw`
-* Rename `bwSig` to `bwSignature` for `BootstrapWitness`
 * Add `BoootstrapWitnessRaw` type
 * Add `EraStake`, `CanGetInstantStake`,  `CanSetInstantStake` , `snapShotFromInstantStake`, `resolveActiveInstantStakeCredentials`
 * Add boolean argument to `fromCborRigorousBothAddr` for lenient `Ptr` decoding

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.18.0.0
 
+* Rename `wvkSig` to `wvkSignature`
 * Remove `eqBootstrapWitnessRaw` and `BootstrapWitnessRaw`
 * Rename `bwSig` to `bwSignature` for `BootstrapWitness`
 * Remove `witVKeyBytes` and `eqWitVKeyRaw`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/WitVKey.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/WitVKey.hs
@@ -7,13 +7,10 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Ledger.Keys.WitVKey (
   WitVKey (WitVKey),
-  witVKeyBytes,
   witVKeyHash,
-  eqWitVKeyRaw,
 )
 where
 
@@ -26,12 +23,7 @@ import Cardano.Ledger.Binary (
   Annotator (..),
   DecCBOR (..),
   EncCBOR (..),
-  ToCBOR (..),
-  annotatorSlice,
-  decodeRecordNamed,
-  fromPlainDecoder,
  )
-import qualified Cardano.Ledger.Binary.Crypto (decodeSignedDSIGN)
 import qualified Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Hashes (
   EraIndependentTxBody,
@@ -42,10 +34,7 @@ import Cardano.Ledger.Hashes (
   hashTxBodySignature,
  )
 import Cardano.Ledger.Keys.Internal (DSIGN, KeyRole (..), VKey, asWitness)
-import Cardano.Ledger.MemoBytes (EqRaw (..), MemoBytes (Memo), decodeMemoized)
 import Control.DeepSeq
-import qualified Data.ByteString.Lazy as BSL
-import qualified Data.ByteString.Short as SBS
 import Data.Ord (comparing)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
@@ -58,17 +47,16 @@ data WitVKey kr = WitVKeyInternal
   , wvkKeyHash :: KeyHash 'Witness
   -- ^ Hash of the witness vkey. We store this here to avoid repeated hashing
   --   when used in ordering.
-  , wvkBytes :: BSL.ByteString
   }
   deriving (Generic, Show, Eq)
 
 deriving via
-  AllowThunksIn '["wvkBytes", "wvkKeyHash"] (WitVKey kr)
+  AllowThunksIn '["wvkKeyHash"] (WitVKey kr)
   instance
     Typeable kr => NoThunks (WitVKey kr)
 
 instance NFData (WitVKey kr) where
-  rnf WitVKeyInternal {wvkKeyHash, wvkBytes} = wvkKeyHash `deepseq` rnf wvkBytes
+  rnf WitVKeyInternal {wvkKeyHash} = wvkKeyHash `seq` ()
 
 instance Typeable kr => Ord (WitVKey kr) where
   compare x y =
@@ -83,69 +71,37 @@ instance Typeable kr => Ord (WitVKey kr) where
     comparing wvkKeyHash x y <> comparing (hashTxBodySignature . wvkSig) x y
 
 instance Typeable kr => Plain.ToCBOR (WitVKey kr) where
-  toCBOR = Plain.encodePreEncoded . BSL.toStrict . wvkBytes
+  toCBOR WitVKeyInternal {wvkKey, wvkSig} =
+    Plain.encodeListLen 2
+      <> Plain.toCBOR wvkKey
+      <> encodeSignedDSIGN wvkSig
 
--- | Encodes memoized bytes created upon construction.
+instance Typeable kr => Plain.FromCBOR (WitVKey kr) where
+  fromCBOR =
+    Plain.decodeRecordNamed "WitVKey" (const 2) $
+      WitVKey <$> Plain.fromCBOR <*> decodeSignedDSIGN
+
 instance Typeable kr => EncCBOR (WitVKey kr)
 
 instance Typeable kr => DecCBOR (Annotator (WitVKey kr)) where
-  decCBOR =
-    annotatorSlice $
-      fromPlainDecoder $
-        Plain.decodeRecordNamed "WitVKey" (const 2) $
-          fmap pure $
-            mkWitVKey <$> Plain.fromCBOR <*> decodeSignedDSIGN
-    where
-      mkWitVKey k sig = WitVKeyInternal k sig (asWitness $ hashKey k)
-      {-# INLINE mkWitVKey #-}
+  decCBOR = pure <$> decCBOR
   {-# INLINE decCBOR #-}
 
-data WitVKeyRaw kr
-  = WitVKeyRaw
-      !(VKey kr)
-      !(SignedDSIGN DSIGN (Hash HASH EraIndependentTxBody))
-      (KeyHash 'Witness)
-
-instance Typeable kr => DecCBOR (WitVKeyRaw kr) where
-  decCBOR = decodeRecordNamed "WitVKey" (const 2) $ do
-    key <- decCBOR
-    sig <- Cardano.Ledger.Binary.Crypto.decodeSignedDSIGN
-    pure $ WitVKeyRaw key sig (asWitness $ hashKey key)
-
-instance Typeable kr => DecCBOR (WitVKey kr) where
-  decCBOR = do
-    Memo (WitVKeyRaw k s kh) bs <- decodeMemoized (decCBOR @(WitVKeyRaw kr))
-    pure $ WitVKeyInternal k s kh (BSL.fromStrict (SBS.fromShort bs))
-
-instance Typeable kr => EqRaw (WitVKey kr) where
-  eqRaw = eqWitVKeyRaw
+instance Typeable kr => DecCBOR (WitVKey kr)
 
 pattern WitVKey ::
-  Typeable kr =>
   VKey kr ->
   SignedDSIGN DSIGN (Hash HASH EraIndependentTxBody) ->
   WitVKey kr
 pattern WitVKey k s <-
-  WitVKeyInternal k s _ _
+  WitVKeyInternal k s _
   where
     WitVKey k s =
-      let bytes =
-            Plain.serialize $
-              Plain.encodeListLen 2
-                <> Plain.toCBOR k
-                <> encodeSignedDSIGN s
-          hash = asWitness $ hashKey k
-       in WitVKeyInternal k s hash bytes
+      let hash = asWitness $ hashKey k
+       in WitVKeyInternal k s hash
 
 {-# COMPLETE WitVKey #-}
 
 -- | Access computed hash. Evaluated lazily
 witVKeyHash :: WitVKey kr -> KeyHash 'Witness
 witVKeyHash = wvkKeyHash
-
--- | Access CBOR encoded representation of the witness. Evaluated lazily
-witVKeyBytes :: WitVKey kr -> BSL.ByteString
-witVKeyBytes = wvkBytes
-
-eqWitVKeyRaw :: Typeable kr => WitVKey kr -> WitVKey kr -> Bool
-eqWitVKeyRaw (WitVKey k1 s1) (WitVKey k2 s2) = k1 == k2 && s1 == s2

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/UTxO.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/UTxO.hs
@@ -69,7 +69,6 @@ import Data.Kind (Type)
 import qualified Data.Map.Strict as Map
 import Data.Monoid (Sum (..))
 import Data.Set (Set)
-import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Lens.Micro (Lens', SimpleGetter, (^.))
 import NoThunks.Class (NoThunks (..))
@@ -170,7 +169,6 @@ txInsFilter (UTxO utxo') txIns = UTxO (utxo' `Map.restrictKeys` txIns)
 
 -- | Verify a transaction body witness
 verifyWitVKey ::
-  Typeable kr =>
   Hash HASH EraIndependentTxBody ->
   WitVKey kr ->
   Bool

--- a/libs/cardano-ledger-core/test/Test/Cardano/Ledger/AddressSpec.hs
+++ b/libs/cardano-ledger-core/test/Test/Cardano/Ledger/AddressSpec.hs
@@ -57,7 +57,7 @@ spec =
             BootstrapWitness
               { bwKey = shelleyVKey
               , bwChainCode = chainCode
-              , bwSig = sig
+              , bwSignature = sig
               , bwAttributes = serialize' byronProtVer $ Byron.addrAttributes byronAddr
               }
       pure $

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -370,10 +370,10 @@ instance Arbitrary ChainCode where
 instance Arbitrary BootstrapWitness where
   arbitrary = do
     bwKey <- arbitrary
-    bwSig <- arbitrary
+    bwSignature <- arbitrary
     bwChainCode <- arbitrary
     bwAttributes <- arbitrary
-    pure $ BootstrapWitness {bwKey, bwSig, bwChainCode, bwAttributes}
+    pure $ BootstrapWitness {bwKey, bwSignature, bwChainCode, bwAttributes}
 
 instance Arbitrary GenDelegPair where
   arbitrary = GenDelegPair <$> arbitrary <*> arbitrary

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
@@ -112,7 +112,6 @@ instance ToExpr CostModels
 instance ToExpr (WitVKey kr)
 
 -- Keys/Bootstrap
-instance ToExpr BootstrapWitnessRaw
 instance ToExpr BootstrapWitness
 
 instance ToExpr ChainCode

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -285,7 +285,6 @@ import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text, pack)
-import Data.Typeable (Typeable)
 import qualified Data.VMap as VMap
 import Data.Void (Void, absurd)
 import Data.Word (Word16, Word32, Word64, Word8)
@@ -2876,12 +2875,7 @@ pcWitVKey _p (WitVKey vk@(VKey x) sig) =
     hash = pcKeyHash (hashKey vk)
     sigstring = show sig
 
-instance
-  ( Reflect era
-  , Typeable keyrole
-  ) =>
-  PrettyA (WitVKey keyrole)
-  where
+instance Reflect era => PrettyA (WitVKey keyrole) where
   prettyA = pcWitVKey @era reify
 
 -- =====================================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -2861,15 +2861,14 @@ pcPair pp1 pp2 (x, y) = parens (hsep [pp1 x, ppString ",", pp2 y])
 
 pcWitVKey ::
   forall era keyrole.
-  Typeable keyrole =>
   Proof era ->
   WitVKey keyrole ->
   PDoc
 pcWitVKey _p (WitVKey vk@(VKey x) sig) =
   ppSexp
     "WitVKey"
-    [ ppString (" VerKey=" ++ (take 10 (drop 19 keystring)))
-    , ppString (" SignKey=" ++ (take 10 (drop 29 sigstring)))
+    [ ppString (" VerKey=" ++ take 10 (drop 19 keystring))
+    , ppString (" SignKey=" ++ take 10 (drop 29 sigstring))
     , " VerKeyHash=" <> hash
     ]
   where
@@ -2878,7 +2877,6 @@ pcWitVKey _p (WitVKey vk@(VKey x) sig) =
     sigstring = show sig
 
 instance
-  forall era keyrole.
   ( Reflect era
   , Typeable keyrole
   ) =>
@@ -2899,12 +2897,12 @@ pcShelleyGovState :: Proof era -> ShelleyGovState era -> PDoc
 pcShelleyGovState p (ShelleyGovState _proposal _futproposal pp prevpp futurepp) =
   ppRecord
     "ShelleyGovState"
-    $ [ ("proposals", ppString "(Proposals ...)")
-      , ("futureProposals", ppString "(Proposals ...)")
-      , ("pparams", pcPParamsSynopsis p pp)
-      , ("prevParams", pcPParamsSynopsis p prevpp)
-      , ("futureParams", pcFuturePParams p futurepp)
-      ]
+    [ ("proposals", ppString "(Proposals ...)")
+    , ("futureProposals", ppString "(Proposals ...)")
+    , ("pparams", pcPParamsSynopsis p pp)
+    , ("prevParams", pcPParamsSynopsis p prevpp)
+    , ("futureParams", pcFuturePParams p futurepp)
+    ]
 
 pcFuturePParams :: Proof era -> FuturePParams era -> PDoc
 pcFuturePParams p = \case


### PR DESCRIPTION
# Description

Addresses two points #4850
# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
