### PR TITLE
Move add/sum functions for `CompactCoin` to `Cardano.Ledger.Coin`

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/DRepPulser.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/DRepPulser.hs
@@ -58,7 +58,7 @@ import Cardano.Ledger.Binary.Coders (
   (!>),
   (<!),
  )
-import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Coin (Coin (..), addCompactCoin)
 import Cardano.Ledger.Conway.Era (ConwayRATIFY)
 import Cardano.Ledger.Conway.Governance.Internal
 import Cardano.Ledger.Conway.Governance.Procedures (GovActionState)
@@ -214,7 +214,7 @@ computeDRepDistr instantStake regDReps proposalDeposits poolDistr dRepDistr =
       let instantStakeCredentials = instantStake ^. instantStakeCredentialsL
           stake = fromMaybe (CompactCoin 0) $ Map.lookup stakeCred instantStakeCredentials
           mProposalDeposit = Map.lookup stakeCred proposalDeposits
-          stakeAndDeposits = maybe stake (addCompact stake) mProposalDeposit
+          stakeAndDeposits = maybe stake (addCompactCoin stake) mProposalDeposit
        in case umElemDelegations umElem of
             Nothing -> (drepAccum, poolAccum)
             Just (RewardDelegationSPO spo _r) ->
@@ -222,11 +222,11 @@ computeDRepDistr instantStake regDReps proposalDeposits poolDistr dRepDistr =
               , addToPoolDistr spo mProposalDeposit poolAccum
               )
             Just (RewardDelegationDRep drep r) ->
