### PR TITLE
Change `Tx` to an associated data type

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
@@ -8,6 +8,7 @@
 module Cardano.Ledger.Allegra (
   Allegra,
   AllegraEra,
+  Tx (..),
 ) where
 
 import Cardano.Ledger.Allegra.Era (AllegraEra)
@@ -17,7 +18,7 @@ import Cardano.Ledger.Allegra.Scripts ()
 import Cardano.Ledger.Allegra.State ()
 import Cardano.Ledger.Allegra.Transition ()
 import Cardano.Ledger.Allegra.Translation ()
-import Cardano.Ledger.Allegra.Tx ()
+import Cardano.Ledger.Allegra.Tx (Tx (..))
 import Cardano.Ledger.Allegra.TxSeq ()
 import Cardano.Ledger.Allegra.UTxO ()
 import Cardano.Ledger.Shelley.API

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Arbitrary.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Arbitrary.hs
@@ -19,7 +19,7 @@ module Test.Cardano.Ledger.Allegra.Arbitrary (
   maxTimelockDepth,
 ) where
 
-import Cardano.Ledger.Allegra (AllegraEra)
+import Cardano.Ledger.Allegra (AllegraEra, Tx (..))
 import Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure)
 import Cardano.Ledger.Allegra.Scripts (
   AllegraEraScript (..),
@@ -130,3 +130,5 @@ instance Arbitrary ValidityInterval where
   shrink = genericShrink
 
 deriving newtype instance Arbitrary (TransitionConfig AllegraEra)
+
+deriving newtype instance Arbitrary (Tx AllegraEra)

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Binary/Annotator.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Binary/Annotator.hs
@@ -15,7 +15,7 @@ module Test.Cardano.Ledger.Allegra.Binary.Annotator (
   module Test.Cardano.Ledger.Shelley.Binary.Annotator,
 ) where
 
-import Cardano.Ledger.Allegra (AllegraEra)
+import Cardano.Ledger.Allegra (AllegraEra, Tx (..))
 import Cardano.Ledger.Allegra.Scripts
 import Cardano.Ledger.Allegra.TxAuxData
 import Cardano.Ledger.Allegra.TxBody
@@ -67,3 +67,5 @@ instance Era era => DecCBOR (TimelockRaw era) where
 
 instance Era era => DecCBOR (Timelock era) where
   decCBOR = MkTimelock <$> decodeMemoized decCBOR
+
+deriving newtype instance DecCBOR (Tx AllegraEra)

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/TreeDiff.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/TreeDiff.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -9,7 +12,7 @@ module Test.Cardano.Ledger.Allegra.TreeDiff (
   module Test.Cardano.Ledger.Shelley.TreeDiff,
 ) where
 
-import Cardano.Ledger.Allegra (AllegraEra)
+import Cardano.Ledger.Allegra (AllegraEra, Tx (..))
 import Cardano.Ledger.Allegra.Rules
 import Cardano.Ledger.Allegra.Scripts
 import Cardano.Ledger.Allegra.TxAuxData
@@ -56,3 +59,5 @@ instance
   , ToExpr (Event (EraRule "PPUP" era))
   ) =>
   ToExpr (AllegraUtxoEvent era)
+
+deriving newtype instance ToExpr (Tx AllegraEra)

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.14.0.0
 
+* Rename `alonzoEqTxRaw` to `alonzoTxEqRaw`
 * Add `Generic` instance to `TransactionScriptFailure`
 * Add `Generic` instance for `AlonzoBbodyEvent`
 * Fix `AlonzoPlutusPurpose` CBOR(Group) instances. #5135

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -15,6 +15,7 @@ module Cardano.Ledger.Alonzo (
   pattern AlonzoTxBody,
   AlonzoScript,
   AlonzoTxAuxData,
+  Tx (..),
 ) where
 
 import Cardano.Ledger.Alonzo.Era
@@ -25,7 +26,7 @@ import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..))
 import Cardano.Ledger.Alonzo.State ()
 import Cardano.Ledger.Alonzo.Transition ()
 import Cardano.Ledger.Alonzo.Translation ()
-import Cardano.Ledger.Alonzo.Tx ()
+import Cardano.Ledger.Alonzo.Tx (Tx (..))
 import Cardano.Ledger.Alonzo.TxAuxData (AlonzoTxAuxData)
 import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut, TxBody (AlonzoTxBody))
 import Cardano.Ledger.Alonzo.TxWits ()

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
@@ -29,7 +29,7 @@ import Cardano.Ledger.Alonzo.Rules.Utxo (AlonzoUtxoPredFailure)
 import Cardano.Ledger.Alonzo.Rules.Utxos (AlonzoUtxosPredFailure)
 import Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoUtxowPredFailure)
 import Cardano.Ledger.Alonzo.Scripts (ExUnits (..), pointWiseExUnits)
-import Cardano.Ledger.Alonzo.Tx (AlonzoTx, totExUnits)
+import Cardano.Ledger.Alonzo.Tx (totExUnits)
 import Cardano.Ledger.Alonzo.TxSeq (AlonzoTxSeq, txSeqTxns)
 import Cardano.Ledger.Alonzo.TxWits (AlonzoEraTxWits (..))
 import Cardano.Ledger.BHeaderView (BHeaderView (..), isOverlaySlot)
@@ -185,7 +185,6 @@ alonzoBbodyTransition ::
   , EraSegWits era
   , AlonzoEraTxWits era
   , TxSeq era ~ AlonzoTxSeq era
-  , Tx era ~ AlonzoTx era
   , AlonzoEraPParams era
   ) =>
   TransitionRule (EraRule "BBODY" era)
@@ -266,11 +265,9 @@ instance
   , Embed (EraRule "LEDGERS" era) (AlonzoBBODY era)
   , Environment (EraRule "LEDGERS" era) ~ ShelleyLedgersEnv era
   , State (EraRule "LEDGERS" era) ~ LedgerState era
-  , Signal (EraRule "LEDGERS" era) ~ Seq (AlonzoTx era)
+  , Signal (EraRule "LEDGERS" era) ~ Seq (Tx era)
   , AlonzoEraTxWits era
-  , Tx era ~ AlonzoTx era
   , TxSeq era ~ AlonzoTxSeq era
-  , Tx era ~ AlonzoTx era
   , EraSegWits era
   , AlonzoEraPParams era
   ) =>

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledger.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledger.hs
@@ -21,7 +21,7 @@ import Cardano.Ledger.Alonzo.Rules.Delegs ()
 import Cardano.Ledger.Alonzo.Rules.Utxo (AlonzoUtxoPredFailure)
 import Cardano.Ledger.Alonzo.Rules.Utxos (AlonzoUtxosPredFailure)
 import Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoUTXOW, AlonzoUtxowEvent, AlonzoUtxowPredFailure)
