### PR TITLE
Introduce `KeyValuePairs` for easier `ToJSON` deriving

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.14.0.0
 
+* Deprecated `toAlonzoGenesisPairs`
 * Removed `MissingRequiredSigners` from `AlonzoUtxowPredFailure`
 * Renamed fields of `AlonzoTx`
   * `body` to `atBody`

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Transition.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Transition.hs
@@ -10,8 +10,9 @@ module Cardano.Ledger.Alonzo.Transition (
 ) where
 
 import Cardano.Ledger.Alonzo.Era
-import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis, toAlonzoGenesisPairs)
+import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
 import Cardano.Ledger.Alonzo.Translation ()
+import Cardano.Ledger.BaseTypes (toKeyValuePairs)
 import Cardano.Ledger.Mary
 import Cardano.Ledger.Mary.Transition (TransitionConfig (MaryTransitionConfig))
 import Cardano.Ledger.Shelley.Transition
@@ -55,7 +56,7 @@ instance ToJSON (TransitionConfig AlonzoEra) where
 toAlonzoTransitionConfigPairs :: KeyValue e a => TransitionConfig AlonzoEra -> [a]
 toAlonzoTransitionConfigPairs alonzoConfig =
   toShelleyTransitionConfigPairs shelleyConfig
-    ++ ["alonzo" .= object (toAlonzoGenesisPairs (alonzoConfig ^. tcTranslationContextL))]
+    ++ ["alonzo" .= object (toKeyValuePairs (alonzoConfig ^. tcTranslationContextL))]
   where
     maryConfig = alonzoConfig ^. tcPreviousEraConfigL
     allegraConfig = maryConfig ^. tcPreviousEraConfigL

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
@@ -68,7 +68,9 @@ import Cardano.Ledger.Babbage.PParams (
  )
 import Cardano.Ledger.Babbage.Scripts ()
 import Cardano.Ledger.BaseTypes (
+  KeyValuePairs (..),
   StrictMaybe (..),
+  ToKeyValuePairs (..),
   strictMaybeToMaybe,
  )
 import Cardano.Ledger.Binary (
@@ -109,7 +111,7 @@ import Cardano.Ledger.Plutus.Data (
  )
 import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData (rnf), rwhnf)
-import Data.Aeson (KeyValue, ToJSON (..), object, pairs, (.=))
+import Data.Aeson (ToJSON (..), (.=))
 import qualified Data.ByteString.Lazy as LBS
 import Data.Maybe (fromMaybe)
 import Data.MemPack
@@ -317,27 +319,18 @@ deriving stock instance
 instance NFData (BabbageTxOut era) where
   rnf = rwhnf
 
-instance
-  (Era era, ToJSON (Datum era), ToJSON (Script era), Val (Value era)) =>
-  ToJSON (BabbageTxOut era)
-  where
-  toJSON = object . toBabbageTxOutPairs
-  toEncoding = pairs . mconcat . toBabbageTxOutPairs
+deriving via
+  KeyValuePairs (BabbageTxOut era)
+  instance
+    (Era era, Val (Value era), ToJSON (Script era)) => ToJSON (BabbageTxOut era)
 
-toBabbageTxOutPairs ::
-  ( Era era
-  , KeyValue e a
-  , Val (Value era)
-  , ToJSON (Script era)
-  ) =>
-  BabbageTxOut era ->
-  [a]
-toBabbageTxOutPairs (BabbageTxOut !addr !val !dat !mRefScript) =
-  [ "address" .= addr
-  , "value" .= val
-  , "datum" .= dat
-  , "referenceScript" .= mRefScript
-  ]
+instance (Era era, Val (Value era), ToJSON (Script era)) => ToKeyValuePairs (BabbageTxOut era) where
+  toKeyValuePairs (BabbageTxOut !addr !val !dat !mRefScript) =
+    [ "address" .= addr
+    , "value" .= val
+    , "datum" .= dat
+    , "referenceScript" .= mRefScript
+    ]
 
 viewCompactTxOut ::
   forall era.

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.20.0.0
 
