### PR TITLE
Removed TxField

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -34,7 +34,6 @@ import Test.Cardano.Ledger.Binary.Twiddle (Twiddle, twiddleInvariantProp)
 import Test.Cardano.Ledger.Common (ToExpr (..))
 import Test.Cardano.Ledger.Conway.Arbitrary ()
 import Test.Cardano.Ledger.Generic.Fields (
-  abstractTx,
   abstractTxBody,
   abstractTxOut,
   abstractWitnesses,
@@ -64,7 +63,6 @@ import Test.Cardano.Ledger.Generic.TxGen (
   Box (..),
   applySTSByProof,
   assembleWits,
-  coreTx,
   coreTxBody,
   coreTxOut,
   genAlonzoTx,
@@ -183,10 +181,6 @@ txOutRoundTrip ::
   EraTxOut era => Proof era -> TxOut era -> Property
 txOutRoundTrip proof x = coreTxOut proof (abstractTxOut proof x) === x
 
-txRoundTrip ::
-  EraTx era => Proof era -> Tx era -> Property
-txRoundTrip proof x = coreTx proof (abstractTx proof x) === x
-
 txBodyRoundTrip ::
   EraTxBody era => Proof era -> TxBody era -> Property
 txBodyRoundTrip proof x = coreTxBody proof (abstractTxBody proof x) === x
@@ -222,14 +216,6 @@ coreTypesRoundTrip =
         , testPropMax 30 "Mary era" $ txOutRoundTrip Mary
         , testPropMax 30 "Allegra era" $ txOutRoundTrip Allegra
         , testPropMax 30 "Shelley era" $ txOutRoundTrip Shelley
-        ]
-    , testGroup
-        "Tx roundtrips"
-        [ testPropMax 30 "Babbage era" $ txRoundTrip Babbage
-        , testPropMax 30 "Alonzo era" $ txRoundTrip Alonzo
-        , testPropMax 30 "Mary era" $ txRoundTrip Mary
-        , testPropMax 30 "Allegra era" $ txRoundTrip Allegra
-        , testPropMax 30 "Shelley era" $ txRoundTrip Shelley
         ]
     ]
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
@@ -113,7 +113,8 @@ import Test.Tasty.QuickCheck (testProperty)
 
 -- | Generate a Tx and an internal Model of the state after the tx
 --   has been applied. That model can be used to generate the next Tx
-genRsTxAndModel :: forall era. Reflect era => Proof era -> Int -> SlotNo -> GenRS era (Tx era)
+genRsTxAndModel ::
+  forall era. Reflect era => Proof era -> Int -> SlotNo -> GenRS era (Tx era)
 genRsTxAndModel proof n slot = do
   (_, tx) <- genAlonzoTx proof slot
   modifyModel (\model -> applyTx proof n slot model tx)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
@@ -15,7 +15,7 @@ module Test.Cardano.Ledger.Generic.Updaters where
 
 import Cardano.Crypto.DSIGN.Class ()
 import Cardano.Ledger.Alonzo.Scripts (emptyCostModels)
