### PR TITLE
Add a nix sha256 for the `constrained-generators` srp

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -21,6 +21,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/constrained-generators.git
+  --sha256: sha256-aGf55Kpp0pVQT8/rE4jPB0s2W1OZopMdFnnEdCPYcvM=
   tag: 35b625eaeaa0953710c0a07add0673fdde5fa052
 
 -- NOTE: If you would like to update the above,


### PR DESCRIPTION
A follow-up to #5171

It avoids a lot of annoying messages when you run `nix develop`