### PR TITLE
Deprecate `balance` in favor of a better named `sumUTxO`

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -89,14 +89,7 @@ import Cardano.Ledger.Rules.ValidationMode (
 import Cardano.Ledger.Shelley.LedgerState (UTxOState (utxosUtxo))
 import Cardano.Ledger.Shelley.Rules (ShelleyPpupPredFailure, ShelleyUtxoPredFailure, UtxoEnv (..))
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
-import Cardano.Ledger.State (
-  EraCertState,
-  EraUTxO (..),
-  UTxO (..),
-  areAllAdaOnly,
-  coinBalance,
-  sumAllValue,
- )
+import Cardano.Ledger.State
 import Cardano.Ledger.TxIn (TxIn)
 import qualified Cardano.Ledger.Val as Val
 import Cardano.Slotting.EpochInfo.API (EpochInfo, epochInfoSlotToUTCTime)
@@ -315,7 +308,7 @@ validateCollateral pp txb utxoCollateral =
       failureIf (null utxoCollateral) NoCollateralInputs
     ]
   where
-    bal = toDeltaCoin $ coinBalance (UTxO utxoCollateral)
+    bal = toDeltaCoin $ sumAllCoin utxoCollateral
 
 -- > (∀(a,_,_) ∈ range (collateral txb ◁ utxo), a ∈ Addrvkey)
 validateScriptsNotPaidUTxO ::

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -314,7 +314,7 @@ alonzoEvalScriptsTxInvalid = do
   pure $!
     utxos
       { utxosUtxo = UTxO utxoKeep
-      , utxosFees = fees <> coinBalance (UTxO utxoDel)
+      , utxosFees = fees <> sumAllCoin utxoDel
       , utxosInstantStake = deleteInstantStake (UTxO utxoDel) (utxos ^. instantStakeL)
       }
 

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -76,8 +76,8 @@ import Cardano.Ledger.Shelley.Scripts
 import Cardano.Ledger.State (
   EraUTxO (..),
   UTxO (..),
-  coinBalance,
   getScriptsNeeded,
+  sumCoinUTxO,
   txInsFilter,
  )
 import Cardano.Ledger.TxIn (TxIn)
@@ -543,7 +543,7 @@ instance EraGen AlonzoEra where
 
 sumCollateral :: (EraTx era, AlonzoEraTxBody era) => Tx era -> UTxO era -> Coin
 sumCollateral tx utxo =
-  coinBalance $ txInsFilter utxo $ tx ^. bodyTxL . collateralInputsTxBodyL
+  sumCoinUTxO $ txInsFilter utxo $ tx ^. bodyTxL . collateralInputsTxBodyL
 
 storageCost :: forall era t. (EraPParams era, EncCBOR t) => Integer -> PParams era -> t -> Coin
 storageCost extra pp x = (extra + encodedLen @era x) <×> pp ^. ppMinFeeAL

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Collateral.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Collateral.hs
@@ -17,7 +17,7 @@ import Cardano.Ledger.Babbage.TxBody (BabbageEraTxBody (..))
 import Cardano.Ledger.BaseTypes (TxIx (..), txIxFromIntegral)
 import Cardano.Ledger.Coin (DeltaCoin, toDeltaCoin)
 import Cardano.Ledger.Core
-import Cardano.Ledger.State (UTxO (..), coinBalance)
+import Cardano.Ledger.State
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.Val ((<->))
 import qualified Data.Map.Strict as Map
@@ -38,7 +38,7 @@ collAdaBalance txBody utxoCollateral = toDeltaCoin $
     SNothing -> colbal
     SJust txOut -> colbal <-> (txOut ^. coinTxOutL @era)
   where
-    colbal = coinBalance $ UTxO utxoCollateral
+    colbal = sumAllCoin utxoCollateral
 
 collOuts ::
   BabbageEraTxBody era =>

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -71,7 +71,7 @@ import Cardano.Ledger.Rules.ValidationMode (
 import Cardano.Ledger.Shelley.LedgerState (UTxOState (utxosUtxo))
 import Cardano.Ledger.Shelley.Rules (ShelleyPpupPredFailure, ShelleyUtxoPredFailure, UtxoEnv)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
-import Cardano.Ledger.State (EraCertState (..), EraUTxO (..), UTxO (..), areAllAdaOnly, balance)
+import Cardano.Ledger.State
 import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Ledger.Val ((<->))
 import qualified Cardano.Ledger.Val as Val (inject, isAdaOnly, pointwise)
@@ -306,7 +306,7 @@ validateCollateralContainsNonADA txBody utxoCollateral =
             then retTxOut ^. valueTxOutL
             else collateralBalance
     -- This is the balance that is provided by the collateral inputs
-    collateralBalance = balance $ UTxO utxoCollateral
+    collateralBalance = sumAllValue utxoCollateral
     -- This is the total amount that will be spent as collateral. This is where we account
     -- for the fact that we can remove Non-Ada assets from collateral inputs, by directing
     -- them to the return TxOut.

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -1710,7 +1710,7 @@ showConwayTxBalance pp certState utxo tx =
     ]
   where
     txBody = tx ^. bodyTxL
