### PR TITLE
Update and fix `ledger-state` benchmarks

### DIFF
--- a/libs/ledger-state/README.md
+++ b/libs/ledger-state/README.md
@@ -9,52 +9,71 @@ the memory overhead.
 In order to be able to use the tool we need to get ahold of current ledger
 state. For this we need to start a cardano node and wait for it to sync.
 
-```haskell
-$ export CARDANO_DATA="${HOME}/iohk/chain/mainnet"
-$ mkdir -p "${CARDANO_DATA}"/db
+```shell
+$ export CARDANO_DATA=${HOME}/iohk/chain/mainnet
+$ mkdir -p "${CARDANO_DATA}/db"
 $ cd "${CARDANO_DATA}"
 ```
 
-Download all the [mainnet related config files](https://developers.cardano.org/docs/get-started/running-cardano/#mainnet--production):
+Download all the [mainnet related config files](https://developers.cardano.org/docs/get-started/cardano-node/running-cardano/#configuration-files):
+
+```shell
+curl -O -J https://book.play.dev.cardano.org/environments/mainnet/config.json
+curl -O -J https://book.play.dev.cardano.org/environments/mainnet/db-sync-config.json
+curl -O -J https://book.play.dev.cardano.org/environments/mainnet/submit-api-config.json
+curl -O -J https://book.play.dev.cardano.org/environments/mainnet/topology.json
+curl -O -J https://book.play.dev.cardano.org/environments/mainnet/byron-genesis.json
+curl -O -J https://book.play.dev.cardano.org/environments/mainnet/shelley-genesis.json
+curl -O -J https://book.play.dev.cardano.org/environments/mainnet/alonzo-genesis.json
+curl -O -J https://book.play.dev.cardano.org/environments/mainnet/conway-genesis.json
 ```
-curl -O -J https://hydra.iohk.io/build/7370192/download/1/mainnet-config.json
-curl -O -J https://hydra.iohk.io/build/7370192/download/1/mainnet-byron-genesis.json
-curl -O -J https://hydra.iohk.io/build/7370192/download/1/mainnet-shelley-genesis.json
-curl -O -J https://hydra.iohk.io/build/7370192/download/1/mainnet-alonzo-genesis.json
-curl -O -J https://hydra.iohk.io/build/7370192/download/1/mainnet-topology.json
+
+Download or build copies of `cardano-node` and `cardano-cli`. A convenient way of doing this is to download the assets from one of the `cardano-node` [releases](https://github.com/IntersectMBO/cardano-node/releases) on GitHub. The Linux executables are statically linked, so will run on any system.
+
 ```
 
 Start the node and wait for it to fully sync
 
-```
+```shell
 $ export CARDANO_NODE_SOCKET_PATH="${CARDANO_DATA}/db/node.socket"
-$ cardano-node run
-  --topology "${CARDANO_DATA}/mainnet-topology.json" \
-  --database-path "${CARDANO_DATA}/db" \
-  --socket-path "${CARDANO_NODE_SOCKET_PATH}" \
-  --host-addr 127.0.0.1 \
-  --port 3001 \
-  --config "${CARDANO_DATA}/mainnet-config.json" &
+$ cardano-node run \
+    --topology "${CARDANO_DATA}/topology.json" \
+    --config "${CARDANO_DATA}/config.json" \
+    --database-path "${CARDANO_DATA}/db" \
+    --socket-path "${CARDANO_NODE_SOCKET_PATH}" \
+    --host-addr 0.0.0.0 \
+    --port 3001 &
 ```
 
-Dump the ledger state and focus back onto the node:
+Dump the ledger state:
 
 ```shell
-$ cardano-cli query ledger-state --mainnet --out-file "${CARDANO_DATA}/ledger-state.bin"
+$ cardano-cli query ledger-state --mainnet \
+    --socket-path "${CARDANO_NODE_SOCKET_PATH}" \
+    --out-file "${CARDANO_DATA}/new-epoch-state.bin"
+```
+
+Bring the node back into the foreground and use Ctrl-C to stop it:
+
+```shell
 $ fg
-```
-Hit Ctr-C to stop the node
-
-## Populate sqlite db
-
-```shell
-$ cabal run -- ledger-state:ledger-state --new-epoch-state-cbor="${CARDANO_DATA}/ledger-state.bin" --sqlite-db="${CARDANO_DATA}/ledger-state.sqlite"
+$ ^C
 ```
 
-## Create NewEpochState from sqlite db
+## Populate sqlite db from `NewEpochState` file
 
 ```shell
