### PR TITLE
Change the type of `dRepDeposits` to `CompactForm Coin`

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.20.0.0
 
+* Change the type of `cppDRepDeposit` to `CompactForm Coin`
+* Add `ppDRepDepositCompactL` and `ppuDRepDepositCompactL`
+* Replace `hkdDRepDepositL` with `hkdDRepDepositCompactL`
 * Delete `Tx` newtype wrapper
 * Hide `Cardano.Ledger.Conway.Translation` module and remove its re-exports: `addrPtrNormalize` and `translateDatum`
 * Removed:

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/State/CertState.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/State/CertState.hs
@@ -36,6 +36,7 @@ import Cardano.Ledger.Binary (
   encodeListLen,
  )
 import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Conway.State.Account (ConwayEraAccounts)
 import Cardano.Ledger.Conway.State.VState
@@ -112,7 +113,7 @@ conwayObligationCertState :: ConwayEraCertState era => CertState era -> Obligati
 conwayObligationCertState certState =
   let accum ans drepState = ans <> drepDeposit drepState
    in (shelleyObligationCertState certState)
-        { oblDRep = F.foldl' accum (Coin 0) (certState ^. certVStateL . vsDRepsL)
+        { oblDRep = fromCompact $ F.foldl' accum mempty (certState ^. certVStateL . vsDRepsL)
         }
 
 conwayCertsTotalDepositsTxBody ::

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/State/VState.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/State/VState.hs
@@ -32,6 +32,7 @@ import Cardano.Ledger.Binary (
  )
 import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
 import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Shelley.State
@@ -64,7 +65,7 @@ data VState era = VState
 
 -- | Function that looks up the deposit for currently registered DRep
 lookupDepositVState :: VState era -> Credential 'DRepRole -> Maybe Coin
-lookupDepositVState vstate = fmap drepDeposit . flip Map.lookup (vstate ^. vsDRepsL)
+lookupDepositVState vstate = fmap (fromCompact . drepDeposit) . flip Map.lookup (vstate ^. vsDRepsL)
 
 instance Default (VState era) where
   def = VState def def (EpochNo 0)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Genesis.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Genesis.hs
@@ -8,7 +8,7 @@
 module Test.Cardano.Ledger.Conway.Genesis (expectedConwayGenesis) where
 
 import Cardano.Ledger.BaseTypes (EpochInterval (..), textToUrl)
-import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Coin (Coin (..), CompactForm (..))
 import Cardano.Ledger.Conway
 import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
 import Cardano.Ledger.Conway.Governance (Anchor (..), Committee (..))
@@ -62,7 +62,7 @@ expectedConwayGenesis =
             , DRepState
                 { drepExpiry = EpochNo 1000
                 , drepAnchor = SNothing
-                , drepDeposit = Coin 5000
+                , drepDeposit = CompactCoin 5000
                 , drepDelegs = mempty
                 }
             )
@@ -77,7 +77,7 @@ expectedConwayGenesis =
                         { anchorUrl = fromJust $ textToUrl 99 "example.com"
                         , anchorDataHash = def
                         }
-                , drepDeposit = Coin 6000
+                , drepDeposit = CompactCoin 6000
                 , drepDelegs = mempty
                 }
             )

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -363,7 +363,7 @@ unRegisterDRep ::
   ImpTestM era ()
 unRegisterDRep drep = do
   drepState <- getDRepState drep
-  let refund = drepDeposit drepState
+  let refund = fromCompact $ drepDeposit drepState
   submitTxAnn_ "UnRegister DRep" $
     mkBasicTx mkBasicTxBody
       & bodyTxL . certsTxBodyL

