### PR TITLE
Fix instant stake calculation test

### DIFF
--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
@@ -56,6 +56,7 @@ commonTests ::
   forall era ledger.
   ( EraGen era
   , EraStake era
+  , InstantStake era ~ ShelleyInstantStake era
   , ChainProperty era
   , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
   , QC.HasTrace ledger (GenEnv MockCrypto era)


### PR DESCRIPTION
# Description

There was a mistake in the test, when #4906 was implemented. Unfortunately that test is very expensive and it only runs on NIGHTLY, that is why it was not caught immediately.

This PR fixes that issue and should resolve this portion of NIGHTLY failing tests failure

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
