### PR TITLE
Made TxBody a data family

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.8.0.0
 
+* Remove `AllegraTxBody`
+* Removed `era` parameter from `AllegraTxBodyRaw`
 * Move `Annotator` instances to `testlib`
 * Expose access to `AllegraTxBodyRaw`, `AllegraTxAuxData` and `TimelockRaw`
 * Expose constructor `MkAllegraTxBody`, `MkTxAuxData` and `MkTimelock`

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Arbitrary.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Arbitrary.hs
@@ -28,11 +28,11 @@ import Cardano.Ledger.Shelley.Scripts (
   pattern RequireSignature,
  )
 
+import Cardano.Ledger.Allegra (AllegraEra)
 import Cardano.Ledger.Allegra.TxAuxData (AllegraTxAuxData (..))
-import Cardano.Ledger.Allegra.TxBody (AllegraTxBody (AllegraTxBody))
+import Cardano.Ledger.Allegra.TxBody (pattern AllegraTxBody)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.API (ShelleyTxAuxData (ShelleyTxAuxData))
-import Data.Maybe.Strict (StrictMaybe)
 import Data.Sequence.Strict (StrictSeq, fromList)
 import Generic.Random (genericArbitraryU)
 import Test.Cardano.Ledger.Shelley.Arbitrary (genMetadata', sizedNativeScriptGens)
@@ -102,15 +102,7 @@ instance
   where
   arbitrary = genericArbitraryU
 
-instance
-  ( EraTxOut era
-  , EraTxCert era
-  , Arbitrary (TxOut era)
-  , Arbitrary (PParamsHKD StrictMaybe era)
-  , Arbitrary (TxCert era)
-  ) =>
-  Arbitrary (AllegraTxBody era)
-  where
+instance Arbitrary (TxBody AllegraEra) where
   arbitrary =
     AllegraTxBody
       <$> arbitrary

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Binary/Annotator.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Binary/Annotator.hs
@@ -14,6 +14,7 @@ module Test.Cardano.Ledger.Allegra.Binary.Annotator (
   module Test.Cardano.Ledger.Shelley.Binary.Annotator,
 ) where
 
+import Cardano.Ledger.Allegra (AllegraEra)
 import Cardano.Ledger.Allegra.Scripts
 import Cardano.Ledger.Allegra.TxAuxData
 import Cardano.Ledger.Allegra.TxBody
@@ -76,6 +77,6 @@ instance
   decCBOR = pure <$> decCBOR
 
 deriving via
-  Mem (AllegraTxBodyRaw () era)
+  Mem (AllegraTxBodyRaw () AllegraEra)
   instance
-    AllegraEraTxBody era => DecCBOR (Annotator (AllegraTxBody era))
+    DecCBOR (Annotator (TxBody AllegraEra))

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/TreeDiff.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/TreeDiff.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -8,6 +9,7 @@ module Test.Cardano.Ledger.Allegra.TreeDiff (
   module Test.Cardano.Ledger.Shelley.TreeDiff,
 ) where
 
+import Cardano.Ledger.Allegra (AllegraEra)
 import Cardano.Ledger.Allegra.Rules
 import Cardano.Ledger.Allegra.Scripts
 import Cardano.Ledger.Allegra.TxAuxData
@@ -38,12 +40,7 @@ instance
   ) =>
   ToExpr (AllegraTxBodyRaw ma era)
 
-instance
-  ( ToExpr (TxOut era)
-  , ToExpr (TxCert era)
-  , ToExpr (Update era)
-  ) =>
-  ToExpr (AllegraTxBody era)
+instance ToExpr (TxBody AllegraEra)
 
 -- Rules/Utxo
 instance

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -11,7 +12,7 @@ module Cardano.Ledger.Alonzo (
   AlonzoEra,
   AlonzoTxOut,
   MaryValue,
-  AlonzoTxBody,
+  pattern AlonzoTxBody,
   AlonzoScript,
   AlonzoTxAuxData,
 )
@@ -27,7 +28,7 @@ import Cardano.Ledger.Alonzo.Transition ()
 import Cardano.Ledger.Alonzo.Translation ()
 import Cardano.Ledger.Alonzo.Tx ()
 import Cardano.Ledger.Alonzo.TxAuxData (AlonzoTxAuxData)
-import Cardano.Ledger.Alonzo.TxBody (AlonzoTxBody, AlonzoTxOut)
+import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut, TxBody (AlonzoTxBody))
 import Cardano.Ledger.Alonzo.TxWits ()
 import Cardano.Ledger.Alonzo.UTxO ()
 import Cardano.Ledger.Mary.Value (MaryValue)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
@@ -52,7 +53,7 @@ module Cardano.Ledger.Alonzo.Tx (
   txdats',
   txscripts',
   txrdmrs,
-  AlonzoTxBody (..),
+  TxBody (AlonzoTxBody),
   -- Figure 4
   totExUnits,
   alonzoMinFeeTx,
@@ -82,9 +83,9 @@ import Cardano.Ledger.Alonzo.Scripts (
  )
 import Cardano.Ledger.Alonzo.TxBody (
   AlonzoEraTxBody (..),
-  AlonzoTxBody (..),
   AlonzoTxBodyUpgradeError,
   ScriptIntegrityHash,
+  TxBody (AlonzoTxBody),
  )
 import Cardano.Ledger.Alonzo.TxWits (
   AlonzoEraTxWits (..),

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -171,7 +171,7 @@ class (MaryEraTxBody era, AlonzoEraTxOut era) => AlonzoEraTxBody era where
 
 -- ======================================
 
-data AlonzoTxBodyRaw era = AlonzoTxBodyRaw
+data AlonzoTxBodyRaw = AlonzoTxBodyRaw
   { atbrInputs :: !(Set TxIn)
   , atbrCollateral :: !(Set TxIn)
   , atbrOutputs :: !(StrictSeq (TxOut AlonzoEra))
@@ -188,24 +188,16 @@ data AlonzoTxBodyRaw era = AlonzoTxBodyRaw
   }
   deriving (Generic)
 
-deriving instance
-  (Era era, Eq (TxOut era), Eq (TxCert era), Eq (PParamsUpdate era)) =>
-  Eq (AlonzoTxBodyRaw era)
+deriving instance Eq AlonzoTxBodyRaw
 
-instance
-  (Era era, NoThunks (TxOut era), NoThunks (TxCert era), NoThunks (PParamsUpdate era)) =>
-  NoThunks (AlonzoTxBodyRaw era)
+instance NoThunks AlonzoTxBodyRaw
 
-instance
-  (Era era, NFData (TxOut era), NFData (TxCert era), NFData (PParamsUpdate era)) =>
-  NFData (AlonzoTxBodyRaw era)
+instance NFData AlonzoTxBodyRaw
 
-deriving instance
-  (Era era, Show (TxOut era), Show (TxCert era), Show (PParamsUpdate era)) =>
-  Show (AlonzoTxBodyRaw era)
+deriving instance Show AlonzoTxBodyRaw
 
 instance Memoized (TxBody AlonzoEra) where
-  type RawType (TxBody AlonzoEra) = AlonzoTxBodyRaw AlonzoEra
+  type RawType (TxBody AlonzoEra) = AlonzoTxBodyRaw
 
 data AlonzoTxBodyUpgradeError
   = -- | The TxBody contains a protocol parameter update that attempts to update
@@ -215,7 +207,7 @@ data AlonzoTxBodyUpgradeError
   deriving (Show)
 
 instance EraTxBody AlonzoEra where
-  newtype TxBody AlonzoEra = MkAlonzoTxBody (MemoBytes (AlonzoTxBodyRaw AlonzoEra))
+  newtype TxBody AlonzoEra = MkAlonzoTxBody (MemoBytes AlonzoTxBodyRaw)
     deriving (ToCBOR, Generic)
     deriving newtype (SafeToHash)
   type TxBodyUpgradeError AlonzoEra = AlonzoTxBodyUpgradeError
@@ -454,7 +446,7 @@ pattern AlonzoTxBody
 
 {-# COMPLETE AlonzoTxBody #-}
 
-type instance MemoHashIndex (AlonzoTxBodyRaw era) = EraIndependentTxBody
+type instance MemoHashIndex AlonzoTxBodyRaw = EraIndependentTxBody
 
 instance HashAnnotated (TxBody AlonzoEra) EraIndependentTxBody where
   hashAnnotated = getMemoSafeHash
@@ -526,10 +518,7 @@ instance EqRaw (TxBody AlonzoEra)
 -- | Encodes memoized bytes created upon construction.
 instance EncCBOR (TxBody AlonzoEra)
 
-instance
-  (Era era, EncCBOR (TxOut era), EncCBOR (TxCert era), EncCBOR (PParamsUpdate era)) =>
-  EncCBOR (AlonzoTxBodyRaw era)
-  where
+instance EncCBOR AlonzoTxBodyRaw where
   encCBOR
     AlonzoTxBodyRaw
       { atbrInputs
@@ -566,10 +555,7 @@ instance
           !> encodeKeyedStrictMaybe 7 atbrAuxDataHash
           !> encodeKeyedStrictMaybe 15 atbrTxNetworkId
 
-instance
-  (Era era, DecCBOR (TxOut era), DecCBOR (TxCert era), DecCBOR (PParamsUpdate era)) =>
-  DecCBOR (AlonzoTxBodyRaw era)
-  where
+instance DecCBOR AlonzoTxBodyRaw where
   decCBOR =
     decode $
       SparseKeyed
@@ -578,7 +564,7 @@ instance
         bodyFields
         requiredFields
     where
-      bodyFields :: Word -> Field (AlonzoTxBodyRaw era)
+      bodyFields :: Word -> Field AlonzoTxBodyRaw
       bodyFields 0 = field (\x tx -> tx {atbrInputs = x}) From
       bodyFields 1 = field (\x tx -> tx {atbrOutputs = x}) From
       bodyFields 2 = field (\x tx -> tx {atbrTxFee = x}) From
@@ -606,7 +592,7 @@ instance
         , (2, "fee")
         ]
 
-emptyAlonzoTxBodyRaw :: AlonzoTxBodyRaw era
+emptyAlonzoTxBodyRaw :: AlonzoTxBodyRaw
 emptyAlonzoTxBodyRaw =
   AlonzoTxBodyRaw
     mempty

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -33,6 +34,7 @@ module Test.Cardano.Ledger.Alonzo.Arbitrary (
 ) where
 
 import Cardano.Ledger.Allegra.Scripts (Timelock)
+import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
 import Cardano.Ledger.Alonzo.PParams (AlonzoPParams (AlonzoPParams), OrdExUnits (OrdExUnits))
@@ -60,7 +62,7 @@ import Cardano.Ledger.Alonzo.TxAuxData (
   AlonzoTxAuxData (..),
   mkAlonzoTxAuxData,
  )
-import Cardano.Ledger.Alonzo.TxBody (AlonzoTxBody (AlonzoTxBody))
+import Cardano.Ledger.Alonzo.TxBody (TxBody (AlonzoTxBody))
 import Cardano.Ledger.Alonzo.TxOut (AlonzoTxOut (AlonzoTxOut))
 import Cardano.Ledger.Alonzo.TxWits (
   AlonzoTxWits (AlonzoTxWits),
@@ -158,15 +160,7 @@ instance
       <*> scale (`div` 15) arbitrary
       <*> arbitrary
 
-instance
-  ( EraTxOut era
-  , EraTxCert era
-  , Arbitrary (TxOut era)
-  , Arbitrary (PParamsHKD StrictMaybe era)
-  , Arbitrary (TxCert era)
-  ) =>
-  Arbitrary (AlonzoTxBody era)
-  where
+instance Arbitrary (TxBody AlonzoEra) where
   arbitrary =
     AlonzoTxBody
       <$> arbitrary

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/Annotator.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/Annotator.hs
@@ -15,6 +15,7 @@ module Test.Cardano.Ledger.Alonzo.Binary.Annotator (
   module Test.Cardano.Ledger.Mary.Binary.Annotator,
 ) where
 
+import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Scripts
 import Cardano.Ledger.Alonzo.Tx hiding (wits)
 import Cardano.Ledger.Alonzo.TxAuxData
@@ -238,10 +239,9 @@ deriving via
     Era era => DecCBOR (Annotator (AlonzoTxAuxData era))
 
 deriving via
-  Mem (AlonzoTxBodyRaw era)
+  Mem (AlonzoTxBodyRaw AlonzoEra)
   instance
-    (Era era, DecCBOR (TxOut era), DecCBOR (TxCert era), DecCBOR (PParamsUpdate era)) =>
-    DecCBOR (Annotator (AlonzoTxBody era))
+    DecCBOR (Annotator (TxBody AlonzoEra))
 
 instance
   (Era era, DecCBOR (TxOut era), DecCBOR (TxCert era), DecCBOR (PParamsUpdate era)) =>

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/Annotator.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/Annotator.hs
@@ -238,15 +238,9 @@ deriving via
   instance
     Era era => DecCBOR (Annotator (AlonzoTxAuxData era))
 
-deriving via
-  Mem (AlonzoTxBodyRaw AlonzoEra)
-  instance
-    DecCBOR (Annotator (TxBody AlonzoEra))
+deriving via Mem AlonzoTxBodyRaw instance DecCBOR (Annotator (TxBody AlonzoEra))
 
-instance
-  (Era era, DecCBOR (TxOut era), DecCBOR (TxCert era), DecCBOR (PParamsUpdate era)) =>
-  DecCBOR (Annotator (AlonzoTxBodyRaw era))
-  where
+instance DecCBOR (Annotator AlonzoTxBodyRaw) where
   decCBOR = pure <$> decCBOR
 
 instance

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
@@ -93,9 +93,7 @@ instance ToExpr DataHash32
 instance ToExpr (CompactForm (Value era)) => ToExpr (AlonzoTxOut era)
 
 -- TxBody
-instance
-  (Era era, ToExpr (TxOut era), ToExpr (TxCert era), ToExpr (PParamsUpdate era)) =>
-  ToExpr (AlonzoTxBodyRaw era)
+instance ToExpr AlonzoTxBodyRaw
 
 instance ToExpr (TxBody AlonzoEra)
 

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
@@ -97,9 +97,7 @@ instance
   (Era era, ToExpr (TxOut era), ToExpr (TxCert era), ToExpr (PParamsUpdate era)) =>
   ToExpr (AlonzoTxBodyRaw era)
 
-instance
-  (Era era, ToExpr (TxOut era), ToExpr (TxCert era), ToExpr (PParamsUpdate era)) =>
-  ToExpr (AlonzoTxBody era)
+instance ToExpr (TxBody AlonzoEra)
 
 -- Tx
 instance ToExpr IsValid

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -45,8 +45,8 @@ import Cardano.Ledger.Alonzo.Tx (
  )
 import Cardano.Ledger.Alonzo.TxAuxData (AlonzoTxAuxData (..), mkAlonzoTxAuxData)
 import Cardano.Ledger.Alonzo.TxBody (
-  AlonzoTxBody (..),
   AlonzoTxOut (..),
+  TxBody (..),
   utxoEntrySize,
  )
 import Cardano.Ledger.Alonzo.TxWits (

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Examples/Consensus.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Examples/Consensus.hs
@@ -16,7 +16,7 @@ import Cardano.Ledger.Alonzo.Scripts (
  )
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), IsValid (..))
 import Cardano.Ledger.Alonzo.TxAuxData (mkAlonzoTxAuxData)
-import Cardano.Ledger.Alonzo.TxBody (AlonzoTxBody (..), AlonzoTxOut (..))
+import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..), TxBody (..))
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), Redeemers (..), TxDats (..))
 import Cardano.Ledger.BaseTypes (NonNegativeInterval, StrictMaybe (..), boundRational)
 import Cardano.Ledger.Coin (Coin (..))
@@ -92,7 +92,7 @@ ledgerExamplesAlonzo =
           (SLE.mkKeyHash 0)
           (emptyPParamsUpdate & ppuCollateralPercentageL .~ SJust 150)
 
