### PR TITLE
Fix stake comparison test

### DIFF
--- a/eras/shelley-ma/test-suite/test/Tests.hs
+++ b/eras/shelley-ma/test-suite/test/Tests.hs
@@ -10,6 +10,7 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.Shelley.Rules (ShelleyLEDGER)
 import qualified Cardano.Protocol.TPraos.Rules.Tickn as TPraos
+import Data.Proxy (Proxy (..))
 import System.Environment (lookupEnv)
 import Test.Cardano.Ledger.Allegra.ScriptTranslation (testScriptPostTranslation)
 import Test.Cardano.Ledger.Allegra.Translation (allegraTranslationTests)
@@ -25,6 +26,7 @@ import qualified Test.Cardano.Ledger.Shelley.Rules.ClassifyTraces as ClassifyTra
   onlyValidChainSignalsAreGenerated,
   relevantCasesAreCovered,
  )
+import qualified Test.Cardano.Ledger.Shelley.Rules.IncrementalStake as IncrementalStake
 import qualified Test.Cardano.Ledger.Shelley.WitVKeys as WitVKeys (tests)
 import qualified Test.Cardano.Ledger.ShelleyMA.Serialisation as Serialisation
 import Test.QuickCheck (Args (maxSuccess), stdArgs)
@@ -85,8 +87,12 @@ nightlyTests =
     "ShelleyMA Ledger - nightly"
     [ testGroup
         "Allegra Ledger - nightly"
-        (Shelley.commonTests @AllegraEra @(ShelleyLEDGER AllegraEra))
+        ( Shelley.commonTests @AllegraEra @(ShelleyLEDGER AllegraEra)
+            ++ [IncrementalStake.incrStakeComparisonTest (Proxy :: Proxy AllegraEra)]
+        )
     , testGroup
         "Mary Ledger - nightly"
-        (Shelley.commonTests @MaryEra @(ShelleyLEDGER MaryEra))
+        ( Shelley.commonTests @MaryEra @(ShelleyLEDGER MaryEra)
+            ++ [IncrementalStake.incrStakeComparisonTest (Proxy :: Proxy MaryEra)]
+        )
     ]

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/IncrementalStake.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/IncrementalStake.hs
@@ -218,7 +218,7 @@ aggregateUtxoCoinByCredential ::
   Map (Credential 'Staking) Coin ->
   Map (Credential 'Staking) Coin
 aggregateUtxoCoinByCredential ptrs (UTxO u) initial =
-  Map.foldl' accum initial u
+  Map.foldl' accum (Map.filter (/= mempty) initial) u
   where
     accum ans out =
       let c = out ^. coinTxOutL

--- a/eras/shelley/test-suite/test/Tests.hs
+++ b/eras/shelley/test-suite/test/Tests.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE TypeApplications #-}
 
 import Cardano.Crypto.Libsodium (sodiumInit)
+import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.Rules (ShelleyLEDGER)
+import Data.Proxy (Proxy (..))
 import System.Environment (lookupEnv)
 import System.IO (hSetEncoding, stdout, utf8)
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (C)
@@ -13,6 +15,7 @@ import qualified Test.Cardano.Ledger.Shelley.Rules.ClassifyTraces as ClassifyTra
   relevantCasesAreCovered,
  )
 import qualified Test.Cardano.Ledger.Shelley.Rules.Deposits as Deposits (tests)
+import qualified Test.Cardano.Ledger.Shelley.Rules.IncrementalStake as IncrementalStake
 import qualified Test.Cardano.Ledger.Shelley.RulesTests as RulesTests (
   chainExamples,
   multisigExamples,
@@ -59,4 +62,6 @@ nightlyTests :: TestTree
 nightlyTests =
   testGroup
     "Shelley tests - nightly"
-    $ Serialisation.tests : commonTests @C @(ShelleyLEDGER C)
+    $ Serialisation.tests
+      : IncrementalStake.incrStakeComparisonTest (Proxy :: Proxy ShelleyEra)
+      : commonTests @C @(ShelleyLEDGER C)


### PR DESCRIPTION
# Description

Following the stake calculation refactoring, entries with empty Coin values are no longer retained in the Stake. However, the test function used for stake comparison hadn't been updated to reflect this change.
This PR updates the test function accordingly and adds the stake comparison test to the shelley and shelley-ma nightly test suites.

Closes https://github.com/IntersectMBO/cardano-ledger/issues/5095

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
