### PR TITLE
`constrained-generators`: Clean up the API 

### DIFF
--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
@@ -395,7 +395,7 @@ ratifyStateSpec _ RatifyEnv {..} =
     preferSmallerCCMinSizeValues pp = match pp $ \simplepp ->
       satisfies (committeeMinSize_ simplepp) $
         chooseSpec
-          (1, TrueSpec)
+          (1, trueSpec)
           (1, constrained (<=. committeeSize))
       where
         committeeSize = lit . fromIntegral . Set.size $ ccColdKeys
@@ -573,7 +573,7 @@ instance ExecSpecRule "ENACT" ConwayEra where
   type ExecState "ENACT" ConwayEra = EnactState ConwayEra
   type ExecSignal "ENACT" ConwayEra = EnactSignal ConwayEra
 
-  environmentSpec _ = TrueSpec
+  environmentSpec _ = trueSpec
   stateSpec = enactStateSpec
   signalSpec = enactSignalSpec
   runAgdaRule env st sig = unComputationResult $ Agda.enactStep env st sig

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
@@ -29,13 +29,12 @@ module Test.Cardano.Ledger.Conformance.SpecTranslate.Core (
 ) where
 
 import Cardano.Ledger.BaseTypes (Inject (..))
-import Constrained.Base ()
+import Constrained.API
 import Control.DeepSeq (NFData)
 import Control.Monad.Except (ExceptT, MonadError (..), runExceptT)
 import Control.Monad.Reader (MonadReader (..), Reader, asks, runReader)
 import Data.Foldable (Foldable (..))
 import Data.Kind (Type)
-import Data.List.NonEmpty (NonEmpty)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Void (Void)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Epoch.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Epoch.hs
@@ -31,7 +31,7 @@ data EpochExecEnv era = EpochExecEnv
   deriving (Generic, Eq, Show)
 
 epochEnvSpec :: Specification (EpochExecEnv ConwayEra)
-epochEnvSpec = TrueSpec
+epochEnvSpec = trueSpec
 
 epochStateSpec ::
   Term EpochNo ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Gov.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Gov.hs
@@ -21,8 +21,6 @@ import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.UMap (umElems, umElemsL)
 import Constrained.API
-import Constrained.Base (IsPred (..))
-import Constrained.Spec.Tree (rootLabel_)
 import Data.Coerce
 import Data.Foldable
 import Data.Map qualified as Map
@@ -149,8 +147,8 @@ proposalsSpec geEpoch gePPolicy geCertState =
             (branch $ \_ _ -> False) -- HardForkInitiation
             -- Treasury Withdrawal
             ( branch $ \ [var|withdrawMap|] [var|policy|] ->
-                Explain (pure "TreasuryWithdrawal fails") $
-                  And
+                explanation (pure "TreasuryWithdrawal fails") $
+                  fold $
                     [ dependsOn gasOther withdrawMap
                     , match geCertState $ \_vState _pState [var|dState|] ->
                         match dState $ \ [var|rewardMap|] _ _ _ ->
@@ -224,7 +222,7 @@ withPrevActId ::
   (Term (StrictMaybe GovActionId) -> Pred) ->
   Pred
 withPrevActId gas k =
-  And
+  fold
     [ match (gasProposalProcedure_ gas) $ \_deposit [var|retAddr|] _action _anchor ->
         match retAddr $ \ [var|net|] _ -> [dependsOn gas net, assert $ net ==. lit Testnet]
     , caseOn

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Basic.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Basic.hs
@@ -46,10 +46,8 @@ import Cardano.Ledger.Plutus.CostModels (CostModels)
 import Cardano.Ledger.Plutus.ExUnits
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..))
 import Constrained.API
-import Constrained.Base
 import Constrained.GenT
 import Constrained.NumOrd
-import Constrained.SumList (genListWithSize)
 import Control.Monad.Identity (Identity (..))
 import Control.Monad.Trans.Fail.String
 import Data.Maybe
@@ -105,12 +103,6 @@ instance OrdLike Coin
 instance NumLike Coin
 
 instance Foldy Coin where
-  genList s s' = map fromSimpleRep <$> genList @Word64 (toSimpleRepSpec s) (toSimpleRepSpec s')
-  theAddFn = AddW
-  theZero = Coin 0
-  genSizedList sz elemSpec foldSpec =
-    map fromSimpleRep
-      <$> genListWithSize @Word64 sz (toSimpleRepSpec elemSpec) (toSimpleRepSpec foldSpec)
   noNegativeValues = True
 
 -- TODO: This is hack to get around the need for `Num` in `NumLike`. We should possibly split
@@ -136,34 +128,34 @@ instance HasSpec EpochInterval
 instance HasSpec UnitInterval where
   type TypeSpec UnitInterval = ()
   emptySpec = ()
-  combineSpec _ _ = TrueSpec
+  combineSpec _ _ = trueSpec
   genFromTypeSpec _ = pureGen arbitrary
-  cardinalTypeSpec _ = TrueSpec
+  cardinalTypeSpec _ = trueSpec
   shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
-  toPreds _ _ = toPred True
+  toPreds _ _ = assert True
 
 instance HasSpec NonNegativeInterval where
   type TypeSpec NonNegativeInterval = ()
   emptySpec = ()
-  combineSpec _ _ = TrueSpec
+  combineSpec _ _ = trueSpec
   genFromTypeSpec _ = pureGen arbitrary
-  cardinalTypeSpec _ = TrueSpec
+  cardinalTypeSpec _ = trueSpec
   shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
-  toPreds _ _ = toPred True
+  toPreds _ _ = assert True
 
 instance HasSimpleRep CostModels
 
 instance HasSpec CostModels where
   type TypeSpec CostModels = ()
   emptySpec = ()
-  combineSpec _ _ = TrueSpec
+  combineSpec _ _ = trueSpec
   genFromTypeSpec _ = pureGen arbitrary
-  cardinalTypeSpec _ = TrueSpec
+  cardinalTypeSpec _ = trueSpec
   shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
-  toPreds _ _ = toPred True
+  toPreds _ _ = assert True
 
 instance HasSimpleRep Prices
 
@@ -240,12 +232,12 @@ succV_ = fromGeneric_ . (+ 1) . toGeneric_
 instance Typeable r => HasSpec (KeyHash r) where
   type TypeSpec (KeyHash r) = ()
   emptySpec = ()
-  combineSpec _ _ = TrueSpec
+  combineSpec _ _ = trueSpec
   genFromTypeSpec _ = pureGen arbitrary
-  cardinalTypeSpec _ = TrueSpec
+  cardinalTypeSpec _ = trueSpec
   shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
-  toPreds _ _ = toPred True
+  toPreds _ _ = assert True
 
 -- =========================================================================================
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -116,15 +116,10 @@ import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import Cardano.Ledger.UMap
 import Cardano.Ledger.Val (Val)
-import Constrained.API
-import Constrained.Base
+import Constrained.API.Extend hiding (Sized)
+import Constrained.API.Extend qualified as C
 import Constrained.GenT (pureGen, vectorOfT)
 import Constrained.Generic