-import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx (..), AlonzoTx (..), IsValid (..))
+import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx (..), IsValid (..))
 import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (
@@ -157,12 +157,11 @@ ledgerTransition = do
 instance
   ( AlonzoEraTx era
   , EraGov era
-  , Tx era ~ AlonzoTx era
   , Embed (EraRule "DELEGS" era) (AlonzoLEDGER era)
   , Embed (EraRule "UTXOW" era) (AlonzoLEDGER era)
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , State (EraRule "UTXOW" era) ~ UTxOState era
-  , Signal (EraRule "UTXOW" era) ~ AlonzoTx era
+  , Signal (EraRule "UTXOW" era) ~ Tx era
   , Environment (EraRule "DELEGS" era) ~ DelegsEnv era
   , State (EraRule "DELEGS" era) ~ CertState era
   , Signal (EraRule "DELEGS" era) ~ Seq (TxCert era)
@@ -172,7 +171,7 @@ instance
   STS (AlonzoLEDGER era)
   where
   type State (AlonzoLEDGER era) = LedgerState era
-  type Signal (AlonzoLEDGER era) = AlonzoTx era
+  type Signal (AlonzoLEDGER era) = Tx era
   type Environment (AlonzoLEDGER era) = LedgerEnv era
   type BaseM (AlonzoLEDGER era) = ShelleyBase
   type PredicateFailure (AlonzoLEDGER era) = ShelleyLedgerPredFailure era

--- a/eras/alonzo/impl/test/Test/Cardano/Ledger/Alonzo/GoldenTranslation.hs
+++ b/eras/alonzo/impl/test/Test/Cardano/Ledger/Alonzo/GoldenTranslation.hs
@@ -23,6 +23,7 @@ module Test.Cardano.Ledger.Alonzo.GoldenTranslation (
 
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Paths_cardano_ledger_alonzo (getDataFileName)
+import Test.Cardano.Ledger.Alonzo.Binary.Annotator ()
 import Test.Cardano.Ledger.Alonzo.Translation.Golden (assertTranslationResultsMatchGolden)
 import Test.Cardano.Ledger.Common
 import Test.HUnit (Assertion)

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
@@ -34,7 +34,7 @@ module Test.Cardano.Ledger.Alonzo.Arbitrary (
 ) where
 
 import Cardano.Ledger.Allegra.Scripts (Timelock)
-import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Alonzo (AlonzoEra, Tx (..))
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
 import Cardano.Ledger.Alonzo.PParams (AlonzoPParams (AlonzoPParams), OrdExUnits (OrdExUnits))
@@ -473,3 +473,5 @@ mkPlutusScript' plutus =
 
 instance Arbitrary (TransitionConfig AlonzoEra) where
   arbitrary = AlonzoTransitionConfig <$> arbitrary <*> arbitrary
+
+deriving newtype instance Arbitrary (Tx AlonzoEra)

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/Annotator.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/Annotator.hs
@@ -261,3 +261,5 @@ instance Era era => DecCBOR (TxDatsRaw era) where
   {-# INLINE decCBOR #-}
 
 deriving newtype instance Era era => DecCBOR (TxDats era)
+
+deriving newtype instance DecCBOR (Tx AlonzoEra)

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
@@ -203,3 +203,5 @@ instance
   , ToExpr (ContextError era)
   ) =>
   ToExpr (TransactionScriptFailure era)
+
+deriving newtype instance ToExpr (Tx AlonzoEra)

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -22,7 +22,7 @@ import Cardano.Ledger.Allegra.Scripts (
   pattern RequireTimeStart,
  )
 import Cardano.Ledger.Allegra.TxAuxData (AllegraTxAuxData (..))
-import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Alonzo (AlonzoEra, Tx (..))
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.PParams
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusTxInfo, mkSupportedPlutusScript)
@@ -481,7 +481,7 @@ instance EraGen AlonzoEra where
                   Just info -> addRedeemMap (getRedeemer2 info) purpose ans -- Add it to the redeemer map
                   Nothing -> ans
 
-  constructTx bod wit auxdata = AlonzoTx bod wit (IsValid v) auxdata
+  constructTx bod wit auxdata = MkAlonzoTx $ AlonzoTx bod wit (IsValid v) auxdata
     where
       v = all twoPhaseValidates (txscripts wit)
       twoPhaseValidates script =

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
@@ -16,7 +16,6 @@ module Test.Cardano.Ledger.Alonzo.Trace () where
 
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Rules (AlonzoLEDGER)
-import Cardano.Ledger.Alonzo.Tx (AlonzoTx)
 import Cardano.Ledger.BaseTypes (Globals)
 import Cardano.Ledger.Shelley.LedgerState (UTxOState)
 import Cardano.Ledger.Shelley.Rules (
@@ -63,7 +62,6 @@ instance
   , Environment (EraRule "DELEGS" era) ~ DelegsEnv era
   , State (EraRule "DELEGS" era) ~ CertState era
   , Signal (EraRule "DELEGS" era) ~ Seq (TxCert era)
-  , Tx era ~ AlonzoTx era
   , ProtVerAtMost era 8
   , EraCertState era
   , Crypto c

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/TxInfo.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/TxInfo.hs
@@ -9,7 +9,7 @@ module Test.Cardano.Ledger.Alonzo.TxInfo (
 ) where
 
 import Cardano.Ledger.Address (Addr (..), BootstrapAddress (..))
-import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Alonzo (AlonzoEra, Tx (..))
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Plutus.Context (
   ContextError,
@@ -92,7 +92,7 @@ txb i o =
     SNothing -- network ID
 
 txEx :: TxIn -> TxOut AlonzoEra -> Tx AlonzoEra
-txEx i o = AlonzoTx (txb i o) mempty (IsValid True) SNothing
+txEx i o = MkAlonzoTx $ AlonzoTx (txb i o) mempty (IsValid True) SNothing
 
 silentlyIgnore :: Tx AlonzoEra -> Assertion
 silentlyIgnore tx =

--- a/eras/alonzo/test-suite/test/Tests.hs
+++ b/eras/alonzo/test-suite/test/Tests.hs
@@ -8,11 +8,11 @@
 module Main where
 
 import Cardano.Ledger.Alonzo (AlonzoEra)
-import Cardano.Ledger.Alonzo.Rules (AlonzoLEDGER)
 import Data.Proxy (Proxy (..))
 import System.Environment (lookupEnv)
 import qualified Test.Cardano.Ledger.Alonzo.ChainTrace as ChainTrace
 import qualified Test.Cardano.Ledger.Alonzo.Golden as Golden
+import Test.Cardano.Ledger.Alonzo.ImpTest ()
 import qualified Test.Cardano.Ledger.Alonzo.Serialisation.Canonical as Canonical
 import qualified Test.Cardano.Ledger.Alonzo.Serialisation.Tripping as Tripping
 import qualified Test.Cardano.Ledger.Alonzo.Translation as Translation
@@ -33,7 +33,7 @@ defaultTests :: TestTree
 defaultTests =
   testGroup
     "Alonzo tests"
-    [ AdaPreservation.tests @AlonzoEra @(AlonzoLEDGER AlonzoEra) 50
+    [ AdaPreservation.tests @AlonzoEra 50
     , Tripping.tests
     , Translation.tests
     , Canonical.tests
@@ -45,7 +45,7 @@ nightlyTests :: TestTree
 nightlyTests =
   testGroup
     "Alonzo tests - nightly"
-    $ Shelley.commonTests @AlonzoEra @(AlonzoLEDGER AlonzoEra)
+    $ Shelley.commonTests @AlonzoEra
       ++ [ IncrementalStake.incrStakeComparisonTest (Proxy :: Proxy AlonzoEra)
          , ChainTrace.tests
          ]

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -10,6 +10,7 @@ module Cardano.Ledger.Babbage (
   BabbageEra,
   BabbageTxOut,
   TxBody (BabbageTxBody),
+  Tx (..),
   AlonzoScript,
   AlonzoTxAuxData,
 ) where
@@ -21,6 +22,7 @@ import Cardano.Ledger.Babbage.Rules ()
 import Cardano.Ledger.Babbage.State ()
 import Cardano.Ledger.Babbage.Transition ()
 import Cardano.Ledger.Babbage.Translation ()
+import Cardano.Ledger.Babbage.Tx (Tx (..))
 import Cardano.Ledger.Babbage.TxBody (BabbageTxOut, TxBody (BabbageTxBody))
 import Cardano.Ledger.Babbage.TxInfo ()
 import Cardano.Ledger.Babbage.UTxO ()

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -46,7 +46,6 @@ import qualified Cardano.Ledger.Alonzo.Rules as Alonzo (
   validateTooManyCollateralInputs,
   validateWrongNetworkInTxBody,
  )
-import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..))
 import Cardano.Ledger.Alonzo.TxWits (unRedeemersL)
 import Cardano.Ledger.Babbage.Collateral (collAdaBalance)
 import Cardano.Ledger.Babbage.Core
@@ -354,14 +353,13 @@ utxoTransition ::
   ( EraUTxO era
   , BabbageEraTxBody era
   , AlonzoEraTxWits era
-  , Tx era ~ AlonzoTx era
   , InjectRuleFailure "UTXO" ShelleyUtxoPredFailure era
   , InjectRuleFailure "UTXO" AllegraUtxoPredFailure era
   , InjectRuleFailure "UTXO" AlonzoUtxoPredFailure era
   , InjectRuleFailure "UTXO" BabbageUtxoPredFailure era
   , Environment (EraRule "UTXO" era) ~ UtxoEnv era
   , State (EraRule "UTXO" era) ~ UTxOState era
-  , Signal (EraRule "UTXO" era) ~ AlonzoTx era
+  , Signal (EraRule "UTXO" era) ~ Tx era
   , BaseM (EraRule "UTXO" era) ~ ShelleyBase
   , STS (EraRule "UTXO" era)
   , -- In this function we we call the UTXOS rule, so we need some assumptions
@@ -455,7 +453,6 @@ instance
   , EraUTxO era
   , BabbageEraTxBody era
   , AlonzoEraTxWits era
-  , Tx era ~ AlonzoTx era
   , EraRule "UTXO" era ~ BabbageUTXO era
   , InjectRuleFailure "UTXO" ShelleyUtxoPredFailure era
   , InjectRuleFailure "UTXO" AllegraUtxoPredFailure era
@@ -472,7 +469,7 @@ instance
   STS (BabbageUTXO era)
   where
   type State (BabbageUTXO era) = UTxOState era
-  type Signal (BabbageUTXO era) = AlonzoTx era
+  type Signal (BabbageUTXO era) = Tx era
   type Environment (BabbageUTXO era) = UtxoEnv era
   type BaseM (BabbageUTXO era) = ShelleyBase
   type PredicateFailure (BabbageUTXO era) = BabbageUtxoPredFailure era

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -119,7 +119,7 @@ instance
   type BaseM (BabbageUTXOS era) = ShelleyBase
   type Environment (BabbageUTXOS era) = UtxoEnv era
   type State (BabbageUTXOS era) = UTxOState era
-  type Signal (BabbageUTXOS era) = AlonzoTx era
+  type Signal (BabbageUTXOS era) = Tx era
   type PredicateFailure (BabbageUTXOS era) = AlonzoUtxosPredFailure era
   type Event (BabbageUTXOS era) = AlonzoUtxosEvent era
   transitionRules = [utxosTransition]
@@ -150,7 +150,6 @@ utxosTransition ::
   , Signal (EraRule "PPUP" era) ~ StrictMaybe (Update era)
   , Embed (EraRule "PPUP" era) (BabbageUTXOS era)
   , State (EraRule "PPUP" era) ~ ShelleyGovState era
-  , Signal (BabbageUTXOS era) ~ Tx era
   , EncCBOR (EraRuleFailure "PPUP" era)
   , Eq (EraRuleFailure "PPUP" era)
   , Show (EraRuleFailure "PPUP" era)
@@ -210,7 +209,6 @@ babbageEvalScriptsTxValid ::
   , EraCertState era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , STS (BabbageUTXOS era)
-  , Signal (BabbageUTXOS era) ~ Tx era
   , Environment (EraRule "PPUP" era) ~ PpupEnv era
   , Signal (EraRule "PPUP" era) ~ StrictMaybe (Update era)
   , Embed (EraRule "PPUP" era) (BabbageUTXOS era)

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Arbitrary.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Arbitrary.hs
@@ -148,3 +148,5 @@ instance Arbitrary (TxBody BabbageEra) where
       <*> arbitrary
 
 deriving newtype instance Arbitrary (TransitionConfig BabbageEra)
+
+deriving newtype instance Arbitrary (Tx BabbageEra)

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Binary/Annotator.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Binary/Annotator.hs
@@ -11,10 +11,12 @@ module Test.Cardano.Ledger.Babbage.Binary.Annotator (
   module Test.Cardano.Ledger.Alonzo.Binary.Annotator,
 ) where
 
-import Cardano.Ledger.Babbage (BabbageEra)
+import Cardano.Ledger.Babbage (BabbageEra, Tx (..))
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.TxBody
 import Cardano.Ledger.Binary
 import Test.Cardano.Ledger.Alonzo.Binary.Annotator
 
 deriving newtype instance DecCBOR (TxBody BabbageEra)
+
+deriving newtype instance DecCBOR (Tx BabbageEra)

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Translation/TranslatableGen.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Translation/TranslatableGen.hs
@@ -17,7 +17,7 @@ import Cardano.Ledger.Alonzo.Plutus.Context (SupportedLanguage (..))
 import Cardano.Ledger.Alonzo.Scripts (AlonzoPlutusPurpose (..), ExUnits (..))
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..))
 import Cardano.Ledger.Alonzo.TxWits
-import Cardano.Ledger.Babbage (BabbageEra)
+import Cardano.Ledger.Babbage (BabbageEra, Tx (..))
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..), TxBody (BabbageTxBody))
 import Cardano.Ledger.Binary (mkSized)
@@ -49,7 +49,7 @@ import Test.QuickCheck (
 
 instance TranslatableGen BabbageEra where
   tgRedeemers = genRedeemers
-  tgTx l = genTx @BabbageEra (genTxBody l)
+  tgTx l = MkBabbageTx <$> genTx @BabbageEra (genTxBody l)
   tgUtxo = utxoWithTx @BabbageEra
 
 utxoWithTx ::

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/TreeDiff.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/TreeDiff.hs
@@ -68,3 +68,5 @@ instance
   , ToExpr (TxCert era)
   ) =>
   ToExpr (BabbageUtxowPredFailure era)
+
+instance ToExpr (Tx BabbageEra)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -10,6 +10,7 @@ module Cardano.Ledger.Conway (
   ConwayEra,
   hardforkConwayBootstrapPhase,
   hardforkConwayDisallowUnelectedCommitteeFromVoting,
+  Tx (..),
 ) where
 
 import Cardano.Ledger.Babbage.TxBody ()
@@ -23,7 +24,7 @@ import Cardano.Ledger.Conway.Rules ()
 import Cardano.Ledger.Conway.State ()
 import Cardano.Ledger.Conway.Transition ()
 import Cardano.Ledger.Conway.Translation ()
-import Cardano.Ledger.Conway.Tx ()
+import Cardano.Ledger.Conway.Tx (Tx (..))
 import Cardano.Ledger.Conway.TxInfo ()
 import Cardano.Ledger.Conway.TxOut ()
 import Cardano.Ledger.Conway.UTxO ()

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
@@ -37,7 +37,7 @@ import Cardano.Ledger.Alonzo.Rules (
  )
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo (AlonzoBbodyPredFailure (..))
 import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
-import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx, AlonzoTx, IsValid (..), isValidTxL)
+import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx, IsValid (..), isValidTxL)
 import Cardano.Ledger.Alonzo.TxSeq (AlonzoTxSeq, txSeqTxns)
 import Cardano.Ledger.Alonzo.TxWits (AlonzoEraTxWits (..))
 import Cardano.Ledger.BHeaderView (BHeaderView (..))
