### PR TITLE
add `queryDRepDelegations` ledger state query

### DIFF
--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.12.0.0
 
+* Add `queryDRepDelegations` state query
 * Remove `filterStakePoolDelegsAndRewards` as unnecessary. Use `queryStakePoolDelegsAndRewards` instead
 * Expose `binaryUpgradeTx`, `binaryUpgradeTxBody`, `binaryUpgradeTxWits`, `binaryUpgradeTxAuxData`, `upgradeTx`, `upgradeTxBody`, `upgradeTxWits`, `upgradeTxAuxData`
 * Add `EraApi` class

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.18.0.0
 
+* Export `credToDRep` and `dRepToCred`
 * Deprecate `PoolParams` in favor of `StakePoolState`. #5196
   * Move the `PoolParams` module to `Cardano.Ledger.State.StakePool` and export from there.
   * Add the `StakePoolState` data type to the new module.

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/DRep.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/DRep.hs
@@ -11,6 +11,8 @@
 module Cardano.Ledger.DRep (
   DRep (DRepCredential, DRepKeyHash, DRepScriptHash, DRepAlwaysAbstain, DRepAlwaysNoConfidence),
   DRepState (..),
+  credToDRep,
+  dRepToCred,
   drepExpiryL,
   drepAnchorL,
   drepDepositL,


### PR DESCRIPTION
# Description

This adds a ledger state query to obtain the delegators (and deposit) for each DRep, including `DRepAlwaysAbstain` and `DRepAlwaysNoConfidence`, which cannot be queried via the existing `queryDRepState`. Since there is no sensible expiry or anchor for those DReps, a new type is introduced that is like `DRepState` but with those fields omitted. The result is computed by folding over the `UMap`.

This would be useful for [amaru](https://github.com/pragma-org/amaru); see for example [this](https://github.com/pragma-org/amaru/blob/2fb3ea8babdeb999d6333d21f1897cd049693cd5/data/fetch.mjs#L202-L224) comment.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.