### PR TITLE
Replace `PPViewHashesDontMatch` with `ScriptIntegrityHashMismatch` starting from PV 11

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.14.0.0
 
+* Add `mkScriptIntegrity`
+* Changed the type of `hashScriptIntegrity`
+* Add `ScriptIntegrityHashMismatch`
+* Rename `ppViewHashesMatch` to `checkScriptIntegrityHash`
 * Add `emptyUpgradePParamsUpdate` method to `AlonzoEraPParams`
 * Add `mkBasicBlockBodyAlonzo` and `txSeqBlockBodyAlonzoL` to use in Babbage, Conway and Dijkstra.
 * Added `eraUnsupportedLanguage`
@@ -44,6 +48,8 @@
 
 ### `testlib`
 
+* Add `Arbitrary` instance for `LangDepView`
+* Add `computeScriptIntegrityPure`, `computeScriptIntegrity` and `computeScriptIntegrityHash`
 * Added `TxInfoPV4` to `VersionedTxInfo`
 * Added `Arbitrary` instance for `TransitionConfig BabbageEra`
 * Added `ToExpr` instances for:

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
@@ -38,7 +38,11 @@ import Cardano.Ledger.Alonzo (AlonzoEra, Tx (..))
 import Cardano.Ledger.Alonzo.BlockBody (AlonzoBlockBody (AlonzoBlockBody))
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
-import Cardano.Ledger.Alonzo.PParams (AlonzoPParams (AlonzoPParams), OrdExUnits (OrdExUnits))
+import Cardano.Ledger.Alonzo.PParams (
+  AlonzoPParams (AlonzoPParams),
+  LangDepView (..),
+  OrdExUnits (OrdExUnits),
+ )
 import Cardano.Ledger.Alonzo.Plutus.Context (
   EraPlutusContext (ContextError),
   EraPlutusTxInfo,
@@ -480,3 +484,6 @@ instance
   Arbitrary (AlonzoBlockBody era)
   where
   arbitrary = AlonzoBlockBody <$> arbitrary
+
+instance Arbitrary LangDepView where
+  arbitrary = LangDepView <$> arbitrary <*> arbitrary

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Invalid.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Invalid.hs
@@ -125,9 +125,9 @@ spec = describe "Invalid transactions" $ do
                       PPViewHashesDontMatch Mismatch {mismatchSupplied = badHash, mismatchExpected = goodHash}
                   ]
 
-          it "Mismatched" $
+          it "Mismatched" . whenMajorVersionAtMost @10 $
             testHashMismatch . SJust =<< arbitrary
-          it "Missing" $
+          it "Missing" . whenMajorVersionAtMost @10 $
             testHashMismatch SNothing
 
         it "UnspendableUTxONoDatumHash" $ do

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.20.0.0
 
+* Add `ScriptIntegrityHashMismatch`
 * Change the type of `cppDRepDeposit` to `CompactForm Coin`
 * Add `ppDRepDepositCompactL` and `ppuDRepDepositCompactL`
 * Replace `hkdDRepDepositL` with `hkdDRepDepositCompactL`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -150,6 +150,7 @@ library testlib
     Test.Cardano.Ledger.Conway.Imp.RatifySpec
     Test.Cardano.Ledger.Conway.Imp.UtxoSpec
     Test.Cardano.Ledger.Conway.Imp.UtxosSpec
+    Test.Cardano.Ledger.Conway.Imp.UtxowSpec
     Test.Cardano.Ledger.Conway.ImpTest
     Test.Cardano.Ledger.Conway.Plutus.PlutusSpec
     Test.Cardano.Ledger.Conway.Proposals

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -8,7 +8,10 @@
 
 module Test.Cardano.Ledger.Conway.Imp (spec, conwaySpec) where
 
