### PR TITLE
Remove heapwords from cardano-ledger-core

### DIFF
--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.17.0.0
 
+* Remove `HeapWords` instances for: #5001
+  - `ShelleyTxOut`
 * Move `Annotator` instances, `txSeqDecoder` and `mapTraverseableDecoderA` to `testlib`
 * Deprecate `witsFromTxWitnesses`
 * Expose access to `ShelleyTxRaw`, `ShelleyTxAuxDataRaw`, `ShelleyTxBodyRaw`, `ShelleyTxWitsRaw`, `MkMultiSig`

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -116,7 +116,6 @@ library
     data-default,
     deepseq,
     groups,
-    heapwords,
     mempack,
     microlens,
     mtl,

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 1.18.0.0
 
+* Remove `HeapWords` instances for: #5001
+  - `Coin`
+  - `DeltaCoin`
+  - `CompactFormCoin`
+  - `CompactFormDeltaCoin`
+  - `SafeHash`
+  - `StrictMaybe DataHash`
+  - `TxId`
+  - `TxIn`
 * Add `addCompactCoin` to `Cardano.Ledger.Coin` and deprecate `Cardano.Ledger.UMap.addCompact`
   in its favor
 * Move `sumCompactCoin` to `Cardano.Ledger.Coin`

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -118,7 +118,6 @@ library
     data-default >=0.8,
     deepseq,
     groups,
-    heapwords,
     iproute,
     measures,
     mempack,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
@@ -35,7 +35,6 @@ module Cardano.Ledger.Coin (
 )
 where
 
-import Cardano.HeapWords (HeapWords)
 import Cardano.Ledger.BaseTypes (
   HasZero (..),
   Inject (..),
@@ -83,7 +82,7 @@ newtype Coin = Coin {unCoin :: Integer}
     )
   deriving (Show) via Quiet Coin
   deriving (Semigroup, Monoid, Group, Abelian) via Sum Integer
-  deriving newtype (PartialOrd, ToCBOR, EncCBOR, HeapWords)
+  deriving newtype (PartialOrd, ToCBOR, EncCBOR)
 
 instance FromCBOR Coin where
   fromCBOR = Coin . toInteger <$> Plain.decodeWord64
@@ -91,7 +90,7 @@ instance FromCBOR Coin where
 instance DecCBOR Coin
 
 newtype DeltaCoin = DeltaCoin Integer
-  deriving (Eq, Ord, Generic, Enum, NoThunks, HeapWords)
+  deriving (Eq, Ord, Generic, Enum, NoThunks)
   deriving (Show) via Quiet DeltaCoin
   deriving (Semigroup, Monoid, Group, Abelian) via Sum Integer
   deriving newtype (PartialOrd, NFData, ToCBOR, DecCBOR, EncCBOR, ToJSON, FromJSON)
@@ -124,7 +123,7 @@ rationalToCoinViaCeiling = Coin . ceiling
 
 instance Compactible Coin where
   newtype CompactForm Coin = CompactCoin {unCompactCoin :: Word64}
-    deriving (Eq, Show, NoThunks, NFData, HeapWords, Prim, Ord, ToCBOR, ToJSON, FromJSON)
+    deriving (Eq, Show, NoThunks, NFData, Prim, Ord, ToCBOR, ToJSON, FromJSON)
     deriving (Semigroup, Monoid, Group, Abelian) via Sum Word64
 
   toCompact (Coin c) = CompactCoin <$> integerToWord64 c
@@ -145,7 +144,7 @@ instance MemPack (CompactForm Coin) where
 
 instance Compactible DeltaCoin where
   newtype CompactForm DeltaCoin = CompactDeltaCoin Word64
-    deriving (Eq, Show, NoThunks, NFData, HeapWords, ToJSON, Prim)
+    deriving (Eq, Show, NoThunks, NFData, ToJSON, Prim)
 
   toCompact (DeltaCoin dc) = CompactDeltaCoin <$> integerToWord64 dc
   fromCompact (CompactDeltaCoin cdc) = DeltaCoin (unCoin (word64ToCoin cdc))

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
@@ -82,7 +82,6 @@ where
 import qualified Cardano.Crypto.DSIGN as DSIGN
 import qualified Cardano.Crypto.Hash as Hash
 import qualified Cardano.Crypto.VRF as VRF
-import Cardano.HeapWords (HeapWords (..))
 import Cardano.Ledger.Binary (
   DecCBOR (..),
   EncCBOR (..),
@@ -332,7 +331,6 @@ newtype SafeHash i = SafeHash (Hash.Hash HASH i)
     , NoThunks
     , NFData
     , SafeToHash
-    , HeapWords
     , ToCBOR
     , FromCBOR
     , EncCBOR

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Data.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Data.hs
@@ -16,8 +16,6 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
--- This is needed for the `HeapWords (StrictMaybe (DataHash c))` instance
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.Ledger.Plutus.Data (
   PlutusData (..),
@@ -39,7 +37,6 @@ module Cardano.Ledger.Plutus.Data (
 )
 where
 
-import Cardano.HeapWords (HeapWords (..), heapWords0, heapWords1)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Binary (
   DecCBOR (..),
@@ -188,10 +185,6 @@ hashData = hashAnnotated
 dataHashSize :: StrictMaybe DataHash -> Integer
 dataHashSize SNothing = 0
 dataHashSize (SJust _) = 10
-
-instance HeapWords (StrictMaybe DataHash) where
-  heapWords SNothing = heapWords0
-  heapWords (SJust a) = heapWords1 a
 
 -- ============================================================================
 -- Datum

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs
@@ -24,8 +24,6 @@ module Cardano.Ledger.TxIn (
 where
 
 import Cardano.Crypto.Hash.Class (hashToTextAsHex)
-import Cardano.HeapWords (HeapWords (..))
-import qualified Cardano.HeapWords as HW
 import Cardano.Ledger.BaseTypes (TxIx (..), mkTxIxPartial)
 import Cardano.Ledger.Binary (
   DecCBOR (..),
@@ -61,11 +59,7 @@ import NoThunks.Class (NoThunks (..))
 -- | A unique ID of a transaction, which is computable from the transaction.
 newtype TxId = TxId {unTxId :: SafeHash EraIndependentTxBody}
   deriving (Show, Eq, Ord, Generic)
-  deriving newtype (NoThunks, ToJSON, FromJSON, HeapWords, EncCBOR, DecCBOR, NFData, MemPack)
-
-instance HeapWords TxIn where
-  heapWords (TxIn txId _) =
-    2 + HW.heapWords txId + 1 {- txIx -}
+  deriving newtype (NoThunks, ToJSON, FromJSON, EncCBOR, DecCBOR, NFData, MemPack)
 
 instance ToJSON TxIn where
   toJSON = toJSON . txInToText


### PR DESCRIPTION
# Description

The ticket only mentions `cardano-ledger-core` as the package to remove the `heapwords` dependency from but there were instances in the `TxOut` module in `cardano-ledger-shelley` as well, so the second commit removes those.

Closes #3847 

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] ~~Tests added or updated when needed.~~
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] ~~Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).~~
- [ ] ~~Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).~~
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