+* Deprecated `toUpgradeConwayPParamsUpdatePairs` and `toConwayGenesisPairs`
 * Add:
   * `alonzoToConwayUtxosPredFailure`
   * `alonzoToConwayUtxosEvent`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -103,6 +103,7 @@ import Cardano.Ledger.BaseTypes (
   EpochInterval (..),
   NonNegativeInterval,
   ProtVer (ProtVer),
+  ToKeyValuePairs (..),
   UnitInterval,
   integralToBounded,
   strictMaybeToMaybe,
@@ -996,12 +997,15 @@ emptyConwayPParamsUpdate =
     }
 
 instance ToJSON (UpgradeConwayPParams Identity) where
-  toJSON = object . toUpgradeConwayPParamsUpdatePairs
-  toEncoding = pairs . mconcat . toUpgradeConwayPParamsUpdatePairs
+  toJSON = object . toKeyValuePairs
+  toEncoding = pairs . mconcat . toKeyValuePairs
+
+instance ToKeyValuePairs (UpgradeConwayPParams Identity) where
+  toKeyValuePairs upp = uncurry (.=) <$> upgradeConwayPParamsHKDPairs upp
 
 toUpgradeConwayPParamsUpdatePairs :: KeyValue e a => UpgradeConwayPParams Identity -> [a]
