### PR TITLE
Relax bounds on `plutus` in `plutus-preprocessor`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -22,7 +22,7 @@ source-repository-package
 -- see CONTRIBUTING.md#to-update-the-referenced-agda-ledger-spec
 index-state:
   , hackage.haskell.org 2025-01-14T00:25:08Z
-  , cardano-haskell-packages 2025-01-08T16:35:32Z
+  , cardano-haskell-packages 2025-03-20T13:25:36Z
 
 packages:
   -- == Byron era ==

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1736355014,
-        "narHash": "sha256-2eKlS3k8Up/2oxDSBrw5aoXHFhBq+WV1HwjWwjetom4=",
+        "lastModified": 1742478374,
+        "narHash": "sha256-T9Foa3IyAWUNS9gWQfiVb61DOgkWCn3gHzhsLdRrmBw=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "b7f0f0885cd6f507cc767263488f4a07ebdd79d1",
+        "rev": "d23ec7e8cb8ef9262659b49622c41eaa54a7ff23",
         "type": "github"
       },
       "original": {

--- a/libs/plutus-preprocessor/plutus-preprocessor.cabal
+++ b/libs/plutus-preprocessor/plutus-preprocessor.cabal
@@ -42,7 +42,7 @@ library
     bytestring,
     cardano-ledger-binary:testlib,
     cardano-ledger-core,
-    plutus-ledger-api ^>=1.37,
+    plutus-ledger-api >=1.37,
     plutus-tx,
     plutus-tx-plugin,
     template-haskell,


### PR DESCRIPTION
# Description

The reason for the upper bound in `plutus-preprocessor` seems to have gone away now

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
