### PR TITLE
Fix COMPLETE pragma for `NativeScript ShelleyEra`

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Scripts.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Scripts.hs
@@ -181,6 +181,14 @@ pattern RequireMOf n ms <- (getRequireMOf -> Just (n, ms))
   where
     RequireMOf n ms = mkRequireMOf n ms
 
+{-# COMPLETE
+  RequireSignature
+  , RequireAllOf
+  , RequireAnyOf
+  , RequireMOf ::
+    ShelleyEra
+  #-}
+
 -- | Encodes memoized bytes created upon construction.
 instance Era era => EncCBOR (MultiSig era)
 


### PR DESCRIPTION
# Description

Addresses only part of #4613 that can be done without moving Era type definitions

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] ~~Tests added or updated when needed.~~
- [ ] ~~`CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).~~
- [ ] ~~Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).~~
- [ ] ~~Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).~~
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