-import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext (ContextError))
+import Cardano.Ledger.Alonzo.Plutus.Context (
+  EraPlutusContext (ContextError),
+  EraPlutusTxInfo,
+ )
 import Cardano.Ledger.Alonzo.Rules (
   AlonzoUtxoPredFailure,
   AlonzoUtxosPredFailure,
@@ -29,8 +32,10 @@ import Cardano.Ledger.Conway.Rules (
   ConwayLedgerPredFailure,
   ConwayNewEpochEvent,
   ConwayUtxoPredFailure,
+  ConwayUtxowPredFailure,
  )
 import Cardano.Ledger.Conway.TxInfo (ConwayContextError)
+import Cardano.Ledger.Plutus (Language (..))
 import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
 import Cardano.Ledger.Shelley.Rules (
   ShelleyDelegPredFailure,
@@ -51,6 +56,7 @@ import qualified Test.Cardano.Ledger.Conway.Imp.LedgerSpec as Ledger
 import qualified Test.Cardano.Ledger.Conway.Imp.RatifySpec as Ratify
 import qualified Test.Cardano.Ledger.Conway.Imp.UtxoSpec as Utxo
 import qualified Test.Cardano.Ledger.Conway.Imp.UtxosSpec as Utxos
+import qualified Test.Cardano.Ledger.Conway.Imp.UtxowSpec as Utxow
 import Test.Cardano.Ledger.Conway.ImpTest (
   ConwayEraImp,
   LedgerSpec,
@@ -78,6 +84,7 @@ spec ::
   , InjectRuleFailure "LEDGER" ConwayGovCertPredFailure era
   , InjectRuleFailure "LEDGER" ConwayLedgerPredFailure era
   , InjectRuleFailure "LEDGER" ConwayUtxoPredFailure era
+  , InjectRuleFailure "LEDGER" ConwayUtxowPredFailure era
   , InjectRuleFailure "BBODY" ConwayBbodyPredFailure era
   , InjectRuleEvent "TICK" ConwayEpochEvent era
   , Event (EraRule "EPOCH" era) ~ ConwayEpochEvent era
@@ -89,6 +96,7 @@ spec ::
   , Eq (Event (EraRule "ENACT" era))
   , Typeable (Event (EraRule "ENACT" era))
   , ToExpr (Event (EraRule "BBODY" era))
+  , EraPlutusTxInfo PlutusV2 era
   ) =>
   Spec
 spec = do
@@ -114,6 +122,7 @@ conwaySpec ::
   , InjectRuleFailure "LEDGER" ConwayGovCertPredFailure era
   , InjectRuleFailure "LEDGER" ConwayLedgerPredFailure era
   , InjectRuleFailure "LEDGER" ConwayUtxoPredFailure era
+  , InjectRuleFailure "LEDGER" ConwayUtxowPredFailure era
   , InjectRuleFailure "BBODY" ConwayBbodyPredFailure era
   , InjectRuleEvent "TICK" ConwayEpochEvent era
   , Event (EraRule "EPOCH" era) ~ ConwayEpochEvent era
@@ -125,6 +134,7 @@ conwaySpec ::
   , Eq (Event (EraRule "ENACT" era))
   , Typeable (Event (EraRule "ENACT" era))
   , ToExpr (Event (EraRule "BBODY" era))
+  , EraPlutusTxInfo PlutusV2 era
   ) =>
   SpecWith (ImpInit (LedgerSpec era))
 conwaySpec = do
@@ -139,3 +149,4 @@ conwaySpec = do
   describe "RATIFY" Ratify.spec
   describe "UTXO" Utxo.spec
   describe "UTXOS" Utxos.spec
+  describe "UTXOW" Utxow.spec

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxowSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxowSpec.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Conway.Imp.UtxowSpec (spec) where
+
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusTxInfo)
+import Cardano.Ledger.Babbage.Tx (ScriptIntegrity (..), getLanguageView)
+import Cardano.Ledger.BaseTypes (
+  Inject (..),
+  Mismatch (..),
+  Network (..),
+  StrictMaybe (..),
+  TxIx (..),
+ )
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway.Core (
+  AlonzoEraTxBody (..),
+  AlonzoEraTxWits (..),
+  CoinPerByte (..),
+  EraIndependentScriptIntegrity,
+  EraTx (..),
+  EraTxBody (..),
+  EraTxOut (..),
+  EraTxWits (..),
+  InjectRuleFailure (..),
+  SafeHash,
+  SafeToHash (..),
+  ppCoinsPerUTxOByteL,
+  txIdTx,
+ )
+import Cardano.Ledger.Conway.Rules (ConwayUtxowPredFailure (..))
+import Cardano.Ledger.Credential (Credential (..), StakeReference)
+import Cardano.Ledger.Plutus (Language (..), SLanguage (..), hashPlutusScript)
+import Cardano.Ledger.TxIn (TxIn (..))
+import Lens.Micro ((&), (.~), (^.))
+import Test.Cardano.Ledger.Conway.ImpTest
+import Test.Cardano.Ledger.Imp.Common
+import Test.Cardano.Ledger.Plutus.Examples (alwaysSucceedsWithDatum)
+
+spec ::
+  forall era.
+  ( ConwayEraImp era
+  , InjectRuleFailure "LEDGER" ConwayUtxowPredFailure era
+  , EraPlutusTxInfo PlutusV2 era
+  ) =>
+  SpecWith (ImpInit (LedgerSpec era))
+spec = do
+  it "Fails with PPViewHashesDontMatch before PV 11" . whenMajorVersionAtMost @10 $ do
+    fixedTx <- fixupTx =<< setupBadPPViewHashTx
+    badScriptIntegrityHash <- arbitrary
+    tx <- substituteIntegrityHashAndFixWits badScriptIntegrityHash fixedTx
+    scriptIntegrityHash <- computeScriptIntegrityHash tx
+    impAnn "Submit a transaction with an invalid script integrity hash"
+      . withNoFixup
+      $ submitFailingTx
+        tx
+        [ injectFailure . PPViewHashesDontMatch $
+            Mismatch
+              { mismatchSupplied = badScriptIntegrityHash
+              , mismatchExpected = scriptIntegrityHash
+              }
+        ]
+  it "Fails with PPViewHashesDontMatchInformative after PV 11" . whenMajorVersionAtLeast @11 $ do
+    fixedTx <- fixupTx =<< setupBadPPViewHashTx
+    pp <- getsPParams id
+    badScriptIntegrityHash <- arbitrary
+    let
+      langView = [getLanguageView pp PlutusV2]
+      scriptIntegrity = ScriptIntegrity @era redeemers dats langView
+      redeemers = fixedTx ^. witsTxL . rdmrsTxWitsL
+      dats = fixedTx ^. witsTxL . datsTxWitsL
+    tx <- substituteIntegrityHashAndFixWits badScriptIntegrityHash fixedTx
+    scriptIntegrityHash <- computeScriptIntegrityHash tx
+    let
+      mismatch =
+        Mismatch
+          { mismatchSupplied = badScriptIntegrityHash
+          , mismatchExpected = scriptIntegrityHash
+          }
+    impAnn "Submit a transaction with an invalid script integrity hash"
+      . withNoFixup
+      $ submitFailingTx
+        tx
+        [ injectFailure $ ScriptIntegrityHashMismatch mismatch (SJust $ originalBytes scriptIntegrity)
+        ]
+
+setupBadPPViewHashTx ::
+  forall era.
+  ConwayEraImp era =>
+  ImpTestM era (Tx era)
+setupBadPPViewHashTx = do
+  modifyPParams $ ppCoinsPerUTxOByteL .~ CoinPerByte (Coin 1)
+  someKeyHash <- arbitrary @StakeReference
+  let scriptTxOut =
+        mkBasicTxOut
+          ( Addr
+              Testnet
+              (ScriptHashObj (hashPlutusScript $ alwaysSucceedsWithDatum SPlutusV2))
+              someKeyHash
+          )
+          (inject $ Coin 1_000_000)
+  scriptTxIn <-
+    impAnn "Submit a transaction that has a script output"
+      . submitTx
+      $ mkBasicTx mkBasicTxBody
+        & bodyTxL . outputsTxBodyL .~ [scriptTxOut]
+  pure $
+    mkBasicTx mkBasicTxBody
+      & bodyTxL . inputsTxBodyL .~ [TxIn (txIdTx scriptTxIn) (TxIx 0)]
+
+substituteIntegrityHashAndFixWits ::
+  forall era.
+  ConwayEraImp era =>
+  StrictMaybe (SafeHash EraIndependentScriptIntegrity) ->
+  Tx era ->
+  ImpTestM era (Tx era)
+substituteIntegrityHashAndFixWits hash tx =
+  let txWithNewHash =
+        tx
+          & bodyTxL . scriptIntegrityHashTxBodyL .~ hash
+          & witsTxL .~ mkBasicTxWits
+   in fixupScriptWits txWithNewHash
+        >>= fixupDatums
+        >>= fixupRedeemers
+        >>= updateAddrTxWits

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Spec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Spec.hs
@@ -41,6 +41,7 @@ import Cardano.Ledger.Conway.Rules (
   ConwayLedgerPredFailure,
   ConwayNewEpochEvent,
   ConwayUtxoPredFailure,
+  ConwayUtxowPredFailure,
  )
 import Cardano.Ledger.Conway.TxCert (ConwayTxCert)
 import Cardano.Ledger.Conway.TxInfo (ConwayContextError)
