### PR TITLE
Move orphan `ToPlutusData` instances with their types

### DIFF
--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
@@ -92,6 +92,7 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core (EraPParams (..))
 import Cardano.Ledger.HKD (HKD, HKDFunctor (..))
 import Cardano.Ledger.Orphans ()
+import Cardano.Ledger.Plutus.ToPlutusData (ToPlutusData (..))
 import Cardano.Ledger.Shelley.PParams (shelleyCommonPParamsHKDPairsV8)
 import Control.DeepSeq (NFData)
 import Data.Aeson as Aeson (
@@ -116,6 +117,10 @@ import Numeric.Natural (Natural)
 newtype CoinPerByte = CoinPerByte {unCoinPerByte :: Coin}
   deriving stock (Eq, Ord)
   deriving newtype (EncCBOR, DecCBOR, ToJSON, FromJSON, NFData, NoThunks, Show)
+
+instance ToPlutusData CoinPerByte where
+  toPlutusData (CoinPerByte c) = toPlutusData @Coin c
+  fromPlutusData x = CoinPerByte <$> fromPlutusData @Coin x
 
 class AlonzoEraPParams era => BabbageEraPParams era where
   hkdCoinsPerUTxOByteL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f CoinPerByte)

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.20.0.0
 
-* Add `MkConwayTxBody` and all members of `ConwayTxBodyRaw`:  
+* Add `MkConwayTxBody` and all members of `ConwayTxBodyRaw`:
   (`ConwayTxBodyRaw`, `ctbrAuxDataHash`, `ctbrCerts`, `ctbrCollateralInputs`,
   `ctbrCollateralReturn`, `ctbrCurrentTreasuryValue`, `ctbrFee`, `ctbrMint`, `ctbrNetworkId`,
   `ctbrOutputs`, `ctbrProposalProcedures`, `ctbrReferenceInputs`, `ctbrReqSignerHashes`,
@@ -15,6 +15,7 @@
 * Added `ConwayEraCertState` class
 * Added `ConwayCertState` and related functions
 * Moved `CertState` to `State` module
+* Move `ToPutusData` instances for `CoinPerByte`, `DRepVotingThresholds` and `PoolVotingThresholds` with their respective types
 
 ## 1.19.0.0
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -118,6 +118,7 @@ import Cardano.Ledger.Plutus.CostModels (
   mkCostModels,
  )
 import Cardano.Ledger.Plutus.Language (Language (PlutusV3))
+import Cardano.Ledger.Plutus.ToPlutusData (ToPlutusData (..))
 import Cardano.Ledger.Shelley.HardForks (bootstrapPhase)
 import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData (..), rwhnf)
@@ -137,6 +138,7 @@ import GHC.Stack (HasCallStack)
 import Lens.Micro
 import NoThunks.Class (NoThunks (..))
 import Numeric.Natural (Natural)
+import qualified PlutusLedgerApi.Common as P (Data (..))
 
 class BabbageEraPParams era => ConwayEraPParams era where
   modifiedPPGroups :: PParamsUpdate era -> Set PPGroups
@@ -291,6 +293,24 @@ instance DecCBOR PoolVotingThresholds where
       pvtPPSecurityGroup <- decCBOR
       pure $ PoolVotingThresholds {..}
 
