### PR TITLE
Add script for bumping CHANGELOGS post-release

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -238,16 +238,19 @@ More on that command in the section below.
    ```
 
 4. Create a PR to `master` that updates `CHANGELOG.md` files for all of the packages that
-   have just been released. The only addition to the file should be a markdown header
-   section with the next patch version bumped, which must bring the `CHANGELOG.md` to the
-   state of the top level section containing a version higher than the highest one ever
-   released. Due to concurrent nature of editing the repository it is possible that
+   have just been released. When done manually, the only addition to the file should be a markdown header
+   section with the next patch version bumped but prefer to use the provided convenience script `./scripts/bump-changelogs.sh`
+   to do this automatically. This will fetch a shallow copy of [CHaP](https://github.com/intersectmbo/cardano-haskell-packages)
+   and check if any of our most recent package versions had a release. If so, the script
+   will bump the corresponding `CHANGELOG`s with the next patch version, which brings
+   the state of the top level section containing a version higher than the highest one ever released.
+   Due to concurrent nature of editing the repository it is possible that
    `CHANGELOG.md` have already received a version bump with a section that fits the
-   higher version criteria, in which case nothing needs to be added. The body of the
-   section, if added, must be empty with just one single asterisk `*`.
+   higher version criteria, in which case nothing will be nor should be added. The body of the
+   section, when added, should be empty with just one single asterisk `*`.
 
    For example, if `cardano-ledger-core-1.20.1.1` was just released, then a new empty
-   `1.20.1.2` section in the `CHANGELOG.md` must be added:
+   `1.20.1.2` section in the `CHANGELOG.md` will be added by the script:
 
    ```markdown
    # Version history for `cardano-ledger-core`

--- a/scripts/bump-changelogs.sh
+++ b/scripts/bump-changelogs.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+CHAP=./cardano-haskell-packages
+# Download a shallow copy of CHaP
+git clone --depth 1 git@github.com:IntersectMBO/cardano-haskell-packages.git $CHAP
+
+cd $CHAP || exit
+# Save all the available packages from CHaP
+CHAP_PACKAGES=$(./scripts/list-packages.sh)
+cd - || exit
+echo "The following packages are available in CHaP:"
+echo "$CHAP_PACKAGES"
+
+# Save the paths to every `cardano-ledger` cabal file
+CABAL_FILES=$(find . -wholename '*/eras/*.cabal' -o -wholename '*/libs/*.cabal')
+
+for i in $CABAL_FILES;
+do
+  # Extract the name of the package (without the path and the extension)
+  PACKAGE=$(basename "$i" .cabal)
+  # Construct the path to the package's `CHANGELOG`
+  CHANGELOG=${i/$PACKAGE.cabal/CHANGELOG.md}
+
+  # Check if package has a `CHANGELOG`
+  if [[ -f "$CHANGELOG" ]]; then
+    # Get the most recent version number in the `CHANGELOG`
+    VERSION=$(grep -m 1 -o "[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+" "$CHANGELOG")
+
+    # Check if the package had a release with
+    # the most recent `CHANGELOG` version number
+    printf "Looking for %s with version %s in CHaP\n" "$PACKAGE" "$VERSION"
+    RESULT=$(echo "$CHAP_PACKAGES" | grep -o "$PACKAGE $VERSION")
+    if [[ -n "$RESULT" ]]; then
+      # A release was found and thus the `CHANGELOG` has to be bumped
+      # with the incremented patch version
+      NEXT_VERSION=$(echo "$VERSION" | awk -F. -v OFS=. '{$NF += 1 ; print}')
+      printf "Bumping %s to %s\n" "$CHANGELOG" "$NEXT_VERSION"
+      sed -i "s/## $VERSION/## $NEXT_VERSION\n\n*\n\n## $VERSION/" "$CHANGELOG"
+    fi
+  fi
+done
+
+rm -rf $CHAP

--- a/scripts/bump-changelogs.sh
+++ b/scripts/bump-changelogs.sh
@@ -41,3 +41,6 @@ do
 done
 
 rm -rf $CHAP
+printf "\n!!!!!!\n%s %s\n!!!!!!\n" \
+  "WARNING! DO NOT BUMP THE VERSION NUMBER IN THE CABAL FILES" \
+  "(unless its dependencies were bumped)!"


### PR DESCRIPTION
# Description

Title says it all. It's a very basic script that fetches a shallow copy of `CHaP` and uses its `list-packages.sh` script to get all the available packages in order to check whether our most recent packages had a release yet. That is to say: check if the most recent version in a package's `CHANGELOG` is available in `CHaP`. If it is, that means we had a release recently and thus the package's `CHANGELOG` must be bumped. 

I opted not to include auto pushing to git for now but I can include it if desired.

This is part of #4583.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
