### PR TITLE
Add mkBasicBlockBody{Shelley,Alonzo} and txSeqBlockBody{Shelley,Alonzo}L

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/BlockBody.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/BlockBody.hs
@@ -13,15 +13,15 @@ import Cardano.Ledger.Allegra.Era (AllegraEra)
 import Cardano.Ledger.Allegra.Tx ()
 import Cardano.Ledger.Core (EraBlockBody (..))
 import Cardano.Ledger.Shelley.BlockBody (
-  ShelleyBlockBody (ShelleyBlockBody),
+  ShelleyBlockBody,
+  mkBasicBlockBodyShelley,
   shelleyBlockBodyHash,
-  shelleyBlockBodyTxs,
+  txSeqBlockBodyShelleyL,
  )
-import Lens.Micro
 
 instance EraBlockBody AllegraEra where
   type BlockBody AllegraEra = ShelleyBlockBody AllegraEra
-  mkBasicBlockBody = ShelleyBlockBody mempty
-  txSeqBlockBodyL = lens shelleyBlockBodyTxs (\_ s -> ShelleyBlockBody s)
+  mkBasicBlockBody = mkBasicBlockBodyShelley
+  txSeqBlockBodyL = txSeqBlockBodyShelleyL
   hashBlockBody = shelleyBlockBodyHash
   numSegComponents = 3

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.14.0.0
 
+* Add `mkBasicBlockBodyAlonzo` and `txSeqBlockBodyAlonzoL` to use in Babbage, Conway and Dijkstra.
 * Added `eraUnsupportedLanguage`
 * Changed return type of `mkPlutusScript` and `mkBinaryPlutusScript` from `Maybe` to `MonadFail`
 * Deprecate `Alonzo.TxSeq` in favour of `Alonzo.BlockBody`. #5156

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/BlockBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/BlockBody.hs
@@ -1,5 +1,7 @@
 module Cardano.Ledger.Alonzo.BlockBody (
   AlonzoBlockBody (AlonzoBlockBody),
+  mkBasicBlockBodyAlonzo,
+  txSeqBlockBodyAlonzoL,
   alonzoBlockBodyHash,
   alonzoBlockBodyTxs,
 ) where

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/BlockBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/BlockBody.hs
@@ -7,11 +7,10 @@ import Cardano.Ledger.Alonzo.BlockBody
 import Cardano.Ledger.Babbage.Era
 import Cardano.Ledger.Babbage.Tx ()
 import Cardano.Ledger.Core
-import Lens.Micro (lens)
 
 instance EraBlockBody BabbageEra where
   type BlockBody BabbageEra = AlonzoBlockBody BabbageEra
-  mkBasicBlockBody = AlonzoBlockBody mempty
-  txSeqBlockBodyL = lens alonzoBlockBodyTxs (\_ s -> AlonzoBlockBody s)
+  mkBasicBlockBody = mkBasicBlockBodyAlonzo
+  txSeqBlockBodyL = txSeqBlockBodyAlonzoL
   hashBlockBody = alonzoBlockBodyHash
   numSegComponents = 4

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/BlockBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/BlockBody.hs
@@ -7,11 +7,10 @@ import Cardano.Ledger.Alonzo.BlockBody
 import Cardano.Ledger.Conway.Era
 import Cardano.Ledger.Conway.Tx ()
 import Cardano.Ledger.Core
-import Lens.Micro (lens)
 
 instance EraBlockBody ConwayEra where
   type BlockBody ConwayEra = AlonzoBlockBody ConwayEra
-  mkBasicBlockBody = AlonzoBlockBody mempty
-  txSeqBlockBodyL = lens alonzoBlockBodyTxs (\_ s -> AlonzoBlockBody s)
+  mkBasicBlockBody = mkBasicBlockBodyAlonzo
+  txSeqBlockBodyL = txSeqBlockBodyAlonzoL
   hashBlockBody = alonzoBlockBodyHash
   numSegComponents = 4

--- a/eras/dijkstra/src/Cardano/Ledger/Dijkstra/BlockBody.hs
+++ b/eras/dijkstra/src/Cardano/Ledger/Dijkstra/BlockBody.hs
@@ -7,11 +7,10 @@ import Cardano.Ledger.Alonzo.BlockBody
 import Cardano.Ledger.Core
 import Cardano.Ledger.Dijkstra.Era
 import Cardano.Ledger.Dijkstra.Tx ()
-import Lens.Micro (lens)
 
 instance EraBlockBody DijkstraEra where
   type BlockBody DijkstraEra = AlonzoBlockBody DijkstraEra
-  mkBasicBlockBody = AlonzoBlockBody mempty
-  txSeqBlockBodyL = lens alonzoBlockBodyTxs (\_ s -> AlonzoBlockBody s)
+  mkBasicBlockBody = mkBasicBlockBodyAlonzo
+  txSeqBlockBodyL = txSeqBlockBodyAlonzoL
   hashBlockBody = alonzoBlockBodyHash
   numSegComponents = 4

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/BlockBody.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/BlockBody.hs
@@ -13,15 +13,15 @@ import Cardano.Ledger.Core (EraBlockBody (..))
 import Cardano.Ledger.Mary.Era (MaryEra)
 import Cardano.Ledger.Mary.Tx ()
 import Cardano.Ledger.Shelley.BlockBody (
-  ShelleyBlockBody (ShelleyBlockBody),
+  ShelleyBlockBody,
+  mkBasicBlockBodyShelley,
   shelleyBlockBodyHash,
-  shelleyBlockBodyTxs,
+  txSeqBlockBodyShelleyL,
  )
-import Lens.Micro
 
 instance EraBlockBody MaryEra where
   type BlockBody MaryEra = ShelleyBlockBody MaryEra
-  mkBasicBlockBody = ShelleyBlockBody mempty
-  txSeqBlockBodyL = lens shelleyBlockBodyTxs (\_ s -> ShelleyBlockBody s)
+  mkBasicBlockBody = mkBasicBlockBodyShelley
+  txSeqBlockBodyL = txSeqBlockBodyShelleyL
   hashBlockBody = shelleyBlockBodyHash
   numSegComponents = 3

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.17.0.0
 
+* Add `mkBasicBlockBodyShelley` and `txSeqBlockBodyShelleyL` to use in Allegra and Mary.
 * Add `Default` instance for `NewEpochState`
 * Remove `epochStateUMapL`, `unifiedL`, `rewards`, `delegations`, `ptrsMap` and `dsUnifiedL`
 * Add `ShelleyEraAccounts` with `mkShelleyAccountState`, `accountsPtrsMapG`, `ptrAccountStateG`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/BlockBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/BlockBody.hs
@@ -1,5 +1,7 @@
 module Cardano.Ledger.Shelley.BlockBody (
   ShelleyBlockBody (ShelleyBlockBody),
+  txSeqBlockBodyShelleyL,
+  mkBasicBlockBodyShelley,
   shelleyBlockBodyHash,
   shelleyBlockBodyTxs,
   auxDataSeqDecoder,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/BlockChain.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/BlockChain.hs
@@ -2,10 +2,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 


### PR DESCRIPTION
And also add the `INLINEABLE` pragma for them to be reused in other eras.

This is a followup to #5156 that addressed #5121.

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] ~~Tests added or updated when needed.~~
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] ~~Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).~~
- [ ] ~~Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).~~
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