@@ -102,6 +103,7 @@ spec ::
   , InjectRuleFailure "LEDGER" ConwayGovCertPredFailure era
   , InjectRuleFailure "LEDGER" ConwayLedgerPredFailure era
   , InjectRuleFailure "LEDGER" ConwayUtxoPredFailure era
+  , InjectRuleFailure "LEDGER" ConwayUtxowPredFailure era
   , InjectRuleEvent "TICK" ConwayEpochEvent era
   , NFData (Event (EraRule "ENACT" era))
   , ToExpr (Event (EraRule "ENACT" era))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Instances.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Instances.hs
@@ -62,10 +62,10 @@ import Test.Cardano.Ledger.Generic.Proof (Reflect)
 import Test.Cardano.Ledger.Generic.TxGen (
   alonzoMkRedeemers,
   alonzoMkRedeemersFromTags,
-  alonzoNewScriptIntegrityHash,
   mkAlonzoPlutusPurposePointer,
   mkConwayPlutusPurposePointer,
  )
+import Test.Cardano.Ledger.Generic.Updaters (alonzoNewScriptIntegrityHash)
 import Test.Cardano.Ledger.Shelley.Generator.Core (genNatural)
 import Test.Cardano.Ledger.Shelley.Utils (epochFromSlotNo)
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
@@ -22,7 +22,6 @@
 module Test.Cardano.Ledger.Generic.TxGen (
   alonzoMkRedeemers,
   alonzoMkRedeemersFromTags,
-  alonzoNewScriptIntegrityHash,
   mkAlonzoPlutusPurposePointer,
   mkConwayPlutusPurposePointer,
   genAlonzoTx,
@@ -141,7 +140,6 @@ import Test.Cardano.Ledger.Generic.ModelState (
   UtxoEntry,
  )
 import Test.Cardano.Ledger.Generic.Proof hiding (lift)
-import Test.Cardano.Ledger.Generic.Updaters (alonzoNewScriptIntegrityHash)
 import Test.Cardano.Ledger.Shelley.Serialisation.EraIndepGenerators ()
 import Test.Cardano.Ledger.Shelley.Utils (epochFromSlotNo, runShelleyBase)
 import Test.QuickCheck

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Updaters.hs
@@ -1,81 +1,23 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Cardano.Ledger.Generic.Updaters where
 
 import Cardano.Crypto.DSIGN.Class ()
-import Cardano.Ledger.Alonzo.Tx (hashScriptIntegrity)
+import Cardano.Ledger.Alonzo.Core (AlonzoEraPParams, AlonzoEraScript, PParams)
+import qualified Cardano.Ledger.Alonzo.Core as Alonzo
+import Cardano.Ledger.Alonzo.Tx (ScriptIntegrity (..), hashScriptIntegrity)
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
 import Cardano.Ledger.Alonzo.TxWits (Redeemers (..), TxDats (..))
-import Cardano.Ledger.Babbage.Core
+import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Plutus.Language (Language (..))
-import Data.Map (Map)
-import qualified Data.Map.Strict as Map
-import Data.Maybe.Strict (StrictMaybe (..))
-import Data.Set (Set)
 import qualified Data.Set as Set
 import Test.Cardano.Ledger.Generic.Proof
 
--- ===========================================================================
--- Upaters and the use of Policy to specify Merge Semantics and use of [t] as inputs.
--- When using the Updaters, one will usually consruct the fields by hand.
--- So if a Field consists of (Set t), (StrictSeq t), [t], (Maybe t), (StrictMaybe t), or (Map key t)
--- we will use a list, and convert to the appropriate type for each Field and Era.
--- Several of these: (Map key t), (Maybe t) and (StrictMaybe t) can be problematic
--- since they only have a well defined Merge semantics when (SemiGroup t) .
--- So we define specialized functions applyMap, applyMaybe and applySMaybe that raise
--- an error if a Merge semantics finds more than one copy of the elements being combined.
--- Users may choose what merge semantics they want by passing the right Policy
--- =============================================================================
-
--- =======================================================================
--- A Policy lets you choose to keep the old (first) or the new (override)
--- or combine (merge) of two values. We only use this for elements in the
--- WitnessesField data type. That is because we assemble witnesses in small
--- pieces and we combine the pieces together. Every field in ShelleyTxWits and
--- AlonzoTxWits has clear way of being merged. We don't use Policies in the other
--- xxxField types because most of those parts cannot be safely combined.
--- (The only execeptions are Coin and Value, but they both have Monoid
--- instances, where we can easliy use (<>) instead.).
-
-class Merge t where
-  first :: t -> t -> t
-  first x _ = x
-  override :: t -> t -> t
-  override _ y = y
-  merge :: t -> t -> t
-
-type Policy = (forall t. Merge t => t -> t -> t)
-
--- We need just these 4 instances to merge components of TxWitnesses
-
-instance Ord a => Merge (Set a) where
-  merge = Set.union
-
-instance Era era => Merge (TxDats era) where
-  merge (TxDats x) (TxDats y) = TxDats (Map.union x y)
-
-instance AlonzoEraScript era => Merge (Redeemers era) where
-  merge (Redeemers x) (Redeemers y) = Redeemers (Map.union x y)
-
-instance Merge (Map ScriptHash v) where
-  merge = Map.union
-
--- ====================================================================
--- Building Era parametric Records
--- ====================================================================
-
--- | This only make sense in the Alonzo era and forward, all other Eras return Nothing
 alonzoNewScriptIntegrityHash ::
+  forall era.
   ( AlonzoEraScript era
   , AlonzoEraPParams era
   ) =>
@@ -84,8 +26,14 @@ alonzoNewScriptIntegrityHash ::
   Redeemers era ->
   TxDats era ->
   StrictMaybe Alonzo.ScriptIntegrityHash
-alonzoNewScriptIntegrityHash pp ls =
-  hashScriptIntegrity (Set.map (Alonzo.getLanguageView pp) (Set.fromList ls))
+alonzoNewScriptIntegrityHash pp ls redeemers@(Redeemers r) dats@(TxDats d)
+  | null d
+  , null r
+  , null ls =
+      SNothing
+  | otherwise =
+      SJust . hashScriptIntegrity @era $
+        ScriptIntegrity redeemers dats (Set.map (Alonzo.getLanguageView pp) $ Set.fromList ls)
 
 languages :: Proof era -> [Language]
 languages Shelley = []


### PR DESCRIPTION
# Description

This PR adds a new `ScriptIntegrityHashMismatch` predicate failure to Conway's `UTXOW` rule. The new predicate failure is similar to the old `PPViewHashesDontMatch` failure, but it also contains the bytestring that was hashed by the node in order to compute the script integrity hash. This new predicate failure will be thrown instead of the old one starting from protocol version 11.

close #4517 

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
