### PR TITLE
Update upper-bound ghc variant to 9.12.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -255,18 +255,19 @@
         "type": "github"
       }
     },
-    "hackage": {
+    "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1736814684,
-        "narHash": "sha256-k4siImrnyJkRwvUrUNB33B8FtdzLJS4IGtZOd2p5ZXk=",
+        "lastModified": 1744590374,
+        "narHash": "sha256-47Rb79BhL4QTABSkXwu3+ZHJUdAaTntCBQrmOPQd2RE=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "cbe2da819ddef522399233062943ed71b284ccab",
+        "rev": "4862557beb59a2ee7844a16471cccbeb55354d16",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "for-stackage",
         "repo": "hackage.nix",
         "type": "github"
       }
@@ -280,7 +281,9 @@
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat_2",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "hackage": "hackage",
+        "hackage": [
+          "hackageNix"
+        ],
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
         "hls-2.2": "hls-2.2",
@@ -321,6 +324,7 @@
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
+        "rev": "a0283c855a38ed70ba521f7a9290e78488ddf11b",
         "type": "github"
       }
     },
@@ -860,6 +864,7 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "formal-ledger-specifications": "formal-ledger-specifications",
+        "hackageNix": "hackageNix",
         "haskellNix": "haskellNix",
         "iohkNix": "iohkNix",
         "nixpkgs": [

--- a/flake.nix
+++ b/flake.nix
@@ -189,7 +189,7 @@
           cabalProject.flake (
             lib.optionalAttrs (system == "x86_64-linux") {
               # on linux, build/test other supported compilers
-              variants = lib.genAttrs ["ghc8107" "ghc984"] (compiler-nix-name: {
+              variants = lib.genAttrs ["ghc8107" "ghc9121"] (compiler-nix-name: {
                 inherit compiler-nix-name;
               });
             }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,19 @@
   description = "cardano-ledger";
 
   inputs = {
-    haskellNix.url = "github:input-output-hk/haskell.nix";
+
+    # Remove this once we no longer need GHC 8.10.7.
+    hackageNix = {
+      url = "github:input-output-hk/hackage.nix?ref=for-stackage";
+      flake = false;
+    };
+    haskellNix = {
+      # GHC 8.10.7 cross compilation for windows is broken in newer versions of haskell.nix.
+      # Unpin this once we no longer need GHC 8.10.7.
+      url = "github:input-output-hk/haskell.nix/a0283c855a38ed70ba521f7a9290e78488ddf11b";
+      inputs.hackage.follows = "hackageNix";
+    };
+
     nixpkgs.follows = "haskellNix/nixpkgs-unstable";
     iohkNix.url = "github:input-output-hk/iohk-nix";
     flake-utils.url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";


### PR DESCRIPTION
# Description

We use these variants to check that our code builds with nix at both ends of the range of ghc versions that we support. Since #4979, ghc 9.12.1 is now the highest version supported, and is also the highest version used in non-nix builds on GitHub.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