-exampleTxBodyAlonzo :: AlonzoTxBody AlonzoEra
+exampleTxBodyAlonzo :: TxBody AlonzoEra
 exampleTxBodyAlonzo =
   AlonzoTxBody
     (Set.fromList [mkTxInPartial (TxId (mkDummySafeHash 1)) 0]) -- inputs

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Serialisation/Generators.hs
@@ -13,8 +13,7 @@ module Test.Cardano.Ledger.Alonzo.Serialisation.Generators where
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..))
-import Cardano.Ledger.Alonzo.Tx (AlonzoTxBody (..))
-import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..))
+import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..), TxBody (..))
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (EncCBOR (..))
 import Cardano.Ledger.Coin (Coin)
@@ -69,7 +68,7 @@ instance Twiddle TxIn where
 instance Twiddle Coin where
   twiddle v = twiddle v . toTerm v
 
-instance Twiddle (AlonzoTxBody AlonzoEra) where
+instance Twiddle (TxBody AlonzoEra) where
   twiddle v txBody = do
     inputs' <- twiddle v $ atbInputs txBody
     outputs' <- twiddle v $ atbOutputs txBody

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -19,7 +19,7 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
  )
 import Cardano.Ledger.Alonzo.Plutus.TxInfo (AlonzoContextError (..), transValidityInterval)
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), IsValid (..))
-import Cardano.Ledger.Alonzo.TxBody (AlonzoTxBody (..), AlonzoTxOut (..))
+import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..), TxBody (..))
 import Cardano.Ledger.BaseTypes (Network (..), StrictMaybe (..), natVersion)
 import qualified Cardano.Ledger.BaseTypes as BT (Inject (..), ProtVer (..))
 import Cardano.Ledger.Coin (Coin (..))

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.12.0.0
 
+* Remove `BabbageTxBody`
+* Removed `era` parameter from `BabbageTxBodyRaw`
 * Move `Annotator` instances to `testlib`
 * Expose access to `BabbageTxBodyRaw`
 * Expose constructor `MkBabbageTxBody`

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -9,7 +9,7 @@ module Cardano.Ledger.Babbage (
   Babbage,
   BabbageEra,
   BabbageTxOut,
-  BabbageTxBody,
+  TxBody (BabbageTxBody),
   AlonzoScript,
   AlonzoTxAuxData,
 )
@@ -22,7 +22,7 @@ import Cardano.Ledger.Babbage.Rules ()
 import Cardano.Ledger.Babbage.State ()
 import Cardano.Ledger.Babbage.Transition ()
 import Cardano.Ledger.Babbage.Translation ()
-import Cardano.Ledger.Babbage.TxBody (BabbageTxBody, BabbageTxOut)
+import Cardano.Ledger.Babbage.TxBody (BabbageTxOut, TxBody (BabbageTxBody))
 import Cardano.Ledger.Babbage.TxInfo ()
 import Cardano.Ledger.Babbage.UTxO ()
 import Cardano.Ledger.Shelley.API

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
@@ -4,7 +4,7 @@
 
 module Cardano.Ledger.Babbage.Tx (
   AlonzoTx (..),
-  BabbageTxBody (..),
+  TxBody (..),
   module X,
 )
 where
@@ -18,8 +18,8 @@ import Cardano.Ledger.Alonzo.TxSeq (
 import Cardano.Ledger.Babbage.Era (BabbageEra)
 import Cardano.Ledger.Babbage.TxAuxData ()
 import Cardano.Ledger.Babbage.TxBody (
-  BabbageTxBody (..),
   BabbageTxBodyUpgradeError,
+  TxBody (..),
  )
 import Cardano.Ledger.Babbage.TxWits ()
 import Cardano.Ledger.Core

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Arbitrary.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Arbitrary.hs
@@ -14,11 +14,9 @@ import Cardano.Ledger.Babbage
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.PParams
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure (..), BabbageUtxowPredFailure (..))
-import Cardano.Ledger.Babbage.Tx
 import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
 import Cardano.Ledger.Babbage.TxInfo (BabbageContextError (..))
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
-import Cardano.Ledger.Binary (Sized)
 import Cardano.Ledger.Plutus
 import Control.State.Transition (STS (PredicateFailure))
 import Data.Functor.Identity (Identity)
@@ -137,17 +135,7 @@ instance
       <*> arbitrary
       <*> arbitrary
 
-instance
-  ( BabbageEraTxBody era
-  , Arbitrary (Sized (TxOut era))
-  , Arbitrary (TxOut era)
-  , Arbitrary (Value era)
-  , Arbitrary (Script era)
-  , Arbitrary (PParamsHKD StrictMaybe era)
-  , Arbitrary (TxCert era)
-  ) =>
-  Arbitrary (BabbageTxBody era)
-  where
+instance Arbitrary (TxBody BabbageEra) where
   arbitrary =
     BabbageTxBody
       <$> arbitrary

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Binary/Annotator.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Binary/Annotator.hs
@@ -10,16 +10,16 @@ module Test.Cardano.Ledger.Babbage.Binary.Annotator (
   module Test.Cardano.Ledger.Alonzo.Binary.Annotator,
 ) where
 
+import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.TxBody
 import Cardano.Ledger.Binary
 import Test.Cardano.Ledger.Alonzo.Binary.Annotator
 
 deriving via
-  Mem (BabbageTxBodyRaw era)
+  Mem (BabbageTxBodyRaw BabbageEra)
   instance
-    (Era era, DecCBOR (TxOut era), DecCBOR (TxCert era), DecCBOR (PParamsUpdate era)) =>
-    DecCBOR (Annotator (BabbageTxBody era))
+    DecCBOR (Annotator (TxBody BabbageEra))
 
 instance
   (Era era, DecCBOR (TxOut era), DecCBOR (TxCert era), DecCBOR (PParamsUpdate era)) =>

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Binary/Annotator.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Binary/Annotator.hs
@@ -16,13 +16,7 @@ import Cardano.Ledger.Babbage.TxBody
 import Cardano.Ledger.Binary
 import Test.Cardano.Ledger.Alonzo.Binary.Annotator
 
-deriving via
-  Mem (BabbageTxBodyRaw BabbageEra)
-  instance
-    DecCBOR (Annotator (TxBody BabbageEra))
+deriving via Mem BabbageTxBodyRaw instance DecCBOR (Annotator (TxBody BabbageEra))
 
-instance
-  (Era era, DecCBOR (TxOut era), DecCBOR (TxCert era), DecCBOR (PParamsUpdate era)) =>
-  DecCBOR (Annotator (BabbageTxBodyRaw era))
-  where
+instance DecCBOR (Annotator BabbageTxBodyRaw) where
   decCBOR = pure <$> decCBOR

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Translation/TranslatableGen.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Translation/TranslatableGen.hs
@@ -18,7 +18,7 @@ import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..))
 import Cardano.Ledger.Alonzo.TxWits
 import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.Babbage.Core
-import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..), BabbageTxOut (..))
+import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..), TxBody (BabbageTxBody))
 import Cardano.Ledger.Binary (mkSized)
 import Cardano.Ledger.Credential (StakeReference (..))
 import Cardano.Ledger.Plutus.Data (Data (..), Datum (..))
@@ -109,7 +109,7 @@ genTxOut l = do
     _ -> arbitrary
   pure $ BabbageTxOut addr value datum script
 
-genTxBody :: Language -> Gen (BabbageTxBody BabbageEra)
+genTxBody :: Language -> Gen (TxBody BabbageEra)
 genTxBody l = do
   let genTxOuts = fromList <$> listOf1 (mkSized (eraProtVerLow @BabbageEra) <$> genTxOut @BabbageEra l)
   let genTxIns = Set.fromList <$> listOf1 (arbitrary :: Gen TxIn)

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/TreeDiff.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/TreeDiff.hs
@@ -52,9 +52,7 @@ instance
   (Era era, ToExpr (TxOut era), ToExpr (TxCert era), ToExpr (PParamsUpdate era)) =>
   ToExpr (BabbageTxBodyRaw era)
 
-instance
-  (Era era, ToExpr (TxOut era), ToExpr (TxCert era), ToExpr (PParamsUpdate era)) =>
-  ToExpr (BabbageTxBody era)
+instance ToExpr (TxBody BabbageEra)
 
 -- Rules/Utxo
 instance

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/TreeDiff.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/TreeDiff.hs
@@ -48,9 +48,7 @@ instance
   ToExpr (BabbageTxOut era)
 
 -- TxBody
-instance
-  (Era era, ToExpr (TxOut era), ToExpr (TxCert era), ToExpr (PParamsUpdate era)) =>
-  ToExpr (BabbageTxBodyRaw era)
+instance ToExpr BabbageTxBodyRaw
 
 instance ToExpr (TxBody BabbageEra)
 

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Examples/Consensus.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Examples/Consensus.hs
@@ -12,7 +12,7 @@ import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), Redeemers (..), TxDats (
 import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Translation ()
-import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..), BabbageTxOut (..))
+import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..), TxBody (..))
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Binary (mkSized)
 import Cardano.Ledger.Coin (Coin (..))

--- a/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
+++ b/eras/babbage/test-suite/src/Test/Cardano/Ledger/Babbage/Serialisation/Generators.hs
@@ -11,6 +11,7 @@
 
 module Test.Cardano.Ledger.Babbage.Serialisation.Generators where
 
+import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Tx
 import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
@@ -30,14 +31,7 @@ instance Twiddle a => Twiddle (Sized a)
 instance (EraScript era, Val (Value era)) => Twiddle (BabbageTxOut era) where
   twiddle v = twiddle v . toTerm v
 
-instance
-  ( Era era
-  , Twiddle (TxOut era)
-  , Twiddle (TxCert era)
-  , BabbageEraTxBody era
-  ) =>
-  Twiddle (BabbageTxBody era)
-  where
+instance Twiddle (TxBody BabbageEra) where
   twiddle v txBody = do
     inputs' <- twiddle v $ btbInputs txBody
     outputs' <- twiddle v $ btbOutputs txBody

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.20.0.0
 
