### PR TITLE
Pure version of `plutusDebug`

### DIFF
--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.18.0.0
 
+* Add a timeout argument to `plutusDebug`
 * Add `pdoExUnitsEnforced` to `PlutusDebugOverrides` and add `defaultPlutusDebugOverrides`
 * Add `NFData` instance for `PlutusDebugInfo`
 * Add `DebugTimedOut` constructor to `PlutusDebugInfo`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.18.0.0
 
+* Add `pdoExUnitsEnforced` to `PlutusDebugOverrides` and add `defaultPlutusDebugOverrides`
 * Add `NFData` instance for `PlutusDebugInfo`
 * Add `DebugTimedOut` constructor to `PlutusDebugInfo`
 * Add `debugPlutusUnbounded`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.18.0.0
 
+* Add `NFData` instance for `PlutusDebugInfo`
+* Add `DebugTimedOut` constructor to `PlutusDebugInfo`
+* Add `debugPlutusUnbounded`
 * Added `binaryUpgradeTx`, `binaryUpgradeTxBody`, `binaryUpgradeTxWits`, `binaryUpgradeTxAuxData`
 * Remove `upgradeTx` and `TxUpgradeError` from `EraTx`
 * Remove `upgradeTxBody` and `TxBodyUpgradeError` from `EraTxBody`

--- a/libs/cardano-ledger-core/app/CLI.hs
+++ b/libs/cardano-ledger-core/app/CLI.hs
@@ -20,6 +20,7 @@ overridesParser =
     <$> option
       (Just <$> str)
       ( long "script"
+          <> short 's'
           <> value Nothing
           <> help "Plutus script hex without context"
       )
@@ -33,12 +34,14 @@ overridesParser =
     <*> option
       (Just <$> auto)
       ( long "language"
+          <> short 'l'
           <> value Nothing
           <> help "Plutus language version"
       )
     <*> option
       (mapM readMaybe . words <$> str)
       ( long "cost-model-values"
+          <> short 'c'
           <> value Nothing
           <> help ""
       )