-              ( addToDRepDistr drep (addCompact stakeAndDeposits r) drepAccum
+              ( addToDRepDistr drep (addCompactCoin stakeAndDeposits r) drepAccum
               , poolAccum
               )
             Just (RewardDelegationBoth spo drep r) ->
-              ( addToDRepDistr drep (addCompact stakeAndDeposits r) drepAccum
+              ( addToDRepDistr drep (addCompactCoin stakeAndDeposits r) drepAccum
               , addToPoolDistr spo mProposalDeposit poolAccum
               )
     addToPoolDistr spo mProposalDeposit distr = fromMaybe distr $ do
@@ -237,7 +237,7 @@ computeDRepDistr instantStake regDReps proposalDeposits poolDistr dRepDistr =
           & poolDistrDistrL %~ Map.insert spo (ips & individualTotalPoolStakeL <>~ proposalDeposit)
           & poolDistrTotalL <>~ proposalDeposit
     addToDRepDistr drep ccoin distr =
-      let updatedDistr = Map.insertWith addCompact drep ccoin distr
+      let updatedDistr = Map.insertWith addCompactCoin drep ccoin distr
        in case drep of
             DRepAlwaysAbstain -> updatedDistr
             DRepAlwaysNoConfidence -> updatedDistr

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs
@@ -131,11 +131,11 @@ import Cardano.Ledger.Binary (
   decodeListLikeWithCountT,
   decodeRecordNamedT,
  )
-import Cardano.Ledger.Coin (Coin, CompactForm (CompactCoin))
+import Cardano.Ledger.Coin (Coin, CompactForm (CompactCoin), addCompactCoin)
+import Cardano.Ledger.Compactible (toCompact)
 import Cardano.Ledger.Conway.Governance.Procedures
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential)
-import Cardano.Ledger.UMap (addCompact, toCompact)
 import Control.DeepSeq (NFData)
 import Control.Exception (assert)
 import Control.Monad (unless)
@@ -545,7 +545,7 @@ proposalsDeposits =
   F.foldl'
     ( \gasMap gas ->
         Map.insertWith
-          addCompact
+          addCompactCoin
           (gas ^. gasReturnAddrL . rewardAccountCredentialL)
           (fromMaybe (CompactCoin 0) $ toCompact $ gas ^. gasDepositL)
           gasMap

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.18.0.0
 
+* Add `addCompactCoin` to `Cardano.Ledger.Coin` and deprecate `Cardano.Ledger.UMap.addCompact`
+  in its favor
+* Move `sumCompactCoin` to `Cardano.Ledger.Coin`
 * Add `eraDecoderWithBytes`
 * Move `Annotator` instances to `testlib`
 * Expose `MkData` constructor.

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
@@ -24,6 +24,8 @@ module Cardano.Ledger.Coin (
   integerToWord64,
   decodePositiveCoin,
   compactCoinOrError,
+  addCompactCoin,
+  sumCompactCoin,
   -- NonZero helpers
   toCompactCoinNonZero,
   unCoinNonZero,
@@ -54,6 +56,7 @@ import Cardano.Ledger.Compactible
 import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Coerce (coerce)
+import Data.Foldable (Foldable (..))
 import Data.Group (Abelian, Group (..))
 import Data.MemPack
 import Data.Monoid (Sum (..))
@@ -65,6 +68,7 @@ import GHC.Stack
 import NoThunks.Class (NoThunks (..))
 import Quiet
 import System.Random.Stateful (Uniform (..), UniformRange (..))
+import Prelude hiding (Foldable (..))
 
 -- | The amount of value held by a transaction output.
 newtype Coin = Coin {unCoin :: Integer}
@@ -172,6 +176,12 @@ instance EncCBOR (CompactForm DeltaCoin) where
 
 instance DecCBOR (CompactForm DeltaCoin) where
   decCBOR = CompactDeltaCoin <$> decCBOR
+
+addCompactCoin :: CompactForm Coin -> CompactForm Coin -> CompactForm Coin
+addCompactCoin (CompactCoin x) (CompactCoin y) = CompactCoin (x + y)
+
+sumCompactCoin :: Foldable t => t (CompactForm Coin) -> CompactForm Coin
+sumCompactCoin = foldl' addCompactCoin (CompactCoin 0)
 
 -- ================================
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
@@ -56,7 +56,7 @@ import Cardano.Ledger.Compactible
 import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Coerce (coerce)
-import Data.Foldable (Foldable (..))
+import qualified Data.Foldable as F (foldl') -- Drop this when ghc >= 9.10
 import Data.Group (Abelian, Group (..))
 import Data.MemPack
 import Data.Monoid (Sum (..))
@@ -68,7 +68,6 @@ import GHC.Stack
 import NoThunks.Class (NoThunks (..))
 import Quiet
 import System.Random.Stateful (Uniform (..), UniformRange (..))
-import Prelude hiding (Foldable (..))
 
 -- | The amount of value held by a transaction output.
 newtype Coin = Coin {unCoin :: Integer}
@@ -181,7 +180,7 @@ addCompactCoin :: CompactForm Coin -> CompactForm Coin -> CompactForm Coin
 addCompactCoin (CompactCoin x) (CompactCoin y) = CompactCoin (x + y)
 
 sumCompactCoin :: Foldable t => t (CompactForm Coin) -> CompactForm Coin
-sumCompactCoin = foldl' addCompactCoin (CompactCoin 0)
+sumCompactCoin = F.foldl' addCompactCoin (CompactCoin 0)
 
 -- ================================
 

--- a/libs/cardano-ledger-core/test/Test/Cardano/Ledger/UMapSpec.hs
+++ b/libs/cardano-ledger-core/test/Test/Cardano/Ledger/UMapSpec.hs
@@ -7,7 +7,7 @@
 module Test.Cardano.Ledger.UMapSpec where
 
 import Cardano.Ledger.BaseTypes (StrictMaybe (SJust, SNothing))
-import Cardano.Ledger.Coin (Coin, CompactForm)
+import Cardano.Ledger.Coin (Coin, CompactForm, addCompactCoin)
 import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Credential (Credential, Ptr)
 import Cardano.Ledger.DRep (DRep)
@@ -18,7 +18,6 @@ import Cardano.Ledger.UMap (
   UMElem (UMElem),
   UMap (UMap, umElems, umPtrs),
   UView (DRepUView, PtrUView, RewDepUView, SPoolUView),
-  addCompact,
   compactRewardMap,
   dRepMap,
   delete,
@@ -216,7 +215,7 @@ oldUnionRewAgg ::
     addC :: CompactForm Coin -> StrictMaybe RDPair -> StrictMaybe RDPair
     addC newR = \case
       SNothing -> SNothing
-      SJust (RDPair r d) -> SJust $ RDPair (addCompact r newR) d
+      SJust (RDPair r d) -> SJust $ RDPair (addCompactCoin r newR) d
 
 spec :: Spec
 spec = do


### PR DESCRIPTION
# Description

Closes #4567

These functions belong in `Cardano.Ledger.Coin` rather than `Cardano.Ledger.UMap`

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
