### PR TITLE
Bumped Conway protocol version max to 11

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.20.0.0
 
+* Bump `ProtVerHigh ConwayEra` to `11`
 * Remove `ConwayTxBody`
 * Removed `era` parameter from `ConwayTxBodyRaw`
 * Add `MkConwayTxBody` and all members of `ConwayTxBodyRaw`:

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
@@ -41,7 +41,7 @@ data ConwayEra
 instance Era ConwayEra where
   type PreviousEra ConwayEra = BabbageEra
   type ProtVerLow ConwayEra = 9
-  type ProtVerHigh ConwayEra = 10
+  type ProtVerHigh ConwayEra = 11
 
   eraName = "Conway"
 

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.7.0.0
 
+* Bump `MaxVersion` to `12`
 * Add `decodeFullFromHexText`
 * Move `translateViaCBORAnnotator`, `decodeFullAnnotator`, `decodeFullAnnotatedBytes`, `decodeFullAnnotatorFromHexText` to `testlib`
 * Moved `Annotator` orphan instance for plutus `Data` into `testlib`

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Version.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Version.hs
@@ -51,7 +51,7 @@ type MinVersion = 0
 
 -- | Maximum supported version. This is the major protocol version of the latest known
 -- protocol version that we want to support, including for development and testing.
-type MaxVersion = 11
+type MaxVersion = 12
 
 instance Enum Version where
   toEnum = errorFail . mkVersion


### PR DESCRIPTION
# Description

Bumped the max protocol version of Conway to `11` in preparation for a future hard-fork.

related #5015

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
