### PR TITLE
`cardano-ledger-byron`: remove `Cabal-syntax` dependency

### DIFF
--- a/eras/byron/ledger/impl/CHANGELOG.md
+++ b/eras/byron/ledger/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for `cardano-ledger-byron`
 
+## 1.3.0.0
+
+* Remove `osHelper` and `archHelper` functions.
+
 ## 1.2.0.0
 
 * Added `Test.Cardano.Chain.Binary.Cddl` module

--- a/eras/byron/ledger/impl/cardano-ledger-byron.cabal
+++ b/eras/byron/ledger/impl/cardano-ledger-byron.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-byron
-version: 1.2.0.0
+version: 1.3.0.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK
@@ -233,7 +233,6 @@ library
     -Wunused-packages
 
   build-depends:
-    Cabal-syntax,
     aeson,
     base >=4.14 && <5,
     base58-bytestring,

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Update/SystemTag.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Update/SystemTag.hs
@@ -12,8 +12,6 @@ module Cardano.Chain.Update.SystemTag (
   SystemTagError (..),
   checkSystemTag,
   systemTagMaxLength,
-  osHelper,
-  archHelper,
 )
 where
 
@@ -36,8 +34,6 @@ import Cardano.Prelude hiding (cborError)
 import Data.Aeson (ToJSON, ToJSONKey)
 import Data.Data (Data)
 import qualified Data.Text as T
-import Distribution.System (Arch (..), OS (..))
-import Distribution.Text (display)
 import Formatting (bprint, int, stext)
 import qualified Formatting.Buildable as B
 import NoThunks.Class (NoThunks (..))
@@ -119,20 +115,3 @@ checkSystemTag (SystemTag tag)
   | T.length tag > systemTagMaxLength = throwError $ SystemTagTooLong tag
   | T.any (not . isAscii) tag = throwError $ SystemTagNotAscii tag
   | otherwise = pure ()
-
--- | Helper to turn an @OS@ into a @Text@ compatible with the @systemTag@
---   previously used in 'configuration.yaml'
-osHelper :: OS -> Text
-osHelper sys = case sys of
-  Windows -> "win"
-  OSX -> "macos"
-  Linux -> "linux"
-  _ -> toS $ display sys
-
--- | Helper to turn an @Arch@ into a @Text@ compatible with the @systemTag@
---   previously used in 'configuration.yaml'
-archHelper :: Arch -> Text
-archHelper archt = case archt of
-  I386 -> "32"
-  X86_64 -> "64"
-  _ -> toS $ display archt


### PR DESCRIPTION
# Description

Grepping across various projects/GitHub code search did not reveal any usage.

Motivated by debugging a Nix/version solving error involving `Cabal-syntax`, and wondering why we even depend on it. Turns out that the only use is for redundant definitions.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