-import Cardano.Ledger.Alonzo.Tx (AlonzoTx (..), hashScriptIntegrity)
+import Cardano.Ledger.Alonzo.Tx (hashScriptIntegrity)
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
 import Cardano.Ledger.Alonzo.TxBody (AlonzoTxOut (..))
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), Redeemers (..), TxDats (..))
@@ -34,9 +34,6 @@ import Cardano.Ledger.Conway.PParams (
 import Cardano.Ledger.Conway.TxBody (ConwayEraTxBody (..))
 import Cardano.Ledger.Plutus.Data (Datum (..))
 import Cardano.Ledger.Plutus.Language (Language (..))
-import Cardano.Ledger.Shelley.Tx as Shelley (
-  ShelleyTx (..),
- )
 import Cardano.Ledger.Shelley.TxOut as Shelley (ShelleyTxOut (..))
 import Cardano.Ledger.Shelley.TxWits as Shelley (
   addrWits,
@@ -102,62 +99,6 @@ instance Merge (Map ScriptHash v) where
 -- ====================================================================
 -- Building Era parametric Records
 -- ====================================================================
-
--- Updaters for Tx
-
-updateTx :: Proof era -> Tx era -> TxField era -> Tx era
-updateTx wit@Shelley tx@(ShelleyTx b w d) dt =
-  case dt of
-    Body fbody -> ShelleyTx fbody w d
-    BodyI bfields -> ShelleyTx (newTxBody wit bfields) w d
-    TxWits fwit -> ShelleyTx b fwit d
-    WitnessesI wfields -> ShelleyTx b (newWitnesses override wit wfields) d
-    AuxData faux -> ShelleyTx b w faux
-    Valid _ -> tx
-updateTx wit@Allegra tx@(ShelleyTx b w d) dt =
-  case dt of
-    Body fbody -> ShelleyTx fbody w d
-    BodyI bfields -> ShelleyTx (newTxBody wit bfields) w d
-    TxWits fwit -> ShelleyTx b fwit d
-    WitnessesI wfields -> ShelleyTx b (newWitnesses override wit wfields) d
-    AuxData faux -> ShelleyTx b w faux
-    Valid _ -> tx
-updateTx wit@Mary tx@(ShelleyTx b w d) dt =
-  case dt of
-    Body fbody -> ShelleyTx fbody w d
-    BodyI bfields -> ShelleyTx (newTxBody wit bfields) w d
-    TxWits fwit -> ShelleyTx b fwit d
-    WitnessesI wfields -> ShelleyTx b (newWitnesses override wit wfields) d
-    AuxData faux -> ShelleyTx b w faux
-    Valid _ -> tx
-updateTx wit@Alonzo (Alonzo.AlonzoTx b w iv d) dt =
-  case dt of
-    Body fbody -> Alonzo.AlonzoTx fbody w iv d
-    BodyI bfields -> Alonzo.AlonzoTx (newTxBody wit bfields) w iv d
-    TxWits fwit -> Alonzo.AlonzoTx b fwit iv d
-    WitnessesI wfields -> Alonzo.AlonzoTx b (newWitnesses override wit wfields) iv d
-    AuxData faux -> Alonzo.AlonzoTx b w iv faux
-    Valid iv' -> Alonzo.AlonzoTx b w iv' d
-updateTx wit@Babbage (AlonzoTx b w iv d) dt =
-  case dt of
-    Body fbody -> AlonzoTx fbody w iv d
-    BodyI bfields -> AlonzoTx (newTxBody wit bfields) w iv d
-    TxWits fwit -> AlonzoTx b fwit iv d
-    WitnessesI wfields -> AlonzoTx b (newWitnesses override wit wfields) iv d
-    AuxData faux -> AlonzoTx b w iv faux
-    Valid iv' -> AlonzoTx b w iv' d
-updateTx wit@Conway (AlonzoTx b w iv d) dt =
-  case dt of
-    Body fbody -> AlonzoTx fbody w iv d
-    BodyI bfields -> AlonzoTx (newTxBody wit bfields) w iv d
-    TxWits fwit -> AlonzoTx b fwit iv d
-    WitnessesI wfields -> AlonzoTx b (newWitnesses override wit wfields) iv d
-    AuxData faux -> AlonzoTx b w iv faux
-    Valid iv' -> AlonzoTx b w iv' d
-{-# NOINLINE updateTx #-}
-
-newTx :: Proof era -> [TxField era] -> Tx era
-newTx era = List.foldl' (updateTx era) (initialTx era)
 
 --------------------------------------------------------------------
 -- Updaters for TxBody


### PR DESCRIPTION
# Description

This PR removes `TxField` datatype from the old era-generic generators. I'll remove rest of these "fields" datatypes in a future PR, but right now this was sufficient for unblocking my other PR.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
