### PR TITLE
Upgrade deprecated Sphinx config option in `doc/`

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,7 +66,8 @@ html_theme = "sphinx_rtd_theme"
 
 html_theme_options = {
     'logo_only': False,
-    'display_version': False,
+    "version_selector": False,
+    "language_selector": False,
     'prev_next_buttons_location': 'bottom',
     'style_external_links': False,
     'style_nav_header_background': '#fcfcfc',


### PR DESCRIPTION
# Description

Since the update of the `nixpkgs` flake input in #5092, the `doc.site` attribute of `flake.nix` has been broken due to the use of a newer version of Sphinx that deprecated an option we're using. This updates the Sphinx config to use the correct options.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
