### PR TITLE
SRP for constrained generators via nix inputs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,43 @@ In particular, we should not release our packages to CHaP while we depend on a `
 
 If we are stuck in a situation where we need a long-running fork of a package, we should release it to CHaP instead (see the [CHaP README](https://github.com/IntersectMBO/cardano-haskell-packages) for more).
 
-If you do add a `source-repository-package`, you need to provide a `--sha256` comment in `cabal.project` so that Nix knows the hash of the content.
+### How to add a `source-repository-package`
+
+As an example, we show how [constrained-generators](https://github.com/input-output-hk/constrained-generators.git) was added (pinned at commit `45559e07fe1651ddd257f2a1215dfd65e30a963f`).
+
+1. Add the repository as an input to `flake.nix`:
+
+   ```nix
+   constrained-generators = {
+     url = "github:input-output-hk/constrained-generators";
+     flake = false;
+   };
+   ```
+
+2. Add an entry to `inputMap` in `flake.nix`:
+
+    ```nix
+    inputMap = {
+      ...
+      "https://github.com/input-output-hk/constrained-generators.git" = inputs.constrained-generators;
+      ...
+    };
+    ```
+
+3. Add an SRP entry to `cabal.project`:
+
+   ```
+   source-repository-package
+     type: git
+     location: https://github.com/input-output-hk/constrained-generators.git
+     tag: 45559e07fe1651ddd257f2a1215dfd65e30a963f
+   ```
+
+4. Update the nix flake:
+
+   ```
+   nix flake update constrained-generators --override-input constrained-generators github:input-output-hk/constrained-generators/45559e07fe1651ddd257f2a1215dfd65e30a963f
+   ```
 
 ## Warnings
 

--- a/cabal.project
+++ b/cabal.project
@@ -21,7 +21,6 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/constrained-generators.git
-  --sha256: sha256-HjRCWK+3uTZBPLkpxr7oDlZe2W5kf/5s32XzXPdi6Go=
   tag: 45559e07fe1651ddd257f2a1215dfd65e30a963f
 
 -- NOTE: If you would like to update the above,

--- a/flake.lock
+++ b/flake.lock
@@ -133,6 +133,22 @@
         "type": "github"
       }
     },
+    "constrained-generators": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1752890418,
+        "narHash": "sha256-HjRCWK+3uTZBPLkpxr7oDlZe2W5kf/5s32XzXPdi6Go=",
+        "owner": "input-output-hk",
+        "repo": "constrained-generators",
+        "rev": "45559e07fe1651ddd257f2a1215dfd65e30a963f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "constrained-generators",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -751,6 +767,7 @@
       "inputs": {
         "CHaP": "CHaP",
         "cardano-mainnet-mirror": "cardano-mainnet-mirror",
+        "constrained-generators": "constrained-generators",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "formal-ledger-specifications": "formal-ledger-specifications",

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,11 @@
 
     pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
 
+    constrained-generators = {
+      url = "github:input-output-hk/constrained-generators";
+      flake = false;
+    };
+
     formal-ledger-specifications = {
       url = "github:IntersectMBO/formal-ledger-specifications";
       flake = false;
@@ -87,6 +92,7 @@
           inputMap = {
             "https://chap.intersectmbo.org/" = inputs.CHaP;
             "https://github.com/IntersectMBO/formal-ledger-specifications.git" = inputs.formal-ledger-specifications;
+            "https://github.com/input-output-hk/constrained-generators.git" = inputs.constrained-generators;
           };
           cabalProjectLocal = ''
             repository cardano-haskell-packages-local


### PR DESCRIPTION
# Description

This PR changes how `constrained-generators` is depended upon to be consistent with how the dependency on `formal-ledger-specifications` is specified.

It also adds documentation for future reference.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