+* Remove `ConwayTxBody`
+* Removed `era` parameter from `ConwayTxBodyRaw`
 * Add `MkConwayTxBody` and all members of `ConwayTxBodyRaw`:
   (`ConwayTxBodyRaw`, `ctbrAuxDataHash`, `ctbrCerts`, `ctbrCollateralInputs`,
   `ctbrCollateralReturn`, `ctbrCurrentTreasuryValue`, `ctbrFee`, `ctbrMint`, `ctbrNetworkId`,

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -37,7 +37,7 @@ module Test.Cardano.Ledger.Conway.Arbitrary (
 
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (CollectError)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
-import Cardano.Ledger.Binary (Sized)
+import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
 import Cardano.Ledger.Conway.Governance
@@ -541,17 +541,7 @@ instance Arbitrary Vote where
   arbitrary = arbitraryBoundedEnum
   shrink = shrinkBoundedEnum
 
-instance
-  ( ConwayEraTxBody era
-  , Arbitrary (Sized (TxOut era))
-  , Arbitrary (TxOut era)
-  , Arbitrary (Value era)
-  , Arbitrary (Script era)
-  , Arbitrary (PParamsUpdate era)
-  , Arbitrary (TxCert era)
-  ) =>
-  Arbitrary (ConwayTxBody era)
-  where
+instance Arbitrary (TxBody ConwayEra) where
   arbitrary =
     ConwayTxBody
       <$> arbitrary

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Annotator.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Annotator.hs
@@ -16,16 +16,7 @@ import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.TxBody
 import Test.Cardano.Ledger.Babbage.Binary.Annotator
 
-instance
-  ( DecCBOR (TxOut era)
-  , EraTxCert era
-  , EraPParams era
-  ) =>
-  DecCBOR (Annotator (ConwayTxBodyRaw era))
-  where
+instance DecCBOR (Annotator ConwayTxBodyRaw) where
   decCBOR = pure <$> decCBOR
 
-deriving via
-  Mem (ConwayTxBodyRaw ConwayEra)
-  instance
-    DecCBOR (Annotator (TxBody ConwayEra))
+deriving via Mem ConwayTxBodyRaw instance DecCBOR (Annotator (TxBody ConwayEra))

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Annotator.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Annotator.hs
@@ -11,6 +11,7 @@ module Test.Cardano.Ledger.Conway.Binary.Annotator (
 ) where
 
 import Cardano.Ledger.Binary
+import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.TxBody
 import Test.Cardano.Ledger.Babbage.Binary.Annotator
@@ -25,10 +26,6 @@ instance
   decCBOR = pure <$> decCBOR
 
 deriving via
-  Mem (ConwayTxBodyRaw era)
+  Mem (ConwayTxBodyRaw ConwayEra)
   instance
-    ( DecCBOR (TxOut era)
-    , EraTxCert era
-    , EraPParams era
-    ) =>
-    DecCBOR (Annotator (ConwayTxBody era))
+    DecCBOR (Annotator (TxBody ConwayEra))

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Translation/TranslatableGen.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Translation/TranslatableGen.hs
@@ -13,7 +13,7 @@ import Cardano.Ledger.Binary (mkSized)
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Governance (VotingProcedures (..))
 import Cardano.Ledger.Conway.Scripts (ConwayPlutusPurpose (..))
-import Cardano.Ledger.Conway.TxBody (ConwayTxBody (..))
+import Cardano.Ledger.Conway.TxBody (TxBody (ConwayTxBody))
 import Cardano.Ledger.Conway.TxCert
 import Cardano.Ledger.Core
 import Cardano.Ledger.Plutus (Data (..), ExUnits, Language (..), SLanguage (..))
@@ -42,7 +42,7 @@ instance TranslatableGen ConwayEra where
   mkTxInfoLanguage PlutusV2 = TxInfoLanguage SPlutusV2
   mkTxInfoLanguage PlutusV3 = TxInfoLanguage SPlutusV3
 
-genTxBody :: Language -> Gen (ConwayTxBody ConwayEra)
+genTxBody :: Language -> Gen (TxBody ConwayEra)
 genTxBody l = do
   let genTxOuts =
         fromList

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
@@ -166,9 +166,7 @@ instance
   ToExpr (ConwayUtxosPredFailure era)
 
 -- TxBody
-instance
-  (EraPParams era, ToExpr (PParamsHKD StrictMaybe era), ToExpr (TxOut era), ToExpr (TxCert era)) =>
-  ToExpr (ConwayTxBodyRaw era)
+instance ToExpr ConwayTxBodyRaw
 
 instance ToExpr (TxBody ConwayEra)
 

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
@@ -170,9 +170,7 @@ instance
   (EraPParams era, ToExpr (PParamsHKD StrictMaybe era), ToExpr (TxOut era), ToExpr (TxCert era)) =>
   ToExpr (ConwayTxBodyRaw era)
 
-instance
-  (EraPParams era, ToExpr (PParamsHKD StrictMaybe era), ToExpr (TxOut era), ToExpr (TxCert era)) =>
-  ToExpr (ConwayTxBody era)
+instance ToExpr (TxBody ConwayEra)
 
 -- Rules/Cert
 instance

--- a/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
+++ b/eras/conway/test-suite/src/Test/Cardano/Ledger/Conway/Examples/Consensus.hs
@@ -25,7 +25,7 @@ import Cardano.Ledger.Conway.Rules (ConwayDELEG, ConwayDelegPredFailure (..), Co
 import Cardano.Ledger.Conway.Scripts (ConwayPlutusPurpose (..))
 import Cardano.Ledger.Conway.Translation ()
 import Cardano.Ledger.Conway.Tx (AlonzoTx (..))
-import Cardano.Ledger.Conway.TxBody (ConwayTxBody (..))
+import Cardano.Ledger.Conway.TxBody (TxBody (..))
 import Cardano.Ledger.Conway.TxCert
 import Cardano.Ledger.Conway.TxWits (AlonzoTxWits (..))
 import Cardano.Ledger.Credential (Credential (KeyHashObj, ScriptHashObj))

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.9.0.0
 
+* Remove `MaryTxBody`
 * Move `Annotator` instances to `testlib`
 * Converted `MaryTxBodyRaw` into a type synonym
 * Expose constructor `MkMaryTxBody`

--- a/eras/mary/impl/src/Cardano/Ledger/Mary.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary.hs
@@ -11,7 +11,7 @@ module Cardano.Ledger.Mary (
   ShelleyTx,
   ShelleyTxOut,
   MaryValue,
-  MaryTxBody,
+  TxBody (..),
 )
 where
 
@@ -23,7 +23,7 @@ import Cardano.Ledger.Mary.State ()
 import Cardano.Ledger.Mary.Transition ()
 import Cardano.Ledger.Mary.Translation ()
 import Cardano.Ledger.Mary.TxAuxData ()
-import Cardano.Ledger.Mary.TxBody (MaryTxBody)
+import Cardano.Ledger.Mary.TxBody (TxBody (..))
 import Cardano.Ledger.Mary.TxSeq ()
 import Cardano.Ledger.Mary.UTxO ()
 import Cardano.Ledger.Mary.Value (MaryValue)

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxBody.hs
@@ -79,7 +79,7 @@ class AllegraEraTxBody era => MaryEraTxBody era where
 -- ===========================================================================
 -- Wrap it all up in a newtype, hiding the insides with a pattern constructor.
 
-type MaryTxBodyRaw era = AllegraTxBodyRaw MultiAsset era
+type MaryTxBodyRaw = AllegraTxBodyRaw MultiAsset MaryEra
 
 -- | Encodes memoized bytes created upon construction.
 instance EncCBOR (TxBody MaryEra)
@@ -87,7 +87,7 @@ instance EncCBOR (TxBody MaryEra)
 instance EqRaw (TxBody MaryEra)
 
 instance Memoized (TxBody MaryEra) where
-  type RawType (TxBody MaryEra) = MaryTxBodyRaw MaryEra
+  type RawType (TxBody MaryEra) = MaryTxBodyRaw
 
 deriving newtype instance Eq (TxBody MaryEra)
 
@@ -101,7 +101,7 @@ deriving newtype instance NFData (TxBody MaryEra)
 
 deriving newtype instance DecCBOR (TxBody MaryEra)
 
-type instance MemoHashIndex (MaryTxBodyRaw era) = EraIndependentTxBody
+type instance MemoHashIndex MaryTxBodyRaw = EraIndependentTxBody
 
 instance HashAnnotated (TxBody MaryEra) EraIndependentTxBody where
   hashAnnotated = getMemoSafeHash
@@ -170,7 +170,7 @@ pattern MaryTxBody
 {-# COMPLETE MaryTxBody #-}
 
 instance EraTxBody MaryEra where
-  newtype TxBody MaryEra = MkMaryTxBody (MemoBytes (MaryTxBodyRaw MaryEra))
+  newtype TxBody MaryEra = MkMaryTxBody (MemoBytes MaryTxBodyRaw)
     deriving newtype (SafeToHash, ToCBOR)
 
   mkBasicTxBody = mkMemoizedEra @MaryEra emptyAllegraTxBodyRaw

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Arbitrary.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Arbitrary.hs
@@ -22,7 +22,7 @@ import Cardano.Crypto.Hash.Class (castHash, hashWith)
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Compactible
 import Cardano.Ledger.Core
-import Cardano.Ledger.Mary.TxBody (MaryTxBody (..))
+import Cardano.Ledger.Mary (MaryEra, TxBody (MaryTxBody))
 import Cardano.Ledger.Mary.Value (
   AssetName (..),
   MaryValue (..),
@@ -34,7 +34,6 @@ import qualified Cardano.Ledger.Mary.Value as ConcreteValue
 import Data.Int (Int64)
 import qualified Data.Map.Strict as Map (empty)
 import Data.Maybe (fromMaybe)
-import Data.Maybe.Strict (StrictMaybe)
 import Data.String (IsString (fromString))
 import Test.Cardano.Data (genNonEmptyMap)
 import Test.Cardano.Ledger.Allegra.Arbitrary ()
@@ -49,16 +48,7 @@ instance Arbitrary AssetName where
         , (7, genShortByteString =<< choose (1, 32))
         ]
 
-instance
-  ( EraTxOut era
-  , EraTxCert era
-  , Era era
-  , Arbitrary (TxOut era)
-  , Arbitrary (PParamsHKD StrictMaybe era)
-  , Arbitrary (TxCert era)
-  ) =>
-  Arbitrary (MaryTxBody era)
-  where
+instance Arbitrary (TxBody MaryEra) where
   arbitrary =
     MaryTxBody
       <$> arbitrary

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Binary/Annotator.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Binary/Annotator.hs
@@ -13,7 +13,4 @@ import Cardano.Ledger.Mary.Core
 import Cardano.Ledger.Mary.TxBody
 import Test.Cardano.Ledger.Allegra.Binary.Annotator
 
-deriving via
-  Mem (MaryTxBodyRaw MaryEra)
-  instance
-    DecCBOR (Annotator (TxBody MaryEra))
+deriving via Mem MaryTxBodyRaw instance DecCBOR (Annotator (TxBody MaryEra))

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Binary/Annotator.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Binary/Annotator.hs
@@ -8,11 +8,12 @@ module Test.Cardano.Ledger.Mary.Binary.Annotator (
 ) where
 
 import Cardano.Ledger.Binary
+import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.Mary.Core
 import Cardano.Ledger.Mary.TxBody
 import Test.Cardano.Ledger.Allegra.Binary.Annotator
 
 deriving via
-  Mem (MaryTxBodyRaw era)
+  Mem (MaryTxBodyRaw MaryEra)
   instance
-    MaryEraTxBody era => DecCBOR (Annotator (MaryTxBody era))
+    DecCBOR (Annotator (TxBody MaryEra))

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/TreeDiff.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/TreeDiff.hs
@@ -12,9 +12,8 @@ module Test.Cardano.Ledger.Mary.TreeDiff (
 ) where
 
 import Cardano.Ledger.Core
-import Cardano.Ledger.Mary.TxBody
+import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.Mary.Value
-import Cardano.Ledger.Shelley.PParams
 import Test.Cardano.Ledger.Allegra.TreeDiff
 
 -- Value
@@ -31,9 +30,4 @@ instance ToExpr AssetName where
 
 deriving newtype instance ToExpr (CompactForm MaryValue)
 
-instance
-  ( ToExpr (TxOut era)
-  , ToExpr (TxCert era)
-  , ToExpr (Update era)
-  ) =>
-  ToExpr (MaryTxBody era)
+instance ToExpr (TxBody MaryEra)

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/AllegraEraGen.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/AllegraEraGen.hs
@@ -28,7 +28,7 @@ import Cardano.Ledger.Allegra.Scripts (
   pattern RequireTimeExpire,
   pattern RequireTimeStart,
  )
-import Cardano.Ledger.Allegra.TxBody (AllegraTxBody (..))
+import Cardano.Ledger.Allegra.TxBody (TxBody (AllegraTxBody))
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Binary (encCBOR, serialize')
 import Cardano.Ledger.Coin (Coin)
@@ -98,16 +98,15 @@ instance EraGen AllegraEra where
   constructTx = ShelleyTx
 
 genTxBody ::
-  AllegraEraTxBody era =>
   SlotNo ->
   Set.Set TxIn ->
-  StrictSeq (TxOut era) ->
-  StrictSeq (TxCert era) ->
+  StrictSeq (TxOut AllegraEra) ->
+  StrictSeq (TxCert AllegraEra) ->
   Withdrawals ->
   Coin ->
-  StrictMaybe (Update era) ->
+  StrictMaybe (Update AllegraEra) ->
   StrictMaybe TxAuxDataHash ->
-  Gen (AllegraTxBody era, [Timelock era])
+  Gen (TxBody AllegraEra, [Timelock AllegraEra])
 genTxBody slot ins outs cert wdrl fee upd ad = do
   validityInterval <- genValidityInterval slot
   pure

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/MaryEraGen.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/MaryEraGen.hs
@@ -23,7 +23,7 @@ import Cardano.Ledger.Allegra.Scripts (AllegraEraScript)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
-import Cardano.Ledger.Mary.TxBody (MaryTxBody (MaryTxBody))
+import Cardano.Ledger.Mary.TxBody (TxBody (MaryTxBody))
 import Cardano.Ledger.Mary.Value (
   AssetName (..),
   MaryValue (..),
@@ -275,26 +275,20 @@ addTokens _proxy _ _ _ StrictSeq.Empty = Nothing
 
 -- | This function is only good in the Mary Era
 genTxBody ::
-  forall era.
-  ( EraGen era
-  , AllegraEraScript era
-  , Value era ~ MaryValue
-  , TxOut era ~ ShelleyTxOut era
-  ) =>
-  PParams era ->
+  PParams MaryEra ->
   SlotNo ->
   Set.Set TxIn ->
-  StrictSeq (ShelleyTxOut era) ->
-  StrictSeq (TxCert era) ->
+  StrictSeq (ShelleyTxOut MaryEra) ->
+  StrictSeq (TxCert MaryEra) ->
   Withdrawals ->
   Coin ->
-  StrictMaybe (Update era) ->
+  StrictMaybe (Update MaryEra) ->
   StrictMaybe TxAuxDataHash ->
-  Gen (MaryTxBody era, [NativeScript era])
+  Gen (TxBody MaryEra, [NativeScript MaryEra])
 genTxBody pparams slot ins outs cert wdrl fee upd meta = do
   validityInterval <- genValidityInterval slot
   mint <- genMint
-  let (mint', outs') = case addTokens (Proxy @era) StrictSeq.Empty pparams mint outs of
+  let (mint', outs') = case addTokens (Proxy @MaryEra) StrictSeq.Empty pparams mint outs of
         Nothing -> (mempty, outs)
         Just os -> (mint, os)
       ps =

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
@@ -20,14 +20,14 @@ import Cardano.Ledger.Allegra.Scripts (
   pattern RequireTimeStart,
  )
 import Cardano.Ledger.Allegra.TxAuxData (pattern AllegraTxAuxData)
-import Cardano.Ledger.Allegra.TxBody (AllegraTxBody (..))
+import Cardano.Ledger.Allegra.TxBody (TxBody (..))
 import Cardano.Ledger.BaseTypes (Network (..), StrictMaybe (..))
 import Cardano.Ledger.Binary (DecCBOR, ToCBOR)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.Mary.Core
-import Cardano.Ledger.Mary.TxBody (MaryTxBody (..))
+import Cardano.Ledger.Mary.TxBody (TxBody (..))
 import Cardano.Ledger.Mary.Value (AssetName (..), MaryValue (..), MultiAsset (..), PolicyID (..))
 import Cardano.Ledger.Shelley.PParams (
   Update,

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.17.0.0
 
+* Remove `ShelleyTxBody`
+* Removed `era` parameter from `ShelleyTxBodyRaw`
 * Remove `HeapWords` instances for: #5001
   - `ShelleyTxOut`
 * Move `Annotator` instances, `txSeqDecoder` and `mapTraverseableDecoderA` to `testlib`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley.hs
@@ -3,7 +3,7 @@ module Cardano.Ledger.Shelley (
   ShelleyEra,
   ShelleyTx,
   ShelleyTxOut,
-  ShelleyTxBody,
+  TxBody (..),
   ShelleyTxAuxData,
   nativeMultiSigTag,
 )
@@ -18,7 +18,7 @@ import Cardano.Ledger.Shelley.Scripts (nativeMultiSigTag)
 import Cardano.Ledger.Shelley.Translation ()
 import Cardano.Ledger.Shelley.Tx (ShelleyTx)
 import Cardano.Ledger.Shelley.TxAuxData (ShelleyTxAuxData)
-import Cardano.Ledger.Shelley.TxBody (ShelleyTxBody)
+import Cardano.Ledger.Shelley.TxBody (TxBody (..))
 import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut)
 import Cardano.Ledger.Shelley.UTxO ()
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Types.hs
@@ -120,7 +120,7 @@ import Cardano.Ledger.Shelley.TxAuxData as X (
   Metadatum (..),
   ShelleyTxAuxData (..),
  )
-import Cardano.Ledger.Shelley.TxBody as X (ShelleyTxBody (..))
+import Cardano.Ledger.Shelley.TxBody as X (TxBody (ShelleyTxBody))
 import Cardano.Ledger.Shelley.TxCert as X (
   GenesisDelegCert (..),
   MIRCert (..),

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -29,7 +29,6 @@ module Test.Cardano.Ledger.Shelley.Arbitrary (
 
 import qualified Cardano.Chain.UTxO as Byron
 import Cardano.Ledger.BaseTypes
-import Cardano.Ledger.Binary (EncCBOR)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.API (
   ApplyTxError (ApplyTxError),
@@ -39,7 +38,7 @@ import Cardano.Ledger.Shelley.API (
   ShelleyGenesis (..),
   ShelleyGenesisStaking (ShelleyGenesisStaking),
   ShelleyTx (ShelleyTx),
-  ShelleyTxBody (ShelleyTxBody),
+  TxBody (ShelleyTxBody),
  )
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState
@@ -488,16 +487,7 @@ instance Arbitrary StakeProportion where
 newtype StakeProportion = StakeProportion Rational
   deriving (Show)
 
-instance
-  ( EraTxOut era
-  , ShelleyEraScript era
-  , Arbitrary (PParamsUpdate era)
-  , Arbitrary (TxOut era)
-  , Arbitrary (TxCert era)
-  , EncCBOR (TxCert era)
-  ) =>
-  Arbitrary (ShelleyTxBody era)
-  where
+instance Arbitrary (TxBody ShelleyEra) where
   arbitrary =
     ShelleyTxBody
       <$> arbitrary

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/Annotator.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/Annotator.hs
@@ -61,20 +61,10 @@ instance Era era => DecCBOR (Annotator (MultiSigRaw era)) where
         pure (3, MultiSigMOf m <$> multiSigs)
       k -> invalidKey k
 
-instance
-  ( Era era
-  , DecCBOR (PParamsUpdate era)
-  , DecCBOR (TxOut era)
-  , DecCBOR (TxCert era)
-  ) =>
-  DecCBOR (Annotator (ShelleyTxBodyRaw era))
-  where
+instance DecCBOR (Annotator ShelleyTxBodyRaw) where
   decCBOR = pure <$> decCBOR
 
-deriving via
-  Mem (ShelleyTxBodyRaw ShelleyEra)
-  instance
-    DecCBOR (Annotator (TxBody ShelleyEra))
+deriving via Mem ShelleyTxBodyRaw instance DecCBOR (Annotator (TxBody ShelleyEra))
 
 instance Era era => DecCBOR (Annotator (ShelleyTxAuxDataRaw era)) where
   decCBOR = pure <$> decCBOR

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/Annotator.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/Annotator.hs
@@ -20,6 +20,7 @@ import Cardano.Ledger.Binary
 import Cardano.Ledger.Binary.Coders
 import qualified Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.BlockChain
 import Cardano.Ledger.Shelley.Scripts
 import Cardano.Ledger.Shelley.Tx.Internal (
@@ -71,9 +72,9 @@ instance
   decCBOR = pure <$> decCBOR
 
 deriving via
-  Mem (ShelleyTxBodyRaw era)
+  Mem (ShelleyTxBodyRaw ShelleyEra)
   instance
-    EraTxBody era => DecCBOR (Annotator (ShelleyTxBody era))
+    DecCBOR (Annotator (TxBody ShelleyEra))
 
 instance Era era => DecCBOR (Annotator (ShelleyTxAuxDataRaw era)) where
   decCBOR = pure <$> decCBOR

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
@@ -82,12 +82,7 @@ instance (EraTxOut era, ToExpr (Value era)) => ToExpr (ShelleyTxOut era) where
   toExpr (ShelleyTxOut x y) = App "ShelleyTxOut" [toExpr x, toExpr y]
 
 -- TxBody
-instance
-  ( ToExpr (TxOut era)
-  , ToExpr (TxCert era)
-  , ToExpr (Update era)
-  ) =>
-  ToExpr (ShelleyTxBodyRaw era)
+instance ToExpr ShelleyTxBodyRaw
 
 instance ToExpr (TxBody ShelleyEra)
 

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
@@ -11,6 +11,7 @@ module Test.Cardano.Ledger.Shelley.TreeDiff (
 
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.AdaPots (AdaPots)
 import Cardano.Ledger.Shelley.Governance
 import Cardano.Ledger.Shelley.LedgerState
@@ -88,12 +89,7 @@ instance
   ) =>
   ToExpr (ShelleyTxBodyRaw era)
 
-instance
-  ( ToExpr (TxOut era)
-  , ToExpr (TxCert era)
-  , ToExpr (Update era)
-  ) =>
-  ToExpr (ShelleyTxBody era)
+instance ToExpr (TxBody ShelleyEra)
 
 -- PoolRank
 instance ToExpr Likelihood

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/BenchmarkFunctions.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/BenchmarkFunctions.hs
@@ -57,7 +57,7 @@ import Cardano.Ledger.Shelley.LedgerState (
 import Cardano.Ledger.Shelley.Rules (LedgerEnv (..), ShelleyLEDGER)
 import Cardano.Ledger.Shelley.State
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..))
-import Cardano.Ledger.Shelley.TxBody (ShelleyTxBody (..))
+import Cardano.Ledger.Shelley.TxBody (TxBody (ShelleyTxBody))
 import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
 import Cardano.Ledger.Shelley.TxWits (addrWits)
 import Cardano.Ledger.Slot (EpochNo (..), SlotNo (..))
@@ -153,7 +153,7 @@ testLEDGER initSt tx env = do
     Right _ -> ()
     Left e -> error $ show e
 
-txbSpendOneUTxO :: ShelleyTxBody ShelleyEra
+txbSpendOneUTxO :: TxBody ShelleyEra
 txbSpendOneUTxO =
   ShelleyTxBody
     (Set.fromList [TxIn genesisId minBound])
@@ -211,7 +211,7 @@ stakeKeyRegistrations keys =
 
 -- Create a transaction body given a sequence of certificates.
 -- It spends the genesis coin given by the index ix.
-txbFromCerts :: TxIx -> StrictSeq (TxCert ShelleyEra) -> ShelleyTxBody ShelleyEra
+txbFromCerts :: TxIx -> StrictSeq (TxCert ShelleyEra) -> TxBody ShelleyEra
 txbFromCerts ix regCerts =
   ShelleyTxBody
     (Set.fromList [TxIn genesisId ix])
@@ -224,7 +224,7 @@ txbFromCerts ix regCerts =
     SNothing
 
 makeSimpleTx ::
-  ShelleyTxBody ShelleyEra ->
+  TxBody ShelleyEra ->
   [KeyPair 'Witness] ->
   ShelleyTx ShelleyEra
 makeSimpleTx txbody keysAddr =
@@ -279,7 +279,7 @@ ledgerRegisterStakeKeys x y state =
 
 -- Create a transaction body that de-registers stake credentials,
 -- corresponding to the keys seeded with (RawSeed x 0 0 0 0) to (RawSeed y 0 0 0 0)
-txbDeRegStakeKey :: Word64 -> Word64 -> ShelleyTxBody ShelleyEra
+txbDeRegStakeKey :: Word64 -> Word64 -> TxBody ShelleyEra
 txbDeRegStakeKey x y =
   ShelleyTxBody
     (Set.fromList [mkTxInPartial genesisId 1])
@@ -317,7 +317,7 @@ ledgerDeRegisterStakeKeys x y state =
 
 -- Create a transaction body that withdrawals from reward accounts,
 -- corresponding to the keys seeded with (RawSeed x 0 0 0 0) to (RawSeed y 0 0 0 0).
-txbWithdrawals :: Word64 -> Word64 -> ShelleyTxBody ShelleyEra
+txbWithdrawals :: Word64 -> Word64 -> TxBody ShelleyEra
 txbWithdrawals x y =
   ShelleyTxBody
     (Set.fromList [mkTxInPartial genesisId 1])
@@ -434,7 +434,7 @@ ledgerReRegisterStakePools x y state =
 
 -- Create a transaction body that retires stake pools,
 -- corresponding to the keys seeded with (RawSeed x 1 0 0 0) to (RawSeed y 1 0 0 0)
-txbRetireStakePool :: Word64 -> Word64 -> ShelleyTxBody ShelleyEra
+txbRetireStakePool :: Word64 -> Word64 -> TxBody ShelleyEra
 txbRetireStakePool x y =
   ShelleyTxBody
     (Set.fromList [mkTxInPartial genesisId 1])
@@ -482,7 +482,7 @@ ledgerStateWithNkeysMpools n m =
 
 -- Create a transaction body that delegates several keys to ONE stake pool,
 -- corresponding to the keys seeded with (RawSeed n 0 0 0 0) to (RawSeed m 0 0 0 0)
-txbDelegate :: Word64 -> Word64 -> ShelleyTxBody ShelleyEra
+txbDelegate :: Word64 -> Word64 -> TxBody ShelleyEra
 txbDelegate n m =
   ShelleyTxBody
     (Set.fromList [mkTxInPartial genesisId 2])

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Consensus.hs
@@ -420,7 +420,7 @@ mkWitnessesPreAlonzo _ txBody keyPairWits =
 exampleCoin :: Coin
 exampleCoin = Coin 10
 
-exampleTxBodyShelley :: ShelleyTxBody ShelleyEra
+exampleTxBodyShelley :: TxBody ShelleyEra
 exampleTxBodyShelley =
   ShelleyTxBody
     exampleTxIns

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/ShelleyEraGen.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/ShelleyEraGen.hs
@@ -26,7 +26,7 @@ import Cardano.Ledger.Shelley.Scripts (
   pattern RequireSignature,
  )
 import Cardano.Ledger.Shelley.TxBody (
-  ShelleyTxBody (ShelleyTxBody, stbInputs, stbOutputs, stbTxFee),
+  TxBody (..),
   Withdrawals (..),
  )
 import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
@@ -99,19 +99,16 @@ instance ScriptClass ShelleyEra where
  -----------------------------------------------------------------------------}
 
 genTxBody ::
-  ( EraTxOut era
-  , EraTxCert era
-  ) =>
-  PParams era ->
+  PParams ShelleyEra ->
   SlotNo ->
   Set TxIn ->
-  StrictSeq (TxOut era) ->
-  StrictSeq (TxCert era) ->
+  StrictSeq (TxOut ShelleyEra) ->
+  StrictSeq (TxCert ShelleyEra) ->
   Withdrawals ->
   Coin ->
-  StrictMaybe (Update era) ->
+  StrictMaybe (Update ShelleyEra) ->
   StrictMaybe TxAuxDataHash ->
-  Gen (ShelleyTxBody era, [MultiSig era])
+  Gen (TxBody ShelleyEra, [MultiSig ShelleyEra])
 genTxBody _pparams slot inputs outputs certs withdrawals fee update adHash = do
   ttl <- genTimeToLive slot
   return

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/GenesisDelegation.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/GenesisDelegation.hs
@@ -19,12 +19,11 @@ import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Block (Block, bheader)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Keys (GenDelegPair (..), asWitness)
-import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Ledger.Shelley (ShelleyEra, TxBody (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.State
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..))
-import Cardano.Ledger.Shelley.TxBody (ShelleyTxBody (..))
 import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
 import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits, addrWits)
 import Cardano.Ledger.Slot (BlockNo (..), SlotNo (..))
@@ -112,7 +111,7 @@ newGenesisVrfKH = hashVerKeyVRF @MockCrypto (vrfVerKey (mkVRFKeyPair @MockCrypto
 feeTx1 :: Coin
 feeTx1 = Coin 1
 
-txbodyEx1 :: ShelleyTxBody ShelleyEra
+txbodyEx1 :: TxBody ShelleyEra
 txbodyEx1 =
   ShelleyTxBody
     (Set.fromList [TxIn genesisId minBound])

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Mir.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Mir.hs
@@ -20,7 +20,7 @@ import Cardano.Ledger.Block (Block, bheader)
 import Cardano.Ledger.Coin (Coin (..), toDeltaCoin)
 import Cardano.Ledger.Credential (Ptr (..), SlotNo32 (..))
 import Cardano.Ledger.Keys (asWitness)
-import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Ledger.Shelley (ShelleyEra, TxBody (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (
   EpochState (..),
@@ -34,7 +34,6 @@ import Cardano.Ledger.Shelley.Rules (
  )
 import Cardano.Ledger.Shelley.State
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..))
-import Cardano.Ledger.Shelley.TxBody (ShelleyTxBody (..))
 import Cardano.Ledger.Shelley.TxCert (ShelleyTxCert (..))
 import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
 import Cardano.Ledger.Shelley.TxWits (addrWits)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
@@ -65,7 +65,7 @@ import Cardano.Ledger.Shelley.PoolRank (
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..))
 import Cardano.Ledger.Shelley.TxBody (
   RewardAccount (..),
-  ShelleyTxBody (..),
+  TxBody (..),
  )
 import Cardano.Ledger.Shelley.TxCert (ShelleyTxCert (..))
 import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
@@ -173,7 +173,7 @@ dariaMIR = Coin 99
 feeTx1 :: Coin
 feeTx1 = Coin 3
 
-txbodyEx1 :: ShelleyTxBody ShelleyEra
+txbodyEx1 :: TxBody ShelleyEra
 txbodyEx1 =
   ShelleyTxBody
     (Set.fromList [TxIn genesisId minBound])
@@ -279,7 +279,7 @@ aliceCoinEx2Ptr = aliceCoinEx1 <-> (aliceCoinEx2Base <+> feeTx2)
 
 -- | The transaction delegates Alice's and Bob's stake to Alice's pool.
 --   Additionally, we split Alice's ADA between a base address and a pointer address.
-txbodyEx2 :: ShelleyTxBody ShelleyEra
+txbodyEx2 :: TxBody ShelleyEra
 txbodyEx2 =
   ShelleyTxBody
     { stbInputs = Set.fromList [TxIn (txIdTxBody txbodyEx1) minBound]
@@ -429,7 +429,7 @@ feeTx4 = Coin 5
 aliceCoinEx4Base :: Coin
 aliceCoinEx4Base = aliceCoinEx2Base <-> feeTx4
 
-txbodyEx4 :: ShelleyTxBody ShelleyEra
+txbodyEx4 :: TxBody ShelleyEra
 txbodyEx4 =
   ShelleyTxBody
     { stbInputs = Set.fromList [TxIn (txIdTxBody txbodyEx2) minBound]
@@ -823,7 +823,7 @@ bobAda10 =
     <+> Coin 7
     <-> feeTx10
 
-txbodyEx10 :: ShelleyTxBody ShelleyEra
+txbodyEx10 :: TxBody ShelleyEra
 txbodyEx10 =
   ShelleyTxBody
     (Set.fromList [mkTxInPartial genesisId 1])
@@ -889,7 +889,7 @@ aliceCoinEx11Ptr = aliceCoinEx4Base <-> feeTx11
 aliceRetireEpoch :: EpochNo
 aliceRetireEpoch = EpochNo 5
 
-txbodyEx11 :: ShelleyTxBody ShelleyEra
+txbodyEx11 :: TxBody ShelleyEra
 txbodyEx11 =
   ShelleyTxBody
     (Set.fromList [TxIn (txIdTxBody txbodyEx4) minBound])

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolReReg.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolReReg.hs
@@ -26,11 +26,10 @@ import Cardano.Ledger.Block (Block, bheader)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Keys (asWitness)
 import Cardano.Ledger.PoolParams (PoolParams (..))
-import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Ledger.Shelley (ShelleyEra, TxBody (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (PulsingRewUpdate, emptyRewardUpdate)
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..))
-import Cardano.Ledger.Shelley.TxBody (ShelleyTxBody (..))
 import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
 import Cardano.Ledger.Shelley.TxWits (addrWits)
 import Cardano.Ledger.Slot (BlockNo (..), SlotNo (..))
@@ -91,7 +90,7 @@ feeTx1 = Coin 3
 aliceCoinEx1 :: Coin
 aliceCoinEx1 = aliceInitCoin <-> Coin 250 <-> feeTx1
 
-txbodyEx1 :: ShelleyTxBody ShelleyEra
+txbodyEx1 :: TxBody ShelleyEra
 txbodyEx1 =
   ShelleyTxBody
     (Set.fromList [TxIn genesisId minBound])
@@ -161,7 +160,7 @@ aliceCoinEx2 = aliceCoinEx1 <-> feeTx2
 newPoolParams :: PoolParams
 newPoolParams = Cast.alicePoolParams {ppCost = Coin 500}
 
-txbodyEx2 :: ShelleyTxBody ShelleyEra
+txbodyEx2 :: TxBody ShelleyEra
 txbodyEx2 =
   ShelleyTxBody
     (Set.fromList [TxIn (txIdTxBody txbodyEx1) minBound])

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/TwoPools.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/TwoPools.hs
@@ -72,7 +72,7 @@ import Cardano.Ledger.Shelley.Rewards (
 import Cardano.Ledger.Shelley.Tx (
   ShelleyTx (..),
  )
-import Cardano.Ledger.Shelley.TxBody (RewardAccount (..), ShelleyTxBody (..))
+import Cardano.Ledger.Shelley.TxBody (RewardAccount (..))
 import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
 import Cardano.Ledger.Shelley.TxWits (
   addrWits,

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Updates.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Updates.hs
@@ -30,7 +30,7 @@ import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (PulsingRewUpdate, emptyRewardUpdate)
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..), Update (..))
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..))
-import Cardano.Ledger.Shelley.TxBody (ShelleyTxBody (..))
+import Cardano.Ledger.Shelley.TxBody (TxBody (..))
 import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
 import Cardano.Ledger.Shelley.TxWits (addrWits)
 import Cardano.Ledger.Slot (
@@ -122,7 +122,7 @@ feeTx1 = Coin 1
 aliceCoinEx1 :: Coin
 aliceCoinEx1 = aliceInitCoin <-> feeTx1
 
-txbodyEx1 :: ShelleyTxBody ShelleyEra
+txbodyEx1 :: TxBody ShelleyEra
 txbodyEx1 =
   ShelleyTxBody
     (Set.fromList [TxIn genesisId minBound])
@@ -197,7 +197,7 @@ feeTx2 = Coin 1
 aliceCoinEx2 :: Coin
 aliceCoinEx2 = aliceCoinEx1 <-> feeTx2
 
-txbodyEx2 :: ShelleyTxBody ShelleyEra
+txbodyEx2 :: TxBody ShelleyEra
 txbodyEx2 =
   ShelleyTxBody
     (Set.fromList [TxIn (txIdTxBody txbodyEx1) minBound])
@@ -273,7 +273,7 @@ feeTx3 = Coin 1
 aliceCoinEx3 :: Coin
 aliceCoinEx3 = aliceCoinEx2 <-> feeTx3
 
-txbodyEx3 :: ShelleyTxBody ShelleyEra
+txbodyEx3 :: TxBody ShelleyEra
 txbodyEx3 =
   ShelleyTxBody
     (Set.fromList [TxIn (txIdTxBody txbodyEx2) minBound])

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
@@ -6,8 +6,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Test.Cardano.Ledger.Shelley.Fees (
   sizeTests,
@@ -26,13 +24,12 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Keys (asWitness)
 import Cardano.Ledger.PoolParams (PoolMetadata (..), StakePoolRelay (..))
-import Cardano.Ledger.Shelley (Shelley)
+import Cardano.Ledger.Shelley (ShelleyEra, TxBody (..))
 import Cardano.Ledger.Shelley.API (
   Addr,
   Credential (..),
   PoolParams (..),
   RewardAccount (..),
-  ShelleyTxBody (..),
   ShelleyTxOut (..),
   TxIn (..),
  )
@@ -81,7 +78,7 @@ import Test.Cardano.Ledger.Shelley.Utils (
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, testCase, (@?=))
 
-sizeTest :: HasCallStack => BSL.ByteString -> ShelleyTx Shelley -> Assertion
+sizeTest :: HasCallStack => BSL.ByteString -> ShelleyTx ShelleyEra -> Assertion
 sizeTest b16 tx = do
   Base16.encode (Plain.serialize tx) @?= b16
   (tx ^. sizeTxF) @?= toInteger (BSL.length b16 `div` 2)
@@ -156,7 +153,7 @@ carlPay = KeyPair vk sk
 
 -- | Simple Transaction which consumes one UTxO and creates one UTxO
 -- | and has one witness
-txbSimpleUTxO :: ShelleyTxBody Shelley
+txbSimpleUTxO :: TxBody ShelleyEra
 txbSimpleUTxO =
   ShelleyTxBody
     { stbInputs = Set.fromList [TxIn genesisId minBound]
@@ -169,7 +166,7 @@ txbSimpleUTxO =
     , stbMDHash = SNothing
     }
 
-txSimpleUTxO :: ShelleyTx Shelley
+txSimpleUTxO :: ShelleyTx ShelleyEra
 txSimpleUTxO =
   ShelleyTx
     { body = txbSimpleUTxO
@@ -186,7 +183,7 @@ txSimpleUTxOBytes16 =
 
 -- | Transaction which consumes two UTxO and creates five UTxO
 -- | and has two witness
-txbMutiUTxO :: ShelleyTxBody Shelley
+txbMutiUTxO :: TxBody ShelleyEra
 txbMutiUTxO =
   ShelleyTxBody
     { stbInputs =
@@ -210,7 +207,7 @@ txbMutiUTxO =
     , stbMDHash = SNothing
     }
 
-txMutiUTxO :: ShelleyTx Shelley
+txMutiUTxO :: ShelleyTx ShelleyEra
 txMutiUTxO =
   ShelleyTx
     { body = txbMutiUTxO
@@ -231,7 +228,7 @@ txMutiUTxOBytes16 =
   "83a4008282582003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c1113140082582003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131401018582583900e9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371fc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df760a82583900e9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371fc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df761482583900e9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371fc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df76181e825839000d2a471489a90f2910ec67ded8e215bfcd669bae77e7f9ab15850abd4e130c0bdeb7768edf2e8f85007fd52073e3dc1871f4c47f9dfca92e1828825839000d2a471489a90f2910ec67ded8e215bfcd669bae77e7f9ab15850abd4e130c0bdeb7768edf2e8f85007fd52073e3dc1871f4c47f9dfca92e18320218c7030aa1008282582037139648f2c22bbf1d0ef9af37cfebc9014b1e0e2a55be87c4b3b231a8d84d2658405ef09b22172cd28678e76e600e899886852e03567e2e72b4815629471e736a0cd424dc71cdaa0d0403371d79ea3d0cb7f28cb0740ebfcd8947343eba99a6aa088258204628aaf16d6e1baa061d1296419542cb09287c639163d0fdbdac0ff23699797e5840ea98ef8052776aa5c182621cfd2ec91011d327527fc2531be9e1a8356c10f25f3fe5a5a7f549a0dc3b17c4ad8e4b8673b63a87977ac899b675f3ce3d6badae01f6"
 
 -- | Transaction which registers a stake key
-txbRegisterStake :: ShelleyTxBody Shelley
+txbRegisterStake :: TxBody ShelleyEra
 txbRegisterStake =
   ShelleyTxBody
     { stbInputs = Set.fromList [TxIn genesisId minBound]
@@ -244,7 +241,7 @@ txbRegisterStake =
     , stbMDHash = SNothing
     }
 
-txRegisterStake :: ShelleyTx Shelley
+txRegisterStake :: ShelleyTx ShelleyEra
 txRegisterStake =
   ShelleyTx
     { body = txbRegisterStake
@@ -260,7 +257,7 @@ txRegisterStakeBytes16 =
   "83a5008182582003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400018182583900e9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371fc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df760a02185e030a048182008200581cc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df76a100818258204628aaf16d6e1baa061d1296419542cb09287c639163d0fdbdac0ff23699797e58403271792b002eb39bcb133668e851a5ffba9c13ad2b5c5a7bbc850a17de8309cbb9649d9e90eb4c9cc82f28f204408d513ccc575ce1f61808f67793429ff1880ef6"
 
 -- | Transaction which delegates a stake key
-txbDelegateStake :: ShelleyTxBody Shelley
+txbDelegateStake :: TxBody ShelleyEra
 txbDelegateStake =
   ShelleyTxBody
     { stbInputs = Set.fromList [TxIn genesisId minBound]
@@ -276,7 +273,7 @@ txbDelegateStake =
     , stbMDHash = SNothing
     }
 
-txDelegateStake :: ShelleyTx Shelley
+txDelegateStake :: ShelleyTx ShelleyEra
 txDelegateStake =
   ShelleyTx
     { body = txbDelegateStake
@@ -295,7 +292,7 @@ txDelegateStakeBytes16 =
   "83a5008182582003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400018182583900e9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371fc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df760a02185e030a048183028200581c4e130c0bdeb7768edf2e8f85007fd52073e3dc1871f4c47f9dfca92e581c5d43e1f1048b2619f51abc0cf505e4d4f9cb84becefd468d1a2fe335a100828258209921fa37a7d167aab519bb937d7ac6e522ad6d259a6173523357b971e05f41ff58403bad563c201b4f62448db12711af2d916776194b5176e9d312d07a328ce7780a63032dce887abc67985629b7aeabb0c334e84094f44d7e51ae51b5c799a83c0d8258204628aaf16d6e1baa061d1296419542cb09287c639163d0fdbdac0ff23699797e584064aef85b046d2d0072cd64844e9f13d86651a1db74d356a10ecd7fb35a664fc466e543ea55cfbffd74025dc092d62c4b22d7e2de4decb4f049df354cfae9790af6"
 
 -- | Transaction which de-registers a stake key
-txbDeregisterStake :: ShelleyTxBody Shelley
+txbDeregisterStake :: TxBody ShelleyEra
 txbDeregisterStake =
   ShelleyTxBody
     { stbInputs = Set.fromList [TxIn genesisId minBound]
@@ -308,7 +305,7 @@ txbDeregisterStake =
     , stbMDHash = SNothing
     }
 
-txDeregisterStake :: ShelleyTx Shelley
+txDeregisterStake :: ShelleyTx ShelleyEra
 txDeregisterStake =
   ShelleyTx
     { body = txbDeregisterStake
@@ -324,7 +321,7 @@ txDeregisterStakeBytes16 =
   "83a5008182582003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400018182583900e9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371fc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df760a02185e030a048182018200581cc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df76a100818258204628aaf16d6e1baa061d1296419542cb09287c639163d0fdbdac0ff23699797e5840409db925fa592b7f4c76e44d738789f4b0ffb2b9cf4567af127121d635491b4eb736e8c92571f1329f14d06aad7ec42ca654ae65eb63b0b01d30cc4454aee80cf6"
 
 -- | Transaction which registers a stake pool
-txbRegisterPool :: ShelleyTxBody Shelley
+txbRegisterPool :: TxBody ShelleyEra
 txbRegisterPool =
   ShelleyTxBody
     { stbInputs = Set.fromList [TxIn genesisId minBound]
@@ -337,7 +334,7 @@ txbRegisterPool =
     , stbMDHash = SNothing
     }
 
-txRegisterPool :: ShelleyTx Shelley
+txRegisterPool :: ShelleyTx ShelleyEra
 txRegisterPool =
   ShelleyTx
     { body = txbRegisterPool
@@ -353,7 +350,7 @@ txRegisterPoolBytes16 =
   "83a5008182582003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400018182583900e9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371fc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df760a02185e030a04818a03581c5d43e1f1048b2619f51abc0cf505e4d4f9cb84becefd468d1a2fe33558208e61e1fa4855ea3aa0b8881a9e2e453c8c73536bdaabb64d36de86ee5a02519a0105d81e82010a581de0c6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df7681581cc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df76818301f66872656c61792e696f826a616c6963652e706f6f6c427b7da100818258204628aaf16d6e1baa061d1296419542cb09287c639163d0fdbdac0ff23699797e5840165c6aa107571daafb1f9093d3cdc184a4068e8ff9243715c13335feb3652dc0d817b3b015a9929c9d83a0dd406fe71658fdccbf7925d2fff316237b499c2003f6"
 
 -- | Transaction which retires a stake pool
-txbRetirePool :: ShelleyTxBody Shelley
+txbRetirePool :: TxBody ShelleyEra
 txbRetirePool =
   ShelleyTxBody
     { stbInputs = Set.fromList [TxIn genesisId minBound]
@@ -366,7 +363,7 @@ txbRetirePool =
     , stbMDHash = SNothing
     }
 
-txRetirePool :: ShelleyTx Shelley
+txRetirePool :: ShelleyTx ShelleyEra
 txRetirePool =
   ShelleyTx
     { body = txbRetirePool
@@ -386,7 +383,7 @@ txRetirePoolBytes16 =
 md :: Era era => ShelleyTxAuxData era
 md = ShelleyTxAuxData $ Map.singleton 0 (List [I 5, S "hello"])
 
-txbWithMD :: ShelleyTxBody Shelley
+txbWithMD :: TxBody ShelleyEra
 txbWithMD =
   ShelleyTxBody
     { stbInputs = Set.fromList [TxIn genesisId minBound]
@@ -396,10 +393,10 @@ txbWithMD =
     , stbTxFee = Coin 94
     , stbTTL = SlotNo 10
     , stbUpdate = SNothing
-    , stbMDHash = SJust $ hashTxAuxData @Shelley md
+    , stbMDHash = SJust $ hashTxAuxData @ShelleyEra md
     }
 
-txWithMD :: ShelleyTx Shelley
+txWithMD :: ShelleyTx ShelleyEra
 txWithMD =
   ShelleyTx
     { body = txbWithMD
@@ -426,7 +423,7 @@ msig =
         ]
     )
 
-txbWithMultiSig :: ShelleyTxBody Shelley
+txbWithMultiSig :: TxBody ShelleyEra
 txbWithMultiSig =
   ShelleyTxBody
     { stbInputs = Set.fromList [TxIn genesisId minBound] -- acting as if this is multi-sig
@@ -439,14 +436,14 @@ txbWithMultiSig =
     , stbMDHash = SNothing
     }
 
-txWithMultiSig :: ShelleyTx Shelley
+txWithMultiSig :: ShelleyTx ShelleyEra
 txWithMultiSig =
   ShelleyTx
     { body = txbWithMultiSig
     , wits =
         mkBasicTxWits
           & addrTxWitsL .~ mkWitnessesVKey (hashAnnotated txbWithMultiSig) [alicePay, bobPay]
-          & scriptTxWitsL .~ Map.singleton (hashScript @Shelley msig) msig
+          & scriptTxWitsL .~ Map.singleton (hashScript @ShelleyEra msig) msig
     , auxiliaryData = SNothing
     }
 
@@ -455,7 +452,7 @@ txWithMultiSigBytes16 =
   "83a4008182582003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400018182583900e9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371fc6852b6aaed73bcf346a57ef99adae3000b51c7c59faaeb15993df760a02185e030aa2008282582037139648f2c22bbf1d0ef9af37cfebc9014b1e0e2a55be87c4b3b231a8d84d265840e3b8f50632325fbd1f82202ce5a8b4672bd96c50a338d70c0aa96720f6f7fbf60e0ce708f3a7e28faa0d78dc437a0b61e02205ddb1db22d02ba35b37a7fe03068258204628aaf16d6e1baa061d1296419542cb09287c639163d0fdbdac0ff23699797e584089c20cb6246483bbd0b2006f658597eff3e8ab3b8a6e9b22cb3c5b95cf0d3a2b96107acef88319fa2dd0fb28adcfdb330bb99f1f0058918a75d951ca9b73660c0181830302838200581ce9686d801fa32aeb4390c2f2a53bb0314a9c744c46a2cada394a371f8200581c0d2a471489a90f2910ec67ded8e215bfcd669bae77e7f9ab15850abd8200581cd0671052191a58c554eee27808b2b836a03ca369ca7a847f8c37d6f9f6"
 
 -- | Transaction with a Reward Withdrawal
-txbWithWithdrawal :: ShelleyTxBody Shelley
+txbWithWithdrawal :: TxBody ShelleyEra
 txbWithWithdrawal =
   ShelleyTxBody
     { stbInputs = Set.fromList [TxIn genesisId minBound]
@@ -469,7 +466,7 @@ txbWithWithdrawal =
     , stbMDHash = SNothing
     }
 
-txWithWithdrawal :: ShelleyTx Shelley
+txWithWithdrawal :: ShelleyTx ShelleyEra
 txWithWithdrawal =
   ShelleyTx
     { body = txbWithWithdrawal
@@ -491,7 +488,7 @@ txWithWithdrawalBytes16 =
 -- given minfeeA and minfeeB are set to 1.
 testEstimateMinFee :: Assertion
 testEstimateMinFee =
-  estimateMinFeeTx @Shelley
+  estimateMinFeeTx @ShelleyEra
     pp
     txSimpleUTxONoWit
     1

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/MultiSigExamples.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/MultiSigExamples.hs
@@ -50,7 +50,7 @@ import Cardano.Ledger.Shelley.Scripts (
 import Cardano.Ledger.Shelley.State
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..))
 import Cardano.Ledger.Shelley.TxAuxData (ShelleyTxAuxData)
-import Cardano.Ledger.Shelley.TxBody (ShelleyTxBody (..))
+import Cardano.Ledger.Shelley.TxBody (TxBody (ShelleyTxBody))
 import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits (..))
 import Cardano.Ledger.Slot (SlotNo (..))
 import Cardano.Ledger.TxIn (TxId, TxIn (..))
@@ -123,11 +123,8 @@ aliceAndBobOrCarlOrDaria =
       ]
 
 initTxBody ::
-  ( EraTxOut era
-  , EraTxCert era
-  ) =>
-  [(Addr, Value era)] ->
-  ShelleyTxBody era
+  [(Addr, Value ShelleyEra)] ->
+  TxBody ShelleyEra
 initTxBody addrs =
   ShelleyTxBody
     (Set.fromList [TxIn genesisId minBound, TxIn genesisId (mkTxIxPartial 1)])
@@ -140,13 +137,10 @@ initTxBody addrs =
     SNothing
 
 makeTxBody ::
-  ( EraTxOut era
-  , EraTxCert era
-  ) =>
   [TxIn] ->
-  [(Addr, Value era)] ->
+  [(Addr, Value ShelleyEra)] ->
   Withdrawals ->
-  ShelleyTxBody era
+  TxBody ShelleyEra
 makeTxBody inp addrCs wdrl =
   ShelleyTxBody
     (Set.fromList inp)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
@@ -53,7 +53,7 @@ import Cardano.Ledger.Shelley.Rules (
  )
 import Cardano.Ledger.Shelley.State
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..))
-import Cardano.Ledger.Shelley.TxBody (ShelleyTxBody (..))
+import Cardano.Ledger.Shelley.TxBody (TxBody (..))
 import Cardano.Ledger.Shelley.TxCert (ShelleyTxCert (..))
 import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
 import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits, addrWits)
@@ -357,7 +357,7 @@ testSpendNonexistentInput =
 testWitnessNotIncluded :: Assertion
 testWitnessNotIncluded =
   let txbody =
-        ShelleyTxBody @C
+        ShelleyTxBody
           (Set.fromList [TxIn genesisId minBound])
           ( StrictSeq.fromList
               [ ShelleyTxOut aliceAddr (Coin 6404)
@@ -381,7 +381,7 @@ testWitnessNotIncluded =
 testSpendNotOwnedUTxO :: Assertion
 testSpendNotOwnedUTxO =
   let txbody =
-        ShelleyTxBody @C
+        ShelleyTxBody
           (Set.fromList [mkGenesisTxIn 1])
           (StrictSeq.singleton $ ShelleyTxOut aliceAddr (Coin 232))
           Empty
@@ -402,7 +402,7 @@ testSpendNotOwnedUTxO =
 testWitnessWrongUTxO :: Assertion
 testWitnessWrongUTxO =
   let txbody =
-        ShelleyTxBody @C
+        ShelleyTxBody
           (Set.fromList [mkGenesisTxIn 1])
           (StrictSeq.singleton $ ShelleyTxOut aliceAddr (Coin 230))
           Empty
@@ -412,7 +412,7 @@ testWitnessWrongUTxO =
           SNothing
           SNothing
       tx2body =
-        ShelleyTxBody @C
+        ShelleyTxBody
           (Set.fromList [mkGenesisTxIn 1])
           (StrictSeq.singleton $ ShelleyTxOut aliceAddr (Coin 230))
           Empty
@@ -494,7 +494,7 @@ testExpiredTx =
 testInvalidWintess :: Assertion
 testInvalidWintess =
   let txb =
-        ShelleyTxBody @C
+        ShelleyTxBody
           (Set.fromList [TxIn genesisId minBound])
           ( StrictSeq.fromList
               [ ShelleyTxOut aliceAddr (Coin 6000)
@@ -521,7 +521,7 @@ testInvalidWintess =
 testWithdrawalNoWit :: Assertion
 testWithdrawalNoWit =
   let txb =
-        ShelleyTxBody @C
+        ShelleyTxBody
           (Set.fromList [TxIn genesisId minBound])
           ( StrictSeq.fromList
               [ ShelleyTxOut aliceAddr (Coin 6000)
@@ -547,7 +547,7 @@ testWithdrawalNoWit =
 testWithdrawalWrongAmt :: Assertion
 testWithdrawalWrongAmt =
   let txb =
-        ShelleyTxBody @C
+        ShelleyTxBody
           (Set.fromList [TxIn genesisId minBound])
           ( StrictSeq.fromList
               [ ShelleyTxOut aliceAddr (Coin 6000)
@@ -645,7 +645,7 @@ testProducedOverMaxWord64 :: Assertion
 testProducedOverMaxWord64 =
   let biggestCoin = fromIntegral (maxBound :: Word64)
       txbody =
-        ShelleyTxBody @C
+        ShelleyTxBody
           (Set.fromList [TxIn genesisId minBound])
           (StrictSeq.fromList [ShelleyTxOut bobAddr (Coin biggestCoin)])
           Empty

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -47,7 +47,7 @@ import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), IsValid (..))
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), Redeemers (..), TxDats (..))
 import Cardano.Ledger.Babbage.TxOut (BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes
-import Cardano.Ledger.Binary (DecShareCBOR (..), Interns, Sized (..))
+import Cardano.Ledger.Binary (Sized (..))
 import Cardano.Ledger.Coin (Coin (..), CompactForm)
 import Cardano.Ledger.Compactible (Compactible)
 import Cardano.Ledger.Conway.Core
@@ -62,8 +62,6 @@ import Cardano.Ledger.Conway.Rules (
  )
 import Cardano.Ledger.Conway.Scripts (AlonzoScript (..), ConwayPlutusPurpose (..))
 import Cardano.Ledger.Conway.Tx (refScriptCostMultiplier, refScriptCostStride)
-import Cardano.Ledger.Conway.TxBody (ConwayTxBody)
-import Cardano.Ledger.Conway.TxCert (ConwayTxCert)
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import Cardano.Ledger.DRep (DRep (..), DRepState (..))
 import Cardano.Ledger.HKD (HKD)
@@ -633,49 +631,6 @@ instance SpecTranslate ctx TxAuxDataHash where
   type SpecRep TxAuxDataHash = Agda.DataHash
 
   toSpecRep (TxAuxDataHash x) = toSpecRep x
-
-instance
-  ( ConwayEraTxBody era
-  , TxBody era ~ ConwayTxBody era
-  , SpecRep (TxOut era) ~ Agda.TxOut
-  , SpecRep (ConwayTxCert era) ~ Agda.DCert
-  , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
-  , TxCert era ~ ConwayTxCert era
-  , Share (TxOut era) ~ Interns (Credential 'Staking)
-  , Inject ctx Integer
-  , Inject ctx TxId
-  , SpecTranslate ctx (TxOut era)
-  , SpecTranslate ctx (ConwayTxCert era)
-  , SpecTranslate ctx (PParamsHKD StrictMaybe era)
-  ) =>
-  SpecTranslate ctx (ConwayTxBody era)
-  where
-  type SpecRep (ConwayTxBody era) = Agda.TxBody
-
-  toSpecRep txb = do
-    sizeTx <- askCtx
-    txId <- askCtx @TxId
-    Agda.MkTxBody
-      <$> toSpecRep (txb ^. inputsTxBodyL)
-      <*> toSpecRep (txb ^. referenceInputsTxBodyL)
-      <*> (Agda.MkHSMap . zip [0 ..] <$> toSpecRep (txb ^. outputsTxBodyL))
-      <*> toSpecRep (txb ^. feeTxBodyL)
-      <*> pure 0
-      <*> toSpecRep (txb ^. vldtTxBodyL)
-      <*> toSpecRep (txb ^. certsTxBodyL)
-      <*> toSpecRep (txb ^. withdrawalsTxBodyL)
-      <*> toSpecRep (txb ^. votingProceduresTxBodyL)
-      <*> toSpecRep (txb ^. proposalProceduresTxBodyL)
-      <*> toSpecRep (txb ^. treasuryDonationTxBodyL)
-      <*> pure Nothing -- TODO implement this properly
-      <*> toSpecRep (txb ^. auxDataHashTxBodyL)
-      <*> toSpecRep (txb ^. networkIdTxBodyL)
-      <*> toSpecRep (txb ^. currentTreasuryValueTxBodyL)
-      <*> pure sizeTx
-      <*> toSpecRep txId
-      <*> toSpecRep (txb ^. collateralInputsTxBodyL)
-      <*> toSpecRep (txb ^. reqSignerHashesTxBodyL)
-      <*> toSpecRep (txb ^. scriptIntegrityHashTxBodyL)
 
 data ConwayTxBodyTransContext = ConwayTxBodyTransContext
   { ctbtcSizeTx :: !Integer

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.18.0.0
 
+* Change `TxBody` to an associated `data` family
 * Remove `HeapWords` instances for: #5001
   - `Coin`
   - `DeltaCoin`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -196,7 +196,7 @@ class
   EraTxBody era
   where
   -- | The body of a transaction.
-  type TxBody era = (r :: Type) | r -> era
+  data TxBody era
 
   type TxBodyUpgradeError era :: Type
   type TxBodyUpgradeError era = Void

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -200,10 +200,10 @@ type ConwayTxBodyTypes =
    , StrictMaybe Coin
    , Coin
    ]
-instance HasSpec (ConwayTxBody ConwayEra)
+instance HasSpec (TxBody ConwayEra)
 
-instance HasSimpleRep (ConwayTxBody ConwayEra) where
-  type TheSop (ConwayTxBody ConwayEra) = '["ConwayTxBody" ::: ConwayTxBodyTypes]
+instance HasSimpleRep (TxBody ConwayEra) where
+  type TheSop (TxBody ConwayEra) = '["ConwayTxBody" ::: ConwayTxBodyTypes]
   toSimpleRep ConwayTxBody {..} =
     inject @"ConwayTxBody" @'["ConwayTxBody" ::: ConwayTxBodyTypes]
       ctbSpendInputs

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/TxBody.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/TxBody.hs
@@ -49,21 +49,21 @@ instance EraSpecPParams era => HasSpec (Update era)
 --   and (Maybe x) instead of (StrictMaybe x). It transforms bewtween the two, in the toSimpleRep
 --   and fromSimpleRep methods. This makes it much easier to write Specifications, because
 --   the Constrained packaage knows about Lists and Maybe.
-type ShelleyTxBodyTypes era =
+type ShelleyTxBodyTypes =
   '[ Set TxIn
-   , [TxOut era]
-   , [TxCert era]
+   , [TxOut ShelleyEra]
+   , [TxCert ShelleyEra]
    , Map RewardAccount Coin
    , Coin
    , SlotNo
-   , Maybe (Update era)
+   , Maybe (Update ShelleyEra)
    , Maybe TxAuxDataHash
    ]
 
 instance HasSimpleRep (TxBody ShelleyEra) where
-  type SimpleRep (TxBody ShelleyEra) = SOP '["ShelleyTxBody" ::: ShelleyTxBodyTypes ShelleyEra]
+  type SimpleRep (TxBody ShelleyEra) = SOP '["ShelleyTxBody" ::: ShelleyTxBodyTypes]
   toSimpleRep (ShelleyTxBody is os certs w c s up aux) =
-    inject @"ShelleyTxBody" @'["ShelleyTxBody" ::: ShelleyTxBodyTypes ShelleyEra]
+    inject @"ShelleyTxBody" @'["ShelleyTxBody" ::: ShelleyTxBodyTypes]
       is
       (toList os)
       (toList certs)
@@ -74,7 +74,7 @@ instance HasSimpleRep (TxBody ShelleyEra) where
       (strictMaybeToMaybe aux)
 
   fromSimpleRep rep =
-    algebra @'["ShelleyTxBody" ::: ShelleyTxBodyTypes ShelleyEra]
+    algebra @'["ShelleyTxBody" ::: ShelleyTxBodyTypes]
       rep
       ( \is os certs w c s up aux ->
           ShelleyTxBody
@@ -97,21 +97,21 @@ instance HasSpec (TxBody ShelleyEra)
 --   and (Maybe x) instead of (StrictMaybe x). It transforms bewtween the two, in the toSimpleRep
 --   and fromSimpleRep methods. This makes it much easier to write Specifications, because
 --   the Constrained packaage knows about Lists and Maybe.
-type AllegraTxBodyTypes era =
+type AllegraTxBodyTypes =
   '[ Set TxIn
-   , [TxOut era]
-   , [TxCert era]
+   , [TxOut AllegraEra]
+   , [TxCert AllegraEra]
    , Map RewardAccount Coin
    , Coin
    , ValidityInterval
-   , Maybe (Update era)
+   , Maybe (Update AllegraEra)
    , Maybe TxAuxDataHash
    ]
 
 instance HasSimpleRep (TxBody AllegraEra) where
-  type SimpleRep (TxBody AllegraEra) = SOP '["AllegraTxBody" ::: AllegraTxBodyTypes AllegraEra]
+  type SimpleRep (TxBody AllegraEra) = SOP '["AllegraTxBody" ::: AllegraTxBodyTypes]
   toSimpleRep (AllegraTxBody is os certs w c vi up aux) =
-    inject @"AllegraTxBody" @'["AllegraTxBody" ::: AllegraTxBodyTypes AllegraEra]
+    inject @"AllegraTxBody" @'["AllegraTxBody" ::: AllegraTxBodyTypes]
       is
       (toList os)
       (toList certs)
@@ -122,7 +122,7 @@ instance HasSimpleRep (TxBody AllegraEra) where
       (strictMaybeToMaybe aux)
 
   fromSimpleRep rep =
-    algebra @'["AllegraTxBody" ::: AllegraTxBodyTypes AllegraEra]
+    algebra @'["AllegraTxBody" ::: AllegraTxBodyTypes]
       rep
       ( \is os certs w c vi up aux ->
           AllegraTxBody
@@ -144,22 +144,22 @@ instance HasSpec (TxBody AllegraEra)
 --   and (Maybe x) instead of (StrictMaybe x). It transforms between the abstractions and the
 --   real types in the toSimpleRep and fromSimpleRep methods. This makes it much easier to
 --   write Specifications, because the Constrained packaage knows about Lists and Maybe.
-type MaryTxBodyTypes era =
+type MaryTxBodyTypes =
   '[ Set TxIn
-   , [TxOut era]
-   , [TxCert era]
+   , [TxOut MaryEra]
+   , [TxCert MaryEra]
    , Map RewardAccount Coin
    , Coin
    , ValidityInterval
-   , Maybe (Update era)
+   , Maybe (Update MaryEra)
    , Maybe TxAuxDataHash
    , MultiAsset
    ]
 
 instance HasSimpleRep (TxBody MaryEra) where
-  type SimpleRep (TxBody MaryEra) = SOP '["MaryTxBody" ::: MaryTxBodyTypes MaryEra]
+  type SimpleRep (TxBody MaryEra) = SOP '["MaryTxBody" ::: MaryTxBodyTypes]
   toSimpleRep (MaryTxBody is os certs w c vi up aux ma) =
-    inject @"MaryTxBody" @'["MaryTxBody" ::: MaryTxBodyTypes MaryEra]
+    inject @"MaryTxBody" @'["MaryTxBody" ::: MaryTxBodyTypes]
       is
       (toList os)
       (toList certs)
@@ -171,7 +171,7 @@ instance HasSimpleRep (TxBody MaryEra) where
       ma
 
   fromSimpleRep rep =
-    algebra @'["MaryTxBody" ::: MaryTxBodyTypes MaryEra]
+    algebra @'["MaryTxBody" ::: MaryTxBodyTypes]
       rep
       ( \is os certs w c vi up aux ma ->
           MaryTxBody
@@ -194,15 +194,15 @@ instance HasSpec (TxBody MaryEra)
 --   and (Maybe x) instead of (StrictMaybe x). It transforms between the abstractions and the
 --   real types in the toSimpleRep and fromSimpleRep methods. This makes it much easier to
 --   write Specifications, because the Constrained packaage knows about Lists and Maybe.
-type AlonzoTxBodyTypes era =
+type AlonzoTxBodyTypes =
   '[ Set TxIn
    , Set TxIn
-   , [TxOut era]
-   , [TxCert era]
+   , [TxOut AlonzoEra]
+   , [TxCert AlonzoEra]
    , Map RewardAccount Coin
    , Coin
    , ValidityInterval
-   , Maybe (Update era)
+   , Maybe (Update AlonzoEra)
    , Set (KeyHash 'Witness)
    , MultiAsset
    , Maybe ScriptIntegrityHash
@@ -211,9 +211,9 @@ type AlonzoTxBodyTypes era =
    ]
 
 instance HasSimpleRep (TxBody AlonzoEra) where
-  type SimpleRep (TxBody AlonzoEra) = SOP '["AlonzoTxBody" ::: AlonzoTxBodyTypes AlonzoEra]
+  type SimpleRep (TxBody AlonzoEra) = SOP '["AlonzoTxBody" ::: AlonzoTxBodyTypes]
   toSimpleRep (AlonzoTxBody inputs colinputs os certs w c vi up kh ma ihash aux nw) =
-    inject @"AlonzoTxBody" @'["AlonzoTxBody" ::: AlonzoTxBodyTypes AlonzoEra]
+    inject @"AlonzoTxBody" @'["AlonzoTxBody" ::: AlonzoTxBodyTypes]
       inputs
       colinputs
       (toList os)
@@ -229,7 +229,7 @@ instance HasSimpleRep (TxBody AlonzoEra) where
       (strictMaybeToMaybe nw)
 
   fromSimpleRep rep =
-    algebra @'["AlonzoTxBody" ::: AlonzoTxBodyTypes AlonzoEra]
+    algebra @'["AlonzoTxBody" ::: AlonzoTxBodyTypes]
       rep
       ( \inputs colinputs os certs w c vi up kh ma ihash aux nw ->
           AlonzoTxBody
@@ -257,18 +257,18 @@ instance HasSpec (TxBody AlonzoEra)
 --   and (Maybe x) instead of (StrictMaybe x). It transforms between the abstractions and the
 --   real types in the toSimpleRep and fromSimpleRep methods. This makes it much easier to
 --   write Specifications, because the Constrained packaage knows about Lists and Maybe.
-type BabbageTxBodyTypes era =
+type BabbageTxBodyTypes =
   '[ Set TxIn
    , Set TxIn
    , Set TxIn
-   , [Sized (TxOut era)]
-   , Maybe (Sized (TxOut era))
+   , [Sized (TxOut BabbageEra)]
+   , Maybe (Sized (TxOut BabbageEra))
    , Maybe Coin
-   , [TxCert era]
+   , [TxCert BabbageEra]
    , Map RewardAccount Coin -- Withdrawals without the newtype
    , Coin
    , ValidityInterval
-   , Maybe (Update era)
+   , Maybe (Update BabbageEra)
    , Set (KeyHash 'Witness)
    , MultiAsset
    , Maybe ScriptIntegrityHash
@@ -277,9 +277,9 @@ type BabbageTxBodyTypes era =
    ]
 
 instance HasSimpleRep (TxBody BabbageEra) where
-  type SimpleRep (TxBody BabbageEra) = SOP '["BabbageTxBody" ::: BabbageTxBodyTypes BabbageEra]
+  type SimpleRep (TxBody BabbageEra) = SOP '["BabbageTxBody" ::: BabbageTxBodyTypes]
   toSimpleRep (BabbageTxBody inputs colinputs refinputs os colOut coin certs w c vi up kh ma ihash aux nw) =
-    inject @"BabbageTxBody" @'["BabbageTxBody" ::: BabbageTxBodyTypes BabbageEra]
+    inject @"BabbageTxBody" @'["BabbageTxBody" ::: BabbageTxBodyTypes]
       inputs
       colinputs
       refinputs
@@ -298,7 +298,7 @@ instance HasSimpleRep (TxBody BabbageEra) where
       (strictMaybeToMaybe nw)
 
   fromSimpleRep rep =
-    algebra @'["BabbageTxBody" ::: BabbageTxBodyTypes BabbageEra]
+    algebra @'["BabbageTxBody" ::: BabbageTxBodyTypes]
       rep
       ( \inputs colinputs refinputs os colret totalcol certs w fee vi up kh ma ihash aux nw ->
           BabbageTxBody

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/TxBody.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/TxBody.hs
@@ -13,17 +13,20 @@
 module Test.Cardano.Ledger.Constrained.Conway.Instances.TxBody where
 
 import Cardano.Ledger.Address (RewardAccount (..))
-import Cardano.Ledger.Allegra.TxBody (AllegraTxBody (..))
-import Cardano.Ledger.Alonzo.TxBody (AlonzoTxBody (..))
-import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..))
+import Cardano.Ledger.Allegra (AllegraEra)
+import Cardano.Ledger.Allegra.TxBody (TxBody (..))
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Alonzo.TxBody (TxBody (..))
+import Cardano.Ledger.Babbage (BabbageEra)
+import Cardano.Ledger.Babbage.TxBody (TxBody (..))
 import Cardano.Ledger.BaseTypes hiding (inject)
-import Cardano.Ledger.Binary (EncCBOR (..), Sized (..))
+import Cardano.Ledger.Binary (Sized (..))
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Mary.TxBody (MaryTxBody (..))
+import Cardano.Ledger.Mary (MaryEra, TxBody (..))
 import Cardano.Ledger.Mary.Value (MultiAsset (..))
+import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.PParams (Update (..))
-import Cardano.Ledger.Shelley.TxBody (ShelleyTxBody (..))
 import Cardano.Ledger.TxIn (TxIn (..))
 import Constrained.API
 import Constrained.Generic
@@ -32,7 +35,6 @@ import Data.Map.Strict (Map)
 import qualified Data.Sequence.Strict as SS (fromList)
 import Data.Set (Set)
 import Data.Typeable
-import Lens.Micro
 import Test.Cardano.Ledger.Constrained.Conway.Instances.Ledger
 
 -- ==============================================================================
@@ -58,15 +60,10 @@ type ShelleyTxBodyTypes era =
    , Maybe TxAuxDataHash
    ]
 
-instance
-  ( EraTxOut era
-  , EncCBOR (TxCert era)
-  ) =>
-  HasSimpleRep (ShelleyTxBody era)
-  where
-  type SimpleRep (ShelleyTxBody era) = SOP '["ShelleyTxBody" ::: ShelleyTxBodyTypes era]
+instance HasSimpleRep (TxBody ShelleyEra) where
+  type SimpleRep (TxBody ShelleyEra) = SOP '["ShelleyTxBody" ::: ShelleyTxBodyTypes ShelleyEra]
   toSimpleRep (ShelleyTxBody is os certs w c s up aux) =
-    inject @"ShelleyTxBody" @'["ShelleyTxBody" ::: ShelleyTxBodyTypes era]
+    inject @"ShelleyTxBody" @'["ShelleyTxBody" ::: ShelleyTxBodyTypes ShelleyEra]
       is
       (toList os)
       (toList certs)
@@ -77,7 +74,7 @@ instance
       (strictMaybeToMaybe aux)
 
   fromSimpleRep rep =
-    algebra @'["ShelleyTxBody" ::: ShelleyTxBodyTypes era]
+    algebra @'["ShelleyTxBody" ::: ShelleyTxBodyTypes ShelleyEra]
       rep
       ( \is os certs w c s up aux ->
           ShelleyTxBody
@@ -91,22 +88,7 @@ instance
             (maybeToStrictMaybe aux)
       )
 
-instance
-  ( EraSpecPParams era
-  , HasSpec (TxOut era)
-  , HasSpec (TxCert era)
-  ) =>
-  HasSpec (ShelleyTxBody era)
-
-fromShelleyBody :: forall era. EraTxBody era => ShelleyTxBody era -> TxBody era
-fromShelleyBody (ShelleyTxBody inputs outputs certs withdrawals coin _slot _up aux) =
-  mkBasicTxBody @era
-    & inputsTxBodyL @era .~ inputs
-    & outputsTxBodyL @era .~ outputs
-    & feeTxBodyL @era .~ coin
-    & withdrawalsTxBodyL @era .~ withdrawals
-    & certsTxBodyL @era .~ certs
-    & auxDataHashTxBodyL @era .~ aux
+instance HasSpec (TxBody ShelleyEra)
 
 -- =======================================================
 -- AllegraTxBody
@@ -126,15 +108,10 @@ type AllegraTxBodyTypes era =
    , Maybe TxAuxDataHash
    ]
 
-instance
-  ( EraTxOut era
-  , EraTxCert era
-  ) =>
-  HasSimpleRep (AllegraTxBody era)
-  where
-  type SimpleRep (AllegraTxBody era) = SOP '["AllegraTxBody" ::: AllegraTxBodyTypes era]
+instance HasSimpleRep (TxBody AllegraEra) where
+  type SimpleRep (TxBody AllegraEra) = SOP '["AllegraTxBody" ::: AllegraTxBodyTypes AllegraEra]
   toSimpleRep (AllegraTxBody is os certs w c vi up aux) =
-    inject @"AllegraTxBody" @'["AllegraTxBody" ::: AllegraTxBodyTypes era]
+    inject @"AllegraTxBody" @'["AllegraTxBody" ::: AllegraTxBodyTypes AllegraEra]
       is
       (toList os)
       (toList certs)
@@ -145,7 +122,7 @@ instance
       (strictMaybeToMaybe aux)
 
   fromSimpleRep rep =
-    algebra @'["AllegraTxBody" ::: AllegraTxBodyTypes era]
+    algebra @'["AllegraTxBody" ::: AllegraTxBodyTypes AllegraEra]
       rep
       ( \is os certs w c vi up aux ->
           AllegraTxBody
@@ -158,23 +135,7 @@ instance
             (maybeToStrictMaybe up)
             (maybeToStrictMaybe aux)
       )
-instance
-  ( EraSpecPParams era
-  , HasSpec (TxOut era)
-  , HasSpec (TxCert era)
-  ) =>
-  HasSpec (AllegraTxBody era)
-
-fromAllegraBody :: forall era. AllegraEraTxBody era => AllegraTxBody era -> TxBody era
-fromAllegraBody (AllegraTxBody inputs outputs certs withdrawals coin vi _up aux) =
-  mkBasicTxBody @era
-    & inputsTxBodyL @era .~ inputs
-    & outputsTxBodyL @era .~ outputs
-    & feeTxBodyL @era .~ coin
-    & withdrawalsTxBodyL @era .~ withdrawals
-    & certsTxBodyL @era .~ certs
-    & auxDataHashTxBodyL @era .~ aux
-    & vldtTxBodyL @era .~ vi
+instance HasSpec (TxBody AllegraEra)
 
 -- =========================================================================
 -- MaryTxBody
@@ -195,15 +156,10 @@ type MaryTxBodyTypes era =
    , MultiAsset
    ]
 
-instance
-  ( EraTxOut era
-  , EraTxCert era
-  ) =>
-  HasSimpleRep (MaryTxBody era)
-  where
-  type SimpleRep (MaryTxBody era) = SOP '["MaryTxBody" ::: MaryTxBodyTypes era]
+instance HasSimpleRep (TxBody MaryEra) where
+  type SimpleRep (TxBody MaryEra) = SOP '["MaryTxBody" ::: MaryTxBodyTypes MaryEra]
   toSimpleRep (MaryTxBody is os certs w c vi up aux ma) =
-    inject @"MaryTxBody" @'["MaryTxBody" ::: MaryTxBodyTypes era]
+    inject @"MaryTxBody" @'["MaryTxBody" ::: MaryTxBodyTypes MaryEra]
       is
       (toList os)
       (toList certs)
@@ -215,7 +171,7 @@ instance
       ma
 
   fromSimpleRep rep =
-    algebra @'["MaryTxBody" ::: MaryTxBodyTypes era]
+    algebra @'["MaryTxBody" ::: MaryTxBodyTypes MaryEra]
       rep
       ( \is os certs w c vi up aux ma ->
           MaryTxBody
@@ -229,24 +185,7 @@ instance
             (maybeToStrictMaybe aux)
             ma
       )
-instance
-  ( EraSpecPParams era
-  , HasSpec (TxOut era)
-  , HasSpec (TxCert era)
-  ) =>
-  HasSpec (MaryTxBody era)
-
-fromMaryBody :: forall era. MaryEraTxBody era => MaryTxBody era -> TxBody era
-fromMaryBody (MaryTxBody inputs outputs certs withdrawals coin vi _up aux ma) =
-  mkBasicTxBody @era
-    & inputsTxBodyL @era .~ inputs
-    & outputsTxBodyL @era .~ outputs
-    & feeTxBodyL @era .~ coin
-    & withdrawalsTxBodyL @era .~ withdrawals
-    & certsTxBodyL @era .~ certs
-    & auxDataHashTxBodyL @era .~ aux
-    & vldtTxBodyL @era .~ vi
-    & mintTxBodyL @era .~ ma
+instance HasSpec (TxBody MaryEra)
 
 -- =================================================================================
 -- AlonzoTxBody
@@ -271,15 +210,10 @@ type AlonzoTxBodyTypes era =
    , Maybe Network
    ]
 
-instance
-  ( EraTxOut era
-  , EraTxCert era
-  ) =>
-  HasSimpleRep (AlonzoTxBody era)
-  where
-  type SimpleRep (AlonzoTxBody era) = SOP '["AlonzoTxBody" ::: AlonzoTxBodyTypes era]
+instance HasSimpleRep (TxBody AlonzoEra) where
+  type SimpleRep (TxBody AlonzoEra) = SOP '["AlonzoTxBody" ::: AlonzoTxBodyTypes AlonzoEra]
   toSimpleRep (AlonzoTxBody inputs colinputs os certs w c vi up kh ma ihash aux nw) =
-    inject @"AlonzoTxBody" @'["AlonzoTxBody" ::: AlonzoTxBodyTypes era]
+    inject @"AlonzoTxBody" @'["AlonzoTxBody" ::: AlonzoTxBodyTypes AlonzoEra]
       inputs
       colinputs
       (toList os)
@@ -295,7 +229,7 @@ instance
       (strictMaybeToMaybe nw)
 
   fromSimpleRep rep =
-    algebra @'["AlonzoTxBody" ::: AlonzoTxBodyTypes era]
+    algebra @'["AlonzoTxBody" ::: AlonzoTxBodyTypes AlonzoEra]
       rep
       ( \inputs colinputs os certs w c vi up kh ma ihash aux nw ->
           AlonzoTxBody
@@ -314,29 +248,7 @@ instance
             (maybeToStrictMaybe nw)
       )
 
-instance
-  ( EraSpecPParams era
-  , HasSpec (TxOut era)
-  , HasSpec (TxCert era)
-  ) =>
-  HasSpec (AlonzoTxBody era)
-
-fromAlonzoBody :: forall era. AlonzoEraTxBody era => AlonzoTxBody era -> TxBody era
-fromAlonzoBody (AlonzoTxBody colinputs inputs outputs certs withdrawals coin vi _up kh ma ihash aux nw) =
-  mkBasicTxBody @era
-    & inputsTxBodyL @era .~ inputs
-    & collateralInputsTxBodyL @era .~ colinputs
-    & outputsTxBodyL @era .~ outputs
-    & feeTxBodyL @era .~ coin
-    & withdrawalsTxBodyL @era .~ withdrawals
-    & certsTxBodyL @era .~ certs
-    & auxDataHashTxBodyL @era .~ aux
-    & vldtTxBodyL @era .~ vi
-    & mintTxBodyL @era .~ ma
-    & collateralInputsTxBodyL @era .~ colinputs
-    & reqSignerHashesTxBodyL @era .~ kh
-    & scriptIntegrityHashTxBodyL @era .~ ihash
-    & networkIdTxBodyL @era .~ nw
+instance HasSpec (TxBody AlonzoEra)
 
 -- =================================================================================
 -- BabbageTxBody
@@ -364,13 +276,10 @@ type BabbageTxBodyTypes era =
    , Maybe Network
    ]
 
-instance
-  (EraTxOut era, EraTxCert era, BabbageEraTxBody era) =>
-  HasSimpleRep (BabbageTxBody era)
-  where
-  type SimpleRep (BabbageTxBody era) = SOP '["BabbageTxBody" ::: BabbageTxBodyTypes era]
+instance HasSimpleRep (TxBody BabbageEra) where
+  type SimpleRep (TxBody BabbageEra) = SOP '["BabbageTxBody" ::: BabbageTxBodyTypes BabbageEra]
   toSimpleRep (BabbageTxBody inputs colinputs refinputs os colOut coin certs w c vi up kh ma ihash aux nw) =
-    inject @"BabbageTxBody" @'["BabbageTxBody" ::: BabbageTxBodyTypes era]
+    inject @"BabbageTxBody" @'["BabbageTxBody" ::: BabbageTxBodyTypes BabbageEra]
       inputs
       colinputs
       refinputs
@@ -389,7 +298,7 @@ instance
       (strictMaybeToMaybe nw)
 
   fromSimpleRep rep =
-    algebra @'["BabbageTxBody" ::: BabbageTxBodyTypes era]
+    algebra @'["BabbageTxBody" ::: BabbageTxBodyTypes BabbageEra]
       rep
       ( \inputs colinputs refinputs os colret totalcol certs w fee vi up kh ma ihash aux nw ->
           BabbageTxBody
@@ -411,29 +320,4 @@ instance
             (maybeToStrictMaybe nw)
       )
 
-instance
-  ( EraSpecPParams era
-  , BabbageEraTxBody era
-  , HasSpec (TxOut era)
-  , HasSpec (TxCert era)
-  ) =>
-  HasSpec (BabbageTxBody era)
-
-fromBabbageBody :: forall era. BabbageEraTxBody era => BabbageTxBody era -> TxBody era
-fromBabbageBody (BabbageTxBody inputs colinputs refinputs os colret totalcol certs w fee vi _up kh ma ihash aux nw) =
-  mkBasicTxBody @era
-    & inputsTxBodyL @era .~ inputs
-    & collateralInputsTxBodyL @era .~ colinputs
-    & referenceInputsTxBodyL @era .~ refinputs
-    & sizedOutputsTxBodyL @era .~ os
-    & sizedCollateralReturnTxBodyL @era .~ colret
-    & totalCollateralTxBodyL @era .~ totalcol
-    & certsTxBodyL @era .~ certs
-    & withdrawalsTxBodyL @era .~ w
-    & feeTxBodyL @era .~ fee
-    & vldtTxBodyL @era .~ vi
-    & reqSignerHashesTxBodyL @era .~ kh
-    & mintTxBodyL @era .~ ma
-    & scriptIntegrityHashTxBodyL @era .~ ihash
-    & auxDataHashTxBodyL @era .~ aux
-    & networkIdTxBodyL @era .~ nw
+instance HasSpec (TxBody BabbageEra)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
@@ -28,7 +28,6 @@ import Cardano.Ledger.Conway.Core (
   EraPParams (..),
   EraTx,
   EraTxAuxData (..),
-  EraTxBody (..),
   EraTxWits (..),
  )
 import Cardano.Ledger.Conway.Governance (GovActionId, Proposals, gasDeposit, pPropsL)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Fields.hs
@@ -44,14 +44,14 @@ module Test.Cardano.Ledger.Generic.Fields (
 where
 
 import Cardano.Ledger.Address (Addr (..))
-import Cardano.Ledger.Allegra.TxBody (AllegraTxBody (..))
+import Cardano.Ledger.Allegra.TxBody (TxBody (..))
 import Cardano.Ledger.Alonzo.PParams (AlonzoPParams (..), unOrdExUnits)
 import Cardano.Ledger.Alonzo.Scripts (CostModels, ExUnits (..), Prices)
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), IsValid (..))
-import Cardano.Ledger.Alonzo.TxBody (AlonzoTxBody (..), AlonzoTxOut (..))
+import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..), TxBody (..))
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), Redeemers (..), TxDats (..))
 import Cardano.Ledger.Babbage.PParams (BabbagePParams (..))
-import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..), BabbageTxOut (..))
+import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..), TxBody (..))
 import Cardano.Ledger.BaseTypes (
   EpochInterval (..),
   Network (..),
@@ -66,17 +66,16 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance (ProposalProcedure, VotingProcedures)
 import Cardano.Ledger.Conway.PParams (ConwayPParams (..))
-import Cardano.Ledger.Conway.TxBody (ConwayTxBody (..))
+import Cardano.Ledger.Conway.TxBody (TxBody (..))
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import Cardano.Ledger.Keys (WitVKey (..))
 import Cardano.Ledger.Keys.Bootstrap (BootstrapWitness (..))
-import Cardano.Ledger.Mary.TxBody (MaryTxBody (..))
+import Cardano.Ledger.Mary (TxBody (..))
 import Cardano.Ledger.Mary.Value (MultiAsset (..))
 import Cardano.Ledger.Plutus.Data (Data (..), Datum (..), hashData)
 import Cardano.Ledger.Shelley.PParams (ShelleyPParams (..))
 import qualified Cardano.Ledger.Shelley.PParams as PP (Update)
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..))
-import Cardano.Ledger.Shelley.TxBody (ShelleyTxBody (..))
 import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
 import Cardano.Ledger.Shelley.TxWits (pattern ShelleyTxWits)
 import Cardano.Ledger.TxIn (TxIn (..))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/PrettyCore.hs
@@ -33,7 +33,6 @@ import Cardano.Ledger.Allegra.Scripts (
   pattern RequireTimeStart,
  )
 import Cardano.Ledger.Allegra.TxAuxData (AllegraTxAuxData (..))
-import Cardano.Ledger.Allegra.TxBody (AllegraTxBody (..))
 import Cardano.Ledger.Alonzo.Core (CoinPerWord (..))
 import Cardano.Ledger.Alonzo.Plutus.Context (ContextError)
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (CollectError (..))
@@ -62,7 +61,7 @@ import Cardano.Ledger.Alonzo.TxAuxData (
   atadrMetadata,
   getAlonzoTxAuxDataScripts,
  )
-import Cardano.Ledger.Alonzo.TxBody (AlonzoTxBody (..), AlonzoTxOut (..))
+import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..))
 import Cardano.Ledger.Alonzo.TxWits (
   AlonzoTxWits,
   AlonzoTxWitsRaw (..),
@@ -175,7 +174,6 @@ import Cardano.Ledger.Keys (
   WitVKey (..),
  )
 import Cardano.Ledger.Keys.Bootstrap (BootstrapWitness (..), ChainCode (..))
-import Cardano.Ledger.Mary.TxBody (MaryTxBody (..))
 import Cardano.Ledger.Mary.Value (
   AssetName (..),
   MaryValue (..),
@@ -248,7 +246,7 @@ import Cardano.Ledger.Shelley.Scripts (
 import Cardano.Ledger.Shelley.State (ShelleyCertState (..))
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..))
 import Cardano.Ledger.Shelley.TxAuxData (Metadatum (..), ShelleyTxAuxData (..))
-import Cardano.Ledger.Shelley.TxBody (ShelleyTxBody (..), ShelleyTxBodyRaw (..))
+import Cardano.Ledger.Shelley.TxBody (ShelleyTxBodyRaw (..))
 import Cardano.Ledger.Shelley.TxCert (
   GenesisDelegCert (..),
   ShelleyDelegCert (..),
@@ -343,10 +341,14 @@ import Test.Cardano.Ledger.Generic.Fields (
  )
 import qualified Test.Cardano.Ledger.Generic.Fields as Fields
 import Test.Cardano.Ledger.Generic.Proof (
+  AllegraEra,
+  AlonzoEra,
   CertStateWit (..),
   GovStateWit (..),
+  MaryEra,
   Proof (..),
   Reflect (..),
+  ShelleyEra,
   unReflect,
   whichCertState,
   whichGovState,
@@ -929,10 +931,7 @@ instance
   prettyA = ppAlonzoTx
 
 ppShelleyTxBody ::
-  ( Reflect era
-  , PrettyA (PParamsUpdate era)
-  ) =>
-  ShelleyTxBody era ->
+  TxBody ShelleyEra ->
   PDoc
 ppShelleyTxBody txBody =
   let ShelleyTxBodyRaw ins outs cs withdrawals fee ttl upd mdh = getMemoRawType txBody
@@ -948,42 +947,35 @@ ppShelleyTxBody txBody =
         , ("metadatahash", ppStrictMaybe ppTxAuxDataHash mdh)
         ]
 
-instance
-  ( EraTxOut era
-  , PrettyA (PParamsUpdate era)
-  , Reflect era
-  ) =>
-  PrettyA (ShelleyTxBody era)
-  where
+instance PrettyA (TxBody ShelleyEra) where
   prettyA = ppShelleyTxBody
 
 ppAllegraTxBody ::
-  forall era. (TxBody era ~ AllegraTxBody era, Reflect era) => AllegraTxBody era -> PDoc
-ppAllegraTxBody txbody = ppRecord ("TxBody " <> pack (show (reify @era))) pairs
+  TxBody AllegraEra -> PDoc
+ppAllegraTxBody txbody = ppRecord ("TxBody " <> pack (show (reify @AllegraEra))) pairs
   where
     fields = abstractTxBody reify txbody
     pairs = concatMap (pcTxBodyField reify) fields
 
-instance (TxBody era ~ AllegraTxBody era, Reflect era) => PrettyA (AllegraTxBody era) where
+instance PrettyA (TxBody AllegraEra) where
   prettyA = ppAllegraTxBody
 
-ppAlonzoTxBody ::
-  forall era. (TxBody era ~ AlonzoTxBody era, Reflect era) => AlonzoTxBody era -> PDoc
-ppAlonzoTxBody txbody = ppRecord ("TxBody " <> pack (show (reify @era))) pairs
+ppAlonzoTxBody :: TxBody AlonzoEra -> PDoc
+ppAlonzoTxBody txbody = ppRecord ("TxBody " <> pack (show (reify @AllegraEra))) pairs
   where
     fields = abstractTxBody reify txbody
     pairs = concatMap (pcTxBodyField reify) fields
 
-instance (TxBody era ~ AlonzoTxBody era, Reflect era) => PrettyA (AlonzoTxBody era) where
+instance PrettyA (TxBody AlonzoEra) where
   prettyA = ppAlonzoTxBody
 
-ppMaryTxBody :: forall era. (TxBody era ~ MaryTxBody era, Reflect era) => MaryTxBody era -> PDoc
-ppMaryTxBody txbody = ppRecord ("TxBody " <> pack (show (reify @era))) pairs
+ppMaryTxBody :: TxBody MaryEra -> PDoc
+ppMaryTxBody txbody = ppRecord ("TxBody " <> pack (show (reify @MaryEra))) pairs
   where
     fields = abstractTxBody reify txbody
     pairs = concatMap (pcTxBodyField reify) fields
 
-instance (TxBody era ~ MaryTxBody era, Reflect era) => PrettyA (MaryTxBody era) where
+instance PrettyA (TxBody MaryEra) where
   prettyA = ppMaryTxBody
 
 -- =============================================================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -12,8 +12,7 @@
 
 module Test.Cardano.Ledger.Generic.Properties where
 
-import Cardano.Ledger.Alonzo.Tx (AlonzoTxBody (..), IsValid (..))
-import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..))
+import Cardano.Ledger.Alonzo.Tx (IsValid (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
 import qualified Cardano.Ledger.Shelley as S (ShelleyEra)
@@ -367,8 +366,8 @@ twiddleInvariantHoldsEras :: TestTree
 twiddleInvariantHoldsEras =
   testGroup
     "Twiddle invariant holds for TxBody"
-    [ twiddleInvariantHolds @(AlonzoTxBody AlonzoEra) "Alonzo"
-    , twiddleInvariantHolds @(BabbageTxBody BabbageEra) "Babbage"
+    [ twiddleInvariantHolds @(TxBody AlonzoEra) "Alonzo"
+    , twiddleInvariantHolds @(TxBody BabbageEra) "Babbage"
     ]
 
 -- ==============================================================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Same.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Same.hs
@@ -16,19 +16,19 @@
 --   equality failed.
 module Test.Cardano.Ledger.Generic.Same where
 
-import Cardano.Ledger.Allegra.TxBody (AllegraTxBody (..))
+import Cardano.Ledger.Allegra.TxBody (TxBody (..))
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..))
-import Cardano.Ledger.Alonzo.TxBody (AlonzoTxBody (..))
+import Cardano.Ledger.Alonzo.TxBody (TxBody (..))
 import Cardano.Ledger.Alonzo.TxSeq (AlonzoTxSeq (..))
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), Redeemers (..), TxDats (..))
-import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..))
+import Cardano.Ledger.Babbage.TxBody (TxBody (..))
 import Cardano.Ledger.Binary (sizedValue)
 import Cardano.Ledger.Block (Block (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance (VotingProcedures (..))
 import Cardano.Ledger.Conway.State (VState (..))
-import Cardano.Ledger.Conway.TxBody (ConwayTxBody (..))
-import Cardano.Ledger.Mary.TxBody (MaryTxBody (..))
+import Cardano.Ledger.Conway.TxBody (TxBody (..))
+import Cardano.Ledger.Mary (TxBody (..))
 import Cardano.Ledger.Shelley.API.Mempool (ApplyTxError)
 import Cardano.Ledger.Shelley.BlockChain (ShelleyTxSeq (..))
 import Cardano.Ledger.Shelley.LedgerState (
@@ -45,7 +45,6 @@ import Cardano.Ledger.Shelley.LedgerState (
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..))
 import Cardano.Ledger.Shelley.Translation ()
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..))
-import Cardano.Ledger.Shelley.TxBody (ShelleyTxBody (..))
 import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits (..))
 import Cardano.Ledger.State (EraCertState (..), UTxO (..))
 import Data.Foldable (toList)
