### PR TITLE
Renamed AlonzoTx fields

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.14.0.0
 
+* Renamed fields of `AlonzoTx`
+  * `body` to `atBody`
+  * `wits` to `atWits`
+  * `auxiliaryData` to `atAuxData`
+  * `isValid` to `atIsValid`
 * Added `Generic` instance for `AlonzoScriptsNeeded`
 * Move to `testlib` `DecCBOR` instances for: `AlonzoTxSeq`, `AlonzoTx`, `TxBody AlonzoEra`, `AlonzoTxAuxDataRaw`, `AlonzoTxAuxData`, `AlonzoScript`, `AlonzoTxWitsRaw`, `AlonzoTxWits`, `RedeemersRaw`, `Redeemers`, `TxDatsRaw`, `TxDats`
 * Added to `PParams`: `ppCollateralPercentage`,`ppCostModels`,`ppMaxBlockExUnits`,`ppMaxCollateralInputs`,`ppMaxTxExUnits`,`ppMaxValSize`,`ppPrices`

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -41,7 +41,7 @@ module Cardano.Ledger.Alonzo.Tx (
   ScriptIntegrity (ScriptIntegrity),
   ScriptIntegrityHash,
   -- Figure 3
-  AlonzoTx (AlonzoTx, body, wits, isValid, auxiliaryData),
+  AlonzoTx (AlonzoTx, atBody, atWits, atIsValid, atAuxData),
   AlonzoEraTx (..),
   mkBasicAlonzoTx,
   bodyAlonzoTxL,
@@ -139,10 +139,10 @@ newtype IsValid = IsValid Bool
   deriving newtype (NoThunks, NFData, ToCBOR, EncCBOR, DecCBOR, ToJSON)
 
 data AlonzoTx era = AlonzoTx
-  { body :: !(TxBody era)
-  , wits :: !(TxWits era)
-  , isValid :: !IsValid
-  , auxiliaryData :: !(StrictMaybe (TxAuxData era))
+  { atBody :: !(TxBody era)
+  , atWits :: !(TxWits era)
+  , atIsValid :: !IsValid
+  , atAuxData :: !(StrictMaybe (TxAuxData era))
   }
   deriving (Generic)
 
@@ -198,17 +198,17 @@ mkBasicAlonzoTx txBody = AlonzoTx txBody mempty (IsValid True) SNothing
 
 -- | `TxBody` setter and getter for `AlonzoTx`.
 bodyAlonzoTxL :: Lens' (AlonzoTx era) (TxBody era)
-bodyAlonzoTxL = lens body (\tx txBody -> tx {body = txBody})
+bodyAlonzoTxL = lens atBody (\tx txBody -> tx {atBody = txBody})
 {-# INLINEABLE bodyAlonzoTxL #-}
 
 -- | `TxWits` setter and getter for `AlonzoTx`.
 witsAlonzoTxL :: Lens' (AlonzoTx era) (TxWits era)
-witsAlonzoTxL = lens wits (\tx txWits -> tx {wits = txWits})
+witsAlonzoTxL = lens atWits (\tx txWits -> tx {atWits = txWits})
 {-# INLINEABLE witsAlonzoTxL #-}
 
 -- | `TxAuxData` setter and getter for `AlonzoTx`.
 auxDataAlonzoTxL :: Lens' (AlonzoTx era) (StrictMaybe (TxAuxData era))
-auxDataAlonzoTxL = lens auxiliaryData (\tx txTxAuxData -> tx {auxiliaryData = txTxAuxData})
+auxDataAlonzoTxL = lens atAuxData (\tx txTxAuxData -> tx {atAuxData = txTxAuxData})
 {-# INLINEABLE auxDataAlonzoTxL #-}
 
 -- | txsize computes the length of the serialised bytes (for estimations)
@@ -222,7 +222,7 @@ sizeAlonzoTxF =
 {-# INLINEABLE sizeAlonzoTxF #-}
 
 isValidAlonzoTxL :: Lens' (AlonzoTx era) IsValid
-isValidAlonzoTxL = lens isValid (\tx valid -> tx {isValid = valid})
+isValidAlonzoTxL = lens atIsValid (\tx valid -> tx {atIsValid = valid})
 {-# INLINEABLE isValidAlonzoTxL #-}
 
 deriving instance
@@ -300,11 +300,11 @@ toCBORForSizeComputation ::
   ) =>
   AlonzoTx era ->
   Encoding
-toCBORForSizeComputation AlonzoTx {body, wits, auxiliaryData} =
+toCBORForSizeComputation AlonzoTx {atBody, atWits, atAuxData} =
   encodeListLen 3
-    <> encCBOR body
-    <> encCBOR wits
-    <> encodeNullMaybe encCBOR (strictMaybeToMaybe auxiliaryData)
+    <> encCBOR atBody
+    <> encCBOR atWits
+    <> encodeNullMaybe encCBOR (strictMaybeToMaybe atAuxData)
 
 alonzoMinFeeTx ::
   ( EraTx era
@@ -358,13 +358,13 @@ toCBORForMempoolSubmission ::
   AlonzoTx era ->
   Encoding
 toCBORForMempoolSubmission
-  AlonzoTx {body, wits, auxiliaryData, isValid} =
+  AlonzoTx {atBody, atWits, atAuxData, atIsValid} =
     encode $
       Rec AlonzoTx
-        !> To body
-        !> To wits
-        !> To isValid
-        !> E (encodeNullMaybe encCBOR . strictMaybeToMaybe) auxiliaryData
+        !> To atBody
+        !> To atWits
+        !> To atIsValid
+        !> E (encodeNullMaybe encCBOR . strictMaybeToMaybe) atAuxData
 
 instance
   ( Era era

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/Annotator.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/Annotator.hs
@@ -19,7 +19,7 @@ module Test.Cardano.Ledger.Alonzo.Binary.Annotator (
 
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Scripts
-import Cardano.Ledger.Alonzo.Tx hiding (body, isValid, wits)
+import Cardano.Ledger.Alonzo.Tx
 import Cardano.Ledger.Alonzo.TxAuxData
 import Cardano.Ledger.Alonzo.TxBody
 import Cardano.Ledger.Alonzo.TxSeq.Internal

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -377,7 +377,7 @@ utxoTransition = do
   let utxo = utxosUtxo utxos
 
   {-   txb := txbody tx   -}
-  let txBody = body tx
+  let txBody = tx ^. bodyTxL
       allInputs = txBody ^. allInputsTxBodyF
       refInputs :: Set TxIn
       refInputs = txBody ^. referenceInputsTxBodyL

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -664,6 +664,7 @@ instance
   , Tx era ~ AlonzoTx era
   , EraTx era
   , BabbageEraTxBody era
+  , AlonzoEraTx era
   ) =>
   SpecTranslate ctx (AlonzoTx era)
   where
@@ -673,10 +674,10 @@ instance
     Agda.MkTx
       <$> withCtx
         (ConwayTxBodyTransContext (tx ^. sizeTxF) (txIdTx tx))
-        (toSpecRep (body tx))
-      <*> toSpecRep (wits tx)
-      <*> toSpecRep (isValid tx)
-      <*> toSpecRep (auxiliaryData tx)
+        (toSpecRep (tx ^. bodyTxL))
+      <*> toSpecRep (tx ^. witsTxL)
+      <*> toSpecRep (tx ^. isValidTxL)
+      <*> toSpecRep (tx ^. auxDataTxL)
 
 instance
   ( EraPParams era

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
@@ -14,7 +14,7 @@ module Test.Cardano.Ledger.Generic.Functions where
 import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext, mkSupportedLanguageM)
 import Cardano.Ledger.Alonzo.Scripts (plutusScriptLanguage)
-import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), IsValid (..))
+import Cardano.Ledger.Alonzo.Tx (IsValid (..))
 import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..))
 import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
 import Cardano.Ledger.Babbage.UTxO (getReferenceScripts)
@@ -203,9 +203,9 @@ maxRefInputs Babbage = 3
 maxRefInputs _ = 0
 
 isValid' :: Proof era -> Tx era -> IsValid
-isValid' Conway x = isValid x
-isValid' Babbage x = isValid x
-isValid' Alonzo x = isValid x
+isValid' Conway x = x ^. isValidTxL
+isValid' Babbage x = x ^. isValidTxL
+isValid' Alonzo x = x ^. isValidTxL
 isValid' _ _ = IsValid True
 {-# NOINLINE isValid' #-}
 


### PR DESCRIPTION
# Description

This PR renames the fields of `AlonzoTx` to make the field naming consistent.

close #5076

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
