### PR TITLE
Some fixes to CDDLs based on the Consensus golden examples of blocks

### DIFF
--- a/eras/allegra/impl/cddl-files/allegra.cddl
+++ b/eras/allegra/impl/cddl-files/allegra.cddl
@@ -126,7 +126,7 @@ major_protocol_version = 1 .. 3
 
 metadata = {* transaction_metadatum_label => transaction_metadatum}
 
-metadata_hash = $hash32
+metadata_hash = bytes .size 2 / $hash32
 
 ; The first field determines where the funds are drawn from.
 ;   0 denotes the reserves,

--- a/eras/alonzo/impl/cddl-files/alonzo.cddl
+++ b/eras/alonzo/impl/cddl-files/alonzo.cddl
@@ -187,7 +187,7 @@ major_protocol_version = 1 .. 7
 
 metadata = {* transaction_metadatum_label => transaction_metadatum}
 
-metadata_hash = $hash32
+metadata_hash = bytes .size 2 / $hash32
 
 mint = multiasset<int64>
 

--- a/eras/babbage/impl/cddl-files/babbage.cddl
+++ b/eras/babbage/impl/cddl-files/babbage.cddl
@@ -195,7 +195,7 @@ major_protocol_version = 1 .. 9
 
 metadata = {* transaction_metadatum_label => transaction_metadatum}
 
-metadata_hash = $hash32
+metadata_hash = bytes .size 2 / $hash32
 
 mint = multiasset<int64>
 

--- a/eras/byron/ledger/impl/cddl-spec/byron.cddl
+++ b/eras/byron/ledger/impl/cddl-spec/byron.cddl
@@ -9,7 +9,7 @@ mainblock = [ "header" : blockhead
             ]
 
 ebblock = [ "header" : ebbhead
-          , "body" : [+ stakeholderid]
+          , "body" : [* stakeholderid]
           , extra : [attributes]
           ]
 

--- a/eras/conway/impl/cddl-files/conway.cddl
+++ b/eras/conway/impl/cddl-files/conway.cddl
@@ -250,7 +250,7 @@ major_protocol_version = 1 .. 10
 
 metadata = {* transaction_metadatum_label => transaction_metadatum}
 
-metadata_hash = $hash32
+metadata_hash = bytes .size 2 / $hash32
 
 mint = multiasset<nonZeroInt64>
 

--- a/eras/mary/impl/cddl-files/mary.cddl
+++ b/eras/mary/impl/cddl-files/mary.cddl
@@ -128,7 +128,7 @@ major_protocol_version = 1 .. 3
 
 metadata = {* transaction_metadatum_label => transaction_metadatum}
 
-metadata_hash = $hash32
+metadata_hash = bytes .size 2 / $hash32
 
 mint = multiasset<int64>
 

--- a/eras/shelley/impl/cddl-files/shelley.cddl
+++ b/eras/shelley/impl/cddl-files/shelley.cddl
@@ -116,7 +116,7 @@ ipv6 = bytes .size 16
 
 major_protocol_version = 1 .. 3
 
-metadata_hash = $hash32
+metadata_hash = bytes .size 2 / $hash32
 
 ; The first field determines where the funds are drawn from.
 ;   0 denotes the reserves,

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/CDDL.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/CDDL.hs
@@ -388,7 +388,7 @@ script_hash =
     $ "script_hash" =:= hash28
 
 metadata_hash :: Rule
-metadata_hash = "metadata_hash" =:= hash32
+metadata_hash = "metadata_hash" =:= (VBytes `sized` (2 :: Word64)) / hash32
 
 nonce :: Rule
 nonce = "nonce" =:= arr [0] / arr [1, a (VBytes `sized` (32 :: Word64))]


### PR DESCRIPTION
# Description

The examples in consensus have:
- An empty list of stakeholder ids in a byron block.
- The metadata hash is 2 bytes long when talking about the `"consensus.pool"` (just so that it is easier to find where this might come from), but for transaction_body they are 32 bytes long.

Someone should check if this is expected or not, but that is right now the case.

Other things that need fixing are:
- `address` is hardcoded
- `reward_account` is hardcoded
- `unit_interval` is hardcoded
- `distinct_VBytes` only allows size 8, 16, ... but the example `plutus_v1_script` in the Conway example has length 6.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
