### PR TITLE
Conway:DELEG: Predfailures for deposits & refunds

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.20.0.0
 
+* Better predicate failures for incorrect deposits and refunds.
+  * Add `hardforkConwayDELEGIncorrectDepositsAndRefunds` for protocol 11 onwards, to `Conway.Era`.
+  * Add `DepositIncorrectDELEG` and `RefundIncorrectDELEG` to `ConwayDelegPredFailure`.
 * Add `ScriptIntegrityHashMismatch`
 * Change the type of `cppDRepDeposit` to `CompactForm Coin`
 * Add `ppDRepDepositCompactL` and `ppuDRepDepositCompactL`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -10,6 +10,7 @@ module Cardano.Ledger.Conway (
   ConwayEra,
   hardforkConwayBootstrapPhase,
   hardforkConwayDisallowUnelectedCommitteeFromVoting,
+  hardforkConwayDELEGIncorrectDepositsAndRefunds,
   Tx (..),
 ) where
 
@@ -18,6 +19,7 @@ import Cardano.Ledger.Conway.BlockBody ()
 import Cardano.Ledger.Conway.Era (
   ConwayEra,
   hardforkConwayBootstrapPhase,
+  hardforkConwayDELEGIncorrectDepositsAndRefunds,
   hardforkConwayDisallowUnelectedCommitteeFromVoting,
  )
 import Cardano.Ledger.Conway.Governance (RunConwayRatify (..))

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
@@ -28,6 +28,7 @@ module Cardano.Ledger.Conway.Era (
   ConwayRATIFY,
   hardforkConwayBootstrapPhase,
   hardforkConwayDisallowUnelectedCommitteeFromVoting,
+  hardforkConwayDELEGIncorrectDepositsAndRefunds,
 ) where
 
 import Cardano.Ledger.Babbage (BabbageEra)
@@ -182,3 +183,7 @@ hardforkConwayBootstrapPhase pv = pvMajor pv == natVersion @9
 -- members to submit votes.
 hardforkConwayDisallowUnelectedCommitteeFromVoting :: ProtVer -> Bool
 hardforkConwayDisallowUnelectedCommitteeFromVoting pv = pvMajor pv > natVersion @10
+
+-- | Starting with protocol version 11, we report incorrect deposit and refunds better
+hardforkConwayDELEGIncorrectDepositsAndRefunds :: ProtVer -> Bool
+hardforkConwayDELEGIncorrectDepositsAndRefunds pv = pvMajor pv > natVersion @10


### PR DESCRIPTION
# Description

- Add `hardforkConwayDELEGIncorrectDepositsAndRefunds` for protocol 11 onwards, to `Conway.Era`.
- Add `DepositIncorrectDELEG` and `RefundIncorrectDELEG` to `ConwayDelegPredFailure`.


Closes #4655 

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] ~~Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).~~
- [ ] ~~Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).~~
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
