### PR TITLE
`doctest` in `nix develop`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -138,7 +138,19 @@
                 (python3.withPackages (ps: with ps; [sphinx sphinx_rtd_theme recommonmark sphinx-markdown-tables sphinxemoji]))
                 haskellPackages.implicit-hie
                 shellcheck
-              ];
+              ] ++
+              (let
+                doctest = haskell-nix.hackage-package {
+                  name = "doctest";
+                  version = "0.24.0";
+                  configureArgs = "-f cabal-doctest";
+                  inherit (config) compiler-nix-name;
+                };
+              in
+                [
+                  (doctest.getComponent "exe:cabal-doctest")
+                  (doctest.getComponent "exe:doctest")
+                ]);
             # disable Hoogle until someone request it
             withHoogle = false;
             # Skip cross compilers for the shell

--- a/scripts/doctest.sh
+++ b/scripts/doctest.sh
@@ -2,8 +2,32 @@
 
 set -euo pipefail
 
-# Install doctest's Cabal integration
-cabal install doctest --flag cabal-doctest --ignore-project --overwrite-policy=always
+# Packages to run doctests for; defaults to all packages if none are specified
+PACKAGES=("$@")
+
+# Install doctest's Cabal integration, if it's not present already
+if [[ -z "$(type -t cabal-doctest)" ]]
+then
+  cabal install doctest --flag cabal-doctest --ignore-project --overwrite-policy=always
+fi
+
+# Ensure doctest and PATH are using the same ghc version
+
+getExecutablePath()
+{
+  "$1" -package-env - -e 'import System.Environment' -e 'putStrLn =<< getExecutablePath'
+}
+
+default_ghc=$(type -p ghc)
+doctest_ghc=$(doctest --info | ghc -e 'interact $ maybe "" id . lookup "ghc" . read')
+
+if [[ "$(getExecutablePath "$default_ghc")" != "$(getExecutablePath "$doctest_ghc")" ]]
+then
+  echo "Incompatible GHC's:" >&2
+  echo "  Default ghc: $(getExecutablePath "$default_ghc")" >&2
+  echo "  Doctest ghc: $(getExecutablePath "$doctest_ghc")" >&2
+  exit 1
+fi
 
 # Ensure the cabal-doctest executable can be found
 PATH=$(cabal path --installdir):$PATH
@@ -21,9 +45,10 @@ cardano-ledger-api:lib:cardano-ledger-api --build-depends=cardano-ledger-babbage
 EOF
 
 # Run the doctests for some or all packages
-cabal-targets.hs "$@" |
+cabal-targets.hs "${PACKAGES[@]}" |
 sort | join -t' ' -a1 -j1 - "$EXTRA_ARGS" |
 while read -ra ARGS
 do
+  echo "***** cabal doctest ${ARGS[0]} *****"
   cabal doctest --repl-options='-w -Wdefault' "${ARGS[@]}"
 done


### PR DESCRIPTION
# Description

* Include `doctest` and `cabal-doctest` in the `nix develop` shell
* Ensure a compatible ghc version is being used for doctests 

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