-$ cabal run -- ledger-state:ledger-state --epoch-state-cbor="${CARDANO_DATA}/ledger-state.bin" --sqlite-db="${CARDANO_DATA}/ledger-state.sqlite"
+$ cabal run -- ledger-state:ledger-state \
+    --new-epoch-state-cbor="${CARDANO_DATA}/new-epoch-state.bin" \
+    --sqlite-db="${CARDANO_DATA}/epoch-state.sqlite"
+```
+
+## Create `EpochState` file from sqlite db
+
+```shell
+$ cabal run -- ledger-state:ledger-state \
+    --epoch-state-cbor="${CARDANO_DATA}/epoch-state.bin" \
+    --sqlite-db="${CARDANO_DATA}/epoch-state.sqlite"
 ```
 
 ## Running benchmarks
@@ -62,7 +81,12 @@ $ cabal run -- ledger-state:ledger-state --epoch-state-cbor="${CARDANO_DATA}/led
 ### Memory
 
 ```shell
-$ cabal bench ledger-state:memory --benchmark-options="--new-epoch-state-cbor=\"${CARDANO_DATA}/ledger-state.bin\" --new-epoch-state-sqlite=\"${CARDANO_DATA}/ledger-state.sqlite\""
+$ cabal build ledger-state:memory
+$ cabal bench ledger-state:memory -v0 \
+    --benchmark-option="--new-epoch-state-cbor=${CARDANO_DATA}/new-epoch-state.bin" \
+    --benchmark-option="--epoch-state-cbor=${CARDANO_DATA}/epoch-state.bin" \
+    --benchmark-option="--sqlite-db=${CARDANO_DATA}/epoch-state.sqlite" |
+  tee ledger-state:memory.txt
 ```
 ### Performance
 
@@ -70,3 +94,12 @@ Performance benchmarks need an actual mainnet ledger state and genesis config
 file to run properly. It is not possible to add extra arguments to criterion cli
 menu, therefore paths to those files must be supplied as environment variables.
 
+```shell
+$ export BENCH_GENESIS_PATH=${CARDANO_DATA}/shelley-genesis.json
+$ export BENCH_LEDGER_STATE_PATH=${CARDANO_DATA}/new-epoch-state.bin
+$ cabal bench ledger-state:performance --benchmark-option=--csv=ledger-state:performance.csv
+```
+
+The csv file will be saved in the `libs/ledger-state` directory.
+
+Since the `performance` benchmark uses only `new-epoch-state.bin` you don't need to run the `sqlite.db` steps above if you want to run only the `performance` benchmark.

--- a/libs/ledger-state/README.md
+++ b/libs/ledger-state/README.md
@@ -51,12 +51,15 @@ $ cardano-node run \
     --port 3001 &
 ```
 
-Dump the ledger state:
+Dump the ledger state and utxo:
 
 ```shell
 $ cardano-cli query ledger-state --mainnet \
     --socket-path "${CARDANO_NODE_SOCKET_PATH}" \
     --out-file "${CARDANO_DATA}/new-epoch-state.bin"
+$ cardano-cli query utxo --mainnet --whole-utxo --output-cbor \
+    --socket-path "${CARDANO_NODE_SOCKET_PATH}" \
+    --out-file "${CARDANO_DATA}/utxo.hex"
 ```
 
 Bring the node back into the foreground and use Ctrl-C to stop it:
@@ -103,6 +106,7 @@ menu, therefore paths to those files must be supplied as environment variables.
 ```shell
 $ export BENCH_GENESIS_PATH=${CARDANO_DATA}/shelley-genesis.json
 $ export BENCH_LEDGER_STATE_PATH=${CARDANO_DATA}/new-epoch-state.bin
+$ export BENCH_UTXO_PATH=${CARDANO_DATA}/utxo.hex
 $ cabal bench ledger-state:performance --benchmark-option=--csv=ledger-state:performance.csv
 ```
 

