### PR TITLE
Fix occurrence of items in maps in byron.cddl

### DIFF
--- a/eras/byron/ledger/impl/cddl-spec/byron.cddl
+++ b/eras/byron/ledger/impl/cddl-spec/byron.cddl
@@ -80,12 +80,12 @@ vssdec = bytes ; This is encoded using the 'Binary' instance
 vssproof = [bytes, bytes, bytes, [* bytes]] ; This is encoded using the
                                             ; 'Binary' instance for Scrape.Proof
 
-ssccomm = [pubkey, [{vsspubkey => vssenc},vssproof], signature]
+ssccomm = [pubkey, [{* vsspubkey => vssenc},vssproof], signature]
 ssccomms = #6.258([* ssccomm])
 
-sscopens = {stakeholderid => vsssec}
+sscopens = {* stakeholderid => vsssec}
 
-sscshares = {addressid => [addressid, [* vssdec]]}
+sscshares = {* addressid => [addressid, [* vssdec]]}
 
 ssccert = [vsspubkey, pubkey, epochid, signature]
 ssccerts = #6.258([* ssccert])


### PR DESCRIPTION
# Description

These maps were wrong in the CDDL. I found this out validating chunk 00007.chunk as a `cborseq`.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