-import Constrained.NumOrd
-import Constrained.Spec.Map
-import Constrained.Spec.Tree ()
-import Constrained.SumList (genListWithSize)
-import Constrained.TheKnot qualified as C
 import Control.DeepSeq (NFData)
 import Crypto.Hash (Blake2b_224)
 import Data.ByteString qualified as BS
@@ -233,14 +228,7 @@ instance OrdLike DeltaCoin
 
 instance NumLike DeltaCoin
 
-instance Foldy DeltaCoin where
-  genList s s' = map fromSimpleRep <$> genList @Integer (toSimpleRepSpec s) (toSimpleRepSpec s')
-  theAddFn = AddW
-  theZero = DeltaCoin 0
-  genSizedList sz elemSpec foldSpec =
-    map fromSimpleRep
-      <$> genListWithSize @Integer sz (toSimpleRepSpec elemSpec) (toSimpleRepSpec foldSpec)
-  noNegativeValues = False
+instance Foldy DeltaCoin
 
 deriving via Integer instance Num DeltaCoin
 
@@ -274,7 +262,7 @@ instance Typeable index => HasSpec (SafeHash index) where
   cardinalTypeSpec _ = TrueSpec
   shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
-  toPreds _ _ = toPred True
+  toPreds _ _ = assert True
 
 instance HasSimpleRep TxId
 
@@ -441,7 +429,7 @@ instance HasSpec PV1.Data where
   cardinalTypeSpec _ = TrueSpec
   shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
-  toPreds _ _ = toPred True
+  toPreds _ _ = assert True
 
 instance Era era => HasSimpleRep (Data era) where
   type SimpleRep (Data era) = PV1.Data
@@ -544,7 +532,7 @@ instance
   cardinalTypeSpec _ = TrueSpec
   shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
-  toPreds _ _ = toPred True
+  toPreds _ _ = assert True
 
 instance HasSimpleRep CompactAddr where
   type SimpleRep CompactAddr = SimpleRep Addr
@@ -597,7 +585,7 @@ instance Typeable b => HasSpec (AbstractHash Blake2b_224 b) where
   shrinkWithTypeSpec _ _ = []
   cardinalTypeSpec _ = TrueSpec
   conformsTo _ _ = True
-  toPreds _ _ = toPred True
+  toPreds _ _ = assert True
 
 instance HasSimpleRep StakeReference
 
@@ -654,7 +642,7 @@ instance Typeable r => HasSpec (VRFVerKeyHash r) where
   cardinalTypeSpec _ = TrueSpec
   shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
-  toPreds _ _ = toPred True
+  toPreds _ _ = assert True
 
 instance (HashAlgorithm a, Typeable b) => HasSpec (Hash a b) where
   type TypeSpec (Hash a b) = ()
@@ -664,7 +652,7 @@ instance (HashAlgorithm a, Typeable b) => HasSpec (Hash a b) where
   cardinalTypeSpec _ = TrueSpec
   shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
-  toPreds _ _ = toPred True
+  toPreds _ _ = assert True
 
 instance HasSimpleRep (ConwayTxCert era)
 
@@ -694,7 +682,7 @@ instance HasSpec StakePoolRelay where
   cardinalTypeSpec _ = TrueSpec
   shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
-  toPreds _ _ = toPred True
+  toPreds _ _ = assert True
 
 instance HasSimpleRep Port
 
@@ -718,7 +706,7 @@ instance HasSpec Url where
   cardinalTypeSpec _ = TrueSpec
   shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
-  toPreds _ _ = toPred True
+  toPreds _ _ = assert True
 
 instance HasSpec Text where
   type TypeSpec Text = ()
@@ -728,7 +716,7 @@ instance HasSpec Text where
   cardinalTypeSpec _ = TrueSpec
   shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
-  toPreds _ _ = toPred True
+  toPreds _ _ = assert True
 
 newtype StringSpec = StringSpec {strSpecLen :: Specification Int}
 
@@ -911,7 +899,7 @@ instance HasSpec Char where
   cardinalTypeSpec _ = TrueSpec
   shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
-  toPreds _ _ = toPred True
+  toPreds _ _ = assert True
 
 instance HasSpec CostModel where
   type TypeSpec CostModel = ()
@@ -921,7 +909,7 @@ instance HasSpec CostModel where
   cardinalTypeSpec _ = TrueSpec
   shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
-  toPreds _ _ = toPred True
+  toPreds _ _ = assert True
 
 instance HasSimpleRep Language
 
@@ -1690,7 +1678,7 @@ instance Typeable r => HasSpec (WitVKey r) where
   cardinalTypeSpec _ = TrueSpec
   shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
-  toPreds _ _ = toPred True
+  toPreds _ _ = assert True
 
 instance HasSpec BootstrapWitness where
   type TypeSpec BootstrapWitness = ()
@@ -1700,7 +1688,7 @@ instance HasSpec BootstrapWitness where
   cardinalTypeSpec _ = TrueSpec
   shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
-  toPreds _ _ = toPred True
+  toPreds _ _ = assert True
 
 instance Era era => HasSimpleRep (LedgerEnv era)
 