--- a/libs/ledger-state/README.md
+++ b/libs/ledger-state/README.md
@@ -30,7 +30,13 @@ curl -O -J https://book.play.dev.cardano.org/environments/mainnet/conway-genesis
 
 Download or build copies of `cardano-node` and `cardano-cli`. A convenient way of doing this is to download the assets from one of the `cardano-node` [releases](https://github.com/IntersectMBO/cardano-node/releases) on GitHub. The Linux executables are statically linked, so will run on any system.
 
+Download a snapshot of the node db using [mithril](https://mithril.network/doc/manual/getting-started/bootstrap-cardano-node/#bootstrap-a-cardano-node-from-a-testnet-mithril-cardano-db-snapshot). This will greatly speed up the process of syncing the node. There's a convenient nix-based script for doing it in `scripts/mithril-download.sh`:
+
+```shell
+$ scripts/mithril-download.sh -d "${CARDANO_DATA}/db" mainnet
 ```
+
+Note that you will need to get a snapshot that's compatible with the version of `cardano-node` you're using.
 
 Start the node and wait for it to fully sync
 

--- a/libs/ledger-state/app/Main.hs
+++ b/libs/ledger-state/app/Main.hs
@@ -14,7 +14,7 @@ import System.IO
 -- | Insight into options:
 --
 -- * `optsNewEpochStateBinaryFile` is for reading a previously serialized
--- * `NewEpochState` produced by cadano-cli` and is used to populate sqlite
+-- * `NewEpochState` produced by cardano-cli` and is used to populate sqlite
 -- * database
 --
 -- * `optsEpochStateBinaryFile` is used for grabbing data from sqlite,
@@ -26,7 +26,7 @@ data Opts = Opts
   -- load into sqlite database
   , optsEpochStateBinaryFile :: Maybe FilePath
   -- ^ Path to the CBOR encoded EpochState data type, which will have data
-  -- from sqlite database written into.
+  -- from sqlite database written into it.
   , optsSqliteDbFile :: Maybe FilePath
   -- ^ Path to Sqlite database file.
   }
@@ -62,7 +62,7 @@ optsParser =
           <> value Nothing
           <> help
             ( "Path to Sqlite database file. When supplied then new-epoch-state "
-                <> "will be loaded into the databse. Requires --new-epoch-state-cbor"
+                <> "will be loaded into the database. Requires --new-epoch-state-cbor"
             )
       )
 
@@ -92,7 +92,7 @@ main = do
       epochState <- loadEpochState dbFp
       putStrLn "Loaded EpochState from the database"
       writeEpochState binFp epochState
-      putStrLn $ "Written EpochState into: " ++ dbFpStr
+      putStrLn $ "Written EpochState into: " ++ binFp
 
 -- forM_ (optsSqliteDbFile opts) $ \dbFpStr -> do
 --   let dbFp = T.pack dbFpStr

--- a/libs/ledger-state/bench/Performance.hs
+++ b/libs/ledger-state/bench/Performance.hs
@@ -38,6 +38,7 @@ import qualified Data.Map.Strict as Map
 import Data.MapExtras (extractKeys, extractKeysSmallSet)
 import Data.Set (Set)
 import qualified Data.Set as Set
+import GHC.Stack (HasCallStack)
 import Lens.Micro ((^.))
 import System.Environment (getEnv)
 import System.Random.Stateful
@@ -176,10 +177,12 @@ selectRandomMapKeys n gen m = runStateGenT_ gen $ \g ->
 extractKeysNaive :: Ord k => Map k a -> Set.Set k -> (Map k a, Map k a)
 extractKeysNaive sm s = (Map.withoutKeys sm s, Map.restrictKeys sm s)
 
-decodeTx :: ByteString -> Tx CurrentEra
+decodeTx :: HasCallStack => ByteString -> Tx CurrentEra
 decodeTx hex = either error id $ do
   bsl <- BSL16.decode hex
-  first show $ decodeFull (eraProtVerHigh @CurrentEra) bsl
+  tx <- first show $ decodeFull (eraProtVerHigh @BabbageEra) bsl
+  -- TODO: remove this after the transactions below are updated
+  first show $ upgradeTx tx
 
 -- | Most basic ada-only transaction:
 --
@@ -235,8 +238,8 @@ validatedTx3 =
       \424643546f6b656e1a006cc9f2021a0002afe90e81581c780648b89ea2f11fa9bbdd67\
       \552db5dd020eda1c9a54142dd9f1b136a10081825820cf2477066091b565f87f044581\
       \7c4df726900b29af3f05d229309afdbf94296d584088444a5845b198a2d255175770be\
-      \7120c2d3482751b14f06dd41d7ff023eeae6e63933b097c023c1ed19df6a061173c45aa\
-      \54cceb568ff1886e2716e84e6260df5f6"
+      \7120c2d3482751b14f06dd41d7ff023eeae6e63933b097c023c1ed19df6a061173c45a\
+      \a54cceb568ff1886e2716e84e6260df5f6"
 
 mkGlobals :: ShelleyGenesis -> Globals
 mkGlobals genesis =