--- a/eras/dijkstra/src/Cardano/Ledger/Dijkstra/PParams.hs
+++ b/eras/dijkstra/src/Cardano/Ledger/Dijkstra/PParams.hs
@@ -135,7 +135,7 @@ data DijkstraPParams f era = DijkstraPParams
   -- ^ Gov action lifetime in number of Epochs
   , dppGovActionDeposit :: !(THKD ('PPGroups 'GovGroup 'SecurityGroup) f Coin)
   -- ^ The amount of the Gov Action deposit
-  , dppDRepDeposit :: !(THKD ('PPGroups 'GovGroup 'NoStakePoolGroup) f Coin)
+  , dppDRepDeposit :: !(THKD ('PPGroups 'GovGroup 'NoStakePoolGroup) f (CompactForm Coin))
   -- ^ The amount of a DRep registration deposit
   , dppDRepActivity :: !(THKD ('PPGroups 'GovGroup 'NoStakePoolGroup) f EpochInterval)
   -- ^ The number of Epochs that a DRep can perform no activity without losing their @Active@ status.
@@ -558,7 +558,7 @@ instance ConwayEraPParams DijkstraEra where
     lens (unTHKD . dppGovActionLifetime) $ \pp x -> pp {dppGovActionLifetime = THKD x}
   hkdGovActionDepositL =
     lens (unTHKD . dppGovActionDeposit) $ \pp x -> pp {dppGovActionDeposit = THKD x}
-  hkdDRepDepositL =
+  hkdDRepDepositCompactL =
     lens (unTHKD . dppDRepDeposit) $ \pp x -> pp {dppDRepDeposit = THKD x}
   hkdDRepActivityL =
     lens (unTHKD . dppDRepActivity) $ \pp x -> pp {dppDRepActivity = THKD x}
@@ -601,7 +601,7 @@ emptyDijkstraPParams =
     , dppCommitteeMaxTermLength = THKD (EpochInterval 0)
     , dppGovActionLifetime = THKD (EpochInterval 0)
     , dppGovActionDeposit = THKD (Coin 0)
-    , dppDRepDeposit = THKD (Coin 0)
+    , dppDRepDeposit = THKD (CompactCoin 0)
     , dppDRepActivity = THKD (EpochInterval 0)
     , dppMinFeeRefScriptCostPerByte = THKD minBound
     , dppMaxRefScriptSizePerBlock = THKD 0

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.18.0.0
 
+* Add `drepDepositCompactL`
+* Change the type of `drepDeposit` to `CompactForm Coin`
 * Remove `AccountState` type synonym for `ChainAccountState`
 * Remove `rewards`, `delegations`, `ptrsMap` and `dsUnifiedL`
 * Replace `dsUnified` with `dsAccounts` in `DState`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/DRep.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/DRep.hs
@@ -28,7 +28,7 @@ import Cardano.Ledger.Binary (
   internsFromSet,
  )
 import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
-import Cardano.Ledger.Coin (Coin)
+import Cardano.Ledger.Coin (Coin, CompactForm, partialCompactCoinL)
 import Cardano.Ledger.Credential (Credential (..), credToText, parseCredential)
 import Cardano.Ledger.Hashes (ScriptHash)
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
@@ -147,7 +147,7 @@ pattern DRepCredential c <- (dRepToCred -> Just c)
 data DRepState = DRepState
   { drepExpiry :: !EpochNo
   , drepAnchor :: !(StrictMaybe Anchor)
-  , drepDeposit :: !Coin
+  , drepDeposit :: !(CompactForm Coin)
   , drepDelegs :: !(Set (Credential 'Staking))
   }
   deriving (Show, Eq, Ord, Generic)
@@ -208,7 +208,10 @@ drepAnchorL :: Lens' DRepState (StrictMaybe Anchor)
 drepAnchorL = lens drepAnchor (\x y -> x {drepAnchor = y})
 
 drepDepositL :: Lens' DRepState Coin
-drepDepositL = lens drepDeposit (\x y -> x {drepDeposit = y})
+drepDepositL = drepDepositCompactL . partialCompactCoinL
+
+drepDepositCompactL :: Lens' DRepState (CompactForm Coin)
+drepDepositCompactL = lens drepDeposit (\x y -> x {drepDeposit = y})
 
 drepDelegsL :: Lens' DRepState (Set (Credential 'Staking))
 drepDelegsL = lens drepDelegs (\x y -> x {drepDelegs = y})

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/ToPlutusData.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/ToPlutusData.hs
@@ -107,7 +107,6 @@ deriving instance ToPlutusData Coin
 
 instance ToPlutusData (CompactForm Coin) where
   toPlutusData = toPlutusData . fromCompact
-
   fromPlutusData (I i) = toCompact (Coin i)
   fromPlutusData _ = Nothing
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/ToPlutusData.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/ToPlutusData.hs
@@ -107,6 +107,7 @@ deriving instance ToPlutusData Coin
 
 instance ToPlutusData (CompactForm Coin) where
   toPlutusData = toPlutusData . fromCompact
+
   fromPlutusData (I i) = toCompact (Coin i)
   fromPlutusData _ = Nothing
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
@@ -251,16 +251,16 @@ vStateSpec univ epoch whoDelegated = constrained $ \ [var|vstate|] ->
     , forAll dreps $ \ [var|pair|] ->
         match pair $ \ [var|drep|] [var|drepstate|] ->
           [ satisfies drep (witCredSpec univ)
-          , match drepstate $ \ [var|expiry|] _anchor [var|drepDdeposit|] [var|delegs|] ->
+          , match drepstate $ \ [var|expiry|] _anchor [var|drepDeposit'|] [var|delegs|] ->
               onJust (lookup_ drep (lit whoDelegated)) $ \ [var|delegSet|] ->
                 [ assertExplain (pure "all delegatees have delegated") $ delegs ==. delegSet
                 , witness univ delegSet
                 , assertExplain (pure "epoch of expiration must follow the current epoch") $ epoch <=. expiry
-                , assertExplain (pure "no deposit is 0") $ lit (Coin 0) <=. drepDdeposit
+                , assertExplain (pure "no deposit is 0") $ match drepDeposit' (lit 0 <=.)
                 ]
           ]
     , assertExplain (pure "num dormant epochs should not be too large") $
-        [epoch <=. numdormant, numdormant <=. epoch + (lit (EpochNo 10))]
+        [epoch <=. numdormant, numdormant <=. epoch + lit (EpochNo 10)]
     , dependsOn numdormant epoch -- Solve epoch first.
     , match committeestate $ \ [var|committeemap|] ->
         [witness univ (dom_ committeemap), satisfies committeemap (hasSize (rangeSize 1 4))]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
@@ -219,6 +219,6 @@ depositsMap certState props =
           (fromCompact . (^. depositAccountStateL))
           (certState ^. certDStateL . accountsL . accountsMapL)
     , Map.mapKeys PoolDeposit $ certState ^. certPStateL . psDepositsL
-    , fmap drepDeposit . Map.mapKeys DRepDeposit $ certState ^. certVStateL . vsDRepsL
+    , fmap (fromCompact . drepDeposit) . Map.mapKeys DRepDeposit $ certState ^. certVStateL . vsDRepsL
     , Map.fromList . fmap (bimap GovActionDeposit gasDeposit) $ OMap.assocList (props ^. pPropsL)
     ]


### PR DESCRIPTION
# Description

This PR changes the type of `dRepDeposits` from `Coin` to `CompactForm`, similar to what I did to `poolDeposits` in #5031.

close #5094

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
