### PR TITLE
Fix RequiresNetworkMagic encoding

### DIFF
--- a/eras/byron/crypto/src/Cardano/Crypto/ProtocolMagic.hs
+++ b/eras/byron/crypto/src/Cardano/Crypto/ProtocolMagic.hs
@@ -25,8 +25,8 @@ import Cardano.Ledger.Binary (
   EncCBOR (..),
   FromCBOR (..),
   ToCBOR (..),
-  decodeTag,
-  encodeTag,
+  decodeWord8,
+  encodeWord8,
   fromByronCBOR,
   toByronCBOR,
  )
@@ -115,15 +115,15 @@ instance FromCBOR RequiresNetworkMagic where
 
 instance EncCBOR RequiresNetworkMagic where
   encCBOR = \case
-    RequiresNoMagic -> encodeTag 0
-    RequiresMagic -> encodeTag 1
+    RequiresNoMagic -> encodeWord8 0
+    RequiresMagic -> encodeWord8 1
 
 instance DecCBOR RequiresNetworkMagic where
   decCBOR =
-    decodeTag >>= \case
+    decodeWord8 >>= \case
       0 -> return RequiresNoMagic
       1 -> return RequiresMagic
-      tag -> fail $ "RequiresNetworkMagic: unknown tag " ++ show tag
+      w8 -> fail $ "RequiresNetworkMagic: unknown constructor " ++ show w8
 
 -- Aeson JSON instances
 -- N.B @RequiresNetworkMagic@'s ToJSON & FromJSON instances do not round-trip.


### PR DESCRIPTION
# Description

The recently added query `DebugGetLedgerConfig` exposes the ledger configuration. It turns out that the serialized form of the Byron Config is ill-formed CBOR because we used tags to encode word8, and tags in CBOR are for tagged content. It is invalid to have a tag with no content. To check, try inputting `C1 # tag(1)` into cbor.me.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
