### PR TITLE
Update formal-ledger-specifications

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
   subdir: hs
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `*-artifacts` BEFORE MERGE!
-  tag: da80e1780155482bc949605049ff0653edd4f2d2
+  tag: 28d3fd4876bbfa347f5eb89a6b70ee15dc9b327f
 
 -- NOTE: If you would like to update the above,
 -- see CONTRIBUTING.md#to-update-the-referenced-agda-ledger-spec

--- a/flake.lock
+++ b/flake.lock
@@ -204,11 +204,11 @@
     "formal-ledger-specifications": {
       "flake": false,
       "locked": {
-        "lastModified": 1746028470,
-        "narHash": "sha256-O4raENpXM4qtRqIHYUe4LtHgydS0wCTCmhTysJp2+uk=",
+        "lastModified": 1752223172,
+        "narHash": "sha256-lIai7FGcEP1FDNE6dfxzfuxWKp+WCxEAIrKXPSL46Fw=",
         "owner": "IntersectMBO",
         "repo": "formal-ledger-specifications",
-        "rev": "da80e1780155482bc949605049ff0653edd4f2d2",
+        "rev": "28d3fd4876bbfa347f5eb89a6b70ee15dc9b327f",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -639,12 +639,8 @@ instance SpecTranslate ctx TxAuxDataHash where
   toSpecRep (TxAuxDataHash x) = toSpecRep x
 
 data ConwayTxBodyTransContext = ConwayTxBodyTransContext
-  { ctbtcSizeTx :: !Integer
-  , ctbtcTxId :: !TxId
+  { ctbtcTxId :: !TxId
   }
-
-instance Inject ConwayTxBodyTransContext Integer where
-  inject = ctbtcSizeTx
 
 instance Inject ConwayTxBodyTransContext TxId where
   inject = ctbtcTxId

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledger.hs
@@ -83,15 +83,12 @@ instance
   toSpecRep = pure . showOpaqueErrorString
 
 instance
-  ( Inject ctx Integer
-  , Inject ctx TxId
-  ) =>
+  Inject ctx TxId =>
   SpecTranslate ctx (TxBody ConwayEra)
   where
   type SpecRep (TxBody ConwayEra) = Agda.TxBody
 
   toSpecRep txb = do
-    sizeTx <- askCtx
     txId <- askCtx @TxId
     Agda.MkTxBody
       <$> toSpecRep (txb ^. inputsTxBodyL)
@@ -109,7 +106,6 @@ instance
       <*> toSpecRep (txb ^. auxDataHashTxBodyL)
       <*> toSpecRep (txb ^. networkIdTxBodyL)
       <*> toSpecRep (txb ^. currentTreasuryValueTxBodyL)
-      <*> pure sizeTx
       <*> toSpecRep txId
       <*> toSpecRep (txb ^. collateralInputsTxBodyL)
       <*> toSpecRep (txb ^. reqSignerHashesTxBodyL)
@@ -121,8 +117,9 @@ instance SpecTranslate ctx (Tx ConwayEra) where
   toSpecRep tx =
     Agda.MkTx
       <$> withCtx
-        (ConwayTxBodyTransContext (tx ^. sizeTxF) (txIdTx tx))
+        (ConwayTxBodyTransContext (txIdTx tx))
         (toSpecRep (tx ^. bodyTxL))
       <*> toSpecRep (tx ^. witsTxL)
+      <*> toSpecRep (tx ^. sizeTxF)
       <*> toSpecRep (tx ^. isValidTxL)
       <*> toSpecRep (tx ^. auxDataTxL)


### PR DESCRIPTION
# Description

Conformance is broken wrt `master` in `fls` since we moved `TxSize` from `TxBody` to `Tx` in the formal spec (PR [#818](https://github.com/IntersectMBO/formal-ledger-specifications/pull/818)).

This PR updates the pointer to `fls` and fixes the build.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
