### PR TITLE
Bump `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,6 +3,14 @@
 # from the repository's root to tell `git blame` to ignore
 # the commits below.
 
+# Apply `fourmolu` with `respectful: false`
+# CommitDate: Mon May 12 14:08:08 2025 -0600
+4b79a7a9fb54aabe567e2a4f83825616046f7ab3
+
+# Apply formatting for new version of `fourmolu-0.17.0.0`
+# CommitDate: Mon May 12 12:39:28 2025 -0600
+f62f99b170623528285ef8f3fb3437c6d3b8a0c0
+
 # Fourmolize with `column-limit` rule enabled
 # CommitDate: Sun Mar 17 21:36:58 2024 +0100
 e4a1422d3f149f9c6070ca78f253d43f2cbfb607


### PR DESCRIPTION
# Description

Adding the revs of the most recent `fourmolu` formatting changes to maintain `git blame` sanity.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