@@ -248,9 +248,8 @@ instance
   ( Embed (EraRule "LEDGERS" era) (EraRule "BBODY" era)
   , Environment (EraRule "LEDGERS" era) ~ ShelleyLedgersEnv era
   , State (EraRule "LEDGERS" era) ~ LedgerState era
-  , Signal (EraRule "LEDGERS" era) ~ Seq (AlonzoTx era)
+  , Signal (EraRule "LEDGERS" era) ~ Seq (Tx era)
   , AlonzoEraTxWits era
-  , Tx era ~ AlonzoTx era
   , TxSeq era ~ AlonzoTxSeq era
   , EraSegWits era
   , AlonzoEraPParams era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -34,7 +34,6 @@ import qualified Cardano.Ledger.Alonzo.Rules as Alonzo (
   AlonzoUtxoEvent (UtxosEvent),
   AlonzoUtxoPredFailure (..),
  )
-import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..))
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure)
 import qualified Cardano.Ledger.Babbage.Rules as Babbage (
   BabbageUtxoPredFailure (..),
@@ -229,7 +228,6 @@ instance
   , EraUTxO era
   , ConwayEraTxBody era
   , AlonzoEraTxWits era
-  , Tx era ~ AlonzoTx era
   , EraRule "UTXO" era ~ ConwayUTXO era
   , InjectRuleFailure "UTXO" ShelleyUtxoPredFailure era
   , InjectRuleFailure "UTXO" AllegraUtxoPredFailure era
@@ -247,7 +245,7 @@ instance
   STS (ConwayUTXO era)
   where
   type State (ConwayUTXO era) = Shelley.UTxOState era
-  type Signal (ConwayUTXO era) = AlonzoTx era
+  type Signal (ConwayUTXO era) = Tx era
   type Environment (ConwayUTXO era) = Shelley.UtxoEnv era
   type BaseM (ConwayUTXO era) = ShelleyBase
   type PredicateFailure (ConwayUTXO era) = ConwayUtxoPredFailure era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
@@ -217,7 +217,7 @@ instance
   type BaseM (ConwayUTXOS era) = Cardano.Ledger.BaseTypes.ShelleyBase
   type Environment (ConwayUTXOS era) = UtxoEnv era
   type State (ConwayUTXOS era) = UTxOState era
-  type Signal (ConwayUTXOS era) = AlonzoTx era
+  type Signal (ConwayUTXOS era) = Tx era
   type PredicateFailure (ConwayUTXOS era) = ConwayUtxosPredFailure era
   type Event (ConwayUTXOS era) = ConwayUtxosEvent era
 

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -37,7 +38,7 @@ module Test.Cardano.Ledger.Conway.Arbitrary (
 
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (CollectError)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
-import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway (ConwayEra, Tx (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
 import Cardano.Ledger.Conway.Governance
@@ -880,3 +881,5 @@ instance Era era => Arbitrary (ConwayCertState era) where
 
 instance Arbitrary (TransitionConfig ConwayEra) where
   arbitrary = ConwayTransitionConfig <$> arbitrary <*> arbitrary
+
+deriving newtype instance Arbitrary (Tx ConwayEra)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Annotator.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Annotator.hs
@@ -12,9 +12,11 @@ module Test.Cardano.Ledger.Conway.Binary.Annotator (
 ) where
 
 import Cardano.Ledger.Binary
-import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway (ConwayEra, Tx (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.TxBody
 import Test.Cardano.Ledger.Babbage.Binary.Annotator
 
 deriving newtype instance DecCBOR (TxBody ConwayEra)
+
+deriving newtype instance DecCBOR (Tx ConwayEra)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -171,7 +171,6 @@ import Cardano.Ledger.Conway.Rules (
   withdrawalCanWithdraw,
  )
 import Cardano.Ledger.Conway.State
-import Cardano.Ledger.Conway.Tx (AlonzoTx)
 import Cardano.Ledger.Conway.TxCert (Delegatee (..))
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.DRep
@@ -1663,13 +1662,12 @@ expectMembers expKhs = do
 showConwayTxBalance ::
   ( EraUTxO era
   , ConwayEraTxBody era
-  , Tx era ~ AlonzoTx era
   , ConwayEraCertState era
   ) =>
   PParams era ->
   CertState era ->
   UTxO era ->
-  AlonzoTx era ->
+  Tx era ->
   String
 showConwayTxBalance pp certState utxo tx =
   unlines
@@ -1702,10 +1700,9 @@ logConwayTxBalance ::
   ( EraUTxO era
   , EraGov era
   , ConwayEraTxBody era
-  , Tx era ~ AlonzoTx era
   , ConwayEraCertState era
   ) =>
-  AlonzoTx era ->
+  Tx era ->
   ImpTestM era ()
 logConwayTxBalance tx = do
   pp <- getsPParams id

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Translation/TranslatableGen.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Translation/TranslatableGen.hs
@@ -11,7 +11,7 @@ import Cardano.Ledger.Alonzo.Plutus.Context (SupportedLanguage (..))
 import Cardano.Ledger.Alonzo.Scripts (AlonzoEraScript, AsIx (..), PlutusPurpose)
 import Cardano.Ledger.Alonzo.TxWits (Redeemers (..))
 import Cardano.Ledger.Binary (mkSized)
-import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway (ConwayEra, Tx (..))
 import Cardano.Ledger.Conway.Governance (VotingProcedures (..))
 import Cardano.Ledger.Conway.Scripts (ConwayPlutusPurpose (..))
 import Cardano.Ledger.Conway.TxBody (TxBody (ConwayTxBody))
@@ -34,7 +34,7 @@ import Test.Cardano.Ledger.Conway.Arbitrary ()
 
 instance TranslatableGen ConwayEra where
   tgRedeemers = genRedeemers
-  tgTx = BabbageTranslatableGen.genTx @ConwayEra . genTxBody
+  tgTx = fmap MkConwayTx . BabbageTranslatableGen.genTx @ConwayEra . genTxBody
   tgUtxo = BabbageTranslatableGen.utxoWithTx @ConwayEra
 
 genTxBody :: SupportedLanguage ConwayEra -> Gen (TxBody ConwayEra)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
@@ -312,3 +312,5 @@ instance ConwayEraCertState era => ToExpr (ConwayCertState era)
 instance
   ToExpr (PredicateFailure (EraRule "LEDGERS" era)) =>
   ToExpr (ConwayBbodyPredFailure era)
+
+instance ToExpr (Tx ConwayEra)

--- a/eras/dijkstra/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -1,12 +1,16 @@
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Dijkstra.Arbitrary () where
 
 import Cardano.Ledger.Dijkstra (DijkstraEra)
-import Cardano.Ledger.Dijkstra.Core (EraTxBody (..))
+import Cardano.Ledger.Dijkstra.Core (EraTx (..), EraTxBody (..))
 import Cardano.Ledger.Dijkstra.Genesis (DijkstraGenesis (..))
 import Cardano.Ledger.Dijkstra.Transition (TransitionConfig (..))
+import Cardano.Ledger.Dijkstra.Tx (Tx (..))
 import Cardano.Ledger.Dijkstra.TxBody (TxBody (..))
 import Test.Cardano.Ledger.Common (Arbitrary (..), scale)
 import Test.Cardano.Ledger.Conway.Arbitrary ()
@@ -39,3 +43,5 @@ instance Arbitrary DijkstraGenesis where
 
 instance Arbitrary (TransitionConfig DijkstraEra) where
   arbitrary = DijkstraTransitionConfig <$> arbitrary <*> arbitrary
+
+deriving newtype instance Arbitrary (Tx DijkstraEra)

--- a/eras/dijkstra/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
+++ b/eras/dijkstra/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
@@ -10,6 +10,10 @@ module Test.Cardano.Ledger.Dijkstra.Binary.Annotator (
 
 import Cardano.Ledger.Binary (DecCBOR)
 import Cardano.Ledger.Dijkstra (DijkstraEra)
+import Cardano.Ledger.Dijkstra.Tx (Tx (..))
 import Cardano.Ledger.Dijkstra.TxBody (TxBody (..))
+import Test.Cardano.Ledger.Conway.Binary.Annotator ()
 
 deriving newtype instance DecCBOR (TxBody DijkstraEra)
+
+deriving newtype instance DecCBOR (Tx DijkstraEra)

--- a/eras/dijkstra/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
+++ b/eras/dijkstra/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
@@ -6,7 +6,7 @@ module Test.Cardano.Ledger.Dijkstra.TreeDiff (
 ) where
 
 import Cardano.Ledger.Dijkstra (DijkstraEra)
-import Cardano.Ledger.Dijkstra.Core (EraTxBody (..), PlutusScript)
+import Cardano.Ledger.Dijkstra.Core (EraTx (..), EraTxBody (..), PlutusScript)
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraTxBodyRaw)
 import Test.Cardano.Ledger.Conway.TreeDiff (ToExpr)
 
@@ -15,3 +15,5 @@ instance ToExpr (PlutusScript DijkstraEra)
 instance ToExpr DijkstraTxBodyRaw
 
 instance ToExpr (TxBody DijkstraEra)
+
+instance ToExpr (Tx DijkstraEra)

--- a/eras/mary/impl/src/Cardano/Ledger/Mary.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary.hs
@@ -12,6 +12,7 @@ module Cardano.Ledger.Mary (
   ShelleyTxOut,
   MaryValue,
   TxBody (..),
+  Tx (..),
 ) where
 
 import Cardano.Ledger.Mary.Era (MaryEra)
@@ -21,6 +22,7 @@ import Cardano.Ledger.Mary.Scripts ()
 import Cardano.Ledger.Mary.State ()
 import Cardano.Ledger.Mary.Transition ()
 import Cardano.Ledger.Mary.Translation ()
+import Cardano.Ledger.Mary.Tx (Tx (..))
 import Cardano.Ledger.Mary.TxAuxData ()
 import Cardano.Ledger.Mary.TxBody (TxBody (..))
 import Cardano.Ledger.Mary.TxSeq ()

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Tx.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Tx.hs
@@ -1,49 +1,71 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Mary.Tx (
   validateTimelock,
+  Tx (..),
 ) where
 
-import Cardano.Ledger.Allegra.Tx (validateTimelock)
+import Cardano.Ledger.Allegra.Tx (Tx (..), validateTimelock)
+import Cardano.Ledger.Binary (Annotator, DecCBOR (..), EncCBOR, ToCBOR)
 import Cardano.Ledger.Core (EraTx (..))
 import Cardano.Ledger.Mary.Era (MaryEra)
 import Cardano.Ledger.Mary.PParams ()
 import Cardano.Ledger.Mary.TxAuxData ()
 import Cardano.Ledger.Mary.TxBody ()
 import Cardano.Ledger.Mary.TxWits ()
+import Cardano.Ledger.MemoBytes (EqRaw (..))
 import Cardano.Ledger.Shelley.Tx (
   ShelleyTx (..),
   auxDataShelleyTxL,
   bodyShelleyTxL,
   mkBasicShelleyTx,
   shelleyMinFeeTx,
+  shelleyTxEqRaw,
   sizeShelleyTxF,
   witsShelleyTxL,
  )
+import Control.DeepSeq (NFData)
+import GHC.Generics (Generic)
+import Lens.Micro (Lens', lens)
+import NoThunks.Class (NoThunks)
 
 -- ========================================
 
 instance EraTx MaryEra where
-  type Tx MaryEra = ShelleyTx MaryEra
+  newtype Tx MaryEra = MkMaryTx {unMaryTx :: ShelleyTx MaryEra}
+    deriving newtype (Eq, NFData, NoThunks, Show, ToCBOR, EncCBOR)
+    deriving (Generic)
 
-  mkBasicTx = mkBasicShelleyTx
+  mkBasicTx = MkMaryTx . mkBasicShelleyTx
 
-  bodyTxL = bodyShelleyTxL
+  bodyTxL = maryTxL . bodyShelleyTxL
   {-# INLINE bodyTxL #-}
 
-  witsTxL = witsShelleyTxL
+  witsTxL = maryTxL . witsShelleyTxL
   {-# INLINE witsTxL #-}
 
-  auxDataTxL = auxDataShelleyTxL
+  auxDataTxL = maryTxL . auxDataShelleyTxL
   {-# INLINE auxDataTxL #-}
 
-  sizeTxF = sizeShelleyTxF
+  sizeTxF = maryTxL . sizeShelleyTxF
   {-# INLINE sizeTxF #-}
 
   validateNativeScript = validateTimelock
   {-# INLINE validateNativeScript #-}
 
   getMinFeeTx pp tx _ = shelleyMinFeeTx pp tx
+
+instance EqRaw (Tx MaryEra) where
+  eqRaw = shelleyTxEqRaw
+
+maryTxL :: Lens' (Tx MaryEra) (ShelleyTx MaryEra)
+maryTxL = lens unMaryTx (\x y -> x {unMaryTx = y})
+
+instance DecCBOR (Annotator (Tx MaryEra)) where
+  decCBOR = fmap MkMaryTx <$> decCBOR

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Arbitrary.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Arbitrary.hs
@@ -25,7 +25,7 @@ import Cardano.Crypto.Hash.Class (castHash, hashWith)
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Compactible
 import Cardano.Ledger.Core
-import Cardano.Ledger.Mary (MaryEra, TxBody (MaryTxBody))
+import Cardano.Ledger.Mary (MaryEra, Tx (..), TxBody (MaryTxBody))
 import Cardano.Ledger.Mary.Transition
 import Cardano.Ledger.Mary.Value (
   AssetName (..),
@@ -235,3 +235,5 @@ hashOfDigitByteStrings :: HashAlgorithm h => [Hash h a]
 hashOfDigitByteStrings = castHash . hashWith id <$> digitByteStrings
 
 deriving newtype instance Arbitrary (TransitionConfig MaryEra)
+
+deriving newtype instance Arbitrary (Tx MaryEra)

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Binary/Annotator.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Binary/Annotator.hs
@@ -9,8 +9,10 @@ module Test.Cardano.Ledger.Mary.Binary.Annotator (
 ) where
 
 import Cardano.Ledger.Binary
-import Cardano.Ledger.Mary (MaryEra)
+import Cardano.Ledger.Mary (MaryEra, Tx (..))
 import Cardano.Ledger.Mary.TxBody
 import Test.Cardano.Ledger.Allegra.Binary.Annotator
 
 deriving newtype instance DecCBOR (TxBody MaryEra)
+
+deriving newtype instance DecCBOR (Tx MaryEra)

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/TreeDiff.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/TreeDiff.hs
@@ -31,3 +31,5 @@ instance ToExpr AssetName where
 deriving newtype instance ToExpr (CompactForm MaryValue)
 
 instance ToExpr (TxBody MaryEra)
+
+instance ToExpr (Tx MaryEra)

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/AllegraEraGen.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/AllegraEraGen.hs
@@ -19,7 +19,7 @@ module Test.Cardano.Ledger.AllegraEraGen (
   genValidityInterval,
 ) where
 
-import Cardano.Ledger.Allegra (AllegraEra)
+import Cardano.Ledger.Allegra (AllegraEra, Tx (..))
 import Cardano.Ledger.Allegra.Core
 import Cardano.Ledger.Allegra.Scripts (
   AllegraEraScript,
@@ -94,7 +94,7 @@ instance EraGen AllegraEra where
   genEraPParamsUpdate = genShelleyPParamsUpdate
   genEraPParams = genPParams
   genEraTxWits _scriptinfo setWitVKey mapScriptWit = ShelleyTxWits setWitVKey mapScriptWit mempty
-  constructTx = ShelleyTx
+  constructTx x y z = MkAllegraTx $ ShelleyTx x y z
 
 genTxBody ::
   SlotNo ->

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Allegra/ScriptTranslation.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Allegra/ScriptTranslation.hs
@@ -5,7 +5,7 @@ module Test.Cardano.Ledger.Allegra.ScriptTranslation (
   testScriptPostTranslation,
 ) where
 
-import Cardano.Ledger.Allegra (AllegraEra)
+import Cardano.Ledger.Allegra (AllegraEra, Tx (..))
 import Cardano.Ledger.Allegra.State
 import Cardano.Ledger.Genesis (NoGenesis (..))
 import Cardano.Ledger.Shelley (ShelleyEra)
@@ -82,7 +82,7 @@ testScriptPostTranslation =
           result =
             runShelleyBase $
               applySTSTest @(S.ShelleyLEDGER AllegraEra)
-                (TRC (env, LedgerState utxoStAllegra def, txa))
+                (TRC (env, LedgerState utxoStAllegra def, MkAllegraTx txa))
        in case result of
             Left e -> error $ show e
             Right _ -> pure ()

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples.hs
@@ -10,7 +10,6 @@ import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.Shelley.API (LedgerEnv (..), ShelleyLEDGER)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (LedgerState (..), UTxOState (..), smartUTxOState)
-import Cardano.Ledger.Shelley.Tx (ShelleyTx (..))
 import Cardano.Ledger.State (UTxO)
 import Control.State.Transition.Extended hiding (Assertion)
 import Data.Default (def)
@@ -30,7 +29,7 @@ ignoreAllButUTxO = fmap (\(LedgerState (UTxOState utxo _ _ _ _ _) _) -> utxo)
 testMaryNoDelegLEDGER ::
   HasCallStack =>
   UTxO MaryEra ->
-  ShelleyTx MaryEra ->
+  Tx MaryEra ->
   LedgerEnv MaryEra ->
   Either (NonEmpty (PredicateFailure (ShelleyLEDGER MaryEra))) (UTxO MaryEra) ->
   Assertion

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
@@ -21,7 +21,7 @@ import Cardano.Ledger.Allegra.Scripts (
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Keys (asWitness)
-import Cardano.Ledger.Mary (MaryEra)
+import Cardano.Ledger.Mary (MaryEra, Tx (..))
 import Cardano.Ledger.Mary.Core
 import Cardano.Ledger.Mary.State
 import Cardano.Ledger.Mary.Value (
@@ -169,7 +169,7 @@ txbodySimpleEx1 =
     unboundedInterval
     mintSimpleEx1
 
-txSimpleEx1 :: ShelleyTx MaryEra
+txSimpleEx1 :: Tx MaryEra
 txSimpleEx1 =
   mkBasicTx txbodySimpleEx1
     & witsTxL .~ (mkBasicTxWits & addrTxWitsL .~ atw & scriptTxWitsL .~ stw)
@@ -218,7 +218,7 @@ txbodySimpleEx2 =
     unboundedInterval
     mempty
 
-txSimpleEx2 :: ShelleyTx MaryEra
+txSimpleEx2 :: Tx MaryEra
 txSimpleEx2 =
   mkBasicTx txbodySimpleEx2
     & witsTxL .~ (mkBasicTxWits & addrTxWitsL .~ atw)
@@ -295,7 +295,7 @@ txbodyTimeEx1 s e =
 txbodyTimeEx1Valid :: TxBody MaryEra
 txbodyTimeEx1Valid = txbodyTimeEx1 (SJust startInterval) (SJust stopInterval)
 
-txTimeEx1 :: TxBody MaryEra -> ShelleyTx MaryEra
+txTimeEx1 :: TxBody MaryEra -> Tx MaryEra
 txTimeEx1 txbody =
   mkBasicTx txbody
     & witsTxL .~ (mkBasicTxWits & addrTxWitsL .~ atw & scriptTxWitsL .~ stw)
@@ -303,19 +303,19 @@ txTimeEx1 txbody =
     atw = mkWitnessesVKey (hashAnnotated txbody) [asWitness Cast.alicePay]
     stw = Map.fromList [(policyID boundedTimePolicyId, boundedTimePolicy)]
 
-txTimeEx1Valid :: ShelleyTx MaryEra
+txTimeEx1Valid :: Tx MaryEra
 txTimeEx1Valid = txTimeEx1 txbodyTimeEx1Valid
 
-txTimeEx1InvalidLHSfixed :: ShelleyTx MaryEra
+txTimeEx1InvalidLHSfixed :: Tx MaryEra
 txTimeEx1InvalidLHSfixed = txTimeEx1 $ txbodyTimeEx1 (SJust beforeStart) (SJust stopInterval)
 
-txTimeEx1InvalidLHSopen :: ShelleyTx MaryEra
+txTimeEx1InvalidLHSopen :: Tx MaryEra
 txTimeEx1InvalidLHSopen = txTimeEx1 $ txbodyTimeEx1 SNothing (SJust stopInterval)
 
-txTimeEx1InvalidRHSfixed :: ShelleyTx MaryEra
+txTimeEx1InvalidRHSfixed :: Tx MaryEra
 txTimeEx1InvalidRHSfixed = txTimeEx1 $ txbodyTimeEx1 (SJust startInterval) (SJust afterStop)
 
-txTimeEx1InvalidRHSopen :: ShelleyTx MaryEra
+txTimeEx1InvalidRHSopen :: Tx MaryEra
 txTimeEx1InvalidRHSopen = txTimeEx1 $ txbodyTimeEx1 (SJust startInterval) SNothing
 
 expectedUTxOTimeEx1 :: UTxO MaryEra
@@ -353,15 +353,16 @@ txbodyTimeEx2 =
     unboundedInterval
     mempty
 
-txTimeEx2 :: ShelleyTx MaryEra
+txTimeEx2 :: Tx MaryEra
 txTimeEx2 =
-  ShelleyTx
-    txbodyTimeEx2
-    mempty
-      { addrWits =
-          mkWitnessesVKey (hashAnnotated txbodyTimeEx2) [asWitness Cast.alicePay]
-      }
-    SNothing
+  MkMaryTx $
+    ShelleyTx
+      txbodyTimeEx2
+      mempty
+        { addrWits =
+            mkWitnessesVKey (hashAnnotated txbodyTimeEx2) [asWitness Cast.alicePay]
+        }
+      SNothing
 
 expectedUTxOTimeEx2 :: UTxO MaryEra
 expectedUTxOTimeEx2 =
@@ -415,7 +416,7 @@ txbodySingWitEx1 =
     unboundedInterval
     mintSingWitEx1
 
-txSingWitEx1Valid :: ShelleyTx MaryEra
+txSingWitEx1Valid :: Tx MaryEra
 txSingWitEx1Valid =
   mkBasicTx txbodySingWitEx1
     & witsTxL .~ (mkBasicTxWits & addrTxWitsL .~ atw & scriptTxWitsL .~ stw)
@@ -431,7 +432,7 @@ expectedUTxOSingWitEx1 =
       , (mkTxInPartial bootstrapTxId 0, ShelleyTxOut Cast.aliceAddr (Val.inject aliceInitCoin))
       ]
 
-txSingWitEx1Invalid :: ShelleyTx MaryEra
+txSingWitEx1Invalid :: Tx MaryEra
 txSingWitEx1Invalid =
   mkBasicTx txbodySingWitEx1
     & witsTxL .~ (mkBasicTxWits & addrTxWitsL .~ atw & scriptTxWitsL .~ stw)
@@ -469,7 +470,7 @@ txbodyNegEx1 =
     unboundedInterval
     mintNegEx1
 
-txNegEx1 :: ShelleyTx MaryEra
+txNegEx1 :: Tx MaryEra
 txNegEx1 =
   mkBasicTx txbodyNegEx1
     & witsTxL .~ (mkBasicTxWits & addrTxWitsL .~ atw & scriptTxWitsL .~ stw)
@@ -559,7 +560,7 @@ txbodyWithBigValue =
     unboundedInterval
     (bigValue <> smallValue)
 
-txBigValue :: ShelleyTx MaryEra
+txBigValue :: Tx MaryEra
 txBigValue =
   mkBasicTx txbodyWithBigValue
     & witsTxL .~ (mkBasicTxWits & addrTxWitsL .~ atw & scriptTxWitsL .~ stw)

--- a/eras/shelley-ma/test-suite/test/Tests.hs
+++ b/eras/shelley-ma/test-suite/test/Tests.hs
@@ -8,7 +8,6 @@ module Main where
 import Cardano.Ledger.Allegra (AllegraEra)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Mary (MaryEra)
-import Cardano.Ledger.Shelley.Rules (ShelleyLEDGER)
 import qualified Cardano.Protocol.TPraos.Rules.Tickn as TPraos
 import Data.Proxy (Proxy (..))
 import System.Environment (lookupEnv)
@@ -17,6 +16,7 @@ import Test.Cardano.Ledger.Allegra.Translation (allegraTranslationTests)
 import Test.Cardano.Ledger.AllegraEraGen ()
 import Test.Cardano.Ledger.Mary.Examples.MultiAssets (multiAssetsExample)
 import Test.Cardano.Ledger.Mary.Golden (goldenScaledMinDeposit)
+import Test.Cardano.Ledger.Mary.ImpTest ()
 import Test.Cardano.Ledger.Mary.Translation (maryTranslationTests)
 import Test.Cardano.Ledger.Mary.Value (valTests)
 import Test.Cardano.Ledger.MaryEraGen ()
@@ -65,7 +65,7 @@ allegraTests =
           (TQC.QuickCheckMaxRatio 50)
           (ClassifyTraces.relevantCasesAreCovered @AllegraEra (maxSuccess stdArgs))
       )
-    , AdaPreservation.tests @AllegraEra @(ShelleyLEDGER AllegraEra) (maxSuccess stdArgs)
+    , AdaPreservation.tests @AllegraEra (maxSuccess stdArgs)
     , ClassifyTraces.onlyValidChainSignalsAreGenerated @AllegraEra
     , WitVKeys.tests
     , testScriptPostTranslation
@@ -87,12 +87,12 @@ nightlyTests =
     "ShelleyMA Ledger - nightly"
     [ testGroup
         "Allegra Ledger - nightly"
-        ( Shelley.commonTests @AllegraEra @(ShelleyLEDGER AllegraEra)
+        ( Shelley.commonTests @AllegraEra
             ++ [IncrementalStake.incrStakeComparisonTest (Proxy :: Proxy AllegraEra)]
         )
     , testGroup
         "Mary Ledger - nightly"
-        ( Shelley.commonTests @MaryEra @(ShelleyLEDGER MaryEra)
+        ( Shelley.commonTests @MaryEra
             ++ [IncrementalStake.incrStakeComparisonTest (Proxy :: Proxy MaryEra)]
         )
     ]

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.17.0.0
 
+* Rename `shelleyEqTxRaw` to `shelleyTxEqRaw`
 * Add `Generic` instances for `ShelleyBbodyEvent` and `ShelleyLedgersEvent`
 * Move some hard-fork triggers and export them from `Cardano.Ledger.Shelley` module:
   * `aggregateRewards` to `hardforkAllegraAggregateRewards`.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley.hs
@@ -4,6 +4,7 @@ module Cardano.Ledger.Shelley (
   ShelleyTx,
   ShelleyTxOut,
   TxBody (..),
+  Tx (..),
   ShelleyTxAuxData,
   nativeMultiSigTag,
   hardforkAllegraAggregatedRewards,
@@ -25,7 +26,7 @@ import Cardano.Ledger.Shelley.PParams ()
 import Cardano.Ledger.Shelley.Rules ()
 import Cardano.Ledger.Shelley.Scripts (nativeMultiSigTag)
 import Cardano.Ledger.Shelley.Translation ()
-import Cardano.Ledger.Shelley.Tx (ShelleyTx)
+import Cardano.Ledger.Shelley.Tx (ShelleyTx, Tx (..))
 import Cardano.Ledger.Shelley.TxAuxData (ShelleyTxAuxData)
 import Cardano.Ledger.Shelley.TxBody (TxBody (..))
 import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut)

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -72,6 +72,7 @@ import Cardano.Ledger.Shelley.Scripts (
 import Cardano.Ledger.Shelley.State
 import Cardano.Ledger.Shelley.Transition
 import Cardano.Ledger.Shelley.Translation (FromByronTranslationContext)
+import Cardano.Ledger.Shelley.Tx (Tx (..))
 import Cardano.Ledger.Shelley.TxAuxData
 import Cardano.Ledger.Shelley.TxCert (
   GenesisDelegCert (..),
@@ -707,6 +708,8 @@ instance
   Arbitrary (ShelleyTx era)
   where
   arbitrary = genTx
+
+deriving newtype instance Arbitrary (Tx ShelleyEra)
 
 instance
   ( Era era

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
@@ -319,3 +319,5 @@ instance ToExpr (ShelleySnapPredFailure era)
 instance ToExpr (ShelleyMirPredFailure era)
 
 instance ToExpr (ShelleyRupdPredFailure era)
+
+instance ToExpr (Tx ShelleyEra)

--- a/eras/shelley/test-suite/bench/Cardano/Ledger/Shelley/Bench/Gen.hs
+++ b/eras/shelley/test-suite/bench/Cardano/Ledger/Shelley/Bench/Gen.hs
@@ -16,7 +16,6 @@ import Cardano.Ledger.Shelley.API (
   Block,
   DelplEnv,
   ShelleyLEDGERS,
-  ShelleyTx,
  )
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (
@@ -108,13 +107,12 @@ genTriple ::
   , Environment (EraRule "DELPL" era) ~ DelplEnv era
   , State (EraRule "DELPL" era) ~ CertState era
   , Signal (EraRule "DELPL" era) ~ TxCert era
-  , Tx era ~ ShelleyTx era
   , ProtVerAtMost era 4
   , ProtVerAtMost era 6
   ) =>
   Proxy era ->
   Int ->
-  IO (GenEnv MockCrypto era, ChainState era, GenEnv MockCrypto era -> IO (ShelleyTx era))
+  IO (GenEnv MockCrypto era, ChainState era, GenEnv MockCrypto era -> IO (Tx era))
 genTriple proxy n = do
   let ge = genEnv proxy defaultConstants
   cs <- genChainState n ge

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/ConcreteCryptoTypes.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/ConcreteCryptoTypes.hs
@@ -7,16 +7,12 @@
 
 module Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (
   MockCrypto,
-  C,
 ) where
 
 import Cardano.Crypto.KES (MockKES)
-import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Protocol.Crypto
 import Cardano.Protocol.TPraos.API (PraosCrypto)
 import Test.Cardano.Protocol.Crypto.VRF.Fake (FakeVRF)
-
-type C = ShelleyEra
 
 data MockCrypto
 

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples.hs
@@ -6,7 +6,7 @@ module Test.Cardano.Ledger.Shelley.Examples (
 ) where
 
 import Cardano.Ledger.Block (Block)
-import Cardano.Ledger.Shelley ()
+import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.LedgerState (nesPdL)
 import Cardano.Ledger.Shelley.Scripts ()
 import Cardano.Ledger.State (individualTotalPoolStakeL, poolDistrDistrL, poolDistrTotalL)
@@ -15,7 +15,7 @@ import Control.State.Transition.Extended hiding (Assertion)
 import Data.List.NonEmpty (NonEmpty)
 import GHC.Stack
 import Lens.Micro
-import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (C, MockCrypto)
+import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (MockCrypto)
 import Test.Cardano.Ledger.Shelley.Rules.Chain (CHAIN, ChainState, chainStateNesL, totalAda)
 import Test.Cardano.Ledger.Shelley.TreeDiff (expectExprEqual)
 import Test.Cardano.Ledger.Shelley.Utils (applySTSTest, maxLLSupply, runShelleyBase)
@@ -33,9 +33,9 @@ data CHAINExample era = CHAINExample
 
 -- | Runs example, applies chain state transition system rule (STS),
 --   and checks that trace ends with expected state or expected error.
-testCHAINExample :: HasCallStack => CHAINExample C -> Assertion
+testCHAINExample :: HasCallStack => CHAINExample ShelleyEra -> Assertion
 testCHAINExample (CHAINExample initSt block (Right expectedSt)) = do
-  ( checkTrace @(CHAIN C) runShelleyBase () $
+  ( checkTrace @(CHAIN ShelleyEra) runShelleyBase () $
       ( pure initSt .- block
           <&> chainStateNesL . nesPdL . poolDistrTotalL .~ mempty
           <&> chainStateNesL . nesPdL . poolDistrDistrL %~ (<&> individualTotalPoolStakeL .~ mempty)
@@ -47,5 +47,5 @@ testCHAINExample (CHAINExample initSt block (Right expectedSt)) = do
     )
     >> expectExprEqual (totalAda expectedSt) maxLLSupply
 testCHAINExample (CHAINExample initSt block predicateFailure@(Left _)) = do
-  let st = runShelleyBase $ applySTSTest @(CHAIN C) (TRC ((), initSt, block))
+  let st = runShelleyBase $ applySTSTest @(CHAIN ShelleyEra) (TRC ((), initSt, block))
   st @?= predicateFailure

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/GenesisDelegation.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/GenesisDelegation.hs
@@ -18,7 +18,7 @@ import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Block (Block, bheader)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Keys (GenDelegPair (..), asWitness)
-import Cardano.Ledger.Shelley (ShelleyEra, TxBody (..))
+import Cardano.Ledger.Shelley (ShelleyEra, Tx (..), TxBody (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.State
@@ -154,7 +154,7 @@ blockEx1 =
   mkBlockFakeVRF @ShelleyEra
     lastByronHeaderHash
     (coreNodeKeysBySchedule @ShelleyEra ppEx 10)
-    [txEx1]
+    [MkShelleyTx txEx1]
     (SlotNo 10)
     (BlockNo 1)
     nonce0

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Mir.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Mir.hs
@@ -19,7 +19,7 @@ import Cardano.Ledger.Block (Block, bheader)
 import Cardano.Ledger.Coin (Coin (..), toDeltaCoin)
 import Cardano.Ledger.Credential (Ptr (..), SlotNo32 (..))
 import Cardano.Ledger.Keys (asWitness)
-import Cardano.Ledger.Shelley (ShelleyEra, TxBody (..))
+import Cardano.Ledger.Shelley (ShelleyEra, Tx (..), TxBody (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (
   EpochState (..),
@@ -156,7 +156,7 @@ blockEx1' txwits pot =
   mkBlockFakeVRF
     lastByronHeaderHash
     (coreNodeKeysBySchedule @ShelleyEra ppEx 10)
-    [txEx1 txwits pot]
+    [MkShelleyTx $ txEx1 txwits pot]
     (SlotNo 10)
     (BlockNo 1)
     nonce0

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
@@ -43,7 +43,7 @@ import Cardano.Ledger.Compactible
 import Cardano.Ledger.Credential (Credential, Ptr (..), SlotNo32 (..))
 import Cardano.Ledger.Keys (asWitness, coerceKeyRole)
 import Cardano.Ledger.PoolParams (PoolParams (..))
-import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Ledger.Shelley (ShelleyEra, Tx (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (
   NewEpochState (..),
@@ -230,7 +230,7 @@ blockEx1 =
   mkBlockFakeVRF
     lastByronHeaderHash
     (coreNodeKeysBySchedule @ShelleyEra ppEx 10)
-    [txEx1]
+    [MkShelleyTx txEx1]
     (SlotNo 10)
     (BlockNo 1)
     nonce0
@@ -319,7 +319,7 @@ blockEx2 =
   mkBlockFakeVRF
     (bhHash $ bheader blockEx1)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 90)
-    [txEx2]
+    [MkShelleyTx txEx2]
     (SlotNo 90)
     (BlockNo 2)
     nonce0
@@ -460,7 +460,7 @@ blockEx4 =
   mkBlockFakeVRF
     (bhHash $ bheader blockEx3)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 190)
-    [txEx4]
+    [MkShelleyTx txEx4]
     (SlotNo 190)
     (BlockNo 4)
     epoch1Nonce
@@ -849,7 +849,7 @@ blockEx10 =
   mkBlockFakeVRF
     (bhHash $ bheader blockEx9)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 420)
-    [txEx10]
+    [MkShelleyTx txEx10]
     (SlotNo 420)
     (BlockNo 10)
     epoch4Nonce
@@ -919,7 +919,7 @@ blockEx11 =
   mkBlockFakeVRF
     (bhHash $ bheader blockEx10)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 490)
-    [txEx11]
+    [MkShelleyTx txEx11]
     (SlotNo 490)
     (BlockNo 11)
     epoch4Nonce

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolReReg.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolReReg.hs
@@ -25,7 +25,7 @@ import Cardano.Ledger.Block (Block, bheader)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Keys (asWitness)
 import Cardano.Ledger.PoolParams (PoolParams (..))
-import Cardano.Ledger.Shelley (ShelleyEra, TxBody (..))
+import Cardano.Ledger.Shelley (ShelleyEra, Tx (..), TxBody (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (PulsingRewUpdate, emptyRewardUpdate)
 import Cardano.Ledger.Shelley.Tx (ShelleyTx (..))
@@ -121,7 +121,7 @@ blockEx1 =
   mkBlockFakeVRF
     lastByronHeaderHash
     (coreNodeKeysBySchedule @ShelleyEra ppEx 10)
-    [txEx1]
+    [MkShelleyTx txEx1]
     (SlotNo 10)
     (BlockNo 1)
     nonce0
@@ -199,7 +199,7 @@ blockEx2 slot =
   mkBlockFakeVRF
     (bhHash $ bheader blockEx1)
     (coreNodeKeysBySchedule @ShelleyEra ppEx slot)
-    [txEx2]
+    [MkShelleyTx txEx2]
     (SlotNo slot)
     (BlockNo 2)
     nonce0

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Updates.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Updates.hs
@@ -24,7 +24,7 @@ import Cardano.Ledger.BaseTypes (
 import Cardano.Ledger.Block (Block, bheader)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Keys (asWitness)
-import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Ledger.Shelley (ShelleyEra, Tx (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (PulsingRewUpdate, emptyRewardUpdate)
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..), Update (..))
@@ -155,7 +155,7 @@ blockEx1 =
   mkBlockFakeVRF
     lastByronHeaderHash
     (coreNodeKeysBySchedule @ShelleyEra ppEx 10)
-    [txEx1]
+    [MkShelleyTx txEx1]
     (SlotNo 10)
     (BlockNo 1)
     nonce0
@@ -229,7 +229,7 @@ blockEx2 =
   mkBlockFakeVRF
     (bhHash $ bheader blockEx1)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 20)
-    [txEx2]
+    [MkShelleyTx txEx2]
     (SlotNo 20)
     (BlockNo 2)
     nonce0
@@ -301,7 +301,7 @@ blockEx3 =
   mkBlockFakeVRF
     (bhHash $ bheader blockEx2)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 80)
-    [txEx3]
+    [MkShelleyTx txEx3]
     (SlotNo 80)
     (BlockNo 3)
     nonce0

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
@@ -23,7 +23,7 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Keys (asWitness)
 import Cardano.Ledger.PoolParams (PoolMetadata (..), StakePoolRelay (..))
-import Cardano.Ledger.Shelley (ShelleyEra, TxBody (..))
+import Cardano.Ledger.Shelley (ShelleyEra, Tx (..), TxBody (..))
 import Cardano.Ledger.Shelley.API (
   Addr,
   Credential (..),
@@ -77,7 +77,7 @@ import Test.Cardano.Ledger.Shelley.Utils (
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, testCase, (@?=))
 
-sizeTest :: HasCallStack => BSL.ByteString -> ShelleyTx ShelleyEra -> Assertion
+sizeTest :: HasCallStack => BSL.ByteString -> Tx ShelleyEra -> Assertion
 sizeTest b16 tx = do
   Base16.encode (Plain.serialize tx) @?= b16
   (tx ^. sizeTxF) @?= toInteger (BSL.length b16 `div` 2)
@@ -165,16 +165,14 @@ txbSimpleUTxO =
     , stbMDHash = SNothing
     }
 
-txSimpleUTxO :: ShelleyTx ShelleyEra
+txSimpleUTxO :: Tx ShelleyEra
 txSimpleUTxO =
-  ShelleyTx
-    { stBody = txbSimpleUTxO
-    , stWits =
-        mempty
-          { addrWits = mkWitnessesVKey (hashAnnotated txbSimpleUTxO) [alicePay]
-          }
-    , stAuxData = SNothing
-    }
+  mkBasicTx txbSimpleUTxO
+    & witsTxL
+      .~ mempty
+        { addrWits = mkWitnessesVKey (hashAnnotated txbSimpleUTxO) [alicePay]
+        }
+    & auxDataTxL .~ SNothing
 
 txSimpleUTxOBytes16 :: BSL.ByteString
 txSimpleUTxOBytes16 =
@@ -206,21 +204,22 @@ txbMutiUTxO =
     , stbMDHash = SNothing
     }
 
-txMutiUTxO :: ShelleyTx ShelleyEra
+txMutiUTxO :: Tx ShelleyEra
 txMutiUTxO =
-  ShelleyTx
-    { stBody = txbMutiUTxO
-    , stWits =
-        mempty
-          { addrWits =
-              mkWitnessesVKey
-                (hashAnnotated txbMutiUTxO)
-                [ alicePay
-                , bobPay
-                ]
-          }
-    , stAuxData = SNothing
-    }
+  MkShelleyTx $
+    ShelleyTx
+      { stBody = txbMutiUTxO
+      , stWits =
+          mempty
+            { addrWits =
+                mkWitnessesVKey
+                  (hashAnnotated txbMutiUTxO)
+                  [ alicePay
+                  , bobPay
+                  ]
+            }
+      , stAuxData = SNothing
+      }
 
 txMutiUTxOBytes16 :: BSL.ByteString
 txMutiUTxOBytes16 =
@@ -240,16 +239,17 @@ txbRegisterStake =
     , stbMDHash = SNothing
     }
 
-txRegisterStake :: ShelleyTx ShelleyEra
+txRegisterStake :: Tx ShelleyEra
 txRegisterStake =
-  ShelleyTx
-    { stBody = txbRegisterStake
-    , stWits =
-        mempty
-          { addrWits = mkWitnessesVKey (hashAnnotated txbRegisterStake) [alicePay]
-          }
-    , stAuxData = SNothing
-    }
+  MkShelleyTx $
+    ShelleyTx
+      { stBody = txbRegisterStake
+      , stWits =
+          mempty
+            { addrWits = mkWitnessesVKey (hashAnnotated txbRegisterStake) [alicePay]
+            }
+      , stAuxData = SNothing
+      }
 
 txRegisterStakeBytes16 :: BSL.ByteString
 txRegisterStakeBytes16 =
@@ -272,19 +272,20 @@ txbDelegateStake =
     , stbMDHash = SNothing
     }
 
-txDelegateStake :: ShelleyTx ShelleyEra
+txDelegateStake :: Tx ShelleyEra
 txDelegateStake =
-  ShelleyTx
-    { stBody = txbDelegateStake
-    , stWits =
-        mempty
-          { addrWits =
-              mkWitnessesVKey
-                (hashAnnotated txbDelegateStake)
-                [asWitness alicePay, asWitness bobStake]
-          }
-    , stAuxData = SNothing
-    }
+  MkShelleyTx $
+    ShelleyTx
+      { stBody = txbDelegateStake
+      , stWits =
+          mempty
+            { addrWits =
+                mkWitnessesVKey
+                  (hashAnnotated txbDelegateStake)
+                  [asWitness alicePay, asWitness bobStake]
+            }
+      , stAuxData = SNothing
+      }
 
 txDelegateStakeBytes16 :: BSL.ByteString
 txDelegateStakeBytes16 =
@@ -304,16 +305,17 @@ txbDeregisterStake =
     , stbMDHash = SNothing
     }
 
-txDeregisterStake :: ShelleyTx ShelleyEra
+txDeregisterStake :: Tx ShelleyEra
 txDeregisterStake =
-  ShelleyTx
-    { stBody = txbDeregisterStake
-    , stWits =
-        mempty
-          { addrWits = mkWitnessesVKey (hashAnnotated txbDeregisterStake) [alicePay]
-          }
-    , stAuxData = SNothing
-    }
+  MkShelleyTx $
+    ShelleyTx
+      { stBody = txbDeregisterStake
+      , stWits =
+          mempty
+            { addrWits = mkWitnessesVKey (hashAnnotated txbDeregisterStake) [alicePay]
+            }
+      , stAuxData = SNothing
+      }
 
 txDeregisterStakeBytes16 :: BSL.ByteString
 txDeregisterStakeBytes16 =
@@ -333,16 +335,17 @@ txbRegisterPool =
     , stbMDHash = SNothing
     }
 
-txRegisterPool :: ShelleyTx ShelleyEra
+txRegisterPool :: Tx ShelleyEra
 txRegisterPool =
-  ShelleyTx
-    { stBody = txbRegisterPool
-    , stWits =
-        mempty
-          { addrWits = mkWitnessesVKey (hashAnnotated txbRegisterPool) [alicePay]
-          }
-    , stAuxData = SNothing
-    }
+  MkShelleyTx $
+    ShelleyTx
+      { stBody = txbRegisterPool
+      , stWits =
+          mempty
+            { addrWits = mkWitnessesVKey (hashAnnotated txbRegisterPool) [alicePay]
+            }
+      , stAuxData = SNothing
+      }
 
 txRegisterPoolBytes16 :: BSL.ByteString
 txRegisterPoolBytes16 =
@@ -362,16 +365,17 @@ txbRetirePool =
     , stbMDHash = SNothing
     }
 
-txRetirePool :: ShelleyTx ShelleyEra
+txRetirePool :: Tx ShelleyEra
 txRetirePool =
-  ShelleyTx
-    { stBody = txbRetirePool
-    , stWits =
-        mempty
-          { addrWits = mkWitnessesVKey (hashAnnotated txbRetirePool) [alicePay]
-          }
-    , stAuxData = SNothing
-    }
+  MkShelleyTx $
+    ShelleyTx
+      { stBody = txbRetirePool
+      , stWits =
+          mempty
+            { addrWits = mkWitnessesVKey (hashAnnotated txbRetirePool) [alicePay]
+            }
+      , stAuxData = SNothing
+      }
 
 txRetirePoolBytes16 :: BSL.ByteString
 txRetirePoolBytes16 =
@@ -395,16 +399,17 @@ txbWithMD =
     , stbMDHash = SJust $ hashTxAuxData @ShelleyEra md
     }
 
-txWithMD :: ShelleyTx ShelleyEra
+txWithMD :: Tx ShelleyEra
 txWithMD =
-  ShelleyTx
-    { stBody = txbWithMD
-    , stWits =
-        mempty
-          { addrWits = mkWitnessesVKey (hashAnnotated txbWithMD) [alicePay]
-          }
-    , stAuxData = SJust md
-    }
+  MkShelleyTx $
+    ShelleyTx
+      { stBody = txbWithMD
+      , stWits =
+          mempty
+            { addrWits = mkWitnessesVKey (hashAnnotated txbWithMD) [alicePay]
+            }
+      , stAuxData = SJust md
+      }
 
 txWithMDBytes16 :: BSL.ByteString
 txWithMDBytes16 =
@@ -435,16 +440,17 @@ txbWithMultiSig =
     , stbMDHash = SNothing
     }
 
-txWithMultiSig :: ShelleyTx ShelleyEra
+txWithMultiSig :: Tx ShelleyEra
 txWithMultiSig =
-  ShelleyTx
-    { stBody = txbWithMultiSig
-    , stWits =
-        mkBasicTxWits
-          & addrTxWitsL .~ mkWitnessesVKey (hashAnnotated txbWithMultiSig) [alicePay, bobPay]
-          & scriptTxWitsL .~ Map.singleton (hashScript @ShelleyEra msig) msig
-    , stAuxData = SNothing
-    }
+  MkShelleyTx $
+    ShelleyTx
+      { stBody = txbWithMultiSig
+      , stWits =
+          mkBasicTxWits
+            & addrTxWitsL .~ mkWitnessesVKey (hashAnnotated txbWithMultiSig) [alicePay, bobPay]
+            & scriptTxWitsL .~ Map.singleton (hashScript @ShelleyEra msig) msig
+      , stAuxData = SNothing
+      }
 
 txWithMultiSigBytes16 :: BSL.ByteString
 txWithMultiSigBytes16 =
@@ -465,19 +471,20 @@ txbWithWithdrawal =
     , stbMDHash = SNothing
     }
 
-txWithWithdrawal :: ShelleyTx ShelleyEra
+txWithWithdrawal :: Tx ShelleyEra
 txWithWithdrawal =
-  ShelleyTx
-    { stBody = txbWithWithdrawal
-    , stWits =
-        mempty
-          { addrWits =
-              mkWitnessesVKey
-                (hashAnnotated txbWithWithdrawal)
-                [asWitness alicePay, asWitness aliceStake]
-          }
-    , stAuxData = SNothing
-    }
+  MkShelleyTx $
+    ShelleyTx
+      { stBody = txbWithWithdrawal
+      , stWits =
+          mempty
+            { addrWits =
+                mkWitnessesVKey
+                  (hashAnnotated txbWithWithdrawal)
+                  [asWitness alicePay, asWitness aliceStake]
+            }
+      , stAuxData = SNothing
+      }
 
 txWithWithdrawalBytes16 :: BSL.ByteString
 txWithWithdrawalBytes16 =
@@ -501,11 +508,9 @@ testEstimateMinFee =
         & ppMinFeeBL .~ Coin 1
 
     txSimpleUTxONoWit =
-      ShelleyTx
-        { stBody = txbSimpleUTxO
-        , stWits = mempty
-        , stAuxData = SNothing
-        }
+      mkBasicTx txbSimpleUTxO
+        & witsTxL .~ mempty
+        & auxDataTxL .~ SNothing
 
 -- NOTE the txsize function takes into account which actual crypto parameter is in use.
 -- These tests are using Blake2b and Ed25519 so that:

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/MultiSigExamples.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/MultiSigExamples.hs
@@ -48,7 +48,6 @@ import Cardano.Ledger.Shelley.Scripts (
   pattern RequireSignature,
  )
 import Cardano.Ledger.Shelley.State
-import Cardano.Ledger.Shelley.Tx (ShelleyTx (..))
 import Cardano.Ledger.Shelley.TxAuxData (ShelleyTxAuxData)
 import Cardano.Ledger.Shelley.TxBody (TxBody (ShelleyTxBody))
 import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits (..))
@@ -157,8 +156,11 @@ makeTx ::
   [KeyPair 'Witness] ->
   Map ScriptHash (MultiSig ShelleyEra) ->
   Maybe (ShelleyTxAuxData ShelleyEra) ->
-  ShelleyTx ShelleyEra
-makeTx txBody keyPairs msigs = ShelleyTx txBody txWits . maybeToStrictMaybe
+  Tx ShelleyEra
+makeTx txBody keyPairs msigs auxData =
+  mkBasicTx txBody
+    & witsTxL .~ txWits
+    & auxDataTxL .~ maybeToStrictMaybe auxData
   where
     txWits :: ShelleyTxWits ShelleyEra
     txWits =

--- a/eras/shelley/test-suite/test/Tests.hs
+++ b/eras/shelley/test-suite/test/Tests.hs
@@ -2,11 +2,9 @@
 
 import Cardano.Crypto.Libsodium (sodiumInit)
 import Cardano.Ledger.Shelley (ShelleyEra)
-import Cardano.Ledger.Shelley.Rules (ShelleyLEDGER)
 import Data.Proxy (Proxy (..))
 import System.Environment (lookupEnv)
 import System.IO (hSetEncoding, stdout, utf8)
-import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (C)
 import Test.Cardano.Ledger.Shelley.PropertyTests (commonTests)
 import qualified Test.Cardano.Ledger.Shelley.Rewards as Rewards (tests)
 import qualified Test.Cardano.Ledger.Shelley.Rules.AdaPreservation as AdaPreservation
@@ -42,13 +40,12 @@ defaultTests :: TestTree
 defaultTests =
   testGroup
     "Shelley tests"
-    [ Deposits.tests @C
-    , ( localOption
-          (QuickCheckMaxRatio 50)
-          (ClassifyTraces.relevantCasesAreCovered @C (maxSuccess stdArgs))
-      )
-    , AdaPreservation.tests @C @(ShelleyLEDGER C) (maxSuccess stdArgs)
-    , ClassifyTraces.onlyValidChainSignalsAreGenerated @C
+    [ Deposits.tests @ShelleyEra
+    , localOption
+        (QuickCheckMaxRatio 50)
+        (ClassifyTraces.relevantCasesAreCovered @ShelleyEra (maxSuccess stdArgs))
+    , AdaPreservation.tests @ShelleyEra (maxSuccess stdArgs)
+    , ClassifyTraces.onlyValidChainSignalsAreGenerated @ShelleyEra
     , WitVKeys.tests
     , Rewards.tests
     , Serialisation.tests
@@ -64,4 +61,4 @@ nightlyTests =
     "Shelley tests - nightly"
     $ Serialisation.tests
       : IncrementalStake.incrStakeComparisonTest (Proxy :: Proxy ShelleyEra)
-      : commonTests @C @(ShelleyLEDGER C)
+      : commonTests @ShelleyEra

--- a/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Examples/Consensus/Allegra.hs
+++ b/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Examples/Consensus/Allegra.hs
@@ -34,7 +34,6 @@ ledgerExamplesAllegra :: ShelleyLedgerExamples AllegraEra
 ledgerExamplesAllegra =
   defaultShelleyLedgerExamples
     (mkWitnessesPreAlonzo (Proxy @AllegraEra))
-    id
     exampleCoin
     (exampleAllegraTxBody exampleCoin)
     exampleAllegraTxAuxData

--- a/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Examples/Consensus/Alonzo.hs
+++ b/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Examples/Consensus/Alonzo.hs
@@ -14,7 +14,7 @@ module Test.Cardano.Ledger.Api.Examples.Consensus.Alonzo (
   exampleAlonzoGenesis,
 ) where
 
-import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Alonzo (AlonzoEra, Tx (..))
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
 import Cardano.Ledger.Alonzo.Scripts (
@@ -166,8 +166,8 @@ exampleTx =
           [alwaysFails @'PlutusV1 2, TimelockScript $ RequireAllOf mempty] -- Scripts
     )
 
-exampleTransactionInBlock :: AlonzoTx AlonzoEra
-exampleTransactionInBlock = AlonzoTx b w (IsValid True) a
+exampleTransactionInBlock :: Tx AlonzoEra
+exampleTransactionInBlock = MkAlonzoTx $ AlonzoTx b w (IsValid True) a
   where
     ShelleyTx b w a = exampleTx
 

--- a/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Examples/Consensus/Babbage.hs
+++ b/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Examples/Consensus/Babbage.hs
@@ -18,7 +18,7 @@ import Cardano.Ledger.Alonzo.Translation ()
 import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), IsValid (..))
 import Cardano.Ledger.Alonzo.TxAuxData (mkAlonzoTxAuxData)
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), Redeemers (..), TxDats (..))
-import Cardano.Ledger.Babbage (BabbageEra)
+import Cardano.Ledger.Babbage (BabbageEra, Tx (..))
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Translation ()
 import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..), TxBody (..))
@@ -178,8 +178,8 @@ exampleTx =
           [alwaysFails @'PlutusV1 2, TimelockScript $ RequireAllOf mempty] -- Scripts
     )
 
-exampleTransactionInBlock :: AlonzoTx BabbageEra
-exampleTransactionInBlock = AlonzoTx b w (IsValid True) a
+exampleTransactionInBlock :: Tx BabbageEra
+exampleTransactionInBlock = MkBabbageTx $ AlonzoTx b w (IsValid True) a
   where
     ShelleyTx b w a = exampleTx
 

--- a/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Examples/Consensus/Conway.hs
+++ b/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Examples/Consensus/Conway.hs
@@ -27,7 +27,7 @@ import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (mkSized)
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway (ConwayEra, Tx (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
 import Cardano.Ledger.Conway.Governance (VotingProcedures (..))
@@ -195,8 +195,8 @@ exampleTx =
           [alwaysFails @'PlutusV1 2, TimelockScript $ RequireAllOf mempty] -- Scripts
     )
 
-exampleTransactionInBlock :: AlonzoTx ConwayEra
-exampleTransactionInBlock = AlonzoTx b w (IsValid True) a
+exampleTransactionInBlock :: Tx ConwayEra
+exampleTransactionInBlock = MkConwayTx $ AlonzoTx b w (IsValid True) a
   where
     ShelleyTx b w a = exampleTx
 

--- a/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Examples/Consensus/Dijkstra.hs
+++ b/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Examples/Consensus/Dijkstra.hs
@@ -37,6 +37,7 @@ import Cardano.Ledger.Conway.TxWits (AlonzoTxWits (..))
 import Cardano.Ledger.Credential (Credential (KeyHashObj, ScriptHashObj))
 import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Genesis (DijkstraGenesis (..))
+import Cardano.Ledger.Dijkstra.Tx (Tx (..))
 import Cardano.Ledger.Dijkstra.TxBody (TxBody (..))
 import Cardano.Ledger.Keys (asWitness)
 import Cardano.Ledger.Mary.Value (MaryValue (..))
@@ -79,9 +80,9 @@ ledgerExamplesDijkstra ::
   SLE.ShelleyLedgerExamples DijkstraEra
 ledgerExamplesDijkstra =
   SLE.ShelleyLedgerExamples
-    { SLE.sleBlock = SLE.exampleShelleyLedgerBlock exampleTransactionInBlock
+    { SLE.sleBlock = SLE.exampleShelleyLedgerBlock $ MkDijkstraTx exampleTransactionInBlock
     , SLE.sleHashHeader = SLE.exampleHashHeader
-    , SLE.sleTx = exampleTransactionInBlock
+    , SLE.sleTx = MkDijkstraTx exampleTransactionInBlock
     , SLE.sleApplyTxError =
         ApplyTxError $
           pure $

--- a/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Examples/Consensus/Mary.hs
+++ b/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Examples/Consensus/Mary.hs
@@ -26,9 +26,8 @@ ledgerExamplesMary :: ShelleyLedgerExamples MaryEra
 ledgerExamplesMary =
   defaultShelleyLedgerExamples
     (mkWitnessesPreAlonzo (Proxy @MaryEra))
-    id
     (exampleMultiAssetValue 1)
-    ((exampleAllegraTxBody (exampleMultiAssetValue 1)) & mintTxBodyL .~ exampleMultiAsset 1)
+    (exampleAllegraTxBody (exampleMultiAssetValue 1) & mintTxBodyL .~ exampleMultiAsset 1)
     exampleAllegraTxAuxData
     NoGenesis
 

--- a/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Upgrade.hs
+++ b/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Upgrade.hs
@@ -208,6 +208,7 @@ specTxUpgrade ::
   , HasCallStack
   , ToExpr (Tx era)
   , DecCBOR (Tx era)
+  , EqRaw (Tx era)
   ) =>
   Spec
 specTxUpgrade = do
@@ -259,6 +260,7 @@ spec ::
   , DecCBOR (TxWits era)
   , DecCBOR (TxBody era)
   , DecCBOR (Tx era)
+  , EqRaw (Tx era)
   ) =>
   BinaryUpgradeOpts ->
   Spec

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
@@ -20,7 +20,7 @@ import Cardano.Ledger.Binary.Coders (Encode (..), encode, (!>))
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Core (
   EraPParams (..),
-  EraTx,
+  EraTx (..),
   EraTxAuxData (..),
   EraTxBody (..),
   EraTxOut (..),
@@ -92,6 +92,7 @@ instance
 
 instance
   ( EraTx era
+  , ToExpr (Tx era)
   , ToExpr (TxOut era)
   , ToExpr (TxBody era)
   , ToExpr (TxWits era)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -43,7 +43,7 @@ import Cardano.Ledger.Allegra.Scripts (
 import Cardano.Ledger.Alonzo (AlonzoTxAuxData, MaryValue)
 import Cardano.Ledger.Alonzo.PParams (OrdExUnits (OrdExUnits))
 import Cardano.Ledger.Alonzo.Scripts (AlonzoPlutusPurpose (..))
-import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), IsValid (..))
+import Cardano.Ledger.Alonzo.Tx (IsValid (..))
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), Redeemers (..), TxDats (..))
 import Cardano.Ledger.Babbage.TxOut (BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes
@@ -122,7 +122,6 @@ import Test.Cardano.Ledger.Conformance (
   askCtx,
   hashToInteger,
   showOpaqueErrorString,
-  withCtx,
  )
 import Test.Cardano.Ledger.Constrained.Conway (DepositPurpose (..))
 import Test.Cardano.Ledger.Constrained.Conway.Epoch
@@ -654,31 +653,6 @@ instance SpecTranslate ctx IsValid where
   type SpecRep IsValid = Bool
 
   toSpecRep (IsValid b) = pure b
-
-instance
-  ( SpecTranslate ctx (TxWits era)
-  , SpecTranslate ctx (TxAuxData era)
-  , SpecTranslate ConwayTxBodyTransContext (TxBody era)
-  , SpecRep (TxWits era) ~ Agda.TxWitnesses
-  , SpecRep (TxAuxData era) ~ Agda.AuxiliaryData
-  , SpecRep (TxBody era) ~ Agda.TxBody
-  , Tx era ~ AlonzoTx era
-  , EraTx era
-  , BabbageEraTxBody era
-  , AlonzoEraTx era
-  ) =>
-  SpecTranslate ctx (AlonzoTx era)
-  where
-  type SpecRep (AlonzoTx era) = Agda.Tx
-
-  toSpecRep tx =
-    Agda.MkTx
-      <$> withCtx
-        (ConwayTxBodyTransContext (tx ^. sizeTxF) (txIdTx tx))
-        (toSpecRep (tx ^. bodyTxL))
-      <*> toSpecRep (tx ^. witsTxL)
-      <*> toSpecRep (tx ^. isValidTxL)
-      <*> toSpecRep (tx ^. auxDataTxL)
 
 instance
   ( EraPParams era

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/ExecSpecRule/MiniTrace.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/ExecSpecRule/MiniTrace.hs
@@ -12,7 +12,7 @@
 
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.MiniTrace where
 
-import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..))
+import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx (..), AlonzoTx (..))
 import Cardano.Ledger.BaseTypes (Inject (..))
 import Cardano.Ledger.Conway (Conway, ConwayEra)
 import Cardano.Ledger.Conway.Governance (
@@ -27,9 +27,9 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.OSet.Strict as OSet
 import Data.Proxy
+import Lens.Micro.Extras (view)
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Conformance
--- \| This is where most of the ExecSpecRule instances are defined
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway (
   nameCerts,
   nameDelegCert,
@@ -143,8 +143,8 @@ nameRatify (RatifySignal xs) = show (length xs) ++ " GovActionStates"
 nameGovSignal :: GovSignal Proof.ConwayEra -> String
 nameGovSignal (GovSignal (VotingProcedures m) os cs) = show (Map.size m) ++ " " ++ show (OSet.size os) ++ " " ++ show (length cs)
 
-nameAlonzoTx :: AlonzoTx era -> String
-nameAlonzoTx (AlonzoTx _body _wits isV _auxdata) = show isV
+nameAlonzoTx :: AlonzoEraTx era => Tx era -> String
+nameAlonzoTx = show . view isValidTxL
 
 -- | Run a minitrace for every instance of ExecRuleSpec
 spec :: Spec

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
@@ -13,7 +13,6 @@
 
 module Test.Cardano.Ledger.Conformance.Imp (spec) where
 
-import Cardano.Ledger.Alonzo.Tx (AlonzoTx)
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Governance
@@ -52,7 +51,7 @@ testImpConformance ::
   ( ConwayEraImp era
   , ExecSpecRule "LEDGER" era
   , ExecContext "LEDGER" era ~ ConwayLedgerExecContext era
-  , ExecSignal "LEDGER" era ~ AlonzoTx era
+  , ExecSignal "LEDGER" era ~ Tx era
   , ExecState "LEDGER" era ~ LedgerState era
   , SpecTranslate (ExecContext "LEDGER" era) (ExecState "LEDGER" era)
   , SpecTranslate (ExecContext "LEDGER" era) (ExecEnvironment "LEDGER" era)
@@ -61,9 +60,10 @@ testImpConformance ::
   , SpecRep (TxWits era) ~ Agda.TxWitnesses
   , SpecRep (TxBody era) ~ Agda.TxBody
   , ExecEnvironment "LEDGER" era ~ LedgerEnv era
-  , Tx era ~ AlonzoTx era
   , SpecTranslate ConwayTxBodyTransContext (TxBody era)
   , ToExpr (SpecRep (PredicateFailure (EraRule "LEDGER" era)))
+  , SpecTranslate (ConwayLedgerExecContext era) (Tx era)
+  , ToExpr (SpecRep (Tx era))
   ) =>
   Globals ->
   Either

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -142,11 +142,10 @@ class
   , ToCBOR (Tx era)
   , Show (Tx era)
   , Eq (Tx era)
-  , EqRaw (Tx era)
   ) =>
   EraTx era
   where
-  type Tx era = (r :: Type) | r -> era
+  data Tx era
 
   mkBasicTx :: TxBody era -> Tx era
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
@@ -81,7 +82,7 @@ import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..), Sized (..))
 import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Compactible
-import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway (ConwayEra, Tx (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Conway.PParams
@@ -1533,6 +1534,13 @@ instance
   , IsNormalType (TxAuxData era)
   ) =>
   HasSpec (ShelleyTx era)
+
+instance HasSimpleRep (Tx ConwayEra) where
+  type TheSop (Tx ConwayEra) = TheSop (AlonzoTx ConwayEra)
+  toSimpleRep = toSimpleRep . unConwayTx
+  fromSimpleRep = MkConwayTx . fromSimpleRep
+
+instance HasSpec (Tx ConwayEra)
 
 instance (EraTx era, EraTxOut era, EraSpecPParams era) => HasSimpleRep (ShelleyTx era) where
   type TheSop (ShelleyTx era) = '["ShelleyTx" ::: ShelleyTxTypes era]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
@@ -26,13 +26,12 @@ import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Core (
   Era (..),
   EraPParams (..),
-  EraTx,
+  EraTx (..),
   EraTxAuxData (..),
   EraTxWits (..),
  )
 import Cardano.Ledger.Conway.Governance (GovActionId, Proposals, gasDeposit, pPropsL)
 import Cardano.Ledger.Conway.State
-import Cardano.Ledger.Conway.Tx (AlonzoTx)
 import Cardano.Ledger.Shelley.API.Types
 import Cardano.Ledger.Shelley.Rules (Identity, epochFromSlot, utxoEnvCertStateL)
 import Cardano.Ledger.UMap (depositMap)
@@ -139,7 +138,7 @@ utxoStateSpec UtxoExecContext {uecUTxO} UtxoEnv {ueSlot, ueCertState} =
     curEpoch = runReader (epochFromSlot ueSlot) testGlobals
 
 data UtxoExecContext era = UtxoExecContext
-  { uecTx :: !(AlonzoTx era)
+  { uecTx :: !(Tx era)
   , uecUTxO :: !(UTxO era)
   , uecUtxoEnv :: !(UtxoEnv era)
   }
@@ -162,6 +161,7 @@ instance
   , ToExpr (PParamsHKD Identity era)
   , EraCertState era
   , ToExpr (CertState era)
+  , ToExpr (Tx era)
   ) =>
   ToExpr (UtxoExecContext era)
 
@@ -171,6 +171,7 @@ instance
   , EncCBOR (TxBody era)
   , EncCBOR (TxAuxData era)
   , EncCBOR (TxWits era)
+  , EncCBOR (Tx era)
   , EraCertState era
   ) =>
   EncCBOR (UtxoExecContext era)
@@ -187,9 +188,9 @@ instance CertState era ~ ConwayCertState era => Inject (UtxoExecContext era) (Co
   inject ctx = (uecUtxoEnv ctx) ^. utxoEnvCertStateL
 
 utxoTxSpec ::
-  HasSpec (AlonzoTx era) =>
+  HasSpec (Tx era) =>
   UtxoExecContext era ->
-  Specification (AlonzoTx era)
+  Specification (Tx era)
 utxoTxSpec UtxoExecContext {uecTx} =
   constrained $ \tx -> tx ==. lit uecTx
 


### PR DESCRIPTION
# Description

This PR changes `Tx` from an associated type to an associated data type.

close #5000

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
