### PR TITLE
Add `expectTxSuccess` to `ShelleyEraImp` and use it in `trySubmitTx`

### DIFF
--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
@@ -39,6 +39,7 @@ instance ShelleyEraImp AllegraEra where
   impSatisfyNativeScript = impAllegraSatisfyNativeScript
 
   fixupTx = shelleyFixupTx
+  expectTxSuccess = impShelleyExpectTxSuccess
 
 impAllegraSatisfyNativeScript ::
   ( AllegraEraScript era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -319,6 +319,7 @@ instance ShelleyEraImp ConwayEra where
   modifyPParams = conwayModifyPParams
 
   fixupTx = babbageFixupTx
+  expectTxSuccess = impBabbageExpectTxSuccess
 
 instance MaryEraImp ConwayEra
 

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
@@ -25,6 +25,7 @@ import Test.Cardano.Ledger.Mary.TreeDiff ()
 instance ShelleyEraImp MaryEra where
   impSatisfyNativeScript = impAllegraSatisfyNativeScript
   fixupTx = shelleyFixupTx
+  expectTxSuccess = impShelleyExpectTxSuccess
 
 class
   ( ShelleyEraImp era


### PR DESCRIPTION
# Description

This function was already written for Alonzo. Now we make it a method of `ShelleyEraImp` because the criteria for success are era-specific.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