-    inputs = balance (txInsFilter utxo (txBody ^. inputsTxBodyL))
+    inputs = sumUTxO (txInsFilter utxo (txBody ^. inputsTxBodyL))
     refunds =
       getTotalRefundsTxBody
         pp

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
@@ -28,7 +28,7 @@ import Cardano.Ledger.State (
   EraUTxO (..),
   ScriptsProvided (..),
   UTxO,
-  balance,
+  sumUTxO,
   txInsFilter,
  )
 import Cardano.Ledger.Val (inject)
@@ -78,7 +78,7 @@ getConsumedMaryValue pp lookupStakingDeposit lookupDRepDeposit utxo txBody =
     mintedMultiAsset = filterMultiAsset (\_ _ -> (> 0)) $ txBody ^. mintTxBodyL
     {- balance (txins tx ◁ u) + wbalance (txwdrls tx) + keyRefunds pp tx -}
     consumedValue =
-      balance (txInsFilter utxo (txBody ^. inputsTxBodyL))
+      sumUTxO (txInsFilter utxo (txBody ^. inputsTxBodyL))
         <> inject (refunds <> withdrawals)
     refunds = getTotalRefundsTxBody pp lookupStakingDeposit lookupDRepDeposit txBody
     withdrawals = fold . unWithdrawals $ txBody ^. withdrawalsTxBodyL

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.17.0.0
 
+* Replace export from `Cardano.Ledger.Shelley.UTxO` of deprecated `balance` and `coinBalance` with `sumUTxO` and `sumCoinUTxO` respectively
 * Remove `ShelleyTxBody`
 * Removed `era` parameter from `ShelleyTxBodyRaw`
 * Remove `HeapWords` instances for: #5001

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
@@ -138,7 +138,7 @@ translateToShelleyLedgerStateFromUtxo transCtxt epochNo utxoByron =
 
     reserves :: Coin
     reserves =