@@ -393,7 +392,7 @@ sameAlonzoTxWits
     , ("RedeemerWits", eqVia (ppMap ppPlutusPurposeAsIx (pcPair pcData pcExUnits)) r1 r2)
     ]
 
-sameTxWits :: Reflect era => Proof era -> TxWits era -> TxWits era -> [(String, Maybe PDoc)]
+sameTxWits :: Proof era -> TxWits era -> TxWits era -> [(String, Maybe PDoc)]
 sameTxWits proof@Shelley x y = sameShelleyTxWits proof x y
 sameTxWits proof@Allegra x y = sameShelleyTxWits proof x y
 sameTxWits proof@Mary x y = sameShelleyTxWits proof x y
@@ -405,10 +404,9 @@ sameTxWits proof@Conway x y = sameAlonzoTxWits proof x y
 -- Comparing TxBody for Sameness
 
 sameShelleyTxBody ::
-  Reflect era =>
-  Proof era ->
-  ShelleyTxBody era ->
-  ShelleyTxBody era ->
+  Proof ShelleyEra ->
+  TxBody ShelleyEra ->
+  TxBody ShelleyEra ->
   [(String, Maybe PDoc)]
 sameShelleyTxBody proof (ShelleyTxBody i1 o1 c1 (Withdrawals w1) f1 s1 pu1 d1) (ShelleyTxBody i2 o2 c2 (Withdrawals w2) f2 s2 pu2 d2) =
   [ ("Inputs", eqVia (ppSet pcTxIn) i1 i2)
@@ -422,10 +420,9 @@ sameShelleyTxBody proof (ShelleyTxBody i1 o1 c1 (Withdrawals w1) f1 s1 pu1 d1) (
   ]
 
 sameAllegraTxBody ::
-  Reflect era =>
-  Proof era ->
-  AllegraTxBody era ->
-  AllegraTxBody era ->
+  Proof AllegraEra ->
+  TxBody AllegraEra ->
+  TxBody AllegraEra ->
   [(String, Maybe PDoc)]
 sameAllegraTxBody proof (AllegraTxBody i1 o1 c1 (Withdrawals w1) f1 v1 pu1 d1) (AllegraTxBody i2 o2 c2 (Withdrawals w2) f2 v2 pu2 d2) =
   [ ("Inputs", eqVia (ppSet pcTxIn) i1 i2)
@@ -439,10 +436,9 @@ sameAllegraTxBody proof (AllegraTxBody i1 o1 c1 (Withdrawals w1) f1 v1 pu1 d1) (
   ]
 
 sameMaryTxBody ::
-  Reflect era =>
-  Proof era ->
-  MaryTxBody era ->
-  MaryTxBody era ->
+  Proof MaryEra ->
+  TxBody MaryEra ->
+  TxBody MaryEra ->
   [(String, Maybe PDoc)]
 sameMaryTxBody proof (MaryTxBody i1 o1 c1 (Withdrawals w1) f1 v1 pu1 d1 m1) (MaryTxBody i2 o2 c2 (Withdrawals w2) f2 v2 pu2 d2 m2) =
   [ ("Inputs", eqVia (ppSet pcTxIn) i1 i2)
@@ -457,10 +453,9 @@ sameMaryTxBody proof (MaryTxBody i1 o1 c1 (Withdrawals w1) f1 v1 pu1 d1 m1) (Mar
   ]
 
 sameAlonzoTxBody ::
-  Reflect era =>
-  Proof era ->
-  AlonzoTxBody era ->
-  AlonzoTxBody era ->
+  Proof AlonzoEra ->
+  TxBody AlonzoEra ->
+  TxBody AlonzoEra ->
   [(String, Maybe PDoc)]
 sameAlonzoTxBody
   proof
@@ -482,12 +477,9 @@ sameAlonzoTxBody
     ]
 
 sameBabbageTxBody ::
-  ( Reflect era
-  , BabbageEraTxBody era
-  ) =>
-  Proof era ->
-  BabbageTxBody era ->
-  BabbageTxBody era ->
+  Proof BabbageEra ->
+  TxBody BabbageEra ->
+  TxBody BabbageEra ->
   [(String, Maybe PDoc)]
 sameBabbageTxBody
   proof
@@ -512,12 +504,9 @@ sameBabbageTxBody
     ]
 
 sameConwayTxBody ::
-  ( ConwayEraTxBody era
-  , Reflect era
-  ) =>
-  Proof era ->
-  ConwayTxBody era ->
-  ConwayTxBody era ->
+  Proof ConwayEra ->
+  TxBody ConwayEra ->
+  TxBody ConwayEra ->
   [(String, Maybe PDoc)]
 sameConwayTxBody
   proof
@@ -550,7 +539,7 @@ sameConwayTxBody
     , ("TreasuryDonation", eqVia pcCoin td1 td2)
     ]
 