@@ -1843,7 +1831,7 @@ class Coercible a b => CoercibleLike a b where
     Specification b
 
 instance Typeable krole => CoercibleLike (KeyHash krole) (KeyHash 'Witness) where
-  coerceSpec (ExplainSpec es x) = explainSpecOpt es (coerceSpec x)
+  coerceSpec (ExplainSpec es x) = explainSpec es (coerceSpec x)
   coerceSpec (TypeSpec z excl) = TypeSpec z $ coerceKeyRole <$> excl
   coerceSpec (MemberSpec s) = MemberSpec $ coerceKeyRole <$> s
   coerceSpec (ErrorSpec e) = ErrorSpec e

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/TxBody.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/TxBody.hs
@@ -28,7 +28,7 @@ import Cardano.Ledger.Mary.Value (MultiAsset (..))
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.PParams (Update (..))
 import Cardano.Ledger.TxIn (TxIn (..))
-import Constrained.API
+import Constrained.API hiding (Sized)
 import Constrained.Generic
 import Data.Foldable (toList)
 import Data.Map.Strict (Map)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/WellFormed.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/WellFormed.hs
@@ -85,7 +85,7 @@ vsX = do
     aggregateDRep
       <$> genFromSpec -- ensures that each credential delegates to exactly one DRep
         @(Map (Credential 'Staking) DRep)
-        TrueSpec
+        trueSpec
   genFromSpec @(VState era) (vstateSpec univ (lit epoch) (lit delegatees))
 
 csX :: forall era. EraSpecLedger era => Gen (CertState era)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/NewEpoch.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/NewEpoch.hs
@@ -6,4 +6,4 @@ import Cardano.Ledger.Shelley.API.Types
 import Constrained.API
 
 newEpochStateSpec :: Specification (NewEpochState ConwayEra)
-newEpochStateSpec = TrueSpec
+newEpochStateSpec = trueSpec

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/ParametricSpec.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/ParametricSpec.hs
@@ -48,6 +48,7 @@ import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.LedgerState (StashedAVVMAddresses)
 import Constrained.API
+import Data.Foldable
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Word (Word64)
@@ -161,7 +162,7 @@ txOutSpec ::
   Term (TxOut era) ->
   Pred
 txOutSpec univ delegs txOut =
-  And
+  fold
     [ assert $ 0 <. txOutCoin_ @era txOut
     , assert $ txOutCoin_ @era txOut <=. fromIntegral (maxBound :: Word64)
     , (caseOn (txOutAddr_ @era txOut))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/TxBodySpec.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/TxBodySpec.hs
@@ -22,7 +22,7 @@ import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Core
 import Cardano.Ledger.Val
 import Constrained.API
-import Constrained.Base (IsPred (..))
+import Data.Foldable
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.TreeDiff
@@ -59,7 +59,7 @@ subMapSubDependsOnSuper ::
   Term (Map k v) ->
   Pred
 subMapSubDependsOnSuper sub super =
-  And
+  fold
     [ dependsOn sub super
     , assert $ super /=. lit (Map.empty)
     , assert $ subset_ (dom_ sub) (dom_ super)
@@ -73,7 +73,7 @@ subMapSuperDependsOnSub ::
   Term (Map k v) ->
   Pred
 subMapSuperDependsOnSub sub super =
-  And
+  fold
     [ dependsOn super sub
     , assert $ super /=. lit (Map.empty)
     , assert $ subset_ (dom_ sub) (dom_ super)
@@ -107,23 +107,6 @@ getDepositRefund pp certState certs =
     vs = certState ^. certVStateL
     ps = certState ^. certPStateL
     ds = certState ^. certDStateL
-
--- | This is exactly the same as reify, except it names the existential varaible for better error messages
-reifyX ::
-  ( HasSpec a
-  , HasSpec b
-  , IsPred p
-  ) =>
-  Term a ->
-  (a -> b) ->
-  (Term b -> p) ->
-  Pred
-reifyX t f body =
-  exists (\eval -> pure $ f (eval t)) $ \ [var|reifyvar|] ->
-    -- NOTE we name the existenital variable 'reifyvar'
-    [ reifies reifyvar t f
-    , Explain (pure ("reifies " ++ show reifyvar)) $ toPred $ body reifyvar
-    ]
 
 -- ==============================================================================
 -- Some code to visualize what is happening, this code will disappear eventually

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -18,7 +18,6 @@ import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Shelley.Rules hiding (epochNo, slotNo)
 import Constrained.API hiding (forAll)
-import Constrained.Generation (shrinkWithSpec)
 import Control.Monad.Reader
 import Control.State.Transition.Extended
 import qualified Data.List.NonEmpty as NE
@@ -150,44 +149,44 @@ prop_GOV =
 -- prop_NEWEPOCH :: Property
 -- prop_NEWEPOCH =
 --   stsPropertyV2 @"NEWEPOCH"
---     TrueSpec
---     (\_env -> TrueSpec)
---     (\_env _st -> TrueSpec)
+--     trueSpec
+--     (\_env -> trueSpec)
+--     (\_env _st -> trueSpec)
 --     $ \_env _st _sig _st' -> True
 
 prop_EPOCH :: EpochNo -> Property
 prop_EPOCH epochNo =
   stsPropertyV2' @"EPOCH"
-    TrueSpec
+    trueSpec
     (\_env -> epochStateSpec (lit epochNo))
     (\_env _st -> epochSignalSpec epochNo)
-    (\_env _st _newEpoch -> TrueSpec)
+    (\_env _st _newEpoch -> trueSpec)
     -- (\_env _st newEpoch -> epochStateSpec (lit newEpoch))
     $ \_env _st _sig _st' -> True
 
 prop_ENACT :: Property
 prop_ENACT =
   stsPropertyV2 @"ENACT"
-    TrueSpec
-    (\_env -> TrueSpec)
+    trueSpec
+    (\_env -> trueSpec)
     -- TODO: this is a bit suspect, there are preconditions on these signals in the spec so we
     -- shouldn't expect this to go through so easily.
-    (\_env _st -> TrueSpec)
+    (\_env _st -> trueSpec)
     $ \_env _st _sig _st' -> True
 
 prop_UTXOS :: Property
 prop_UTXOS =
   stsPropertyV2 @"UTXOS"
-    TrueSpec
-    (\_env -> TrueSpec)
-    (\_env _st -> TrueSpec)
+    trueSpec
+    (\_env -> trueSpec)
+    (\_env _st -> trueSpec)
     $ \_env _st _sig _st' -> True
 
 -- prop_LEDGER :: Property
 -- prop_LEDGER = property $ do
 --  pure $ stsPropertyV2 @"LEDGER"
---    TrueSpec
---    (\_env -> TrueSpec)
+--    trueSpec
+--    (\_env -> trueSpec)
 --    -- TODO: the `GenDelegs` don't appear to be used (?!) so we just give an
 --    -- empty map here. One could consider generating them instead
 --    ledgerTxSpec
@@ -196,26 +195,26 @@ prop_UTXOS =
 -- prop_TICKF :: Property
 -- prop_TICKF =
 --   stsPropertyV2 @"TICKF"
---     TrueSpec
---     (\_env -> TrueSpec)
---     (\_env _st -> TrueSpec)
+--     trueSpec
+--     (\_env -> trueSpec)
+--     (\_env _st -> trueSpec)
 --     $ \_env _st _sig _st' -> True
 
 prop_RATIFY :: Property
 prop_RATIFY =
   stsPropertyV2 @"RATIFY"
-    TrueSpec
-    (\_env -> TrueSpec)
-    (\_env _st -> TrueSpec)
+    trueSpec
+    (\_env -> trueSpec)
+    (\_env _st -> trueSpec)
     -- TODO: we should probably check more things here
     $ \_env _st _sig _st' -> True
 
 -- prop_CERTS :: Property
 -- prop_CERTS =
 --   stsPropertyV2 @"CERTS"
---     TrueSpec
---     (\_env -> TrueSpec)
---     (\_env _st -> TrueSpec)
+--     trueSpec
+--     (\_env -> trueSpec)
+--     (\_env _st -> trueSpec)
 --     -- TODO: we should probably check more things here
 --     $ \_env _st _sig _st' -> True
 
@@ -271,9 +270,9 @@ prop_GOVCERT =
 prop_UTXOW :: Property
 prop_UTXOW =
   stsPropertyV2 @"UTXOW"
-    TrueSpec
-    (\_env -> TrueSpec)
-    (\_env _st -> TrueSpec)
+    trueSpec
+    (\_env -> trueSpec)
+    (\_env _st -> trueSpec)
     $ \_env _st _sig _st' -> True
 
 -- prop_UTXO :: Property
@@ -288,41 +287,41 @@ prop_UTXOW =
 -- prop_BBODY :: Property
 -- prop_BBODY =
 --   stsPropertyV2 @"BBODY"
---     TrueSpec
---     (\_env -> TrueSpec)
---     (\_env _st -> TrueSpec)
+--     trueSpec
+--     (\_env -> trueSpec)
+--     (\_env _st -> trueSpec)
 --     $ \_env _st _sig _st' -> True
 
 -- prop_LEDGERS :: Property
 -- prop_LEDGERS =
 --   stsPropertyV2 @"LEDGERS"
---     TrueSpec
---     (\_env -> TrueSpec)
---     (\_env _st -> TrueSpec)
+--     trueSpec
+--     (\_env -> trueSpec)
+--     (\_env _st -> trueSpec)
 --     $ \_env _st _sig _st' -> True
 
 -- prop_RUPD :: Property
 -- prop_RUPD =
 --   stsPropertyV2 @"RUPD"
---     TrueSpec
---     (\_env -> TrueSpec)
---     (\_env _st -> TrueSpec)
+--     trueSpec
+--     (\_env -> trueSpec)
+--     (\_env _st -> trueSpec)
 --     $ \_env _st _sig _st' -> True
 
 -- prop_SNAP :: Property
 -- prop_SNAP =
 --   stsPropertyV2 @"SNAP"
---     TrueSpec
---     (\_env -> TrueSpec)
---     (\_env _st -> TrueSpec)
+--     trueSpec
+--     (\_env -> trueSpec)
+--     (\_env _st -> trueSpec)
 --     $ \_env _st _sig _st' -> True
 
 -- prop_TICK :: Property
 -- prop_TICK =
 --   stsPropertyV2 @"TICK"
---     TrueSpec
---     (\_env -> TrueSpec)
---     (\_env _st -> TrueSpec)
+--     trueSpec
+--     (\_env -> trueSpec)
+--     (\_env _st -> trueSpec)
 --     $ \_env _st _sig _st' -> True
 
 ------------------------------------------------------------------------

--- a/libs/constrained-generators/bench/Constrained/Bench.hs
+++ b/libs/constrained-generators/bench/Constrained/Bench.hs
@@ -10,7 +10,6 @@
 module Constrained.Bench where
 
 import Constrained.API
-import Constrained.Spec.Tree
 import Control.DeepSeq
 import Criterion
 import Data.Map (Map)
@@ -21,14 +20,14 @@ benchmarks :: Benchmark
 benchmarks =
   bgroup
     "constrained"
-    [ benchSpec 10 30 "TrueSpec@Map" (TrueSpec :: Specification (Map Int Int))
-    , benchSpec 10 30 "TrueSpec@[]" (TrueSpec :: Specification [Int])
-    , benchSpec 10 30 "TrueSpec@Set" (TrueSpec :: Specification (Set Int))
+    [ benchSpec 10 30 "TrueSpec@Map" (trueSpec :: Specification (Map Int Int))
+    , benchSpec 10 30 "TrueSpec@[]" (trueSpec :: Specification [Int])
+    , benchSpec 10 30 "TrueSpec@Set" (trueSpec :: Specification (Set Int))
     , benchSpec
         10
         30
         "TrueSpec@Tree"
-        (giveHint (Nothing, 30) <> TrueSpec :: Specification (Tree Int))
+        (giveHint (Nothing, 30) <> trueSpec :: Specification (Tree Int))
     , benchSpec 10 30 "roseTreeMaybe" roseTreeMaybe
     , benchSpec 10 30 "listSumPair" listSumPair
     ]

--- a/libs/constrained-generators/constrained-generators.cabal
+++ b/libs/constrained-generators/constrained-generators.cabal
@@ -19,6 +19,7 @@ source-repository head
 library
   exposed-modules:
     Constrained.API
+    Constrained.API.Extend
     Constrained.AbstractSyntax
     Constrained.Base
     Constrained.Conformance

--- a/libs/constrained-generators/src/Constrained/API.hs
+++ b/libs/constrained-generators/src/Constrained/API.hs
@@ -1,236 +1,183 @@
 {-# LANGUAGE PatternSynonyms #-}
 
 module Constrained.API (
-  PredD (..),
-  TermD (..),
-  SpecificationD (..),
-  GenericallyInstantiated,
-  Logic (..),
-  Semantics (..),
-  Syntax (..),
-  Foldy (..),
-  NumSpec (..),
-  MaybeBounded (..),
-  NonEmpty ((:|)),
+  -- * Types
   Specification,
-  pattern TypeSpec,
-  Term,
-  Fun (..),
-  name,
-  named,
   Pred,
+  Term,
+  NonEmpty ((:|)),
+
+  -- * Type classes and constraints
   HasSpec (..),
   HasSimpleRep (..),
+  Foldy (..),
   OrdLike (..),
-  conformsToSpecE,
-  conformsToSpec,
-  satisfies,
-  genFromSpecT,
-  genFromSpec,
-  debugSpec,
-  genFromSpecWithSeed,
-  simplifySpec,
-  cardinality,
-  ifElse,
-  whenTrue,
-  simplifyTerm,
+  Forallable (..),
+  HasGenHint (..),
+  Sized (..),
+  NumLike (..),
+  GenericallyInstantiated,
+  IsPred,
+  Logic,
+  Semantics,
+  Syntax,
+  Numeric,
+  IsNormalType,
+
+  -- * Core syntax
   constrained,
-  assertExplain,
+  constrained',
+  match,
+  letBind,
   assert,
+  assertExplain,
+  assertReified,
   forAll,
+  forAll',
   exists,
   unsafeExists,
-  letBind,
+  whenTrue,
+  ifElse,
+  dependsOn,
   reify,
-  assertReified,
+  reify',
+  reifies,
   explanation,
   monitor,
-  reifies,
-  dependsOn,
-  lit,
   genHint,
-  giveHint,
+  caseOn,
+  branch,
+  branchW,
+  onCon,
+  isCon,
+  onJust,
+  isJust,
+  lit,
+  con,
+  sel,
+  var,
+  name,
+
+  -- * Function symbols
+
+  -- ** Numbers
   (<.),
   (<=.),
   (>=.),
   (>.),
   (==.),
   (/=.),
-  not_,
-  or_,
-  (||.),
-  toGeneric_,
-  fromGeneric_,
   (+.),
   (-.),
   negate_,
-  addFn,
-  negateFn,
-  Numeric,
+
+  -- ** Booleans
+  not_,
+  (||.),
+
+  -- ** Pairs
   pair_,
   fst_,
   snd_,
-  prodSnd_,
-  prodFst_,
-  prod_,
-  IsNormalType,
-  injLeft_,
-  injRight_,
+
+  -- ** Either
   left_,
   right_,
-  cJust_,
-  cNothing_,
-  caseOn,
-  branch,
-  branchW,
-  forAll',
-  constrained',
-  reify',
-  con,
-  onCon,
-  isCon,
-  sel,
-  match,
-  onJust,
-  isJust,
-  chooseSpec,
-  equalSpec,
-  notEqualSpec,
-  notMemberSpec,
+
+  -- ** Maybe
+  just_,
+  nothing_,
+
+  -- ** Higher-order functions
   id_,
   flip_,
   compose_,
+
+  -- ** List
   foldMap_,
   sum_,
   elem_,
   singletonList_,
   append_,
   (++.),
-  sizeOf,
   sizeOf_,
   null_,
-  hasSize,
-  rangeSize,
   length_,
-  genFromSizeSpec,
-  between,
-  maxSpec,
-  SetW (..),
-  SetSpec (..),
+
+  -- ** Set
   singleton_,
   member_,
   union_,
   subset_,
   disjoint_,
   fromList_,
-  pattern Elem,
-  pattern ToGeneric,
-  pattern FromGeneric,
-  pattern Unary,
-  pattern (:<:),
-  pattern (:>:),
-  printPlan,
-  NumLike,
-  PairSpec (..),
-  MapSpec (..),
+
+  -- ** Map
   dom_,
   rng_,
   lookup_,
   mapMember_,
-  fstSpec,
-  sndSpec,
-  var,
-  Prod (..),
+  rootLabel_,
+
+  -- ** Generics
+  fromGeneric_,
+  toGeneric_,
+
+  -- * Composing specifications
+  satisfies,
+  chooseSpec,
+  trueSpec,
+  equalSpec,
+  notEqualSpec,
+  notMemberSpec,
+  hasSize,
+  explainSpec,
+  rangeSize,
+  between,
+  typeSpec,
+  defaultMapSpec,
+
+  -- * Generation, Shrinking, and Testing
+
+  -- ** Generating
+  genFromSpec,
+  genFromSpecT,
+  genFromSpecWithSeed,
+  genFromSizeSpec,
+
+  -- ** Shrinking
+  shrinkWithSpec,
+
+  -- ** Debugging
+  debugSpec,
+  printPlan,
+
+  -- ** Testing
+  conformsToSpec,
+  conformsToSpecE,
+  conformsToSpecProp,
+
+  -- ** Building properties
+  monitorSpec,
+  forAllSpec,
+  forAllSpecShow,
+  forAllSpecDiscard,
 ) where
 
 import Constrained.AbstractSyntax
-import Constrained.Base (
-  Fun (..),
-  GenericallyInstantiated,
-  HasSpec (..),
-  Logic (..),
-  Pred,
-  Specification,
-  Term,
-  constrained,
-  equalSpec,
-  fromGeneric_,
-  giveHint,
-  name,
-  named,
-  notEqualSpec,
-  notMemberSpec,
-  toGeneric_,
-  pattern FromGeneric,
-  pattern ToGeneric,
-  pattern TypeSpec,
-  pattern Unary,
-  pattern (:<:),
-  pattern (:>:),
- )
-import Constrained.Conformance (
-  conformsToSpec,
-  conformsToSpecE,
-  satisfies,
- )
-import Constrained.Core (NonEmpty ((:|)))
+import Constrained.Base
+import Constrained.Conformance
+import Constrained.Core
 import Constrained.FunctionSymbol
 import Constrained.Generation
-import Constrained.Generic (HasSimpleRep (..), Prod (..))
-import Constrained.NumOrd (
-  MaybeBounded (..),
-  NumLike,
-  NumSpec (..),
-  Numeric,
-  OrdLike (..),
-  addFn,
-  cardinality,
-  negateFn,
-  negate_,
-  (+.),
-  (-.),
-  (<.),
-  (<=.),
-  (>.),
-  (>=.),
- )
-import Constrained.Spec.Map (
-  MapSpec (..),
-  dom_,
-  fstSpec,
-  lookup_,
-  mapMember_,
-  rng_,
-  sndSpec,
- )
-import Constrained.Spec.Set (
-  SetSpec (..),
-  SetW (..),
-  disjoint_,
-  fromList_,
-  member_,
-  singleton_,
-  subset_,
-  union_,
- )
+import Constrained.Generic
+import Constrained.NumOrd
+import Constrained.Properties
+import Constrained.Spec.Map
+import Constrained.Spec.Set
 import Constrained.Spec.SumProd
-import Constrained.Syntax (
-  assert,
-  assertExplain,
-  assertReified,
-  dependsOn,
-  exists,
-  explanation,
-  forAll,
-  genHint,
-  letBind,
-  lit,
-  monitor,
-  reifies,
-  reify,
-  unsafeExists,
-  var,
- )
+import Constrained.Spec.Tree
+import Constrained.Syntax
 import Constrained.TheKnot
 
 infix 4 /=.
@@ -256,3 +203,6 @@ infixr 5 ++.
 
 null_ :: (HasSpec a, Sized a) => Term a -> Term Bool
 null_ xs = sizeOf_ xs ==. 0
+
+trueSpec :: Specification a
+trueSpec = TrueSpec

--- a/libs/constrained-generators/src/Constrained/API/Extend.hs
+++ b/libs/constrained-generators/src/Constrained/API/Extend.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+module Constrained.API.Extend (
+  -- * Abstract syntax
+  SpecificationD (..),
+  pattern TypeSpec,
+  PredD (..),
+  TermD (..),
+  BinderD (..),
+
+  -- * Implementing new functions
+  appTerm,
+  Semantics (..),
+  Syntax (..),
+
+  -- ** The `Logic` instance
+  Logic (..),
+  HOLE (..),
+  pattern Unary,
+  pattern (:<:),
+  pattern (:>:),
+
+  -- ** Built-in 'TypeSpec's
+  PairSpec (..),
+  MapSpec (..),
+  SetSpec (..),
+  NumSpec (..),
+  TreeSpec (..),
+
+  -- * Re-export of `Constrained.API`
+  module Constrained.API,
+) where
+
+import Constrained.API
+import Constrained.AbstractSyntax
+import Constrained.Base
+import Constrained.FunctionSymbol
+import Constrained.NumOrd
+import Constrained.Spec.Map
+import Constrained.Spec.Set
+import Constrained.Spec.SumProd
+import Constrained.Spec.Tree

--- a/libs/constrained-generators/src/Constrained/Base.hs
+++ b/libs/constrained-generators/src/Constrained/Base.hs
@@ -552,7 +552,7 @@ instance HasSpec Bool where
   cardinalTrueSpec = equalSpec 2
   shrinkWithTypeSpec _ = shrink
   conformsTo _ _ = True
-  toPreds _ _ = toPred True
+  toPreds _ _ = TruePred
 
 instance HasSpec () where
   type TypeSpec () = ()
@@ -643,7 +643,7 @@ fromSimpleRepSpec ::
   Specification (SimpleRep a) ->
   Specification a
 fromSimpleRepSpec = \case
-  ExplainSpec es s -> explainSpecOpt es (fromSimpleRepSpec s)
+  ExplainSpec es s -> explainSpec es (fromSimpleRepSpec s)
   TrueSpec -> TrueSpec
   ErrorSpec e -> ErrorSpec e
   TypeSpec s'' cant -> TypeSpec s'' $ map fromSimpleRep cant
@@ -658,7 +658,7 @@ toSimpleRepSpec ::
   Specification a ->
   Specification (SimpleRep a)
 toSimpleRepSpec = \case
-  ExplainSpec es s -> explainSpecOpt es (toSimpleRepSpec s)
+  ExplainSpec es s -> explainSpec es (toSimpleRepSpec s)
   TrueSpec -> TrueSpec
   ErrorSpec e -> ErrorSpec e
   TypeSpec s'' cant -> TypeSpec s'' $ map toSimpleRep cant
@@ -806,12 +806,8 @@ memberSpecList xs messages =
 
 explainSpec :: [String] -> Specification a -> Specification a
 explainSpec [] x = x
+explainSpec es (ExplainSpec es' spec) = ExplainSpec (es ++ es') spec
 explainSpec es spec = ExplainSpec es spec
-
-explainSpecOpt :: [String] -> Specification a -> Specification a
-explainSpecOpt [] x = x
-explainSpecOpt es1 (ExplainSpec es2 x) = explainSpecOpt (es1 ++ es2) x
-explainSpecOpt es spec = ExplainSpec es spec
 
 equalSpec :: a -> Specification a
 equalSpec = MemberSpec . pure

--- a/libs/constrained-generators/src/Constrained/Conformance.hs
+++ b/libs/constrained-generators/src/Constrained/Conformance.hs
@@ -17,7 +17,7 @@ import Constrained.Base (
   addToErrorSpec,
   combineSpec,
   conformsTo,
-  explainSpecOpt,
+  explainSpec,
   forAllToList,
   memberSpecList,
   notMemberSpec,
@@ -204,7 +204,7 @@ checkPredE env msgs = \case
           GenError es -> Just (msgs <> catMessageList es)
   Explain es p -> checkPredE env (msgs <> es) p
 
--- | conformsToSpec with explanation. Nothing if (conformsToSpec a spec),
+-- | @conformsToSpec@ with explanation. Nothing if (conformsToSpec a spec),
 --   but (Just explanations) if not(conformsToSpec a spec).
 conformsToSpecE ::
   forall a.
@@ -259,8 +259,8 @@ satisfies _ (ErrorSpec e) = FalsePred e
 -- ==================================================================
 
 instance HasSpec a => Semigroup (Specification a) where
-  ExplainSpec es x <> y = explainSpecOpt es (x <> y)
-  x <> ExplainSpec es y = explainSpecOpt es (x <> y)
+  ExplainSpec es x <> y = explainSpec es (x <> y)
+  x <> ExplainSpec es y = explainSpec es (x <> y)
   TrueSpec <> s = s
   s <> TrueSpec = s
   ErrorSpec e <> ErrorSpec e' =

--- a/libs/constrained-generators/src/Constrained/Examples/CheatSheet.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/CheatSheet.hs
@@ -6,7 +6,6 @@
 module Constrained.Examples.CheatSheet where
 
 import Constrained.API
-import Constrained.Properties (forAllSpec)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import GHC.Generics

--- a/libs/constrained-generators/src/Constrained/Examples/Fold.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Fold.hs
@@ -19,7 +19,7 @@ import Test.QuickCheck hiding (forAll, total)
 -- Specifications we use in the examples and in the tests
 
 oddSpec :: Specification Int
-oddSpec = ExplainSpec ["odd via (y+y+1)"] $
+oddSpec = explainSpec ["odd via (y+y+1)"] $
   constrained $ \ [var|oddx|] ->
     exists
       (\eval -> pure (div (eval oddx - 1) 2))
@@ -27,9 +27,9 @@ oddSpec = ExplainSpec ["odd via (y+y+1)"] $
 
 evenSpec ::
   forall n.
-  (TypeSpec n ~ NumSpec n, Integral n, HasSpec n, MaybeBounded n) =>
+  (NumLike n, Integral n) =>
   Specification n
-evenSpec = ExplainSpec ["even via (x+x)"] $
+evenSpec = explainSpec ["even via (x+x)"] $
   constrained $ \ [var|evenx|] ->
     exists
       (\eval -> pure (div (eval evenx) 2))
@@ -126,14 +126,14 @@ pickProp = do
 -- | Build properties about calls to 'genListWithSize'
 testFoldSpec ::
   forall a.
-  (Foldy a, Random a, Integral a, TypeSpec a ~ NumSpec a, Arbitrary a, MaybeBounded a) =>
+  Foldy a =>
   Specification Integer ->
   Specification a ->
   Specification a ->
   Outcome ->
   Gen Property
 testFoldSpec size elemSpec total outcome = do
-  ans <- genFromGenT $ inspect $ genListWithSize size elemSpec total
+  ans <- genFromGenT $ inspect $ genSizedList size elemSpec total
   let callString = parensList ["GenListWithSize", show size, fst (predSpecPair elemSpec), show total]
       fails xs = unlines [callString, "Should fail, but it succeeds with", show xs]
       succeeds xs =

--- a/libs/constrained-generators/src/Constrained/Examples/ManualExamples.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/ManualExamples.hs
@@ -15,7 +15,6 @@
 module Constrained.Examples.ManualExamples where
 
 import Constrained.API
-import Constrained.Properties (forAllSpec)
 import Data.Set (Set)
 import GHC.Generics
 import GHC.Natural
@@ -53,11 +52,10 @@ leqPair = constrained $ \p ->
 sumPair :: Specification (Int, Int)
 sumPair = constrained $ \p ->
   match p $ \x y ->
-    And
-      [ assert $ x <=. y
-      , assert $ y >=. 20
-      , assert $ x + y ==. 25
-      ]
+    [ assert $ x <=. y
+    , assert $ y >=. 20
+    , assert $ x + y ==. 25
+    ]
 
 ex1 :: Specification Int
 ex1 = constrained $ \_x -> True
@@ -292,14 +290,14 @@ ex22b = constrained $ \ [var|pair|] ->
 ex24 :: Specification Int
 ex24 = constrained $ \ [var|oddx|] ->
   unsafeExists
-    (\ [var|y|] -> [Assert $ oddx ==. y + y + 1])
+    (\ [var|y|] -> [assert $ oddx ==. y + y + 1])
 
 ex25 :: Specification Int
-ex25 = ExplainSpec ["odd via (y+y+1)"] $
+ex25 = explainSpec ["odd via (y+y+1)"] $
   constrained $ \ [var|oddx|] ->
     exists
       (\eval -> pure (div (eval oddx - 1) 2))
-      (\ [var|y|] -> [Assert $ oddx ==. y + y + 1])
+      (\ [var|y|] -> [assert $ oddx ==. y + y + 1])
 
 {-  Conditionals
 1.  `whenTrue`
@@ -342,7 +340,7 @@ ex28a = constrained $ \s ->
   ]
 
 ex28b :: Specification (Set Int)
-ex28b = ExplainSpec ["5 must be in the set"] $
+ex28b = explainSpec ["5 must be in the set"] $
   constrained $ \s ->
     [ assert $ member_ (lit 5) s
     , forAll s $ \x -> [x >. lit 6, x <. lit 20]
@@ -447,16 +445,16 @@ skeleton2 :: Specification Nested
 skeleton2 = constrained $ \ [var|nest|] ->
   match nest $ \ [var|three|] [var|rect|] [var|line|] ->
     [ (caseOn (three :: Term Three))
-        (branch @Pred $ \_i -> TruePred) -- One,
-        (branch @Pred $ \_k -> TruePred) -- Two,
-        (branch @Pred $ \_j -> TruePred) -- Three,
-    , match @Pred rect $ \ [var|_wid|] [var|_len|] [var|_square|] -> TruePred
-    , forAll @Pred line $ \ [var|_point|] -> TruePred
+        (branch @Pred $ \_i -> truePred) -- One,
+        (branch @Pred $ \_k -> truePred) -- Two,
+        (branch @Pred $ \_j -> truePred) -- Three,
+    , match @Pred rect $ \ [var|_wid|] [var|_len|] [var|_square|] -> truePred
+    , forAll @Pred line $ \ [var|_point|] -> truePred
     ]
 
 -- We can do a similar thing by introducing `truePred` with the monomorphic type.
 truePred :: Pred
-truePred = TruePred
+truePred = mempty
 
 skeleton :: Specification Nested
 skeleton = constrained $ \ [var|nest|] ->

--- a/libs/constrained-generators/src/Constrained/Examples/Map.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Map.hs
@@ -75,7 +75,7 @@ elemSpec = constrained' $ \ [var|key|] [var|val|] [var|mapp|] ->
 lookupSpecific :: Specification (Int, Int, Map Int Int)
 lookupSpecific = constrained' $ \ [var|k|] [var|v|] [var|m|] ->
   [ m `dependsOn` k
-  , assert $ lookup_ k m ==. cJust_ v
+  , assert $ lookup_ k m ==. just_ v
   ]
 
 mapRestrictedValues :: Specification (Map (Either Int ()) Int)
@@ -124,4 +124,4 @@ mapSetSmall = constrained $ \x ->
 -- | this tests the function saturatePred
 mapIsJust :: Specification (Int, Int)
 mapIsJust = constrained' $ \ [var| x |] [var| y |] ->
-  cJust_ x ==. lookup_ y (lit $ Map.fromList [(z, z) | z <- [100 .. 102]])
+  just_ x ==. lookup_ y (lit $ Map.fromList [(z, z) | z <- [100 .. 102]])

--- a/libs/constrained-generators/src/Constrained/Examples/MapMember.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/MapMember.hs
@@ -36,7 +36,7 @@ mapMemberB ::
 mapMemberB m key val =
   And
     [ assert $ member_ key (dom_ (lit m))
-    , assert $ cJust_ val ==. lookup_ key (lit m)
+    , assert $ just_ val ==. lookup_ key (lit m)
     ]
 
 mapMemberC ::

--- a/libs/constrained-generators/src/Constrained/Examples/Set.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Set.hs
@@ -6,7 +6,6 @@
 module Constrained.Examples.Set where
 
 import Constrained.API
-import Constrained.Base (Forallable)
 import Constrained.Examples.Basic
 import Data.Set (Set)
 import qualified Data.Set as Set

--- a/libs/constrained-generators/src/Constrained/Examples/Tree.hs
+++ b/libs/constrained-generators/src/Constrained/Examples/Tree.hs
@@ -4,7 +4,7 @@
 module Constrained.Examples.Tree where
 
 import Constrained.API
-import Constrained.Spec.Tree (BinTree (..), rootLabel_)
+import Constrained.Spec.Tree (BinTree (..))
 import Data.Tree
 
 allZeroTree :: Specification (BinTree Int)

--- a/libs/constrained-generators/src/Constrained/Generation.hs
+++ b/libs/constrained-generators/src/Constrained/Generation.hs
@@ -143,7 +143,7 @@ simplifySpec spec = case regularizeNames spec of
   ErrorSpec es -> ErrorSpec es
   TypeSpec ts cant -> TypeSpec ts cant
   TrueSpec -> TrueSpec
-  ExplainSpec es s -> explainSpecOpt es (simplifySpec s)
+  ExplainSpec es s -> explainSpec es (simplifySpec s)
 
 -- ------- Stages of simplifying -------------------------------
 
@@ -377,7 +377,7 @@ computeSpecSimplified x pred3 = localGESpec $ case simplifyPred pred3 of
   And ps -> do
     spec <- fold <$> mapM (computeSpecSimplified x) ps
     case spec of
-      ExplainSpec es (SuspendedSpec y ps') -> pure $ explainSpecOpt es (SuspendedSpec y $ simplifyPred ps')
+      ExplainSpec es (SuspendedSpec y ps') -> pure $ explainSpec es (SuspendedSpec y $ simplifyPred ps')
       SuspendedSpec y ps' -> pure $ SuspendedSpec y $ simplifyPred ps'
       s -> pure s
   Let t b -> pure $ SuspendedSpec x (Let t b)
@@ -936,10 +936,10 @@ pinnedBy _ _ = Nothing
 
 --    mapIsJust :: Specification BaseFn (Int, Int)
 --    mapIsJust = constrained' $ \ [var| x |] [var| y |] ->
---      assert $ cJust_ x ==. lookup_ y (lit $ Map.fromList [(z, z) | z <- [100 .. 102]])
+--      assert $ just_ x ==. lookup_ y (lit $ Map.fromList [(z, z) | z <- [100 .. 102]])
 
 -- Without this code the example wouldn't work because `y` is completely unconstrained during
--- generation. With this code we essentially rewrite occurences of `cJust_ A == B` to
+-- generation. With this code we essentially rewrite occurences of `just_ A == B` to
 -- `[cJust A == B, case B of Nothing -> False; Just _ -> True]` to add extra information
 -- about the variables in `B`. Consequently, `y` in the example above is
 -- constrained to `MemberSpec [100 .. 102]` in the plan.

--- a/libs/constrained-generators/src/Constrained/NumOrd.hs
+++ b/libs/constrained-generators/src/Constrained/NumOrd.hs
@@ -33,7 +33,7 @@ import Constrained.Base (
   appTerm,
   constrained,
   equalSpec,
-  explainSpecOpt,
+  explainSpec,
   flipCtx,
   fromSimpleRepSpec,
   memberSpecList,
@@ -559,8 +559,8 @@ operateSpec ::
   Specification n ->
   Specification n ->
   Specification n
-operateSpec operator f ft (ExplainSpec es x) y = explainSpecOpt es $ operateSpec operator f ft x y
-operateSpec operator f ft x (ExplainSpec es y) = explainSpecOpt es $ operateSpec operator f ft x y
+operateSpec operator f ft (ExplainSpec es x) y = explainSpec es $ operateSpec operator f ft x y
+operateSpec operator f ft x (ExplainSpec es y) = explainSpec es $ operateSpec operator f ft x y
 operateSpec operator f ft x y = case (x, y) of
   (ErrorSpec xs, ErrorSpec ys) -> ErrorSpec (xs <> ys)
   (ErrorSpec xs, _) -> ErrorSpec xs
@@ -614,7 +614,7 @@ instance Number Integer => Num (Specification Integer) where
 --   from (TypeSpec Integer) to (Specification Integer)
 cardinality ::
   forall a. (Number Integer, HasSpec a) => Specification a -> Specification Integer
-cardinality (ExplainSpec es s) = explainSpecOpt es (cardinality s)
+cardinality (ExplainSpec es s) = explainSpec es (cardinality s)
 cardinality TrueSpec = cardinalTrueSpec @a
 cardinality (MemberSpec es) = equalSpec (toInteger $ length (nub (NE.toList es)))
 cardinality ErrorSpec {} = equalSpec 0
@@ -681,14 +681,16 @@ data IntW (as :: [Type]) b where
 deriving instance Eq (IntW dom rng)
 
 instance Show (IntW d r) where
-  show AddW = "addFn"
-  show NegateW = "negateFn"
+  show AddW = "+"
+  show NegateW = "negate_"
 
 instance Semantics IntW where
   semantics AddW = (+)
   semantics NegateW = negate
 
-instance Syntax IntW -- Use default methods
+instance Syntax IntW where
+  isInfix AddW = True
+  isInfix NegateW = False
 
 type Numeric a = (HasSpec a, Ord a, Num a, TypeSpec a ~ NumSpec a, MaybeBounded a)
 

--- a/libs/constrained-generators/src/Constrained/Properties.hs
+++ b/libs/constrained-generators/src/Constrained/Properties.hs
@@ -2,30 +2,29 @@
 {-# LANGUAGE TypeApplications #-}
 
 -- | Useful of helpers for writing properties with constrained generators
-module Constrained.Properties where
+module Constrained.Properties (
+  conformsToSpecProp,
+  forAllSpec,
+  forAllSpecShow,
+  forAllSpecDiscard,
+) where
 
-import Constrained.API
-import Constrained.Base ()
-import Constrained.Conformance (
-  monitorSpec,
- )
-import Constrained.GenT (
-  GE (..),
-  errorGE,
-  fromGEDiscard,
-  strictGen,
- )
+import Constrained.Base
+import Constrained.Conformance
+import Constrained.GenT
 import Constrained.Generation
-import Constrained.NumOrd ()
-import Constrained.Spec.Set ()
-import Constrained.Spec.SumProd ()
 import qualified Data.List.NonEmpty as NE
 import qualified Test.QuickCheck as QC
 
+-- | Like @Constrained.Conformance.conformsToSpec@ but in @Test.QuickCheck.Property@ form.
 conformsToSpecProp :: forall a. HasSpec a => a -> Specification a -> QC.Property
 conformsToSpecProp a s = case conformsToSpecE a (simplifySpec s) (pure "call to conformsToSpecProp") of
   Nothing -> QC.property True
   Just msgs -> QC.counterexample (unlines (NE.toList msgs)) False
+
+-- | Quanitfy over a @Constrained.Base.Specification@.
+forAllSpec :: (HasSpec a, QC.Testable p) => Specification a -> (a -> p) -> QC.Property
+forAllSpec spec prop = forAllSpecShow spec show prop
 
 forAllSpecShow ::
   (HasSpec a, QC.Testable p) => Specification a -> (a -> String) -> (a -> p) -> QC.Property
@@ -34,9 +33,7 @@ forAllSpecShow spec pp prop =
    in QC.forAllShrinkShow (genFromSpec sspec) (shrinkWithSpec sspec) pp $ \a ->
         monitorSpec spec a $ prop a
 
-forAllSpec :: (HasSpec a, QC.Testable p) => Specification a -> (a -> p) -> QC.Property
-forAllSpec spec prop = forAllSpecShow spec show prop
-
+-- | Quanitfy over a @Constrained.Base.Specification@ and discard any test where generation fails.
 forAllSpecDiscard :: (HasSpec a, QC.Testable p) => Specification a -> (a -> p) -> QC.Property
 forAllSpecDiscard spec prop =
   let sspec = simplifySpec spec

--- a/libs/constrained-generators/src/Constrained/Spec/Map.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Map.hs
@@ -344,7 +344,7 @@ instance Logic MapW where
                letBind (fst_ kv) $ \k' ->
                  letBind (snd_ kv) $ \v ->
                    whenTrue (Lit k ==. k') $
-                     -- TODO: What you want to write is `cJust_ v `satisfies` spec` but we can't
+                     -- TODO: What you want to write is `just_ v `satisfies` spec` but we can't
                      -- do that because we don't have access to `IsNormalType v` here. When
                      -- we refactor the `IsNormalType` machinery we will be able to make
                      -- this nicer.

--- a/libs/constrained-generators/src/Constrained/Spec/SumProd.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/SumProd.hs
@@ -35,8 +35,8 @@ module Constrained.Spec.SumProd (
   chooseSpec,
   left_,
   right_,
-  cJust_,
-  cNothing_,
+  just_,
+  nothing_,
   fst_,
   snd_,
   fstW,
@@ -539,11 +539,11 @@ con =
   curryList @(ConstrOf c (TheSop a)) @Term
     (fromGeneric_ @a . inj_ @c @(TheSop a) . prodOver_)
 
-cJust_ :: (HasSpec a, IsNormalType a) => Term a -> Term (Maybe a)
-cJust_ = con @"Just"
+just_ :: (HasSpec a, IsNormalType a) => Term a -> Term (Maybe a)
+just_ = con @"Just"
 
-cNothing_ :: (HasSpec a, IsNormalType a) => Term (Maybe a)
-cNothing_ = con @"Nothing" (Lit ())
+nothing_ :: (HasSpec a, IsNormalType a) => Term (Maybe a)
+nothing_ = con @"Nothing" (Lit ())
 
 sel ::
   forall n a c as.

--- a/libs/constrained-generators/src/Constrained/SumList.hs
+++ b/libs/constrained-generators/src/Constrained/SumList.hs
@@ -182,7 +182,7 @@ genNumList elemSIn foldSIn = do
     )
     $ gen narrowedSpecs 50 [] >>= pureGen . shuffle
   where
-    normalize (ExplainSpec es x) = explainSpecOpt es <$> normalize x
+    normalize (ExplainSpec es x) = explainSpec es <$> normalize x
     normalize spec@SuspendedSpec {} = do
       sz <- sizeT
       spec' <- buildMemberSpec sz (100 :: Int) mempty spec

--- a/libs/constrained-generators/src/Constrained/Test.hs
+++ b/libs/constrained-generators/src/Constrained/Test.hs
@@ -13,55 +13,17 @@
 -- | Useful properties for debugging HasSpec instances and this library itself
 module Constrained.Test where
 
-import Constrained.API
-import Constrained.Base (
-  AppRequires,
-  BaseW (..),
-  HOLE (..),
-  appTerm,
-  memberSpecList,
-  typeSpec,
- )
-import Constrained.Conformance (
-  monitorSpec,
- )
-import Constrained.Core (
-  Value (..),
-  Var (..),
-  unValue,
- )
-import Constrained.FunctionSymbol (getWitness)
-import Constrained.GenT (
-  GE (..),
-  fromGEDiscard,
-  fromGEProp,
-  strictGen,
- )
+import Constrained.API.Extend
+import Constrained.Base
+import Constrained.Core
+import Constrained.FunctionSymbol
+import Constrained.GenT
 import Constrained.Generation
-import Constrained.List (
-  All,
-  FunTy,
-  List (..),
-  ListCtx (..),
-  TypeList,
-  fillListCtx,
-  lengthList,
-  listShape,
-  mapListCtxC,
-  mapMListC,
-  uncurryList,
-  uncurryList_,
- )
-import Constrained.NumOrd (
-  IntW (..),
-  OrdW (..),
- )
+import Constrained.List
+import Constrained.NumOrd
 import Constrained.PrettyUtils
-import Constrained.Properties
-import Constrained.Spec.Map (
-  MapW (..),
- )
-import Constrained.Spec.SumProd ()
+import Constrained.Spec.Map
+import Constrained.Spec.Set
 import Constrained.TheKnot
 import Data.List (nub)
 import qualified Data.List.NonEmpty as NE

--- a/libs/constrained-generators/test/Constrained/Tests.hs
+++ b/libs/constrained-generators/test/Constrained/Tests.hs
@@ -14,7 +14,7 @@
 
 module Constrained.Tests where
 
-import Constrained.API
+import Constrained.API.Extend
 import Constrained.Examples.Basic
 import Constrained.Examples.Either
 import Constrained.Examples.Fold (


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

closes #5048 

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