-      word64ToCoin (fbtcMaxLovelaceSupply transCtxt) <-> coinBalance utxoShelley
+      word64ToCoin (fbtcMaxLovelaceSupply transCtxt) <-> sumCoinUTxO utxoShelley
 
     epochState :: EpochState ShelleyEra
     epochState =

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/AdaPots.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/AdaPots.hs
@@ -71,7 +71,7 @@ totalAdaPotsES (EpochState (ChainAccountState {casTreasury, casReserves}) ls _ _
     UTxOState u _ fees_ _ _ _ = lsUTxOState ls
     certState = ls ^. lsCertStateL
     rewards_ = fromCompact $ sumRewardsUView (rewards $ certState ^. certDStateL)
-    coins = coinBalance u
+    coins = sumCoinUTxO u
     govStateObligations = obligationGovState (ls ^. lsUTxOStateL . utxosGovStateL)
 
 sumAdaPots :: AdaPots -> Coin
@@ -145,7 +145,7 @@ consumedTxBody ::
 consumedTxBody txBody pp dpstate utxo =
   Consumed
     { conInputs =
-        coinBalance (txInsFilter utxo (txBody ^. inputsTxBodyL))
+        sumCoinUTxO (txInsFilter utxo (txBody ^. inputsTxBodyL))
     , conRefunds = certsTotalRefundsTxBody pp dpstate txBody
     , conWithdrawals = fold . unWithdrawals $ txBody ^. withdrawalsTxBodyL
     }
@@ -159,7 +159,7 @@ producedTxBody ::
   Produced
 producedTxBody txBody pp dpstate =
   Produced
-    { proOutputs = coinBalance (txouts txBody)
+    { proOutputs = sumCoinUTxO (txouts txBody)
     , proFees = txBody ^. feeTxBodyL
     , proDeposits = certsTotalDepositsTxBody pp dpstate txBody
     }

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/NewEpochState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/NewEpochState.hs
@@ -140,7 +140,7 @@ returnRedeemAddrsToReserves es = es {esChainAccountState = acnt', esLState = ls'
     utxoR = UTxO redeemers :: UTxO era
     acnt' =
       acnt
-        { casReserves = casReserves acnt <+> coinBalance utxoR
+        { casReserves = casReserves acnt <+> sumCoinUTxO utxoR
         }
     us' = us {utxosUtxo = UTxO nonredeemers :: UTxO era}
     ls' = ls {lsUTxOState = us'}

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -327,7 +327,7 @@ instance
     , PostCondition
         "Deposit pot must not be negative (post)"
         (\_ st' -> utxosDeposited st' >= mempty)
-    , let utxoBalance us = Val.inject (utxosDeposited us <> utxosFees us) <> balance (utxosUtxo us)
+    , let utxoBalance us = Val.inject (utxosDeposited us <> utxosFees us) <> sumUTxO (utxosUtxo us)
           withdrawals :: TxBody era -> Value era
           withdrawals txb = Val.inject $ F.foldl' (<>) mempty $ unWithdrawals $ txb ^. withdrawalsTxBodyL
        in PostCondition

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Transition.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Transition.hs
@@ -300,7 +300,7 @@ createInitialState tc =
     initialUtxo :: UTxO era
     initialUtxo = mempty
     reserves :: Coin
-    reserves = word64ToCoin (sgMaxLovelaceSupply sg) <-> coinBalance initialUtxo
+    reserves = word64ToCoin (sgMaxLovelaceSupply sg) <-> sumCoinUTxO initialUtxo
 
 -- | Register the initial staking information in the 'NewEpochState'.
 --
@@ -447,7 +447,7 @@ registerInitialFunds tc nes =
     -- Update the reserves
     accountState' =
       accountState
-        { casReserves = casReserves accountState <-> coin (balance initialFundsUtxo)
+        { casReserves = casReserves accountState <-> sumCoinUTxO initialFundsUtxo
         }
 
     ledgerState' =

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -61,11 +61,11 @@ import Cardano.Ledger.State as UTxO (
   ScriptsProvided (..),
   UTxO (..),
   areAllAdaOnly,
-  balance,
-  coinBalance,
   getScriptHash,
   sumAllCoin,
   sumAllValue,
+  sumCoinUTxO,
+  sumUTxO,
   txInsFilter,
   txinLookup,
   txins,
@@ -165,7 +165,7 @@ getConsumedCoin ::
   Coin
 getConsumedCoin pp lookupRefund utxo txBody =
   {- balance (txins tx ◁ u) + wbalance (txwdrls tx) + keyRefunds dpstate tx -}
-  coinBalance (txInsFilter utxo (txBody ^. inputsTxBodyL))
+  sumCoinUTxO (txInsFilter utxo (txBody ^. inputsTxBodyL))
     <> refunds
     <> withdrawals
   where

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Chain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Chain.hs
@@ -31,7 +31,6 @@ import Cardano.Ledger.Slot (
  )
 import qualified Cardano.Ledger.UMap as UM
 import Cardano.Ledger.Val ((<->))
-import qualified Cardano.Ledger.Val as Val
 import Cardano.Protocol.TPraos.API
 import Cardano.Protocol.TPraos.BHeader (
   HashHeader (..),
@@ -146,7 +145,7 @@ mkGenesisChainState ge@(GenEnv _ _ constants) (IRC _slotNo) = do
       (At $ LastAppliedBlock (BlockNo 0) (SlotNo 0) (lastByronHeaderHash p))
       epoch0
       utxo0
-      (maxLLSupply <-> Val.coin (balance utxo0))
+      (maxLLSupply <-> sumCoinUTxO utxo0)
       delegs0
       pParams
       (hashHeaderToNonce (lastByronHeaderHash p))

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/IncrementalStake.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/IncrementalStake.hs
@@ -133,7 +133,7 @@ incrStakeComp SourceSignalTarget {source = chainSt, signal = block} =
           )
           $ utxoBalanace === fromCompact instantStakeBalanace
         where
-          utxoBalanace = coinBalance u'
+          utxoBalanace = sumCoinUTxO u'
           instantStakeBalanace = fold (sisCredentialStake is') <> fold (sisPtrStake is')
           ptrs = ptrsMap $ dp ^. certDStateL
           ptrs' = ptrsMap $ dp' ^. certDStateL

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Init.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Init.hs
@@ -29,7 +29,6 @@ import Cardano.Ledger.Slot (
   SlotNo (..),
  )
 import Cardano.Ledger.Val ((<->))
-import qualified Cardano.Ledger.Val as Val
 import Cardano.Protocol.TPraos.BHeader (
   HashHeader (..),
   LastAppliedBlock (..),
@@ -98,7 +97,7 @@ initSt utxo =
     (At $ LastAppliedBlock (BlockNo 0) (SlotNo 0) lastByronHeaderHash)
     (EpochNo 0)
     utxo
-    (maxLLSupply <-> Val.coin (balance utxo))
+    (maxLLSupply <-> sumCoinUTxO utxo)
     genDelegs
     (ppEx @era)
     nonce0

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/Tx/Body.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/Tx/Body.hs
@@ -88,10 +88,10 @@ evaluateTransactionBalanceShelley ::
 evaluateTransactionBalanceShelley pp dpstate utxo txBody = consumed <-> produced
   where
     produced =
-      balance (txouts txBody)
+      sumUTxO (txouts txBody)
         <+> inject (txBody ^. feeTxBodyL <+> totalTxDeposits pp dpstate txBody)
     consumed =
-      balance (txInsFilter utxo (txBody ^. inputsTxBodyL))
+      sumUTxO (txInsFilter utxo (txBody ^. inputsTxBodyL))
         <> inject (refunds <> withdrawals)
     refunds = keyTxRefunds pp dpstate txBody
     withdrawals = fold . unWithdrawals $ txBody ^. withdrawalsTxBodyL

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.18.0.0
 
+* Add `sumUTxO` and `sumCoinUTxO`
+* Deprecate `balance` and `coinBalance` in favor of `sumUTxO` and `sumCoinUTxO`
 * Remove `delegators` field from JSON serialiser for `DRepState` for correct round-tripping. #5004
 * Change `TxBody` to an associated `data` family
 * Remove `HeapWords` instances for: #5001

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
@@ -43,7 +43,7 @@ import Cardano.Ledger.Shelley.LedgerState (
  )
 import Cardano.Ledger.Shelley.State (ShelleyCertState (..))
 import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
-import Cardano.Ledger.State (EraUTxO (..), UTxO (..), coinBalance, unScriptsProvided)
+import Cardano.Ledger.State (EraUTxO (..), UTxO (..), sumCoinUTxO, unScriptsProvided)
 import Cardano.Ledger.TxIn (TxIn (..))
 import qualified Cardano.Ledger.UMap as UM
 import Cardano.Ledger.Val (Val ((<+>), (<->)), inject)
@@ -168,7 +168,7 @@ txInBalance ::
   Set TxIn ->
   MUtxo era ->
   Coin
-txInBalance txinSet m = coinBalance (UTxO (restrictKeys m txinSet))
+txInBalance txinSet m = sumCoinUTxO (UTxO (restrictKeys m txinSet))
 
 -- | Break a TxOut into its mandatory and optional parts
 txoutFields :: Proof era -> TxOut era -> (Addr, Value era, [TxOutField era])

--- a/libs/ledger-state/bench/Performance.hs
+++ b/libs/ledger-state/bench/Performance.hs
@@ -129,8 +129,8 @@ main = do
     , env (pure utxo) $ \utxo' ->
         bgroup
           "UTxO"
-          [ bench "balance" $ nf balance utxo'
-          , bench "coinBalance" $ nf coinBalance utxo'
+          [ bench "sumUTxO" $ nf sumUTxO utxo'
+          , bench "sumCoinUTxO" $ nf sumCoinUTxO utxo'
           , -- We need to filter out all multi-assets to prevent `areAllAdaOnly`
             -- from short circuiting and producing results that are way better
             -- than the worst case


### PR DESCRIPTION
# Description

Same deprecation was applied to a similar function `coinBalance`, which is repaced by `sumCoinUTxO`

Balance as a name that is not very well suited to the UTxO. It is a much better name for account base model, where accounts do have balances. Moreover, the name usage of "reward" describing balance in accounts on Cardano have outgrown itself, since those accounts are no longer used just for depositing rewards, but also for refunding deposits and depositing treasury withdrawals. There is a very likely chance that for Leios we'll need to promote those accounts to have more capability (withdraw as well as deposit), which means a general term "balance" will be better suited for accounts, instead of rewards. As such, these functions are deprecated.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
