### PR TITLE
Refactor transValidityInterval: era split, remove protocol branching,…

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Era.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Era.hs
@@ -14,7 +14,7 @@ module Cardano.Ledger.Alonzo.Era (
   AlonzoUTXOW,
   AlonzoBBODY,
   AlonzoLEDGER,
-  hardforkConwayTranslateUpperBoundForPlutusScripts,
+
 ) where
 
 import Cardano.Ledger.BaseTypes (ProtVer (pvMajor), natVersion)
@@ -96,5 +96,4 @@ type instance EraRule "UPEC" AlonzoEra = ShelleyUPEC AlonzoEra
 
 -- | Starting with protocol version 9, we translate the upper bound of validity
 -- interval correctly for Plutus scripts.
-hardforkConwayTranslateUpperBoundForPlutusScripts :: ProtVer -> Bool
-hardforkConwayTranslateUpperBoundForPlutusScripts pv = pvMajor pv > natVersion @8
+

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Era.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Era.hs
@@ -94,6 +94,3 @@ type instance EraRule "TICKF" AlonzoEra = ShelleyTICKF AlonzoEra
 
 type instance EraRule "UPEC" AlonzoEra = ShelleyUPEC AlonzoEra
 
--- | Starting with protocol version 9, we translate the upper bound of validity
--- interval correctly for Plutus scripts.
-

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
@@ -231,6 +231,7 @@ transValidityInterval ::
   forall proxy era a.
   Inject (AlonzoContextError era) a =>
   proxy era ->
+  ProtVer ->
   EpochInfo (Either Text) ->
   SystemStart ->
   ValidityInterval ->

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
@@ -20,6 +20,8 @@ module Cardano.Ledger.Conway.TxInfo (
   ConwayEraPlutusTxInfo (..),
   transTxBodyWithdrawals,
   transTxCert,
+  -- Era-specific translation for Plutus validity interval
+  transValidityInterval,
   transDRepCred,
   transColdCommitteeCred,
   transHotCommitteeCred,
@@ -396,7 +398,7 @@ instance EraPlutusTxInfo 'PlutusV1 ConwayEra where
   toPlutusTxInfo proxy LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} = do
     guardConwayFeaturesForPlutusV1V2 ltiTx
     timeRange <-
-      Alonzo.transValidityInterval ltiTx ltiProtVer ltiEpochInfo ltiSystemStart (txBody ^. vldtTxBodyL)
+      transValidityInterval ltiTx ltiEpochInfo ltiSystemStart (txBody ^. vldtTxBodyL)
     inputs <- mapM (transTxInInfoV1 ltiUTxO) (Set.toList (txBody ^. inputsTxBodyL))
     mapM_ (transTxInInfoV1 ltiUTxO) (Set.toList (txBody ^. referenceInputsTxBodyL))
     outputs <-
@@ -431,7 +433,7 @@ instance EraPlutusTxInfo 'PlutusV2 ConwayEra where
   toPlutusTxInfo proxy LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} = do
     guardConwayFeaturesForPlutusV1V2 ltiTx
     timeRange <-
-      Alonzo.transValidityInterval ltiTx ltiProtVer ltiEpochInfo ltiSystemStart (txBody ^. vldtTxBodyL)
+      transValidityInterval ltiTx ltiEpochInfo ltiSystemStart (txBody ^. vldtTxBodyL)
     inputs <- mapM (Babbage.transTxInInfoV2 ltiUTxO) (Set.toList (txBody ^. inputsTxBodyL))
     refInputs <- mapM (Babbage.transTxInInfoV2 ltiUTxO) (Set.toList (txBody ^. referenceInputsTxBodyL))
     outputs <-
@@ -468,7 +470,7 @@ instance EraPlutusTxInfo 'PlutusV3 ConwayEra where
 
   toPlutusTxInfo proxy LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} = do
     timeRange <-
-      Alonzo.transValidityInterval ltiTx ltiProtVer ltiEpochInfo ltiSystemStart (txBody ^. vldtTxBodyL)
+      transValidityInterval ltiTx ltiEpochInfo ltiSystemStart (txBody ^. vldtTxBodyL)
     let
       txInputs = txBody ^. inputsTxBodyL
       refInputs = txBody ^. referenceInputsTxBodyL


### PR DESCRIPTION
… cleanup Alonzo/Conway logic - 2025-07-01 07:33:54

Refactor transValidityInterval to use era-specific logic: implement Conway-specific translation (no protocol branching, always strict upper bound), update Conway instances, and clean up Alonzo to always use pre-Conway logic. Remove protocol-version-based branching and obsolete helpers.