-sameTxBody :: Reflect era => Proof era -> TxBody era -> TxBody era -> [(String, Maybe PDoc)]
+sameTxBody :: Proof era -> TxBody era -> TxBody era -> [(String, Maybe PDoc)]
 sameTxBody proof@Shelley x y = sameShelleyTxBody proof x y
 sameTxBody proof@Allegra x y = sameAllegraTxBody proof x y
 sameTxBody proof@Mary x y = sameMaryTxBody proof x y
@@ -590,7 +579,7 @@ sameAlonzoTx proof (AlonzoTx b1 w1 v1 aux1) (AlonzoTx b2 w2 v2 aux2) =
        ]
 {-# NOINLINE sameAlonzoTx #-}
 
-sameTx :: Reflect era => Proof era -> Tx era -> Tx era -> [(String, Maybe PDoc)]
+sameTx :: Proof era -> Tx era -> Tx era -> [(String, Maybe PDoc)]
 sameTx proof@Shelley x y = sameShelleyTx proof x y
 sameTx proof@Allegra x y = sameShelleyTx proof x y
 sameTx proof@Mary x y = sameShelleyTx proof x y
@@ -620,8 +609,7 @@ sameShelleyTxSeq proof (ShelleyTxSeq ss1) (ShelleyTxSeq ss2) =
     f n t1 t2 = SomeM (show n) (sameTx proof) t1 t2
 
 sameAlonzoTxSeq ::
-  ( Reflect era
-  , AlonzoEraTx era
+  ( AlonzoEraTx era
   , SafeToHash (TxWits era)
   ) =>
   Proof era ->
@@ -633,7 +621,7 @@ sameAlonzoTxSeq proof (AlonzoTxSeq ss1) (AlonzoTxSeq ss2) =
   where
     f n t1 t2 = SomeM (show n) (sameTx proof) t1 t2
 
-sameTxSeq :: Reflect era => Proof era -> TxSeq era -> TxSeq era -> [(String, Maybe PDoc)]
+sameTxSeq :: Proof era -> TxSeq era -> TxSeq era -> [(String, Maybe PDoc)]
 sameTxSeq proof@Shelley x y = sameShelleyTxSeq proof x y
 sameTxSeq proof@Allegra x y = sameShelleyTxSeq proof x y
 sameTxSeq proof@Mary x y = sameShelleyTxSeq proof x y


### PR DESCRIPTION
# Description

This PR changes `TxBody` from a type family to a data family.

close #4999 

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