+instance ToPlutusData PoolVotingThresholds where
+  toPlutusData x =
+    P.List
+      [ toPlutusData (pvtMotionNoConfidence x)
+      , toPlutusData (pvtCommitteeNormal x)
+      , toPlutusData (pvtCommitteeNoConfidence x)
+      , toPlutusData (pvtHardForkInitiation x)
+      , toPlutusData (pvtPPSecurityGroup x)
+      ]
+  fromPlutusData (P.List [a, b, c, d, e]) =
+    PoolVotingThresholds
+      <$> fromPlutusData a
+      <*> fromPlutusData b
+      <*> fromPlutusData c
+      <*> fromPlutusData d
+      <*> fromPlutusData e
+  fromPlutusData _ = Nothing
+
 data DRepVotingThresholds = DRepVotingThresholds
   { dvtMotionNoConfidence :: !UnitInterval
   , dvtCommitteeNormal :: !UnitInterval
@@ -343,6 +363,34 @@ instance FromJSON DRepVotingThresholds where
         <*> o .: "ppTechnicalGroup"
         <*> o .: "ppGovGroup"
         <*> o .: "treasuryWithdrawal"
+
+instance ToPlutusData DRepVotingThresholds where
+  toPlutusData x =
+    P.List
+      [ toPlutusData (dvtMotionNoConfidence x)
+      , toPlutusData (dvtCommitteeNormal x)
+      , toPlutusData (dvtCommitteeNoConfidence x)
+      , toPlutusData (dvtUpdateToConstitution x)
+      , toPlutusData (dvtHardForkInitiation x)
+      , toPlutusData (dvtPPNetworkGroup x)
+      , toPlutusData (dvtPPEconomicGroup x)
+      , toPlutusData (dvtPPTechnicalGroup x)
+      , toPlutusData (dvtPPGovGroup x)
+      , toPlutusData (dvtTreasuryWithdrawal x)
+      ]
+  fromPlutusData (P.List [a, b, c, d, e, f, g, h, i, j]) =
+    DRepVotingThresholds
+      <$> fromPlutusData a
+      <*> fromPlutusData b
+      <*> fromPlutusData c
+      <*> fromPlutusData d
+      <*> fromPlutusData e
+      <*> fromPlutusData f
+      <*> fromPlutusData g
+      <*> fromPlutusData h
+      <*> fromPlutusData i
+      <*> fromPlutusData j
+  fromPlutusData _ = Nothing
 
 dvtPPNetworkGroupL :: Lens' DRepVotingThresholds UnitInterval
 dvtPPNetworkGroupL = lens dvtPPNetworkGroup (\x y -> x {dvtPPNetworkGroup = y})

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Plutus/Context.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Plutus/Context.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Conway.Plutus.Context (
   pparamUpdateToData,
@@ -25,12 +24,9 @@ import Cardano.Ledger.Alonzo.PParams (
   ppuPricesL,
  )
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusTxInfo)
-import Cardano.Ledger.Babbage.PParams (CoinPerByte (..), ppuCoinsPerUTxOByteL)
-import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Babbage.PParams (ppuCoinsPerUTxOByteL)
 import Cardano.Ledger.Conway.PParams (
   ConwayEraPParams (..),
-  DRepVotingThresholds (..),
-  PoolVotingThresholds (..),
   ppuCommitteeMaxTermLengthL,
   ppuCommitteeMinSizeL,
   ppuDRepActivityL,
@@ -102,61 +98,6 @@ pparamUpdateFromData pparamMap (Map pairs) =
       val <- fromPlutusData value
       pure (ppu & ppuL .~ SJust val, Map.delete tg leftOverMap)
 pparamUpdateFromData _ _ = Nothing
-
--- ===================================================================
--- ToPlutusData instances necessary for (PParamUpdate (CowayEra c))
-
-instance ToPlutusData PoolVotingThresholds where
-  toPlutusData x =
-    List
-      [ toPlutusData (pvtMotionNoConfidence x)
-      , toPlutusData (pvtCommitteeNormal x)
-      , toPlutusData (pvtCommitteeNoConfidence x)
-      , toPlutusData (pvtHardForkInitiation x)
-      , toPlutusData (pvtPPSecurityGroup x)
-      ]
-  fromPlutusData (List [a, b, c, d, e]) =
-    PoolVotingThresholds
-      <$> fromPlutusData a
-      <*> fromPlutusData b
-      <*> fromPlutusData c
-      <*> fromPlutusData d
-      <*> fromPlutusData e
-  fromPlutusData _ = Nothing
-
-instance ToPlutusData DRepVotingThresholds where
-  toPlutusData x =
-    List
-      [ toPlutusData (dvtMotionNoConfidence x)
-      , toPlutusData (dvtCommitteeNormal x)
-      , toPlutusData (dvtCommitteeNoConfidence x)
-      , toPlutusData (dvtUpdateToConstitution x)
-      , toPlutusData (dvtHardForkInitiation x)
-      , toPlutusData (dvtPPNetworkGroup x)
-      , toPlutusData (dvtPPEconomicGroup x)
-      , toPlutusData (dvtPPTechnicalGroup x)
-      , toPlutusData (dvtPPGovGroup x)
-      , toPlutusData (dvtTreasuryWithdrawal x)
-      ]
-  fromPlutusData (List [a, b, c, d, e, f, g, h, i, j]) =
-    DRepVotingThresholds
-      <$> fromPlutusData a
-      <*> fromPlutusData b
-      <*> fromPlutusData c
-      <*> fromPlutusData d
-      <*> fromPlutusData e
-      <*> fromPlutusData f
-      <*> fromPlutusData g
-      <*> fromPlutusData h
-      <*> fromPlutusData i
-      <*> fromPlutusData j
-  fromPlutusData _ = Nothing
-
-instance ToPlutusData CoinPerByte where
-  toPlutusData (CoinPerByte c) = toPlutusData @Coin c
-  fromPlutusData x = CoinPerByte <$> fromPlutusData @Coin x
-
--- ==========================================================
 
 -- | A Map for the Conway era
 conwayPParamMap :: ConwayEraPParams era => Map Word (PParam era)


### PR DESCRIPTION
# Description

This is some yak shaving that I need for the [PParams refactoring](https://github.com/IntersectMBO/cardano-ledger/issues/4962)
Not sure why these were defined as orphan instances to begin with - maybe to keep things to do with Plutus more contained, but in order to define the pparams  in a reusable way across eras, we need to access `ToPlutusData` instances from within `PParams`. 

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