-toUpgradeConwayPParamsUpdatePairs upp =
-  uncurry (.=) <$> upgradeConwayPParamsHKDPairs upp
+toUpgradeConwayPParamsUpdatePairs = toKeyValuePairs
+{-# DEPRECATED toUpgradeConwayPParamsUpdatePairs "In favor of `toKeyValuePairs`" #-}
 
 upgradeConwayPParamsHKDPairs :: UpgradeConwayPParams Identity -> [(Key, Aeson.Value)]
 upgradeConwayPParamsHKDPairs UpgradeConwayPParams {..} =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Transition.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Transition.hs
@@ -17,8 +17,9 @@ module Cardano.Ledger.Conway.Transition (
 import Cardano.Ledger.Alonzo.Transition (toAlonzoTransitionConfigPairs)
 import Cardano.Ledger.Babbage
 import Cardano.Ledger.Babbage.Transition (TransitionConfig (BabbageTransitionConfig))
+import Cardano.Ledger.BaseTypes (toKeyValuePairs)
 import Cardano.Ledger.Conway.Era
-import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..), toConwayGenesisPairs)
+import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
 import Cardano.Ledger.Conway.Rules.Deleg (processDelegation)
 import Cardano.Ledger.Conway.State (
   ConwayEraCertState (..),
@@ -107,7 +108,7 @@ instance ToJSON (TransitionConfig ConwayEra) where
 toConwayTransitionConfigPairs :: KeyValue e a => TransitionConfig ConwayEra -> [a]
 toConwayTransitionConfigPairs conwayConfig =
   toAlonzoTransitionConfigPairs alonzoConfig
-    ++ ["conway" .= object (toConwayGenesisPairs (conwayConfig ^. tcTranslationContextL))]
+    ++ ["conway" .= object (toKeyValuePairs (conwayConfig ^. tcTranslationContextL))]
   where
     babbageConfig = conwayConfig ^. tcPreviousEraConfigL
     alonzoConfig = babbageConfig ^. tcPreviousEraConfigL

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Value.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Value.hs
@@ -41,7 +41,7 @@ module Cardano.Ledger.Mary.Value (
 ) where
 
 import qualified Cardano.Crypto.Hash.Class as Hash
-import Cardano.Ledger.BaseTypes (Inject (..))
+import Cardano.Ledger.BaseTypes (Inject (..), KeyValuePairs (..), ToKeyValuePairs (..))
 import Cardano.Ledger.Binary (
   DecCBOR (..),
   Decoder,
@@ -72,7 +72,7 @@ import Control.DeepSeq (NFData (..), deepseq, rwhnf)
 import Control.Exception (assert)
 import Control.Monad (forM_, guard, unless, when)
 import Control.Monad.ST (runST)
-import Data.Aeson (FromJSON, FromJSONKey, ToJSON (..), object, (.=))
+import Data.Aeson (FromJSON, FromJSONKey, ToJSON (..), (.=))
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (ToJSONKey (..), toJSONKeyText)
 import qualified Data.ByteString as BS
@@ -183,6 +183,7 @@ instance DecCBOR MultiAsset where
 -- | The Value representing MultiAssets
 data MaryValue = MaryValue !Coin !MultiAsset
   deriving (Show, Generic)
+  deriving (ToJSON) via KeyValuePairs MaryValue
 
 instance Eq MaryValue where
   x == y = pointwise (==) x y
@@ -373,15 +374,11 @@ decodeIntegerBounded64 = do
 -- ========================================================================
 -- JSON
 
-instance ToJSON MaryValue where
-  toJSON = object . toMaryValuePairs
-  toEncoding = Aeson.pairs . mconcat . toMaryValuePairs
-
-toMaryValuePairs :: Aeson.KeyValue e a => MaryValue -> [a]
-toMaryValuePairs (MaryValue l ps) =
-  [ "lovelace" .= l
-  , "policies" .= ps
-  ]
+instance ToKeyValuePairs MaryValue where
+  toKeyValuePairs (MaryValue l ps) =
+    [ "lovelace" .= l
+    , "policies" .= ps
+    ]
 
 instance ToJSON AssetName where
   toJSON = Aeson.String . assetNameToTextAsHex

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.17.0.0
 
+* Deprecated `toShelleyGenesisPairs`
+* Removed `toShelleyGenesisPairs`
 * Remove `ShelleyTxRaw`, `MkShelleyTx`, `segWitTx`, `unsafeConstructTxWithBytes`
 * Added `Generic` instances for:
   * `ShelleyBbodyState`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
@@ -23,7 +23,9 @@ module Cardano.Ledger.Shelley.LedgerState.Types where
 import Cardano.Ledger.BaseTypes (
   BlocksMade (..),
   EpochNo,
+  KeyValuePairs (..),
   StrictMaybe (..),
+  ToKeyValuePairs (..),
  )
 import Cardano.Ledger.Binary (
   DecCBOR (decCBOR),
@@ -53,7 +55,7 @@ import Cardano.Ledger.UMap (UMap (..))
 import Control.DeepSeq (NFData)
 import Control.Monad.State.Strict (evalStateT)
 import Control.Monad.Trans (MonadTrans (lift))
-import Data.Aeson (KeyValue, ToJSON (..), object, pairs, (.=))
+import Data.Aeson (ToJSON (..), (.=))
 import Data.Default (Default, def)
 import Data.Map.Strict (Map)
 import Data.VMap (VB, VMap, VP)
@@ -172,26 +174,26 @@ instance (EraTxOut era, EraGov era, EraStake era, EraCertState era) => ToCBOR (E
 instance (EraTxOut era, EraGov era, EraStake era, EraCertState era) => FromCBOR (EpochState era) where
   fromCBOR = fromEraCBOR @era
 
-instance (EraTxOut era, EraGov era, EraStake era, EraCertState era) => ToJSON (EpochState era) where
-  toJSON = object . toEpochStatePairs
-  toEncoding = pairs . mconcat . toEpochStatePairs
+deriving via
+  KeyValuePairs (EpochState era)
+  instance
+    (EraTxOut era, EraGov era, EraStake era, EraCertState era) => ToJSON (EpochState era)
 
-toEpochStatePairs ::
+instance
   ( EraTxOut era
   , EraGov era
   , EraStake era
-  , KeyValue e a
   , EraCertState era
   ) =>
-  EpochState era ->
-  [a]
-toEpochStatePairs es@(EpochState _ _ _ _) =
-  let EpochState {..} = es
-   in [ "esChainAccountState" .= esChainAccountState
-      , "esSnapshots" .= esSnapshots
-      , "esLState" .= esLState
-      , "esNonMyopic" .= esNonMyopic
-      ]
+  ToKeyValuePairs (EpochState era)
+  where
+  toKeyValuePairs es@(EpochState _ _ _ _) =
+    let EpochState {..} = es
+     in [ "esChainAccountState" .= esChainAccountState
+        , "esSnapshots" .= esSnapshots
+        , "esLState" .= esLState
+        , "esNonMyopic" .= esNonMyopic
+        ]
 
 -- =============================
 
@@ -295,20 +297,20 @@ instance (EraTxOut era, EraGov era, EraStake era) => ToCBOR (UTxOState era) wher
 instance (EraTxOut era, EraGov era, EraStake era) => FromCBOR (UTxOState era) where
   fromCBOR = fromEraShareCBOR @era
 
-instance (EraTxOut era, EraGov era, EraStake era) => ToJSON (UTxOState era) where
-  toJSON = object . toUTxOStatePairs
-  toEncoding = pairs . mconcat . toUTxOStatePairs
+deriving via
+  KeyValuePairs (UTxOState era)
+  instance
+    (EraTxOut era, EraGov era, EraStake era) => ToJSON (UTxOState era)
 
-toUTxOStatePairs ::
-  (EraTxOut era, EraGov era, EraStake era, KeyValue e a) => UTxOState era -> [a]
-toUTxOStatePairs utxoState@(UTxOState _ _ _ _ _ _) =
-  let UTxOState {..} = utxoState
-   in [ "utxo" .= utxosUtxo
-      , "deposited" .= utxosDeposited
-      , "fees" .= utxosFees
-      , "ppups" .= utxosGovState
-      , "stake" .= utxosInstantStake
-      ]
+instance (EraTxOut era, EraGov era, EraStake era) => ToKeyValuePairs (UTxOState era) where
+  toKeyValuePairs utxoState@(UTxOState _ _ _ _ _ _) =
+    let UTxOState {..} = utxoState
+     in [ "utxo" .= utxosUtxo
+        , "deposited" .= utxosDeposited
+        , "fees" .= utxosFees
+        , "ppups" .= utxosGovState
+        , "stake" .= utxosInstantStake
+        ]
 
 -- | New Epoch state and environment
 data NewEpochState era = NewEpochState
@@ -541,17 +543,24 @@ instance (EraTxOut era, EraGov era, EraStake era, EraCertState era) => ToCBOR (L
 instance (EraTxOut era, EraGov era, EraStake era, EraCertState era) => FromCBOR (LedgerState era) where
   fromCBOR = fromEraShareCBOR @era
 
-instance (EraTxOut era, EraGov era, EraStake era, EraCertState era) => ToJSON (LedgerState era) where
-  toJSON = object . toLedgerStatePairs
-  toEncoding = pairs . mconcat . toLedgerStatePairs
+deriving via
+  KeyValuePairs (LedgerState era)
+  instance
+    (EraTxOut era, EraGov era, EraStake era, EraCertState era) => ToJSON (LedgerState era)
 
-toLedgerStatePairs ::
-  (EraTxOut era, EraGov era, KeyValue e a, EraStake era, EraCertState era) => LedgerState era -> [a]
-toLedgerStatePairs ls@(LedgerState _ _) =
-  let LedgerState {..} = ls
-   in [ "utxoState" .= lsUTxOState
-      , "delegationState" .= lsCertState
-      ]
+instance
+  ( EraTxOut era
+  , EraGov era
+  , EraStake era
+  , EraCertState era
+  ) =>
+  ToKeyValuePairs (LedgerState era)
+  where
+  toKeyValuePairs ls@(LedgerState _ _) =
+    let LedgerState {..} = ls
+     in [ "utxoState" .= lsUTxOState
+        , "delegationState" .= lsCertState
+        ]
 
 -- ====================================================
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/RewardUpdate.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/RewardUpdate.hs
@@ -32,7 +32,12 @@ module Cardano.Ledger.Shelley.RewardUpdate (
   PulsingRewUpdate (..),
 ) where
 
-import Cardano.Ledger.BaseTypes (ProtVer (..), ShelleyBase)
+import Cardano.Ledger.BaseTypes (
+  KeyValuePairs (..),
+  ProtVer (..),
+  ShelleyBase,
+  ToKeyValuePairs (..),
+ )
 import Cardano.Ledger.Binary (
   DecCBOR (..),
   EncCBOR (..),
@@ -59,7 +64,7 @@ import Cardano.Ledger.Shelley.Rewards (
   rewardOnePoolMember,
  )
 import Control.DeepSeq (NFData (..))
-import Data.Aeson (KeyValue, ToJSON (..), Value (Null), object, pairs, (.=))
+import Data.Aeson (ToJSON (..), Value (Null), (.=))
 import Data.Default (def)
 import Data.Group (invert)
 import Data.Kind (Type)
@@ -109,6 +114,7 @@ data RewardUpdate = RewardUpdate
   , nonMyopic :: !NonMyopic
   }
   deriving (Show, Eq, Generic)
+  deriving (ToJSON) via KeyValuePairs RewardUpdate
 
 instance NoThunks RewardUpdate
 
@@ -133,19 +139,15 @@ instance DecCBOR RewardUpdate where
       nm <- decNoShareCBOR
       pure $ RewardUpdate dt (invert dr) rw (invert df) nm
 
-instance ToJSON RewardUpdate where
-  toJSON = object . toRewardUpdatePair
-  toEncoding = pairs . mconcat . toRewardUpdatePair
-
-toRewardUpdatePair :: KeyValue e a => RewardUpdate -> [a]
-toRewardUpdatePair ru@(RewardUpdate _ _ _ _ _) =
-  let RewardUpdate {..} = ru
-   in [ "deltaT" .= deltaT
-      , "deltaR" .= deltaR
-      , "rs" .= rs
-      , "deltaF" .= deltaF
-      , "nonMyopic" .= nonMyopic
-      ]
+instance ToKeyValuePairs RewardUpdate where
+  toKeyValuePairs ru@(RewardUpdate _ _ _ _ _) =
+    let RewardUpdate {..} = ru
+     in [ "deltaT" .= deltaT
+        , "deltaR" .= deltaR
+        , "rs" .= rs
+        , "deltaF" .= deltaF
+        , "nonMyopic" .= nonMyopic
+        ]
 
 emptyRewardUpdate :: RewardUpdate
 emptyRewardUpdate =

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Transition.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Transition.hs
@@ -242,7 +242,7 @@ toShelleyTransitionConfigPairs ::
   TransitionConfig ShelleyEra ->
   [a]
 toShelleyTransitionConfigPairs stc@(ShelleyTransitionConfig _) =
-  ["shelley" .= object (toShelleyGenesisPairs (stcShelleyGenesis stc))]
+  ["shelley" .= object (toKeyValuePairs (stcShelleyGenesis stc))]
 
 -- | Helper function for constructing the initial state for any era
 --

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxOut.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxOut.hs
@@ -25,6 +25,7 @@ module Cardano.Ledger.Shelley.TxOut (
 ) where
 
 import Cardano.Ledger.Address (Addr (..), CompactAddr, compactAddr, decompactAddr)
+import Cardano.Ledger.BaseTypes (KeyValuePairs (..), ToKeyValuePairs (..))
 import Cardano.Ledger.Binary (
   DecCBOR (..),
   DecShareCBOR (..),
@@ -45,7 +46,7 @@ import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.PParams ()
 import Cardano.Ledger.Val (Val)
 import Control.DeepSeq (NFData (rnf))
-import Data.Aeson (KeyValue, ToJSON (..), object, pairs, (.=))
+import Data.Aeson (ToJSON (..), (.=))
 import Data.Maybe (fromMaybe)
 import Data.MemPack
 import GHC.Stack (HasCallStack)
@@ -177,12 +178,13 @@ instance (Era era, EncCBOR (CompactForm (Value era))) => ToCBOR (ShelleyTxOut er
 instance (Era era, DecCBOR (CompactForm (Value era))) => FromCBOR (ShelleyTxOut era) where
   fromCBOR = fromEraCBOR @era
 
-instance (Era era, Val (Value era)) => ToJSON (ShelleyTxOut era) where
-  toJSON = object . toTxOutPair
-  toEncoding = pairs . mconcat . toTxOutPair
+deriving via
+  KeyValuePairs (ShelleyTxOut era)
+  instance
+    (Era era, Val (Value era)) => ToJSON (ShelleyTxOut era)
 
-toTxOutPair :: (KeyValue e a, Era era, Val (Value era)) => ShelleyTxOut era -> [a]
-toTxOutPair (ShelleyTxOut !addr !amount) =
-  [ "address" .= addr
-  , "amount" .= amount
-  ]
+instance (Era era, Val (Value era)) => ToKeyValuePairs (ShelleyTxOut era) where
+  toKeyValuePairs (ShelleyTxOut !addr !amount) =
+    [ "address" .= addr
+    , "amount" .= amount
+    ]


### PR DESCRIPTION
# Description

We use a common pattern for efficiency of ToJSON instance to first define a function that converts to `KeyValue` pairs and then uses that function for creating an instance for `ToJSON`

This process can be automated with `DerivingVia`. This PR implements this automation.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
