### PR TITLE
Move era definitions to `core:internal`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -65,6 +65,11 @@ packages:
 program-options
   ghc-options: -Werror
 
+if (impl(ghc >=9.8))
+  program-options
+    ghc-options:
+      -Wwarn=x-unsafe-internal
+
 package plutus-preprocessor
   haddock-options: "--optghc=-fplugin-opt PlutusTx.Plugin:defer-errors"
 

--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -69,7 +69,7 @@ library
     base >=4.18 && <5,
     bytestring,
     cardano-ledger-binary >=1.4,
-    cardano-ledger-core >=1.17,
+    cardano-ledger-core:{cardano-ledger-core, internal} >=1.17,
     cardano-ledger-shelley ^>=1.17,
     cardano-slotting,
     cardano-strict-containers,

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Era.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Era.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Allegra.Era (
   AllegraEra,
@@ -13,12 +14,10 @@ module Cardano.Ledger.Allegra.Era (
 
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Genesis (EraGenesis, NoGenesis)
+import Cardano.Ledger.Internal.Era (AllegraEra)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.Rules
-
--- | The Allegra era
-data AllegraEra
 
 instance Era AllegraEra where
   type PreviousEra AllegraEra = ShelleyEra

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -85,7 +85,7 @@ library
     cardano-data ^>=1.2.1,
     cardano-ledger-allegra ^>=1.8,
     cardano-ledger-binary ^>=1.7,
-    cardano-ledger-core ^>=1.18,
+    cardano-ledger-core:{cardano-ledger-core, internal} ^>=1.18,
     cardano-ledger-mary ^>=1.9,
     cardano-ledger-shelley ^>=1.17,
     cardano-slotting,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Era.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Era.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Alonzo.Era (
   AlonzoEra,
@@ -10,14 +11,12 @@ module Cardano.Ledger.Alonzo.Era (
   AlonzoLEDGER,
 ) where
 
+import Cardano.Ledger.Internal.Era (AlonzoEra)
 import Cardano.Ledger.Mary (MaryEra, MaryValue)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.Rules
 
 -- =====================================================
-
--- | The Alonzo era
-data AlonzoEra
 
 instance Era AlonzoEra where
   type PreviousEra AlonzoEra = MaryEra

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -81,7 +81,7 @@ library
     cardano-ledger-allegra ^>=1.8,
     cardano-ledger-alonzo ^>=1.14,
     cardano-ledger-binary >=1.6,
-    cardano-ledger-core >=1.17,
+    cardano-ledger-core:{cardano-ledger-core, internal} >=1.17,
     cardano-ledger-mary ^>=1.9,
     cardano-ledger-shelley ^>=1.17,
     cardano-strict-containers,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Era.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Era.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Babbage.Era (
   BabbageEra,
@@ -13,6 +14,7 @@ import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Rules (AlonzoBBODY)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Genesis (EraGenesis, NoGenesis)
+import Cardano.Ledger.Internal.Era (BabbageEra)
 import Cardano.Ledger.Mary.Value (MaryValue)
 import qualified Cardano.Ledger.Shelley.API as API
 import Cardano.Ledger.Shelley.Rules (
@@ -27,9 +29,6 @@ import Cardano.Ledger.Shelley.Rules (
  )
 
 -- =====================================================
-
--- | The Babbage era
-data BabbageEra
 
 instance Era BabbageEra where
   type PreviousEra BabbageEra = AlonzoEra

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -98,7 +98,7 @@ library
     cardano-ledger-alonzo ^>=1.14,
     cardano-ledger-babbage ^>=1.12,
     cardano-ledger-binary ^>=1.7,
-    cardano-ledger-core ^>=1.18,
+    cardano-ledger-core:{cardano-ledger-core, internal} ^>=1.18,
     cardano-ledger-mary ^>=1.9,
     cardano-ledger-shelley ^>=1.17,
     cardano-slotting,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Conway.Era (
   ConwayEra,
@@ -24,6 +25,7 @@ module Cardano.Ledger.Conway.Era (
 
 import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.Core
+import Cardano.Ledger.Internal.Era (ConwayEra)
 import Cardano.Ledger.Mary.Value (MaryValue)
 import qualified Cardano.Ledger.Shelley.API as API
 import Cardano.Ledger.Shelley.Rules (
@@ -34,9 +36,6 @@ import Cardano.Ledger.Shelley.Rules (
  )
 
 -- =====================================================
-
--- | The Conway era
-data ConwayEra
 
 instance Era ConwayEra where
   type PreviousEra ConwayEra = BabbageEra

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -79,7 +79,7 @@ library
     cardano-data ^>=1.2,
     cardano-ledger-allegra ^>=1.8,
     cardano-ledger-binary >=1.4,
-    cardano-ledger-core >=1.17,
+    cardano-ledger-core:{cardano-ledger-core, internal} >=1.17,
     cardano-ledger-shelley ^>=1.17,
     cardano-strict-containers,
     containers,

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Era.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Era.hs
@@ -4,17 +4,17 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Mary.Era (MaryEra) where
 
 import Cardano.Ledger.Allegra (AllegraEra)
 import Cardano.Ledger.Allegra.Rules (AllegraUTXO, AllegraUTXOW)
 import Cardano.Ledger.Genesis (EraGenesis, NoGenesis)
+import Cardano.Ledger.Internal.Era (MaryEra)
 import Cardano.Ledger.Mary.Value (MaryValue)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.Rules
-
-data MaryEra
 
 instance Era MaryEra where
   type PreviousEra MaryEra = AllegraEra

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -108,7 +108,7 @@ library
     cardano-data ^>=1.2.2,
     cardano-ledger-binary ^>=1.7,
     cardano-ledger-byron,
-    cardano-ledger-core ^>=1.18,
+    cardano-ledger-core:{cardano-ledger-core, internal} ^>=1.18,
     cardano-slotting,
     cardano-strict-containers,
     containers,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Era.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Era.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Shelley.Era (
   ShelleyEra,
@@ -27,8 +28,7 @@ module Cardano.Ledger.Shelley.Era (
 
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Core (ByronEra, Era (..), EraRule, Value)
-
-data ShelleyEra
+import Cardano.Ledger.Internal.Era (ShelleyEra)
 
 instance Era ShelleyEra where
   type PreviousEra ShelleyEra = ByronEra

--- a/flake.nix
+++ b/flake.nix
@@ -140,14 +140,20 @@
           # package customizations as needed. Where cabal.project is not
           # specific enough, or doesn't allow setting these.
           modules = [
-            ({pkgs, ...}: {
+            ({pkgs, ...}: let
+              ghcVersion = pkgs.haskell-nix.compiler."${config.compiler-nix-name}".version;
+            in {
               # packages.plutus-core.components.library.ghcOptions = [ "-fexternal-interpreter" ];
               # uncomment if necessary when profiling
               packages.byron-spec-chain.configureFlags = ["--ghc-option=-Werror"];
               packages.byron-spec-ledger.configureFlags = ["--ghc-option=-Werror"];
               packages.non-integral.configureFlags = ["--ghc-option=-Werror"];
-              packages.cardano-ledger-shelley.configureFlags = ["--ghc-option=-Werror"];
-              packages.cardano-ledger-shelley-ma-test.configureFlags = ["--ghc-option=-Werror"];
+              packages.cardano-ledger-shelley.configureFlags = if (builtins.compareVersions ghcVersion "9.8.0") >= 0
+                                                               then ["--ghc-options='-Werror -Wwarn=x-unsafe-internal'"]
+                                                               else ["--ghc-option=-Werror"];
+              packages.cardano-ledger-shelley-ma-test.configureFlags = if (builtins.compareVersions ghcVersion "9.8.0") >= 0
+                                                               then ["--ghc-options='-Werror -Wwarn=x-unsafe-internal'"]
+                                                               else ["--ghc-option=-Werror"];
               packages.small-steps.configureFlags = ["--ghc-option=-Werror"];
               packages.cardano-ledger-byron = {
                 configureFlags = ["--ghc-option=-Werror"];

--- a/hie.yaml
+++ b/hie.yaml
@@ -225,6 +225,9 @@ cradle:
     - path: "libs/cardano-ledger-core/src"
       component: "lib:cardano-ledger-core"
 
+    - path: "libs/cardano-ledger-core/internal"
+      component: "cardano-ledger-core:lib:internal"
+
     - path: "libs/cardano-ledger-core/testlib"
       component: "cardano-ledger-core:lib:testlib"
 

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx.hs
@@ -9,7 +9,7 @@
 --
 -- Let's start by defining the GHC extensions and imports.
 --
--- >>> :set -XScopedTypeVariables
+-- >>> :set -XScopedTypeVariables -Wno-unrecognised-warning-flags -Wno-x-unsafe-internal
 -- >>> import Test.QuickCheck
 -- >>> import qualified Data.Sequence.Strict as StrictSeq
 -- >>> import Cardano.Ledger.Api.Era (BabbageEra)

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Out.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Out.hs
@@ -11,7 +11,7 @@
 --
 -- Let's start by defining the GHC extensions and imports.
 --
--- >>> :set -XTypeApplications
+-- >>> :set -XTypeApplications -Wno-unrecognised-warning-flags -Wno-x-unsafe-internal
 -- >>> import Cardano.Ledger.Api.Era (BabbageEra)
 -- >>> import Lens.Micro
 -- >>> import Test.Cardano.Ledger.Babbage.Serialisation.Generators () -- Needed for doctests only

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -145,6 +145,22 @@ library
   if flag(asserts)
     ghc-options: -fno-ignore-asserts
 
+library internal
+  exposed-modules:
+    Cardano.Ledger.Internal.Era
+
+  visibility: public
+  hs-source-dirs: internal
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wpartial-fields
+    -Wunused-packages
+
 library testlib
   exposed-modules:
     Test.Cardano.Ledger.Common

--- a/libs/cardano-ledger-core/internal/Cardano/Ledger/Internal/Era.hs
+++ b/libs/cardano-ledger-core/internal/Cardano/Ledger/Internal/Era.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- |
+-- WARNING! This module contains types that are meant for internal use only.
+-- Even when used internally, care must be taken that these types are NOT used
+-- prior to their eras.
+module Cardano.Ledger.Internal.Era where
+
+data ShelleyEra
+#if __GLASGOW_HASKELL__ >= 908
+{-# WARNING in "x-unsafe-internal" ShelleyEra ["!! FOR INTERNAL (`cardano-ledger`) USE ONLY !!", "This is not meant to be used prior to Shelley era."] #-}
+#endif
+
+data AllegraEra
+#if __GLASGOW_HASKELL__ >= 908
+{-# WARNING in "x-unsafe-internal" AllegraEra ["!! FOR INTERNAL (`cardano-ledger`) USE ONLY !!", "This is not meant to be used prior to Allegra era."] #-}
+#endif
+
+data MaryEra
+#if __GLASGOW_HASKELL__ >= 908
+{-# WARNING in "x-unsafe-internal" MaryEra ["!! FOR INTERNAL (`cardano-ledger`) USE ONLY !!", "This is not meant to be used prior to Mary era."] #-}
+#endif
+
+data AlonzoEra
+#if __GLASGOW_HASKELL__ >= 908
+{-# WARNING in "x-unsafe-internal" AlonzoEra ["!! FOR INTERNAL (`cardano-ledger`) USE ONLY !!", "This is not meant to be used prior to Alonzo era."] #-}
+#endif
+
+data BabbageEra
+#if __GLASGOW_HASKELL__ >= 908
+{-# WARNING in "x-unsafe-internal" BabbageEra ["!! FOR INTERNAL (`cardano-ledger`) USE ONLY !!", "This is not meant to be used prior to Babbage era."] #-}
+#endif
+
+data ConwayEra
+#if __GLASGOW_HASKELL__ >= 908
+{-# WARNING in "x-unsafe-internal" ConwayEra ["!! FOR INTERNAL (`cardano-ledger`) USE ONLY !!", "This is not meant to be used prior to Conway era."] #-}
+#endif
+
+data DijkstraEra
+#if __GLASGOW_HASKELL__ >= 908
+{-# WARNING in "x-unsafe-internal" DijkstraEra ["!! FOR INTERNAL (`cardano-ledger`) USE ONLY !!", "This is not meant to be used prior to Dijkstra era."] #-}
+#endif


### PR DESCRIPTION
# Description
Resolves #5069 
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
