### PR TITLE
`constrained-generators`: Use csongor's trick to make type errors nicer

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -393,6 +393,7 @@ instance
       err = error $ "toCompact @" ++ show (typeOf x) ++ " " ++ show x
 instance
   ( Compactible a
+  , GenericallyInstantiated (CompactForm a)
   , Typeable (TypeSpec (SimpleRep a))
   , Show (TypeSpec (SimpleRep a))
   , HasSpec a
@@ -873,7 +874,13 @@ instance Typeable a => HasSimpleRep (THKD tag Identity a) where
   type SimpleRep (THKD tag Identity a) = a
   fromSimpleRep = THKD
   toSimpleRep (THKD a) = a
-instance (IsNormalType a, Typeable tag, HasSpec a) => HasSpec (THKD tag Identity a)
+instance
+  ( IsNormalType a
+  , Typeable tag
+  , HasSpec a
+  , GenericallyInstantiated (THKD tag Identity a)
+  ) =>
+  HasSpec (THKD tag Identity a)
 
 instance HasSimpleRep GovActionPurpose
 instance HasSpec GovActionPurpose

--- a/libs/constrained-generators/constrained-generators.cabal
+++ b/libs/constrained-generators/constrained-generators.cabal
@@ -45,6 +45,7 @@ library
     Constrained.SumList
     Constrained.Syntax
     Constrained.TheKnot
+    Constrained.TypeErrors
 
   hs-source-dirs: src
   default-language: Haskell2010

--- a/libs/constrained-generators/src/Constrained/API.hs
+++ b/libs/constrained-generators/src/Constrained/API.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE ViewPatterns #-}
 
 module Constrained.API (
+  GenericallyInstantiated,
   Logic (..),
   Semantics (..),
   Syntax (..),
@@ -144,6 +145,7 @@ where
 
 import Constrained.Base (
   Fun (..),
+  GenericallyInstantiated,
   HasSpec (..),
   Logic (..),
   Pred (..),

--- a/libs/constrained-generators/src/Constrained/NumSpec.hs
+++ b/libs/constrained-generators/src/Constrained/NumSpec.hs
@@ -17,6 +17,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE ViewPatterns #-}
 -- Random Natural, Arbitrary Natural, Uniform Natural
 {-# OPTIONS_GHC -Wno-orphans #-}

--- a/libs/constrained-generators/src/Constrained/Properties.hs
+++ b/libs/constrained-generators/src/Constrained/Properties.hs
@@ -162,9 +162,9 @@ prop_conformEmpty ::
 prop_conformEmpty a = QC.property $ conformsTo a (emptySpec @a)
 
 prop_univSound :: TestableFn -> QC.Property
-prop_univSound (TestableFn fn) =
+prop_univSound (TestableFn (fn :: t as b)) =
   QC.label (show fn) $
-    QC.forAllShrinkBlind QC.arbitrary QC.shrink $ \tc@(TestableCtx ctx) ->
+    QC.forAllShrinkBlind @QC.Property (QC.arbitrary @(TestableCtx as)) QC.shrink $ \tc@(TestableCtx ctx) ->
       QC.forAllShrinkBlind QC.arbitrary QC.shrink $ \spec ->
         QC.counterexample ("\nfn ctx = " ++ showCtxWith fn tc) $
           QC.counterexample (show $ "\nspec =" <+> pretty spec) $
@@ -221,7 +221,7 @@ showCtxWith fn (TestableCtx ctx) = show tm
     tm :: Term b
     tm =
       uncurryList (appTerm fn) $
-        fillListCtx (mapListCtxC @HasSpec (lit @_ . unValue) ctx) (\HOLE -> V $ Var 0 "v")
+        fillListCtx (mapListCtxC @HasSpec @_ @Value @Term (lit @_ . unValue) ctx) (\HOLE -> V $ Var 0 "v")
 
 data TestableFn where
   TestableFn ::

--- a/libs/constrained-generators/src/Constrained/Spec/SumProd.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/SumProd.hs
@@ -18,6 +18,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}

--- a/libs/constrained-generators/src/Constrained/SumList.hs
+++ b/libs/constrained-generators/src/Constrained/SumList.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE ViewPatterns #-}
 
 -- | Operations for generating random elements of Num like types, that sum to a particular total.

--- a/libs/constrained-generators/src/Constrained/Syntax.hs
+++ b/libs/constrained-generators/src/Constrained/Syntax.hs
@@ -601,6 +601,7 @@ runCaseOn s ((x :-> ps) :> bs@(_ :> _)) f = case s of
 letSubexpressionElimination :: HasSpec Bool => Pred -> Pred
 letSubexpressionElimination = go []
   where
+    adjustSub :: HasSpec a => Var a -> Subst -> Subst
     adjustSub x sub =
       [ x' := t
       | x' := t <- sub
@@ -663,6 +664,7 @@ letFloating = fold . go []
   where
     goBlock ctx ps = goBlock' (freeVarNames ctx <> freeVarNames ps) ctx ps
 
+    goBlock' :: Set Int -> [Pred] -> [Pred] -> [Pred]
     goBlock' _ ctx [] = ctx
     goBlock' fvs ctx (Let t (x :-> p) : ps) =
       -- We can do `goBlock'` here because we've already done let floating

--- a/libs/constrained-generators/src/Constrained/TypeErrors.hs
+++ b/libs/constrained-generators/src/Constrained/TypeErrors.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+
+module Constrained.TypeErrors (
+  AssertComputes,
+  module X,
+) where
+
+import Data.Kind
+#if MIN_VERSION_base(4,17,0)
+import GHC.TypeError as X
+#else
+import GHC.TypeLits as X
+#endif
+
+-- NOTE: this module implementes this very neat little trick for observing when type
+-- families are stuck https://blog.csongor.co.uk/report-stuck-families/ which allows
+-- us to report much better type errors when our generics tricks fail.
+--
+-- The idea of this type family is that if `ty` evaluates to a type (other than Dummy which
+-- we haven't exported) then `Computes ty (TE err)` will evaluate to `()` without
+-- getting stuck and without expanding `TE` to `TypeError err`.
+--
+-- If, on the other hand, GHC gets stuck evaluating `ty` it will (hopefully) try to normalize
+-- everything and (hopefully) end up with `Computes (TypeError err) ty` which in turn will cause
+-- it to throw `err` as a type error.
+--
+-- Now, the important thing here is that you can't do `Computes _ _ = ()` because that doesn't
+-- force the evaluation of `ty` and consequently doesn't end up with GHC wanting to report
+-- that `Computes tyThatDoesntCompute (TE err)` fails and consequently normalizing `TE err`
+-- and finally arriving at `TypeError err`.
+type family Computes (ty :: Type) (err :: Constraint) :: Constraint where
+  Computes Dummy _ =
+    TypeError
+      (Text "This shouldn't be reachable because " :<>: ShowType Dummy :<>: Text " shouldn't be exported!")
+  Computes _ _ = ()
+
+-- This is intentionally hidden in here to avoid any funny business
+data Dummy
+
+-- NOTE: this indirection is necessary only for older versions of GHC where this is
+-- "the right" amount of strictness - apparently it's not necessary on newer versions of GHC!
+-- The alternative would be to just do `AssertComputes ty em = Computes ty (TypeError em)` below
+-- and that works fine on e.g. ghc 9.12 (and other recent versions) but fails on 8.10.7 because
+-- GHC is "too eager" to throw the type error.
+type family TE em where
+  TE em = TypeError em
+
+type AssertComputes ty em = Computes ty (TE em)

--- a/libs/constrained-generators/test/Constrained/Test.hs
+++ b/libs/constrained-generators/test/Constrained/Test.hs
@@ -41,7 +41,6 @@ import Data.Int
 import qualified Data.List.NonEmpty as NE
 import Data.Map (Map)
 import Data.Set (Set)
-import Data.Typeable
 import Data.Word
 import GHC.Natural
 import Test.Hspec
@@ -264,9 +263,6 @@ sizeTests =
     testSpec "hasSizeSet" hasSizeSet
     testSpec "hasSizeMap" hasSizeMap
 
-data NumberyType where
-  N :: (Typeable a, Numbery a) => Proxy a -> NumberyType
-
 testNumberyListSpec :: String -> (forall a. Numbery a => Specification [a]) -> Spec
 testNumberyListSpec = testNumberyListSpec' True
 
@@ -275,25 +271,17 @@ testNumberyListSpecNoShrink = testNumberyListSpec' False
 
 testNumberyListSpec' :: Bool -> String -> (forall a. Numbery a => Specification [a]) -> Spec
 testNumberyListSpec' withShrink n p =
-  describe n $
-    sequence_
-      [ testSpec' withShrink (show $ typeRep proxy) (p @a)
-      | N (proxy :: Proxy a) <- numberyTypes
-      ]
-  where
-    numberyTypes =
-      [ N @Int Proxy
-      , N @Integer Proxy
-      , N @Natural Proxy
-      , N @Word64 Proxy
-      , N @Word32 Proxy
-      , N @Word16 Proxy
-      , N @Word8 Proxy
-      , N @Int64 Proxy
-      , N @Int32 Proxy
-      , N @Int16 Proxy
-      , N @Int8 Proxy
-      ]
+  describe n $ do
+    testSpec' withShrink "Integer" (p @Integer)
+    testSpec' withShrink "Natural" (p @Natural)
+    testSpec' withShrink "Word64" (p @Word64)
+    testSpec' withShrink "Word32" (p @Word32)
+    testSpec' withShrink "Word16" (p @Word16)
+    testSpec' withShrink "Word8" (p @Word8)
+    testSpec' withShrink "Int64" (p @Int64)
+    testSpec' withShrink "Int32" (p @Int32)
+    testSpec' withShrink "Int16" (p @Int16)
+    testSpec' withShrink "Int8" (p @Int8)
 
 testSpec :: HasSpec a => String -> Specification a -> Spec
 testSpec = testSpec' True


### PR DESCRIPTION
# Description

TODO:
- [x] Document the module that exports the trick
- [x] ~Go over as many confusing type families as possible and try to improve them~ can also do this in a follow-up PR now that we've established the idea

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