--- a/libs/ledger-state/bench/Performance.hs
+++ b/libs/ledger-state/bench/Performance.hs
@@ -93,6 +93,9 @@ main = do
               bench "Tx2" . whnf (applyTx' mempoolEnv mempoolState)
           , env (pure (extractTx validatedTx3)) $
               bench "Tx3" . whnf (applyTx' mempoolEnv mempoolState)
+          , env
+              (pure [validatedTx1, validatedTx2, validatedTx3])
+              $ bench "Tx1+Tx2+Tx3" . whnf (F.foldl' (\ms -> fst . applyTx' mempoolEnv ms . extractTx) mempoolState)
           ]
     , env (pure (getUTxO es)) $ \utxo ->
         bgroup

--- a/libs/ledger-state/ledger-state.cabal
+++ b/libs/ledger-state/ledger-state.cabal
@@ -36,6 +36,7 @@ library
 
   build-depends:
     base >=4.14 && <5,
+    base16-bytestring,
     bytestring,
     cardano-crypto-class,
     cardano-ledger-alonzo,

--- a/libs/ledger-state/ledger-state.cabal
+++ b/libs/ledger-state/ledger-state.cabal
@@ -125,6 +125,7 @@ benchmark performance
     cardano-data,
     cardano-ledger-api:{cardano-ledger-api, testlib},
     cardano-ledger-binary,
+    cardano-ledger-conway,
     cardano-ledger-core:{cardano-ledger-core, testlib},
     cardano-ledger-shelley,
     cardano-slotting,

--- a/scripts/mithril-download.sh
+++ b/scripts/mithril-download.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Author: michal.rus@iohk.io
+
+export NETWORK=mainnet
+export UNPACK_DIR=cardano-db
+export MITHRIL_VERSION=2513.0
+
+usage()
+{
+	cat <<-EOF
+		Usage: $(basename "$0") [-h] [-d DIR] [-v VERSION] NETWORK
+		  Download cardano-db using mithril
+
+		Options:
+		  -h          Show this help text
+		  -d DIR      Unpack the DB into DIR (default: $UNPACK_DIR)
+		  -v VERSION  Use version VERSION of the mithril client (default: $MITHRIL_VERSION)
+
+		Arguments:
+		  NETWORK     Download the DB for NETWORK (default: $NETWORK)
+	EOF
+
+	exit "${1:-0}"
+}
+
+while getopts hd:v: OPT
+do
+	case "$OPT" in
+		\?) usage 1 >&2;;
+		h)  usage;;
+		d)  UNPACK_DIR=$OPTARG;;
+		v)  MITHRIL_VERSION=$OPTARG;;
+	esac
+done
+
+shift $((OPTIND - 1))
+
+case $# in
+	0) ;;
+	1) NETWORK=$1;;
+	*) usage 2 >&2;;
+esac
+
+case "$NETWORK" in
+	"mainnet") MITHRIL_NETWORK="release-mainnet" ;;
+	"preprod") MITHRIL_NETWORK="release-preprod" ;;
+	"preview") MITHRIL_NETWORK="pre-release-preview" ;;
+	*) echo >&2 "fatal: invalid NETWORK value: $NETWORK"; exit 1 ;;
+esac
+export MITHRIL_NETWORK
+
+export AGGREGATOR_ENDPOINT="https://aggregator.${MITHRIL_NETWORK}.api.mithril.network/aggregator"
+
+# shellcheck disable=SC2016
+nix shell \
+		"github:input-output-hk/mithril/${MITHRIL_VERSION}#mithril-client-cli" \
+		nixpkgs#jq \
+		nixpkgs#bash \
+		nixpkgs#curl \
+		--command bash -c '
+	set -euo pipefail
+
+	SNAPSHOT_DIGEST=$(mithril-client cardano-db snapshot list --json | jq -r ".[0].digest")
+
+	GENESIS_VERIFICATION_KEY=$(curl -fsSL "https://raw.githubusercontent.com/input-output-hk/mithril/${MITHRIL_VERSION}/mithril-infra/configuration/${MITHRIL_NETWORK}/genesis.vkey")
+	export GENESIS_VERIFICATION_KEY
+
+	set -x
+	mithril-client cardano-db download "$SNAPSHOT_DIGEST" --download-dir "$UNPACK_DIR"
+'


### PR DESCRIPTION
# Description

* The `performance` benchmark in `ledger-state` has been broken since the start of Conway
* The instructions in the `README` are out of date
* Help and progress information is inaccurate
* We can now take advantage of `mithril` to speed up the process of getting a ledger snapshot
* Snapshots are different since the introduction of UTxO-HD in node `10.4`

These changes include a temporary workaround for the fact that the pre-stored transactions are no longer valid in Conway. With this workaround it's possible to run the benchmarks but they're measuring failing transactions which isn't representative of real traffic. When the transactions are fixed the workaround can be removed (eg with `git revert` since they're in their own commit).

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
