### PR TITLE
`constrained-generators`: Get rid of a bunch of uses of `dom_`

### DIFF
--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
@@ -162,7 +162,7 @@ conwayCertExecContextSpec univ wdrlsize = constrained $ \ [var|ccec|] ->
   match ccec $ \ [var|withdrawals|] [var|deposits|] _ [var|delegatees|] ->
     [ assert $
         [ witness univ (dom_ withdrawals)
-        , assert $ sizeOf_ (dom_ withdrawals) <=. (lit wdrlsize)
+        , assert $ sizeOf_ withdrawals <=. (lit wdrlsize)
         ]
     , forAll (dom_ deposits) $ \dp -> satisfies dp (witnessDepositPurpose univ)
     , satisfies delegatees (delegateeSpec @era univ)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
@@ -129,7 +129,7 @@ genesisDelegCertSpec ds =
       GenDelegs genDelegs = dsGenDelegs ds
    in constrained $ \ [var|gdc|] ->
         match gdc $ \ [var|gkh|] [var|vkh|] [var|hashVrf|] ->
-          [ assert $ member_ gkh (dom_ (lit genDelegs))
+          [ assert $ mapMember_ gkh (lit genDelegs)
           , reify gkh coldKeyHashes (\ [var|coldkeys|] -> member_ vkh coldkeys)
           , reify gkh vrfKeyHashes (\ [var|vrfkeys|] -> member_ hashVrf vrfkeys)
           ]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
@@ -95,7 +95,7 @@ bootstrapDStateSpec univ delegatees withdrawals =
           , reify rdMap id $ \ [var|rdmp|] ->
               assertExplain (pure "dom sPoolMap is a subset of dom rdMap") $ dom_ sPoolMap `subset_` dom_ rdmp
           , -- ptrMap
-            assertExplain (pure "dom ptrMap is empty") $ dom_ ptrMap ==. mempty
+            assertExplain (pure "ptrMap is empty") $ ptrMap ==. lit mempty
           ]
       ]
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
@@ -63,7 +63,7 @@ rewDepMapSpec univ wdrl =
    in constrained $ \ [var|rdmap|] ->
         [ -- can't be bigger than the witness set (n keys + n scripts)
           -- must also have enough slack to accomodate the credentials in wdrl (m)
-          assert $ sizeOf_ (dom_ rdmap) <=. lit maxRewDepSize -- If this is too large
+          assert $ sizeOf_ rdmap <=. lit maxRewDepSize -- If this is too large
         , assert $ subset_ (lit (wdrlCredentials wdrl)) (dom_ rdmap) -- it is hard to satisfy this
         , forAll' rdmap $ \ [var|cred|] [var| rdpair|] ->
             [ witness univ cred
@@ -88,7 +88,7 @@ rewDepMapSpec2 univ wdrl =
    in constrained $ \ [var|rdmap|] ->
         [ -- size of rdmap, can't be bigger than the witness set (n keys + n scripts)
           -- must also have enough slack to accomodate the credentials in wdrl (m)
-          assert $ sizeOf_ (dom_ rdmap) <=. lit maxRewDepSize
+          assert $ sizeOf_ (rdmap) <=. lit maxRewDepSize
         , assertExplain (pure "some rewards (not in withdrawals) are zero") $
             forAll rdmap $
               \ [var| keycoinpair |] -> match keycoinpair $ \cred [var| rdpair |] ->
@@ -99,7 +99,7 @@ rewDepMapSpec2 univ wdrl =
                 ]
         , forAll (lit withdrawalPairs) $ \ [var| pair |] ->
             match pair $ \ [var| wcred |] [var| coin |] ->
-              [ assertExplain (pure "withdrawalKeys are a subset of the rdMap") $ member_ wcred (dom_ rdmap)
+              [ assertExplain (pure "withdrawalKeys are a subset of the rdMap") $ mapMember_ wcred rdmap
               , -- Force the reward in the RDPair to the withdrawal amount.
                 onJust (lookup_ wcred rdmap) $ \ [var|rdpair|] ->
                   match rdpair $ \rew _deposit -> assert $ rew ==. coin
@@ -151,7 +151,7 @@ dStateSpec univ wdrls = constrained $ \ [var| dstate |] ->
           reify rdMap id $ \ [var|rdmp|] ->
             assertExplain (pure "dom sPoolMap is a subset of dom rdMap") $ dom_ sPoolMap `subset_` dom_ rdmp
         , -- ptrMapo
-          assertExplain (pure "dom ptrMap is empty") $ dom_ ptrMap ==. mempty
+          assertExplain (pure "ptrMap is empty") $ ptrMap ==. lit mempty
         ]
     ]
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Epoch.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Epoch.hs
@@ -90,7 +90,7 @@ proposalExists ::
   Pred
 proposalExists gasId proposals =
   reify proposals proposalsActionsMap $ \ [var|actionMap|] ->
-    gasId `member_` dom_ actionMap
+    gasId `mapMember_` actionMap
 
 epochSignalSpec :: EpochNo -> Specification EpochNo
 epochSignalSpec curEpoch = constrained $ \e ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/GovCert.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/GovCert.hs
@@ -41,7 +41,7 @@ vStateSpec ::
 vStateSpec univ delegatees = constrained $ \ [var|vstate|] ->
   match vstate $ \ [var|dreps|] [var|committeestate|] [var|_numdormant|] ->
     [ match committeestate $ \ [var|committeemap|] -> witness univ (dom_ committeemap)
-    , assert $ dom_ dreps ==. (lit delegatees) -- TODO, there are missing constraints about the (rng_ dreps)
+    , assert $ dom_ dreps ==. lit delegatees -- TODO, there are missing constraints about the (rng_ dreps)
     , forAll dreps $ \ [var|pair|] ->
         match pair $ \ [var|drep|] [var|drepstate|] ->
           [ dependsOn drepstate drep
@@ -77,7 +77,7 @@ govCertSpec univ ConwayGovCertEnv {..} certState =
           -- that each branch is choosen with similar frequency
           -- ConwayRegDRep
           ( branchW 1 $ \ [var|keyreg|] [var|coinreg|] _ ->
-              [ assert $ not_ $ member_ keyreg (dom_ (lit deposits))
+              [ assert $ not_ $ mapMember_ keyreg (lit deposits)
               , assert $ coinreg ==. lit (cgcePParams ^. ppDRepDepositL)
               , witness univ keyreg
               ]
@@ -139,7 +139,7 @@ govCertEnvSpec univ =
     match gce $ \ [var|pp|] _ [var|committee|] [var|proposalmap|] ->
       [ satisfies pp pparamsSpec
       , unsafeExists (\x -> [satisfies x (committeeWitness univ), assert $ committee ==. cSJust_ x])
-      , assert $ sizeOf_ (dom_ proposalmap) <=. lit 5
-      , assert $ sizeOf_ (dom_ proposalmap) >=. lit 1
+      , assert $ sizeOf_ (proposalmap) <=. lit 5
+      , assert $ sizeOf_ (proposalmap) >=. lit 1
       , forAll (rng_ proposalmap) $ \x -> satisfies x (govActionStateWitness univ)
       ]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
@@ -199,7 +199,7 @@ goodDrep univ =
         , satisfies (snd_ pair) (hasSize (rangeSize 1 5))
         , forAll (snd_ pair) (`satisfies` (witCredSpec @era univ))
         ]
-    , satisfies (dom_ dRepMap) (hasSize (rangeSize 6 10))
+    , satisfies dRepMap (hasSize (rangeSize 6 10))
     ]
 
 -- ========================================================================
@@ -301,7 +301,7 @@ dstateSpec univ acct poolreg = constrained $ \ [var| ds |] ->
           [ genHint 5 sPoolMap
           , assertExplain (pure "dom sPoolMap is a subset of dom rdMap") $ dom_ sPoolMap `subset_` rdcreds
           , assertExplain (pure "The delegations delegate to actual pools") $
-              forAll (rng_ sPoolMap) (\ [var|keyhash|] -> member_ keyhash (dom_ poolreg))
+              forAll (rng_ sPoolMap) (\ [var|keyhash|] -> mapMember_ keyhash poolreg)
           ]
       , -- futureGenDelegs and genDelegs and irewards can be solved in any order
         satisfies irewards (irewardSpec @era univ acct)
@@ -344,9 +344,9 @@ pstateSpec univ currepoch = constrained $ \ [var|pState|] ->
         dom_ stakePoolParams `disjoint_` dom_ futureStakePoolParams
     , assertExplain (pure "retiring after current epoch") $
         forAll (rng_ retiring) (\ [var|epoch|] -> currepoch <=. epoch)
-    , assert $ sizeOf_ (dom_ futureStakePoolParams) <=. 4
-    , assert $ 3 <=. sizeOf_ (dom_ stakePoolParams)
-    , assert $ sizeOf_ (dom_ stakePoolParams) <=. 8
+    , assert $ sizeOf_ (futureStakePoolParams) <=. 4
+    , assert $ 3 <=. sizeOf_ stakePoolParams
+    , assert $ sizeOf_ stakePoolParams <=. 8
     ]
 
 accountStateSpec :: Specification ChainAccountState

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/ParametricSpec.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/ParametricSpec.hs
@@ -184,7 +184,7 @@ delegatedStakeReference delegs =
   constrained $ \ [var|ref|] ->
     caseOn
       ref
-      (branchW 9 $ \ [var|base|] -> member_ base (dom_ delegs))
+      (branchW 9 $ \ [var|base|] -> mapMember_ base delegs)
       (branchW 1 $ \_ptr -> True)
       (branchW 1 $ \_null -> True) -- just an occaisional NullRef
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/WitnessUniverse.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/WitnessUniverse.hs
@@ -856,11 +856,11 @@ govActionStateWitness univ = ExplainSpec ["Witnessing GovActionState"] $
     match govactstate $
       \_gaid [var|comVotemap|] [var|drepVotemap|] [var|poolVotemap|] [var|proposalProc|] _proposed _expires ->
         [ witness univ (dom_ comVotemap)
-        , assert $ sizeOf_ (dom_ comVotemap) ==. lit 3
+        , assert $ sizeOf_ comVotemap ==. lit 3
         , witness univ (dom_ drepVotemap)
-        , assert $ sizeOf_ (dom_ drepVotemap) ==. lit 2
+        , assert $ sizeOf_ drepVotemap ==. lit 2
         , witness univ (dom_ poolVotemap)
-        , assert $ sizeOf_ (dom_ poolVotemap) ==. lit 2
+        , assert $ sizeOf_ poolVotemap ==. lit 2
         , satisfies proposalProc (proposalProcedureWitness univ)
         ]
 
@@ -904,7 +904,7 @@ committeeWitness ::
 committeeWitness univ =
   constrained $ \ [var|committee|] ->
     match committee $ \ [var|epochMap|] _threshold ->
-      [witness univ (dom_ epochMap), assert $ sizeOf_ (dom_ epochMap) ==. lit 3]
+      [witness univ (dom_ epochMap), assert $ sizeOf_ epochMap ==. lit 3]
 
 go9 :: IO ()
 go9 = do

--- a/libs/constrained-generators/src/Constrained/API.hs
+++ b/libs/constrained-generators/src/Constrained/API.hs
@@ -136,6 +136,7 @@ module Constrained.API (
   dom_,
   rng_,
   lookup_,
+  mapMember_,
   fstSpec,
   sndSpec,
   var,
@@ -198,6 +199,7 @@ import Constrained.Spec.Map (
   dom_,
   fstSpec,
   lookup_,
+  mapMember_,
   rng_,
   sndSpec,
  )

--- a/libs/constrained-generators/src/Constrained/Examples/Map.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Map.hs
@@ -38,7 +38,7 @@ knownDomainMap = constrained $ \m ->
   ]
 
 mapSizeConstrained :: Specification (Map Three Int)
-mapSizeConstrained = constrained $ \m -> sizeOf_ (dom_ m) <=. 3
+mapSizeConstrained = constrained $ \m -> sizeOf_ m <=. 3
 
 sumRange :: Specification (Map Word64 Word64)
 sumRange = constrained $ \m -> sum_ (rng_ m) ==. lit 10
@@ -80,7 +80,7 @@ lookupSpecific = constrained' $ \ [var|k|] [var|v|] [var|m|] ->
 
 mapRestrictedValues :: Specification (Map (Either Int ()) Int)
 mapRestrictedValues = constrained $ \m ->
-  [ assert $ sizeOf_ (dom_ m) ==. 6
+  [ assert $ sizeOf_ m ==. 6
   , forAll' m $ \k v ->
       [ caseOn
           k
@@ -97,7 +97,7 @@ mapRestrictedValues = constrained $ \m ->
 -- before we ever go to generate the keys.
 mapRestrictedValuesThree :: Specification (Map Three Int)
 mapRestrictedValuesThree = constrained $ \m ->
-  [ assert $ sizeOf_ (dom_ m) ==. 3
+  [ assert $ sizeOf_ m ==. 3
   , forAll' m $ \k v ->
       [ caseOn
           k
@@ -112,7 +112,7 @@ mapRestrictedValuesThree = constrained $ \m ->
 
 mapRestrictedValuesBool :: Specification (Map Bool Int)
 mapRestrictedValuesBool = constrained $ \m ->
-  [ assert $ sizeOf_ (dom_ m) ==. 2
+  [ assert $ sizeOf_ m ==. 2
   , forAll' m $ \k v -> [v `dependsOn` k, whenTrue k (100 <=. v)]
   ]
 

--- a/libs/constrained-generators/src/Constrained/Spec/Map.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Map.hs
@@ -391,3 +391,10 @@ lookup_ ::
   Term (Map k v) ->
   Term (Maybe v)
 lookup_ = appTerm LookupW
+
+mapMember_ ::
+  (HasSpec k, HasSpec v, Ord k, IsNormalType k, IsNormalType v) =>
+  Term k ->
+  Term (Map k v) ->
+  Term Bool
+mapMember_ k m = not_ $ lookup_ k m ==. lit Nothing


### PR DESCRIPTION
# Description

closes https://github.com/IntersectMBO/cardano-ledger/issues/5130

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