@@ -57,6 +60,7 @@ overridesParser =
     <*> option
       (Just <$> auto)
       ( long "timeout"
+          <> short 't'
           <> value Nothing
           <> help
             ( "Timeout in number of milliseconds. Default is 5000000 ms (or 5 seconds). "
@@ -67,6 +71,5 @@ overridesParser =
 optsParser :: Parser Opts
 optsParser =
   Opts
-    <$> strArgument
-      (metavar "SCRIPT_WITH_CONTEXT(BASE64)")
+    <$> strArgument (metavar "SCRIPT_WITH_CONTEXT(BASE64)")
     <*> overridesParser

--- a/libs/cardano-ledger-core/app/CLI.hs
+++ b/libs/cardano-ledger-core/app/CLI.hs
@@ -6,6 +6,7 @@ module CLI (
 import Cardano.Ledger.Binary (mkVersion64)
 import Cardano.Ledger.Plutus.Evaluate
 import Options.Applicative
+import Text.Read (readMaybe)
 
 data Opts = Opts
   { optsScriptWithContext :: !String
@@ -36,7 +37,7 @@ overridesParser =
           <> help "Plutus language version"
       )
     <*> option
-      (str >>= pure . Just . map read . words)
+      (mapM readMaybe . words <$> str)
       ( long "cost-model-values"
           <> value Nothing
           <> help ""

--- a/libs/cardano-ledger-core/app/CLI.hs
+++ b/libs/cardano-ledger-core/app/CLI.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NumericUnderscores #-}
+
 module CLI (
   Opts (..),
   optsParser,
@@ -10,6 +12,7 @@ import Text.Read (readMaybe)
 
 data Opts = Opts
   { optsScriptWithContext :: !String
+  , optsTimeout :: !Int
   , optsOverrides :: !PlutusDebugOverrides
   }
   deriving (Show)
@@ -66,19 +69,19 @@ overridesParser =
                 <> "disabling this reporting of expected execution units."
             )
       )
-    <*> option
-      (Just <$> auto)
-      ( long "timeout"
-          <> short 't'
-          <> value Nothing
-          <> help
-            ( "Timeout in number of milliseconds. Default is 5000000 ms (or 5 seconds). "
-                <> "Specifying a negative number will effectively remove the timeout and unbound execution."
-            )
-      )
 
 optsParser :: Parser Opts
 optsParser =
   Opts
     <$> strArgument (metavar "SCRIPT_WITH_CONTEXT(BASE64)")
+    <*> option
+      auto
+      ( long "timeout"
+          <> short 't'
+          <> value 5_000_000
+          <> help
+            ( "Timeout in number of milliseconds. Default is 5000000 ms (or 5 seconds). "
+                <> "Specifying a negative number will effectively remove the timeout and unbound execution."
+            )
+      )
     <*> overridesParser

--- a/libs/cardano-ledger-core/app/CLI.hs
+++ b/libs/cardano-ledger-core/app/CLI.hs
@@ -57,6 +57,15 @@ overridesParser =
           <> value Nothing
           <> help ""
       )
+    <*> switch
+      ( long "enforce-execution-units"
+          <> help
+            ( "By default plutus-debug upon a failure will re-evaluate supplied script one more time "
+                <> "without bounding execution in order to report expected execution units. "
+                <> "In case when this unbounded computation is a problem, this flag allows for "
+                <> "disabling this reporting of expected execution units."
+            )
+      )
     <*> option
       (Just <$> auto)
       ( long "timeout"

--- a/libs/cardano-ledger-core/app/CLI.hs
+++ b/libs/cardano-ledger-core/app/CLI.hs
@@ -53,6 +53,15 @@ overridesParser =
           <> value Nothing
           <> help ""
       )
+    <*> option
+      (Just <$> auto)
+      ( long "timeout"
+          <> value Nothing
+          <> help
+            ( "Timeout in number of milliseconds. Default is 5000000 ms (or 5 seconds). "
+                <> "Specifying a negative number will effectively remove the timeout and unbound execution."
+            )
+      )
 
 optsParser :: Parser Opts
 optsParser =

--- a/libs/cardano-ledger-core/app/PlutusDebug.hs
+++ b/libs/cardano-ledger-core/app/PlutusDebug.hs
@@ -20,7 +20,7 @@ main = do
                   <> "and the script itself with the available command line options."
               )
             <> footer
-              ( "EXAMPLE: plutus-debug \"hgmCAVksj...\" --script \"5906ab010...\" "
+              ( "EXAMPLE: plutus-debug \"hgmCAVksj...\" --script \"WQrOAQEAMjI...\" "
                   <> "Note when rewriting the script with the `--script` option "
                   <> "you will have to provide the hex of the Plutus script as seen in "
                   <> "`Test.Cardano.Ledger.Plutus.Examples`."

--- a/libs/cardano-ledger-core/app/PlutusDebug.hs
+++ b/libs/cardano-ledger-core/app/PlutusDebug.hs
@@ -26,4 +26,4 @@ main = do
                   <> "`Test.Cardano.Ledger.Plutus.Examples`."
               )
         )
-  debugPlutus optsScriptWithContext optsOverrides >>= print
+  debugPlutus optsScriptWithContext optsTimeout optsOverrides >>= print

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
@@ -17,14 +17,14 @@
 {-# LANGUAGE UndecidableSuperClasses #-}
 
 module Cardano.Ledger.Plutus.Evaluate (
-  PlutusDebugOverrides (..),
-  defaultPlutusDebugOverrides,
   PlutusWithContext (..),
   ScriptFailure (..),
   ScriptResult (..),
   scriptPass,
   scriptFail,
   PlutusDebugInfo (..),
+  PlutusDebugOverrides (..),
+  defaultPlutusDebugOverrides,
   debugPlutus,
   debugPlutusUnbounded,
   runPlutusScript,
@@ -275,14 +275,23 @@ instance NFData PlutusDebugInfo where
         logs `deepseq` evalError `seqEvalError` pwc `deepseq` rnf mExBudget
     DebugTimedOut t -> rnf t
 
+-- | Various overrides that can be supplied to `plutusDebug` and `plutusDebugUnbouded`
 data PlutusDebugOverrides = PlutusDebugOverrides
   { pdoScript :: !(Maybe ByteString)
+  -- ^ Hex encoded version of the script
   , pdoProtocolVersion :: !(Maybe Version)
+  -- ^ Protocol version to be used for decoding and exection
   , pdoLanguage :: !(Maybe Language)
+  -- ^ Plutus ledger language version
   , pdoCostModelValues :: !(Maybe [Int64])
+  -- ^ Cost model to be used for deciding execution units
   , pdoExUnitsMem :: !(Maybe Natural)
+  -- ^ Memory execution units to be used for execution
   , pdoExUnitsSteps :: !(Maybe Natural)
+  -- ^ CPU execution units to be used for execution
   , pdoExUnitsEnforced :: !Bool
+  -- ^ Setting this flag to True will disable reporting expected execution units upon a failure,
+  -- which would protect against a potentially unbounded script execution.
   }
   deriving (Show)
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
@@ -354,7 +354,7 @@ debugPlutus scriptsWithContext limit opts =
 debugPlutusUnbounded :: HasCallStack => String -> PlutusDebugOverrides -> PlutusDebugInfo
 debugPlutusUnbounded scriptsWithContext opts =
   case B64.decode (BSU.fromString scriptsWithContext) of
-    Left e -> DebugBadHex (show e)
+    Left e -> DebugBadHex e
     Right bs ->
       case Plain.decodeFull' bs of
         Left e -> DebugCannotDecode $ show e

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
@@ -284,7 +283,6 @@ data PlutusDebugOverrides = PlutusDebugOverrides
   , pdoExUnitsMem :: !(Maybe Natural)
   , pdoExUnitsSteps :: !(Maybe Natural)
   , pdoExUnitsEnforced :: !Bool
-  , pdoTimeout :: !(Maybe Int)
   }
   deriving (Show)
 
@@ -298,7 +296,6 @@ defaultPlutusDebugOverrides =
     , pdoExUnitsMem = Nothing
     , pdoExUnitsSteps = Nothing
     , pdoExUnitsEnforced = False
-    , pdoTimeout = Nothing
     }
 
 -- TODO: Add support for overriding arguments.
@@ -335,14 +332,12 @@ overrideContext PlutusWithContext {..} PlutusDebugOverrides {..} =
 
 -- | Execute a hex encoded script with the context that was produced within the ledger predicate
 -- failure. Using `PlutusDebugOverrides` it is possible to override any part of the execution.
-debugPlutus :: HasCallStack => String -> PlutusDebugOverrides -> IO PlutusDebugInfo
-debugPlutus scriptsWithContext opts =
+debugPlutus :: HasCallStack => String -> Int -> PlutusDebugOverrides -> IO PlutusDebugInfo
+debugPlutus scriptsWithContext limit opts =
   timeout limit (pure $!! debugPlutusUnbounded scriptsWithContext opts)
     <&> \case
       Nothing -> DebugTimedOut limit
       Just res -> res
-  where
-    limit = fromMaybe 5_000_000 $ pdoTimeout opts
 
 -- | This is just like `debugPlutus`, except it is pure and if a supplied script contains an
 -- infinite loop or a very expensive computation, it might not terminate within a reasonable

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
@@ -19,6 +19,7 @@
 
 module Cardano.Ledger.Plutus.Evaluate (
   PlutusDebugOverrides (..),
+  defaultPlutusDebugOverrides,
   PlutusWithContext (..),
   ScriptFailure (..),
   ScriptResult (..),
@@ -286,6 +287,19 @@ data PlutusDebugOverrides = PlutusDebugOverrides
   , pdoTimeout :: !(Maybe Int)
   }
   deriving (Show)
+
+defaultPlutusDebugOverrides :: PlutusDebugOverrides
+defaultPlutusDebugOverrides =
+  PlutusDebugOverrides
+    { pdoScript = Nothing
+    , pdoProtocolVersion = Nothing
+    , pdoLanguage = Nothing
+    , pdoCostModelValues = Nothing
+    , pdoExUnitsMem = Nothing
+    , pdoExUnitsSteps = Nothing
+    , pdoExUnitsEnforced = False
+    , pdoTimeout = Nothing
+    }
 
 -- TODO: Add support for overriding arguments.
 overrideContext :: HasCallStack => PlutusWithContext -> PlutusDebugOverrides -> PlutusWithContext


### PR DESCRIPTION
# Description

It was brought to my attention at some point that there is some functionality in Hydra that uses `plutusDebug` (see https://github.com/cardano-scaling/hydra/issues/2076), but #4503  turned it into `IO` action instead. `IO` is only necessary for timeout functionality, which is not needed if we can guarantee that computation is bounded, therefore this PR adds a pure alternative `plutusDebugUnbouded` that can be used in pure setting.
It also adds a flag for enforcing bounded computation and an additional fag for customizing the timeout period

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
