### PR TITLE
Added plutus preprocessor check to CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,5 +16,6 @@ to the issue. -->
       **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
 - [x] Code formatted (use `scripts/fourmolize.sh`).
 - [x] Cabal files formatted (use `scripts/cabal-format.sh`).
+- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
 - [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
 - [ ] Self-reviewed the diff.

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -387,7 +387,7 @@ jobs:
     - name: Run fourmolu
       run: ./scripts/fourmolize.sh
 
-  gen-cddl:
+  codegen:
     needs: build
 
     runs-on: ubuntu-latest
@@ -400,7 +400,7 @@ jobs:
       SECP256K1_REF: ac83be33d0956faf6b7f61a60ab524ef7d6a473a
 
       SECP_CACHE_VERSION: "2022-12-30"
-      ghc-version: "9.10.1"
+      ghc-version: "9.6.7"
       os: ubuntu-latest
 
     defaults:
@@ -473,6 +473,9 @@ jobs:
 
     - name: Run gen-cddl
       run: ./scripts/gen-cddl.sh
+
+    - name: Run gen-plutus
+      run: ./scripts/gen-plutus.sh
 
   cabal-format:
     runs-on: ubuntu-latest

--- a/scripts/gen-plutus.sh
+++ b/scripts/gen-plutus.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Generating plutus examples..."
+cabal run plutus-preprocessor
+echo "Regenerated plutus examples"
+
+git diff --exit-code


### PR DESCRIPTION
# Description

Adds a check to CI that checks whether generated plutus examples are up-to-date.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
