### PR TITLE
Untaint era definitions, while preserving the safety warning.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -66,11 +66,6 @@ packages:
 program-options
   ghc-options: -Werror
 
-if (impl(ghc >=9.8))
-  program-options
-    ghc-options:
-      -Wwarn=x-unsafe-internal
-
 package plutus-preprocessor
   haddock-options: "--optghc=-fplugin-opt PlutusTx.Plugin:defer-errors"
 

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Era.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Era.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -5,6 +6,9 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+#if __GLASGOW_HASKELL__ >= 908
+{-# OPTIONS_GHC -Wno-x-unsafe-ledger-internal #-}
+#endif
 
 module Cardano.Ledger.Allegra.Era (
   AllegraEra,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Era.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Era.hs
@@ -1,6 +1,10 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+#if __GLASGOW_HASKELL__ >= 908
+{-# OPTIONS_GHC -Wno-x-unsafe-ledger-internal #-}
+#endif
 
 module Cardano.Ledger.Alonzo.Era (
   AlonzoEra,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Era.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Era.hs
@@ -1,6 +1,10 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+#if __GLASGOW_HASKELL__ >= 908
+{-# OPTIONS_GHC -Wno-x-unsafe-ledger-internal #-}
+#endif
 
 module Cardano.Ledger.Babbage.Era (
   BabbageEra,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
@@ -1,6 +1,10 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+#if __GLASGOW_HASKELL__ >= 908
+{-# OPTIONS_GHC -Wno-x-unsafe-ledger-internal #-}
+#endif
 
 module Cardano.Ledger.Conway.Era (
   ConwayEra,

--- a/eras/dijkstra/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/cardano-ledger-dijkstra.cabal
@@ -78,7 +78,7 @@ library
     cardano-ledger-babbage,
     cardano-ledger-binary,
     cardano-ledger-conway,
-    cardano-ledger-core,
+    cardano-ledger-core:{cardano-ledger-core, internal},
     cardano-ledger-mary,
     cardano-ledger-shelley,
     cardano-strict-containers,

--- a/eras/dijkstra/src/Cardano/Ledger/Dijkstra/Era.hs
+++ b/eras/dijkstra/src/Cardano/Ledger/Dijkstra/Era.hs
@@ -1,5 +1,10 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+#if __GLASGOW_HASKELL__ >= 908
+{-# OPTIONS_GHC -Wno-x-unsafe-ledger-internal #-}
+#endif
 
 module Cardano.Ledger.Dijkstra.Era (
   DijkstraEra,
@@ -15,11 +20,10 @@ import Cardano.Ledger.Conway.Core (
   VoidEraRule,
  )
 import Cardano.Ledger.Conway.Rules
+import Cardano.Ledger.Internal.Era (DijkstraEra)
 import Cardano.Ledger.Mary (MaryValue)
 import qualified Cardano.Ledger.Shelley.API as API
 import Cardano.Ledger.Shelley.Rules
-
-data DijkstraEra
 
 instance Era DijkstraEra where
   type PreviousEra DijkstraEra = ConwayEra

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Era.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Era.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -5,6 +6,9 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+#if __GLASGOW_HASKELL__ >= 908
+{-# OPTIONS_GHC -Wno-x-unsafe-ledger-internal #-}
+#endif
 
 module Cardano.Ledger.Mary.Era (MaryEra) where
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Era.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Era.hs
@@ -1,6 +1,10 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+#if __GLASGOW_HASKELL__ >= 908
+{-# OPTIONS_GHC -Wno-x-unsafe-ledger-internal #-}
+#endif
 
 module Cardano.Ledger.Shelley.Era (
   ShelleyEra,

--- a/flake.nix
+++ b/flake.nix
@@ -148,20 +148,14 @@
           # package customizations as needed. Where cabal.project is not
           # specific enough, or doesn't allow setting these.
           modules = [
-            ({pkgs, ...}: let
-              ghcVersion = pkgs.haskell-nix.compiler."${config.compiler-nix-name}".version;
-            in {
+            ({pkgs, ...}: {
               # packages.plutus-core.components.library.ghcOptions = [ "-fexternal-interpreter" ];
               # uncomment if necessary when profiling
               packages.byron-spec-chain.configureFlags = ["--ghc-option=-Werror"];
               packages.byron-spec-ledger.configureFlags = ["--ghc-option=-Werror"];
               packages.non-integral.configureFlags = ["--ghc-option=-Werror"];
-              packages.cardano-ledger-shelley.configureFlags = if (builtins.compareVersions ghcVersion "9.8.0") >= 0
-                                                               then ["--ghc-options='-Werror -Wwarn=x-unsafe-internal'"]
-                                                               else ["--ghc-option=-Werror"];
-              packages.cardano-ledger-shelley-ma-test.configureFlags = if (builtins.compareVersions ghcVersion "9.8.0") >= 0
-                                                               then ["--ghc-options='-Werror -Wwarn=x-unsafe-internal'"]
-                                                               else ["--ghc-option=-Werror"];
+              packages.cardano-ledger-shelley.configureFlags = ["--ghc-option=-Werror"];
+              packages.cardano-ledger-shelley-ma-test.configureFlags = ["--ghc-option=-Werror"];
               packages.small-steps.configureFlags = ["--ghc-option=-Werror"];
               packages.cardano-ledger-byron = {
                 configureFlags = ["--ghc-option=-Werror"];

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx.hs
@@ -9,7 +9,7 @@
 --
 -- Let's start by defining the GHC extensions and imports.
 --
--- >>> :set -XScopedTypeVariables -Wno-unrecognised-warning-flags -Wno-x-unsafe-internal
+-- >>> :set -XScopedTypeVariables
 -- >>> import Test.QuickCheck
 -- >>> import qualified Data.Sequence.Strict as StrictSeq
 -- >>> import Cardano.Ledger.Api.Era (BabbageEra)

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Out.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Out.hs
@@ -11,7 +11,7 @@
 --
 -- Let's start by defining the GHC extensions and imports.
 --
--- >>> :set -XTypeApplications -Wno-unrecognised-warning-flags -Wno-x-unsafe-internal
+-- >>> :set -XTypeApplications
 -- >>> import Cardano.Ledger.Api.Era (BabbageEra)
 -- >>> import Lens.Micro
 -- >>> import Test.Cardano.Ledger.Babbage.Serialisation.Generators () -- Needed for doctests only

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -149,6 +149,9 @@ library internal
   exposed-modules:
     Cardano.Ledger.Internal.Era
 
+  other-modules:
+    Cardano.Ledger.Internal.Definition.Era
+
   visibility: public
   hs-source-dirs: internal
   default-language: Haskell2010

--- a/libs/cardano-ledger-core/internal/Cardano/Ledger/Internal/Definition/Era.hs
+++ b/libs/cardano-ledger-core/internal/Cardano/Ledger/Internal/Definition/Era.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Cardano.Ledger.Internal.Definition.Era (
+  ShelleyEra,
+  AllegraEra,
+  MaryEra,
+  AlonzoEra,
+  BabbageEra,
+  ConwayEra,
+  DijkstraEra,
+) where
+
+data ShelleyEra
+
+data AllegraEra
+
+data MaryEra
+
+data AlonzoEra
+
+data BabbageEra
+
+data ConwayEra
+
+data DijkstraEra

--- a/libs/cardano-ledger-core/internal/Cardano/Ledger/Internal/Era.hs
+++ b/libs/cardano-ledger-core/internal/Cardano/Ledger/Internal/Era.hs
@@ -5,39 +5,21 @@
 -- WARNING! This module contains types that are meant for internal use only.
 -- Even when used internally, care must be taken that these types are NOT used
 -- prior to their eras.
-module Cardano.Ledger.Internal.Era where
-
-data ShelleyEra
 #if __GLASGOW_HASKELL__ >= 908
-{-# WARNING in "x-unsafe-internal" ShelleyEra ["!! FOR INTERNAL (`cardano-ledger`) USE ONLY !!", "This is not meant to be used prior to Shelley era."] #-}
+module Cardano.Ledger.Internal.Era
+{-# WARNING in "x-unsafe-ledger-internal"
+  [ "For Ledger internal use only!"
+  , "Downstream users must import these era types from"
+  , "`cardano-ledger-[era]:lib:Cardano.Ledger.[Era]` modules!"] #-} (
+  module Cardano.Ledger.Internal.Definition.Era,
+) where
+#else
+module Cardano.Ledger.Internal.Era (
+  module Cardano.Ledger.Internal.Definition.Era,
+) where
 #endif
 
-data AllegraEra
-#if __GLASGOW_HASKELL__ >= 908
-{-# WARNING in "x-unsafe-internal" AllegraEra ["!! FOR INTERNAL (`cardano-ledger`) USE ONLY !!", "This is not meant to be used prior to Allegra era."] #-}
-#endif
-
-data MaryEra
-#if __GLASGOW_HASKELL__ >= 908
-{-# WARNING in "x-unsafe-internal" MaryEra ["!! FOR INTERNAL (`cardano-ledger`) USE ONLY !!", "This is not meant to be used prior to Mary era."] #-}
-#endif
-
-data AlonzoEra
-#if __GLASGOW_HASKELL__ >= 908
-{-# WARNING in "x-unsafe-internal" AlonzoEra ["!! FOR INTERNAL (`cardano-ledger`) USE ONLY !!", "This is not meant to be used prior to Alonzo era."] #-}
-#endif
-
-data BabbageEra
-#if __GLASGOW_HASKELL__ >= 908
-{-# WARNING in "x-unsafe-internal" BabbageEra ["!! FOR INTERNAL (`cardano-ledger`) USE ONLY !!", "This is not meant to be used prior to Babbage era."] #-}
-#endif
-
-data ConwayEra
-#if __GLASGOW_HASKELL__ >= 908
-{-# WARNING in "x-unsafe-internal" ConwayEra ["!! FOR INTERNAL (`cardano-ledger`) USE ONLY !!", "This is not meant to be used prior to Conway era."] #-}
-#endif
-
-data DijkstraEra
-#if __GLASGOW_HASKELL__ >= 908
-{-# WARNING in "x-unsafe-internal" DijkstraEra ["!! FOR INTERNAL (`cardano-ledger`) USE ONLY !!", "This is not meant to be used prior to Dijkstra era."] #-}
-#endif
+-- The Era types are defined in a separate private module, just so they do not get tainted by the
+-- WARNING pragma. With a re-export approach only this module is marked with the warning, but not
+-- the types that are being exported.
+import Cardano.Ledger.Internal.Definition.Era


### PR DESCRIPTION
# Description

#5089 introduced a problem that this PR fixes. Marking individual types with a warning is definitely not what we want to do, because it will affect all of the downstream users and will result in a warning until they manually disable it.

We need to mark the module with the warning, instead of the types, because types are safe to use, unless they are imported from the internal module.

In order for this to work, we need to define the types in a hidden module first and then re-export them from an internal module that is marked with a custom warning.

Also custom warning was changed from `x-unsafe-internal` to `x-unsafe-ledger-internal`, since this warning is specific to Ledger and we do not want to accidentally conflict with some other custom warning in another library that uses the same name

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
