### PR TITLE
`constrained-generators`: Split abstract syntax out of `Base.hs`

### DIFF
--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
@@ -45,7 +45,6 @@ import Test.Cardano.Ledger.Conway.Arbitrary ()
 
 import Cardano.Ledger.Conway (ConwayEra)
 import Constrained.API (
-  Specification (..),
   assert,
   constrained,
   constrained',
@@ -119,7 +118,7 @@ instance ExecSpecRule "LEDGER" ConwayEra where
 
   genExecContext = do
     ctx <- arbitrary
-    env <- genFromSpec TrueSpec
+    env <- genFromSpec mempty
     ConwayLedgerExecContext
       <$> arbitrary
       <*> genFromSpec (enactStateSpec ctx env)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledgers.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledgers.hs
@@ -10,7 +10,7 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Ledgers () where
 
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Governance (EnactState)
-import Constrained.API (Specification (..))
+import Constrained.API ()
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance (
   ExecSpecRule (..),
@@ -21,7 +21,7 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway ()
 instance ExecSpecRule "LEDGERS" ConwayEra where
   type ExecContext "LEDGERS" ConwayEra = EnactState ConwayEra
 
-  environmentSpec _ = TrueSpec
-  stateSpec _ _ = TrueSpec
-  signalSpec _ _ _ = TrueSpec
+  environmentSpec _ = mempty
+  stateSpec _ _ = mempty
+  signalSpec _ _ _ = mempty
   runAgdaRule env st sig = unComputationResult $ Agda.ledgersStep env st sig

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Epoch.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Epoch.hs
@@ -64,7 +64,7 @@ epochStateSpec epochNo = constrained $ \es ->
                       reify proposals (toInteger . proposalsSize) $ \ [var|sz|] ->
                         [ ifElse
                             (sz <=. 0)
-                            (expired ==. (Lit mempty))
+                            (expired ==. mempty)
                             (sizeOf_ expired <. sz)
                         ]
                     , forAll expired $ \ [var| gasId |] ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -874,6 +874,7 @@ instance Typeable a => HasSimpleRep (THKD tag Identity a) where
   type SimpleRep (THKD tag Identity a) = a
   fromSimpleRep = THKD
   toSimpleRep (THKD a) = a
+
 instance
   ( IsNormalType a
   , Typeable tag

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/WitnessUniverse.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/WitnessUniverse.hs
@@ -429,7 +429,7 @@ witShelleyTxCert univ =
       (caseOn txcert)
         ( branchW 5 $ \delegcert ->
             (caseOn delegcert)
-              (branch $ \_register -> TruePred)
+              (branch $ \_register -> TruePred :: Pred)
               (branch $ \unregisterAuthor -> satisfies unregisterAuthor (witCredSpec univ))
               (branch $ \delegateAuthor _ -> satisfies delegateAuthor (witCredSpec univ))
         )
@@ -440,7 +440,7 @@ witShelleyTxCert univ =
         )
         ( branchW 1 $ \genesiscert -> match genesiscert $ \authorkey _ _ -> satisfies authorkey (witKeyHashSpec univ)
         )
-        (branchW 1 $ \_mircert -> FalsePred (pure "NO MIR"))
+        (branchW 1 $ \_mircert -> FalsePred (pure "NO MIR") :: Pred)
 
 -- | Constrains all the Certificate Authors. Sometimes thay are keyHashes, and sometimes Credentials
 witConwayTxCert ::
@@ -455,7 +455,7 @@ witConwayTxCert univ =
             (caseOn delegcert)
               ( branch $ \registerAuthor deposit ->
                   (caseOn deposit)
-                    (branch $ \_ -> TruePred)
+                    (branch $ \_ -> TruePred :: Pred)
                     (branch $ \_ -> satisfies registerAuthor (witCredSpec univ))
               )
               (branch $ \unregisterAuthor _ -> satisfies unregisterAuthor (witCredSpec univ))

--- a/libs/constrained-generators/constrained-generators.cabal
+++ b/libs/constrained-generators/constrained-generators.cabal
@@ -19,9 +19,11 @@ source-repository head
 library
   exposed-modules:
     Constrained.API
+    Constrained.AbstractSyntax
     Constrained.Base
     Constrained.Conformance
     Constrained.Core
+    Constrained.DependencyInjection
     Constrained.Env
     Constrained.Examples
     Constrained.Examples.Basic
@@ -32,11 +34,13 @@ library
     Constrained.Examples.Map
     Constrained.Examples.Set
     Constrained.Examples.Tree
+    Constrained.FunctionSymbol
     Constrained.GenT
     Constrained.Generic
     Constrained.Graph
     Constrained.List
     Constrained.NumSpec
+    Constrained.PrettyUtils
     Constrained.Properties
     Constrained.Spec.Map
     Constrained.Spec.Set

--- a/libs/constrained-generators/src/Constrained/API.hs
+++ b/libs/constrained-generators/src/Constrained/API.hs
@@ -5,6 +5,9 @@
 {-# LANGUAGE ViewPatterns #-}
 
 module Constrained.API (
+  PredD (..),
+  TermD (..),
+  SpecificationD (..),
   GenericallyInstantiated,
   Logic (..),
   Semantics (..),
@@ -13,12 +16,13 @@ module Constrained.API (
   NumSpec (..),
   MaybeBounded (..),
   NonEmpty ((:|)),
-  Specification (..),
-  Term (..),
+  Specification,
+  pattern TypeSpec,
+  Term,
   Fun (..),
   name,
   named,
-  Pred (..),
+  Pred,
   HasSpec (..),
   HasSimpleRep (..),
   OrdLike (..),
@@ -143,16 +147,15 @@ module Constrained.API (
 )
 where
 
+import Constrained.AbstractSyntax
 import Constrained.Base (
   Fun (..),
   GenericallyInstantiated,
   HasSpec (..),
   Logic (..),
-  Pred (..),
-  Semantics (..),
-  Specification (..),
-  Syntax (..),
-  Term (..),
+  Pred,
+  Specification,
+  Term,
   constrained,
   equalSpec,
   fromGeneric_,
@@ -164,6 +167,7 @@ import Constrained.Base (
   toGeneric_,
   pattern FromGeneric,
   pattern ToGeneric,
+  pattern TypeSpec,
   pattern Unary,
   pattern (:<:),
   pattern (:>:),
@@ -174,6 +178,7 @@ import Constrained.Conformance (
   satisfies,
  )
 import Constrained.Core (NonEmpty ((:|)))
+import Constrained.FunctionSymbol
 import Constrained.Generic (HasSimpleRep (..), Prod (..))
 import Constrained.NumSpec (
   MaybeBounded (..),

--- a/libs/constrained-generators/src/Constrained/AbstractSyntax.hs
+++ b/libs/constrained-generators/src/Constrained/AbstractSyntax.hs
@@ -1,0 +1,381 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Constrained.AbstractSyntax where
+
+import Constrained.Core
+import Constrained.DependencyInjection
+import Constrained.Env
+import Constrained.FunctionSymbol
+import Constrained.GenT
+import Constrained.Generic
+import Constrained.List
+import Constrained.PrettyUtils
+
+import Control.Monad.Identity
+
+import Data.Kind
+import Data.List.NonEmpty qualified as NE
+import Data.String
+import Data.Typeable
+
+import Prettyprinter hiding (cat)
+
+import Test.QuickCheck
+
+------------------------------------------------------------------------
+-- The first-order term language
+------------------------------------------------------------------------
+
+-- See `Constrained.DependencyInjection` to better understand `deps` - it's a
+-- pointer to postpone having to define `HasSpec` and friends here.
+data TermD deps a where
+  App ::
+    AppRequiresD deps t dom rng =>
+    t dom rng ->
+    List (TermD deps) dom ->
+    TermD deps rng
+  Lit :: (Typeable a, Eq a, Show a) => a -> TermD deps a
+  V :: (HasSpecD deps a, Typeable a) => Var a -> TermD deps a
+
+type AppRequiresD deps (t :: [Type] -> Type -> Type) dom rng =
+  ( LogicD deps t
+  , Syntax t
+  , Semantics t
+  , TypeList dom
+  , Eq (t dom rng)
+  , Show (t dom rng)
+  , Typeable t
+  , All Typeable dom
+  , Typeable dom
+  , Typeable rng
+  , All (HasSpecD deps) dom
+  , All Show dom
+  , HasSpecD deps rng
+  , Show rng
+  )
+
+instance Eq (TermD deps a) where
+  V x == V x' = x == x'
+  Lit a == Lit b = a == b
+  App (w1 :: x1) (ts :: List (TermD deps) dom1) == App (w2 :: x2) (ts' :: List (TermD deps) dom2) =
+    case (eqT @dom1 @dom2, eqT @x1 @x2) of
+      (Just Refl, Just Refl) ->
+        w1 == w2
+          && ts == ts'
+      _ -> False
+  _ == _ = False
+
+-- Semantics --------------------------------------------------------------
+
+runTermE :: forall a deps. Env -> TermD deps a -> Either (NE.NonEmpty String) a
+runTermE env = \case
+  Lit a -> Right a
+  V v -> case lookupEnv env v of
+    Just a -> Right a
+    Nothing -> Left (pure ("Couldn't find " ++ show v ++ " in " ++ show env))
+  App f ts -> do
+    vs <- mapMList (fmap Identity . runTermE env) ts
+    pure $ uncurryList_ runIdentity (semantics f) vs
+
+runTerm :: MonadGenError m => Env -> TermD deps a -> m a
+runTerm env x = case runTermE env x of
+  Left msgs -> fatalErrorNE msgs
+  Right val -> pure val
+
+-- Utilities --------------------------------------------------------------
+
+-- | Sound but not complete inequality on terms
+fastInequality :: TermD deps a -> TermD deps b -> Bool
+fastInequality (V (Var i _)) (V (Var j _)) = i /= j
+fastInequality Lit {} Lit {} = False
+fastInequality (App _ as) (App _ bs) = go as bs
+  where
+    go :: List (TermD deps) as -> List (TermD deps) bs -> Bool
+    go Nil Nil = False
+    go (a :> as') (b :> bs') = fastInequality a b || go as' bs'
+    go _ _ = True
+fastInequality _ _ = True
+
+-- Pretty-printing --------------------------------------------------------
+
+-- | Syntactic operations are ones that have to do with the structure and appearence of the type.
+-- See `Constrained.DependencyInjection` to better understand `deps` - it's a
+-- pointer to postpone having to define `HasSpec` and friends here.
+class Syntax (t :: [Type] -> Type -> Type) where
+  isInfix :: t dom rng -> Bool
+  isInfix _ = False
+  prettySymbol ::
+    forall deps dom rng ann.
+    t dom rng ->
+    List (TermD deps) dom ->
+    Int ->
+    Maybe (Doc ann)
+  prettySymbol _ _ _ = Nothing
+
+instance Show a => Pretty (WithPrec (TermD deps a)) where
+  pretty (WithPrec p t) = case t of
+    Lit n -> fromString $ showsPrec p n ""
+    V x -> viaShow x
+    App x Nil -> viaShow x
+    App f as
+      | Just doc <- prettySymbol f as p -> doc -- Use Function Symbol specific pretty printers
+    App f as
+      | isInfix f
+      , a :> b :> Nil <- as ->
+          parensIf (p > 9) $ prettyPrec 10 a <+> viaShow f <+> prettyPrec 10 b
+      | otherwise -> parensIf (p > 10) $ viaShow f <+> align (fillSep (ppListShow (prettyPrec 11) as))
+
+instance Show a => Pretty (TermD deps a) where
+  pretty = prettyPrec 0
+
+instance Show a => Show (TermD deps a) where
+  showsPrec p t = shows $ pretty (WithPrec p t)
+
+------------------------------------------------------------------------
+-- The language for predicates
+------------------------------------------------------------------------
+
+-- This is _essentially_ a first-order logic with some extra spicyness thrown
+-- in to handle things like sum types and the specific problems you get into
+-- when generating from constraints (mostly to do with choosing the order in
+-- which to generate things).
+
+-- See `Constrained.DependencyInjection` to better understand `deps` - it's a
+-- pointer to postpone having to define `HasSpec` and friends here.
+data PredD deps where
+  ElemPred ::
+    (HasSpecD deps a, Show a) =>
+    Bool ->
+    TermD deps a ->
+    NonEmpty a ->
+    PredD deps
+  Monitor :: ((forall a. TermD deps a -> a) -> Property -> Property) -> PredD deps
+  And :: [PredD deps] -> PredD deps
+  Exists ::
+    -- | Constructive recovery function for checking
+    -- existential quantification
+    ((forall b. TermD deps b -> b) -> GE a) ->
+    BinderD deps a ->
+    PredD deps
+  -- This is here because we sometimes need to delay substitution until we're done building
+  -- terms and predicates. This is because our surface syntax relies on names being "a bit"
+  -- lazily bound to avoid infinite loops when trying to create new names.
+  Subst ::
+    ( HasSpecD deps a
+    , Show a
+    ) =>
+    Var a ->
+    TermD deps a ->
+    PredD deps ->
+    PredD deps
+  Let ::
+    TermD deps a ->
+    BinderD deps a ->
+    PredD deps
+  Assert :: TermD deps Bool -> PredD deps
+  Reifies ::
+    ( HasSpecD deps a
+    , HasSpecD deps b
+    , Show a
+    , Show b
+    ) =>
+    -- | This depends on the `a` term
+    TermD deps b ->
+    TermD deps a ->
+    -- | Recover a useable value from the `a` term.
+    (a -> b) ->
+    PredD deps
+  DependsOn ::
+    ( HasSpecD deps a
+    , HasSpecD deps b
+    , Show a
+    , Show b
+    ) =>
+    TermD deps a ->
+    TermD deps b ->
+    PredD deps
+  ForAll ::
+    ( ForallableD deps t e
+    , HasSpecD deps t
+    , HasSpecD deps e
+    , Show t
+    , Show e
+    ) =>
+    TermD deps t ->
+    BinderD deps e ->
+    PredD deps
+  Case ::
+    ( HasSpecD deps (SumOver as)
+    , Show (SumOver as)
+    ) =>
+    TermD deps (SumOver as) ->
+    -- | Each branch of the type is bound with
+    -- only one variable because `as` are types.
+    -- Constructors with multiple arguments are
+    -- encoded with `ProdOver` (c.f. `Constrained.Univ`).
+    List (Weighted (BinderD deps)) as ->
+    PredD deps
+  -- monadic-style `when` - if the first argument is False the second
+  -- doesn't apply.
+  When ::
+    TermD deps Bool ->
+    PredD deps ->
+    PredD deps
+  GenHint ::
+    ( HasGenHintD deps a
+    , Show a
+    , Show (HintD deps a)
+    ) =>
+    HintD deps a ->
+    TermD deps a ->
+    PredD deps
+  TruePred :: PredD deps
+  FalsePred :: NE.NonEmpty String -> PredD deps
+  Explain :: NE.NonEmpty String -> PredD deps -> PredD deps
+
+data BinderD deps a where
+  (:->) ::
+    (HasSpecD deps a, Show a) =>
+    Var a ->
+    PredD deps ->
+    BinderD deps a
+
+deriving instance Show (BinderD deps a)
+
+data Weighted f a = Weighted {weight :: Maybe Int, thing :: f a}
+  deriving (Functor, Traversable, Foldable)
+
+mapWeighted :: (f a -> g b) -> Weighted f a -> Weighted g b
+mapWeighted f (Weighted w t) = Weighted w (f t)
+
+traverseWeighted :: Applicative m => (f a -> m (g a)) -> Weighted f a -> m (Weighted g a)
+traverseWeighted f (Weighted w t) = Weighted w <$> f t
+
+instance Semigroup (PredD deps) where
+  FalsePred xs <> FalsePred ys = FalsePred (xs <> ys)
+  FalsePred es <> _ = FalsePred es
+  _ <> FalsePred es = FalsePred es
+  TruePred <> p = p
+  p <> TruePred = p
+  p <> p' = And (unpackPred p ++ unpackPred p')
+    where
+      unpackPred (And ps) = ps
+      unpackPred x = [x]
+
+instance Monoid (PredD deps) where
+  mempty = TruePred
+
+-- Pretty-printing --------------------------------------------------------
+
+instance Pretty (PredD deps) where
+  pretty = \case
+    ElemPred True term vs ->
+      align $
+        sep
+          [ "memberPred"
+          , pretty term
+          , "(" <> viaShow (length vs) <> " items)"
+          , brackets (fillSep (punctuate "," (map viaShow (NE.toList vs))))
+          ]
+    ElemPred False term vs -> align $ sep ["notMemberPred", pretty term, fillSep (punctuate "," (map viaShow (NE.toList vs)))]
+    Exists _ (x :-> p) -> align $ sep ["exists" <+> viaShow x <+> "in", pretty p]
+    Let t (x :-> p) -> align $ sep ["let" <+> viaShow x <+> "=" /> pretty t <+> "in", pretty p]
+    And ps -> braces $ vsep' $ map pretty ps
+    Assert t -> "assert $" <+> pretty t
+    Reifies t' t _ -> "reifies" <+> pretty (WithPrec 11 t') <+> pretty (WithPrec 11 t)
+    DependsOn a b -> pretty a <+> "<-" /> pretty b
+    ForAll t (x :-> p) -> "forall" <+> viaShow x <+> "in" <+> pretty t <+> "$" /> pretty p
+    Case t bs -> "case" <+> pretty t <+> "of" /> vsep' (ppList_ pretty bs)
+    When b p -> "whenTrue" <+> pretty (WithPrec 11 b) <+> "$" /> pretty p
+    Subst x t p -> "[" <> pretty t <> "/" <> viaShow x <> "]" <> pretty p
+    GenHint h t -> "genHint" <+> fromString (showsPrec 11 h "") <+> "$" <+> pretty t
+    TruePred -> "True"
+    FalsePred {} -> "False"
+    Monitor {} -> "monitor"
+    Explain es p -> "Explain" <+> viaShow (NE.toList es) <+> "$" /> pretty p
+
+instance Show (PredD deps) where
+  show = show . pretty
+
+instance Pretty (f a) => Pretty (Weighted f a) where
+  pretty (Weighted Nothing t) = pretty t
+  pretty (Weighted (Just w) t) = viaShow w <> "~" <> pretty t
+
+instance Pretty (BinderD deps a) where
+  pretty (x :-> p) = viaShow x <+> "->" <+> pretty p
+
+------------------------------------------------------------------------
+-- The language of specifications
+------------------------------------------------------------------------
+
+-- | A `Specification a` denotes a set of `a`s
+data SpecificationD deps a where
+  -- | Explain a Specification
+  ExplainSpec :: [String] -> SpecificationD deps a -> SpecificationD deps a
+  -- | Elements of a known set
+  MemberSpec ::
+    -- | It must be an element of this OrdSet (List). Try hard not to put duplicates in the List.
+    NE.NonEmpty a ->
+    SpecificationD deps a
+  -- | The empty set
+  ErrorSpec ::
+    NE.NonEmpty String ->
+    SpecificationD deps a
+  -- | The set described by some predicates
+  -- over the bound variable.
+  SuspendedSpec ::
+    HasSpecD deps a =>
+    -- | This variable ranges over values denoted by
+    -- the spec
+    Var a ->
+    -- | And the variable is subject to these constraints
+    PredD deps ->
+    SpecificationD deps a
+  -- | A type-specific spec
+  TypeSpecD ::
+    HasSpecD deps a =>
+    TypeSpecD deps a ->
+    -- | It can't be any of the elements of this set
+    [a] ->
+    SpecificationD deps a
+  -- | Anything
+  TrueSpec :: SpecificationD deps a
+
+instance (Show a, Typeable a, Show (TypeSpecD deps a)) => Pretty (WithPrec (SpecificationD deps a)) where
+  pretty (WithPrec d s) = case s of
+    ExplainSpec es z -> "ExplainSpec" <+> viaShow es <+> "$" /> pretty z
+    ErrorSpec es -> "ErrorSpec" /> vsep' (map fromString (NE.toList es))
+    TrueSpec -> fromString $ "TrueSpec @(" ++ showType @a ++ ")"
+    MemberSpec xs -> "MemberSpec" <+> short (NE.toList xs)
+    SuspendedSpec x p -> parensIf (d > 10) $ "constrained $ \\" <+> viaShow x <+> "->" /> pretty p
+    -- TODO: require pretty for `TypeSpec` to make this much nicer
+    TypeSpecD ts cant ->
+      parensIf (d > 10) $
+        "TypeSpec"
+          /> vsep
+            [ fromString (showsPrec 11 ts "")
+            , viaShow cant
+            ]
+
+instance (Show a, Typeable a, Show (TypeSpecD deps a)) => Pretty (SpecificationD deps a) where
+  pretty = pretty . WithPrec 0
+
+instance (Show a, Typeable a, Show (TypeSpecD deps a)) => Show (SpecificationD deps a) where
+  showsPrec d = shows . pretty . WithPrec d

--- a/libs/constrained-generators/src/Constrained/Conformance.hs
+++ b/libs/constrained-generators/src/Constrained/Conformance.hs
@@ -22,13 +22,12 @@
 
 module Constrained.Conformance where
 
+import Constrained.AbstractSyntax
 import Constrained.Base (
-  Binder (..),
   HasSpec,
-  Pred (..),
-  Specification (..),
-  Term (..),
-  Weighted (..),
+  Pred,
+  Specification,
+  Term,
   addToErrorSpec,
   combineSpec,
   conformsTo,
@@ -36,8 +35,8 @@ import Constrained.Base (
   forAllToList,
   memberSpecList,
   notMemberSpec,
-  showType,
   toPreds,
+  pattern TypeSpec,
  )
 import Constrained.Core (
   NonEmpty ((:|)),
@@ -60,10 +59,9 @@ import Constrained.GenT (
 import Constrained.List (
   mapList,
  )
+import Constrained.PrettyUtils
 import Constrained.Syntax (
   runCaseOn,
-  runTerm,
-  runTermE,
   substitutePred,
  )
 

--- a/libs/constrained-generators/src/Constrained/Core.hs
+++ b/libs/constrained-generators/src/Constrained/Core.hs
@@ -28,6 +28,7 @@ import Constrained.List (
   List (..),
   mapList,
  )
+import Constrained.PrettyUtils
 
 import Control.Applicative
 import Data.Function
@@ -111,6 +112,9 @@ unValue (Value v) = v
 
 data Evidence c where
   Evidence :: c => Evidence c
+
+instance Typeable c => Show (Evidence c) where
+  show _ = "Evidence@(" ++ showType @c ++ ")"
 
 unionWithMaybe :: (a -> a -> a) -> Maybe a -> Maybe a -> Maybe a
 unionWithMaybe f ma ma' = (f <$> ma <*> ma') <|> ma <|> ma'

--- a/libs/constrained-generators/src/Constrained/DependencyInjection.hs
+++ b/libs/constrained-generators/src/Constrained/DependencyInjection.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Constrained.DependencyInjection where
+
+import Data.Kind
+
+-- In this module we introduce the `Dependencies` class which is intended to
+-- collect type classes and type families that are necessary in the abstract
+-- syntax of terms, predicates, and specifications but which we don't want to
+-- define in the same place. This is typically because the type classes have
+-- large default instances that mean the type classes themselves need a lot
+-- of code before we can define them. By making these classes abstract in the
+-- GADTs we avoid the code-base blowing up with a lot of interdependencies.
+
+-- The `Dependencies` class will eventually only be instantiated once by an
+-- uninhabited type `data Deps`.
+
+-- NOTE TO SELF: it may be necessary / nice to introduce some functions here
+-- too if it makes life easier.
+class Dependencies d where
+  type HasSpecD d :: Type -> Constraint
+  type TypeSpecD d :: Type -> Type
+  type LogicD d :: ([Type] -> Type -> Type) -> Constraint
+  type ForallableD d :: Type -> Type -> Constraint
+  type HasGenHintD d :: Type -> Constraint
+  type HintD d :: Type -> Type

--- a/libs/constrained-generators/src/Constrained/Examples/Fold.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Fold.hs
@@ -26,7 +26,7 @@ oddSpec = ExplainSpec ["odd via (y+y+1)"] $
   constrained $ \ [var|oddx|] ->
     exists
       (\eval -> pure (div (eval oddx - 1) 2))
-      (\ [var|y|] -> [Assert $ oddx ==. y + y + 1])
+      (\ [var|y|] -> [assert $ oddx ==. y + y + 1])
 
 evenSpec ::
   forall n.
@@ -36,16 +36,16 @@ evenSpec = ExplainSpec ["even via (x+x)"] $
   constrained $ \ [var|evenx|] ->
     exists
       (\eval -> pure (div (eval evenx) 2))
-      (\ [var|somey|] -> [Assert $ evenx ==. somey + somey])
+      (\ [var|somey|] -> [assert $ evenx ==. somey + somey])
 
 sum3WithLength :: Integer -> Specification ([Int], Int, Int, Int)
 sum3WithLength n =
   constrained $ \ [var|quad|] ->
     match quad $ \ [var|l|] [var|n1|] [var|n2|] [var|n3|] ->
-      [ Assert $ sizeOf_ l ==. lit n
+      [ assert $ sizeOf_ l ==. lit n
       , forAll l $ \ [var|item|] -> item >=. lit 0
-      , Assert $ sum_ l ==. n1 + n2 + n3
-      , Assert $ n1 + n2 + n3 >=. lit (fromInteger n)
+      , assert $ sum_ l ==. n1 + n2 + n3
+      , assert $ n1 + n2 + n3 >=. lit (fromInteger n)
       ]
 
 sum3 :: Specification [Int]

--- a/libs/constrained-generators/src/Constrained/FunctionSymbol.hs
+++ b/libs/constrained-generators/src/Constrained/FunctionSymbol.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Constrained.FunctionSymbol where
+
+import Constrained.List
+
+import Data.Kind
+import Data.Typeable
+
+-- ========================================================================
+-- Useful for testing if two function symbols are `the same` for some notion of `the same`
+
+sameFunSym ::
+  forall (t1 :: [Type] -> Type -> Type) d1 r1 (t2 :: [Type] -> Type -> Type) d2 r2.
+  ( Typeable t1
+  , Typeable d1
+  , Typeable r1
+  , Typeable t2
+  , Typeable d2
+  , Typeable r2
+  , Eq (t1 d1 r1)
+  ) =>
+  t1 d1 r1 ->
+  t2 d2 r2 ->
+  Maybe (t1 :~: t2, d1 :~: d2, r1 :~: r2)
+sameFunSym x y = do
+  Refl <- eqT @t1 @t2
+  Refl <- eqT @d1 @d2
+  Refl <- eqT @r1 @r2
+  if x == y
+    then Just (Refl, Refl, Refl)
+    else Nothing
+
+-- | Here we only care about the Type 't', the dom, and the rng can be
+-- anything. Useful for defining patterns.
+getWitness ::
+  forall t t' d r.
+  ( Typeable t
+  , Typeable d
+  , Typeable r
+  , Typeable t'
+  ) =>
+  t d r -> Maybe (t' d r)
+getWitness = cast
+
+-- | Semantic operations are ones that give the function symbol, meaning as a function.
+--   I.e. how to apply the function to a list of arguments and return a value.
+class Semantics (t :: [Type] -> Type -> Type) where
+  semantics :: t d r -> FunTy d r -- e.g. FunTy '[a, Int] Bool ~ a -> Int -> Bool

--- a/libs/constrained-generators/src/Constrained/Generic.hs
+++ b/libs/constrained-generators/src/Constrained/Generic.hs
@@ -153,6 +153,11 @@ type family SimplifyRep f where
 
 instance HasSimpleRep Bool
 
+instance HasSimpleRep () where
+  type SimpleRep () = ()
+  toSimpleRep x = x
+  fromSimpleRep x = x
+
 -- ===============================================================
 -- How to move back and forth from (SimpleRep a) to 'a' in a
 -- generic way, derived by the Generics machinery is captured

--- a/libs/constrained-generators/src/Constrained/PrettyUtils.hs
+++ b/libs/constrained-generators/src/Constrained/PrettyUtils.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans -Wno-unticked-promoted-constructors #-}
+
+module Constrained.PrettyUtils where
+
+import Constrained.List
+
+import Data.String (fromString)
+import Data.Typeable
+import Prettyprinter
+
+-- ===================================================================
+-- Pretty Printer Helper functions
+-- ===================================================================
+
+data WithPrec a = WithPrec Int a
+
+parensIf :: Bool -> Doc ann -> Doc ann
+parensIf True = parens
+parensIf False = id
+
+prettyPrec :: Pretty (WithPrec a) => Int -> a -> Doc ann
+prettyPrec p = pretty . WithPrec p
+
+ppList_ :: forall f as ann. (forall a. f a -> Doc ann) -> List f as -> [Doc ann]
+ppList_ _ Nil = []
+ppList_ pp (a :> as) = pp a : ppList_ pp as
+
+ppListShow ::
+  forall f as ann. All Show as => (forall a. Show a => f a -> Doc ann) -> List f as -> [Doc ann]
+ppListShow _ Nil = []
+ppListShow pp (a :> as) = pp a : ppListShow pp as
+
+prettyType :: forall t x. Typeable t => Doc x
+prettyType = fromString $ show (typeRep (Proxy @t))
+
+vsep' :: [Doc ann] -> Doc ann
+vsep' = align . mconcat . punctuate hardline
+
+(/>) :: Doc ann -> Doc ann -> Doc ann
+h /> cont = hang 2 $ sep [h, align cont]
+
+infixl 5 />
+
+showType :: forall t. Typeable t => String
+showType = show (typeRep (Proxy @t))
+
+short :: forall a x. (Show a, Typeable a) => [a] -> Doc x
+short [] = "[]"
+short [x] =
+  let raw = show x
+      refined = if length raw <= 20 then raw else take 20 raw ++ " ... "
+   in "[" <+> fromString refined <+> "]"
+short xs =
+  let raw = show xs
+   in if length raw <= 50
+        then fromString raw
+        else "([" <+> viaShow (length xs) <+> "elements ...] @" <> prettyType @a <> ")"

--- a/libs/constrained-generators/src/Constrained/Properties.hs
+++ b/libs/constrained-generators/src/Constrained/Properties.hs
@@ -21,7 +21,6 @@ import Constrained.Base (
   BaseW (..),
   HOLE (..),
   appTerm,
-  (/>),
  )
 import Constrained.Conformance (
   monitorSpec,
@@ -56,6 +55,7 @@ import Constrained.NumSpec (
   IntW (..),
   NumOrdW (..),
  )
+import Constrained.PrettyUtils
 import Constrained.Spec.Map (
   MapW (..),
  )

--- a/libs/constrained-generators/src/Constrained/Spec/Map.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Map.hs
@@ -25,13 +25,16 @@
 
 module Constrained.Spec.Map where
 
+import Constrained.AbstractSyntax
 import Constrained.Base
 import Constrained.Conformance
 import Constrained.Core
+import Constrained.FunctionSymbol
 import Constrained.GenT
 import Constrained.Generic (Prod (..))
 import Constrained.List
 import Constrained.NumSpec (cardinality, geqSpec, leqSpec, nubOrd)
+import Constrained.PrettyUtils
 import Constrained.Spec.Set
 import Constrained.Spec.SumProd
 import Constrained.Syntax

--- a/libs/constrained-generators/src/Constrained/Spec/Set.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Set.hs
@@ -31,17 +31,14 @@
 
 module Constrained.Spec.Set where
 
+import Constrained.AbstractSyntax
 import Constrained.Base (
-  Binder (..),
   Forallable (..),
   HOLE (..),
   HasSpec (..),
   Logic (..),
-  Pred (..),
-  Semantics (..),
-  Specification (..),
-  Syntax (..),
-  Term (..),
+  Specification,
+  Term,
   appTerm,
   constrained,
   equalSpec,
@@ -51,12 +48,8 @@ import Constrained.Base (
   memberSpecList,
   notEqualSpec,
   notMemberSpec,
-  parensIf,
-  prettyPrec,
-  short,
-  showType,
   typeSpec,
-  (/>),
+  pattern TypeSpec,
   pattern Unary,
  )
 import Constrained.Conformance (
@@ -64,9 +57,11 @@ import Constrained.Conformance (
   satisfies,
  )
 import Constrained.Core
+import Constrained.FunctionSymbol
 import Constrained.GenT
 import Constrained.List
 import Constrained.NumSpec
+import Constrained.PrettyUtils
 import Constrained.SumList (knownUpperBound, maxFromSpec)
 import Constrained.Syntax
 import Constrained.TheKnot
@@ -276,14 +271,14 @@ instance Semantics SetW where
   semantics = setSem
 
 instance Syntax SetW where
-  prettyWit SubsetW (Lit n :> y :> Nil) p = Just $ parensIf (p > 10) $ "subset_" <+> short (Set.toList n) <+> prettyPrec 10 y
-  prettyWit SubsetW (y :> Lit n :> Nil) p = Just $ parensIf (p > 10) $ "subset_" <+> prettyPrec 10 y <+> short (Set.toList n)
-  prettyWit DisjointW (Lit n :> y :> Nil) p = Just $ parensIf (p > 10) $ "disjoint_" <+> short (Set.toList n) <+> prettyPrec 10 y
-  prettyWit DisjointW (y :> Lit n :> Nil) p = Just $ parensIf (p > 10) $ "disjoint_" <+> prettyPrec 10 y <+> short (Set.toList n)
-  prettyWit UnionW (Lit n :> y :> Nil) p = Just $ parensIf (p > 10) $ "union_" <+> short (Set.toList n) <+> prettyPrec 10 y
-  prettyWit UnionW (y :> Lit n :> Nil) p = Just $ parensIf (p > 10) $ "union_" <+> prettyPrec 10 y <+> short (Set.toList n)
-  prettyWit MemberW (y :> Lit n :> Nil) p = Just $ parensIf (p > 10) $ "member_" <+> prettyPrec 10 y <+> short (Set.toList n)
-  prettyWit _ _ _ = Nothing
+  prettySymbol SubsetW (Lit n :> y :> Nil) p = Just $ parensIf (p > 10) $ "subset_" <+> short (Set.toList n) <+> prettyPrec 10 y
+  prettySymbol SubsetW (y :> Lit n :> Nil) p = Just $ parensIf (p > 10) $ "subset_" <+> prettyPrec 10 y <+> short (Set.toList n)
+  prettySymbol DisjointW (Lit n :> y :> Nil) p = Just $ parensIf (p > 10) $ "disjoint_" <+> short (Set.toList n) <+> prettyPrec 10 y
+  prettySymbol DisjointW (y :> Lit n :> Nil) p = Just $ parensIf (p > 10) $ "disjoint_" <+> prettyPrec 10 y <+> short (Set.toList n)
+  prettySymbol UnionW (Lit n :> y :> Nil) p = Just $ parensIf (p > 10) $ "union_" <+> short (Set.toList n) <+> prettyPrec 10 y
+  prettySymbol UnionW (y :> Lit n :> Nil) p = Just $ parensIf (p > 10) $ "union_" <+> prettyPrec 10 y <+> short (Set.toList n)
+  prettySymbol MemberW (y :> Lit n :> Nil) p = Just $ parensIf (p > 10) $ "member_" <+> prettyPrec 10 y <+> short (Set.toList n)
+  prettySymbol _ _ _ = Nothing
 
 instance (Ord a, HasSpec a, HasSpec (Set a)) => Semigroup (Term (Set a)) where
   (<>) = union_

--- a/libs/constrained-generators/src/Constrained/Spec/SumProd.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/SumProd.hs
@@ -64,17 +64,18 @@ module Constrained.Spec.SumProd (
   SumW (..),
 ) where
 
+import Constrained.AbstractSyntax
 import Constrained.Base (
   BaseW (..),
-  Binder (..),
+  Binder,
   Forallable (..),
   Fun (..),
+  GenericRequires,
   HasSpec (..),
   IsPred (..),
-  Pred (..),
-  Specification (..),
-  Term (..),
-  Weighted (..),
+  Pred,
+  Specification,
+  Term,
   appTerm,
   bind,
   constrained,
@@ -408,10 +409,7 @@ right_ = fromGeneric_ . injRight_
 
 caseOn ::
   forall a.
-  ( HasSpec a
-  , HasSpec (SimpleRep a)
-  , HasSimpleRep a
-  , TypeSpec a ~ TypeSpec (SimpleRep a)
+  ( GenericRequires a
   , SimpleRep a ~ SumOver (Cases (SimpleRep a))
   , TypeList (Cases (SimpleRep a))
   ) =>
@@ -465,9 +463,9 @@ branchW w body =
 
 match ::
   forall p a.
-  ( HasSpec a
-  , IsProductType a
+  ( IsProductType a
   , IsPred p
+  , GenericRequires a
   ) =>
   Term a ->
   FunTy (MapList Term (ProductAsList a)) p ->
@@ -481,12 +479,11 @@ con ::
   ( SimpleRep a ~ SOP (TheSop a)
   , TypeSpec a ~ TypeSpec (SOP (TheSop a))
   , TypeList (ConstrOf c (TheSop a))
-  , HasSpec a
-  , HasSimpleRep a
   , r ~ FunTy (MapList Term (ConstrOf c (TheSop a))) (Term a)
   , ResultType r ~ Term a
   , SOPTerm c (TheSop a)
   , ConstrTerm (ConstrOf c (TheSop a))
+  , GenericRequires a
   ) =>
   r
 con =
@@ -510,6 +507,7 @@ sel ::
   , HasSpec a
   , HasSpec (ProdOver as)
   , HasSimpleRep a
+  , GenericRequires a
   ) =>
   Term a ->
   Term (At n as)
@@ -528,6 +526,7 @@ forAll' ::
   , IsPred p
   , IsProd (SimpleRep a)
   , HasSpec a
+  , GenericRequires a
   ) =>
   Term t ->
   FunTy (MapList Term (Args (SimpleRep a))) p ->
@@ -545,6 +544,7 @@ constrained' ::
   , IsProd (SimpleRep a)
   , HasSpec a
   , IsPred p
+  , GenericRequires a
   ) =>
   FunTy (MapList Term (Args (SimpleRep a))) p ->
   Specification a
@@ -562,6 +562,7 @@ reify' ::
   , HasSpec a
   , HasSpec b
   , IsPred p
+  , GenericRequires b
   ) =>
   Term a ->
   (a -> b) ->
@@ -582,10 +583,7 @@ instance
 onCon ::
   forall c a p.
   ( IsConstrOf c (ProdOver (ConstrOf c (TheSop a))) (TheSop a)
-  , TypeSpec a ~ TypeSpec (SimpleRep a)
-  , HasSimpleRep a
-  , HasSpec a
-  , HasSpec (SimpleRep a)
+  , GenericRequires a
   , SumOver (Cases (SOP (TheSop a))) ~ SimpleRep a
   , All HasSpec (Cases (SOP (TheSop a)))
   , HasSpec (ProdOver (ConstrOf c (TheSop a)))
@@ -608,13 +606,10 @@ onCon tm p =
 isCon ::
   forall c a.
   ( IsConstrOf c (ProdOver (ConstrOf c (TheSop a))) (TheSop a)
-  , TypeSpec a ~ TypeSpec (SimpleRep a)
-  , HasSimpleRep a
-  , HasSpec a
-  , HasSpec (SimpleRep a)
   , SumOver (Cases (SOP (TheSop a))) ~ SimpleRep a
   , All HasSpec (Cases (SOP (TheSop a)))
   , HasSpec (ProdOver (ConstrOf c (TheSop a)))
+  , GenericRequires a
   ) =>
   Term a ->
   Pred

--- a/libs/constrained-generators/src/Constrained/Spec/Tree.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Tree.hs
@@ -16,24 +16,22 @@
 
 module Constrained.Spec.Tree (BinTree (..), TreeW (..), rootLabel_, TreeSpec (..)) where
 
+import Constrained.AbstractSyntax
 import Constrained.Base (
-  Binder (..),
   Forallable (..),
   HOLE (..),
   HasGenHint (..),
   HasSpec (..),
   Logic (..),
-  Pred (..),
-  Semantics (..),
-  Specification (..),
-  Syntax (..),
-  Term (..),
+  Specification,
+  Term,
   appTerm,
   constrained,
   errorLikeMessage,
   explainSpec,
   isErrorLike,
   typeSpec,
+  pattern TypeSpec,
   pattern Unary,
  )
 import Constrained.Conformance (
@@ -43,6 +41,7 @@ import Constrained.Conformance (
 import Constrained.Core (
   unionWithMaybe,
  )
+import Constrained.FunctionSymbol
 import Constrained.GenT (
   oneofT,
  )
@@ -241,8 +240,7 @@ deriving instance Show (TreeW d r)
 instance Semantics TreeW where
   semantics RootLabelW = \(Node a _) -> a
 
-instance Syntax TreeW where
-  inFix _ = False
+instance Syntax TreeW
 
 instance Logic TreeW where
   propagate f ctxt (ExplainSpec es s) = explainSpec es $ propagate f ctxt s

--- a/libs/constrained-generators/src/Constrained/SumList.hs
+++ b/libs/constrained-generators/src/Constrained/SumList.hs
@@ -27,6 +27,7 @@ import Data.Semigroup (sconcat)
 import System.Random (Random (..))
 import Test.QuickCheck (Arbitrary, Gen, choose, shuffle, vectorOf)
 
+import Constrained.AbstractSyntax
 import Constrained.Base
 import Constrained.Conformance (conformsToSpec)
 import Constrained.Core (Value (..))
@@ -54,6 +55,7 @@ import Constrained.NumSpec (
   ltSpec,
   nubOrd,
  )
+import Constrained.PrettyUtils
 import Control.Applicative ((<|>))
 import Control.Monad (guard)
 import Data.List ((\\))


### PR DESCRIPTION
# Description

This is a first step towards a design that separates concerns more than we currently do. Fututure work here includes going over and moving things upstream of the knotty parts (`HasSpec`) as far as possible before we begin the work of splitting up `HasSpec`.

The motivation for doing it in this order is to make sure we've minimized the amount of code that depends directly on `HasSpec` before we start messing with it.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
