### PR TITLE
Refactor some parts of cardano-ledger-conformance to prepare for Dijkstra

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,8 +257,7 @@ from [the Shelley ledger spec](./eras/shelley/formal-spec)).
 
 ### To build the Haskell code from the Agda ledger spec
 
-See [Build the spec using nix-build](https://github.com/IntersectMBO/formal-ledger-specifications/tree/master?tab=readme-ov-file#build-the-spec-using-nix-build)
-and [Contributing](https://github.com/IntersectMBO/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
+See [Contributing](https://github.com/IntersectMBO/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
 in the [formal-ledger-specifications repo](https://github.com/IntersectMBO/formal-ledger-specifications).
 
 ### To update the referenced Agda ledger spec

--- a/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
+++ b/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
@@ -55,6 +55,7 @@ library
     Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Ledgers
     Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool
     Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Utxo
+    Test.Cardano.Ledger.Conformance.SpecTranslate.Core
 
   default-language: Haskell2010
   ghc-options:

--- a/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
+++ b/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
@@ -23,8 +23,8 @@ library
     Test.Cardano.Ledger.Conformance
     Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway
     Test.Cardano.Ledger.Conformance.ExecSpecRule.Core
+    Test.Cardano.Ledger.Conformance.SpecTranslate.Base
     Test.Cardano.Ledger.Conformance.SpecTranslate.Conway
-    Test.Cardano.Ledger.Conformance.SpecTranslate.Core
     Test.Cardano.Ledger.Conformance.Utils
 
   hs-source-dirs: src

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance.hs
@@ -2,5 +2,5 @@ module Test.Cardano.Ledger.Conformance (module X) where
 
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core as X
 import Test.Cardano.Ledger.Conformance.Orphans as X ()
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Core as X
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base as X
 import Test.Cardano.Ledger.Conformance.Utils as X

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance.hs
@@ -3,4 +3,5 @@ module Test.Cardano.Ledger.Conformance (module X) where
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core as X
 import Test.Cardano.Ledger.Conformance.Orphans as X ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Base as X
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Core as X
 import Test.Cardano.Ledger.Conformance.Utils as X

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
@@ -24,8 +24,8 @@ import Data.Either (isRight)
 import Data.Maybe (fromMaybe)
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance (integerToHash)
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway (vkeyFromInteger)
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (signatureFromInteger)
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway ()
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Core (signatureFromInteger, vkeyFromInteger)
 import Test.Cardano.Ledger.Conway.Arbitrary ()
 import Test.Cardano.Ledger.Conway.ImpTest ()
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
@@ -52,7 +52,7 @@ import Prettyprinter.Render.Terminal
 import System.FilePath ((<.>))
 import Test.Cardano.Ledger.Api.DebugTools (writeCBOR)
 import Test.Cardano.Ledger.Binary.TreeDiff (Pretty (..), ansiWlPretty, ediff, ppEditExpr)
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Core (
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
   SpecNormalize (..),
   SpecTranslate (..),
   runSpecTransM,

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -18,7 +18,7 @@ import Data.Void (Void)
 import GHC.Generics (Generic)
 import MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Common (NFData, ToExpr)
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Core (OpaqueErrorString, SpecNormalize (..))
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (OpaqueErrorString, SpecNormalize (..))
 import Test.Cardano.Ledger.Conformance.Utils
 import Test.Cardano.Ledger.Conway.TreeDiff (Expr (..), ToExpr (..))
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Base.hs
@@ -14,7 +14,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Test.Cardano.Ledger.Conformance.SpecTranslate.Core (
+module Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
   SpecTranslate (..),
   SpecNormalize (..),
   OpaqueErrorString (..),

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Base.hs
@@ -27,19 +27,19 @@ module Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
   toSpecRep_,
 ) where
 
-import Cardano.Ledger.Binary (Sized (..))
 import Cardano.Ledger.BaseTypes (Inject (..), NonNegativeInterval, UnitInterval, unboundRational)
+import Cardano.Ledger.Binary (Sized (..))
 import Cardano.Ledger.Compactible (Compactible (..), fromCompact)
-import Data.List.NonEmpty (NonEmpty)
 import Control.DeepSeq (NFData)
 import Control.Monad.Except (ExceptT, MonadError (..), runExceptT)
 import Control.Monad.Reader (MonadReader (..), Reader, asks, runReader)
 import Data.Bitraversable (bimapM)
 import Data.Foldable (Foldable (..))
 import Data.Kind (Type)
-import Data.Maybe.Strict (StrictMaybe (..), strictMaybeToMaybe)
+import Data.List.NonEmpty (NonEmpty)
 import Data.Map (Map)
 import qualified Data.Map as Map
+import Data.Maybe.Strict (StrictMaybe (..), strictMaybeToMaybe)
 import Data.OMap.Strict (OMap)
 import qualified Data.OMap.Strict as OMap
 import Data.OSet.Strict (OSet)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway.hs
@@ -1,12 +1,6 @@
-module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway (
-  vkeyFromInteger,
-  vkeyToInteger,
-) where
+module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway () where
 
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (
-  vkeyFromInteger,
-  vkeyToInteger,
- )
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Certs ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
@@ -34,7 +34,6 @@ import Lens.Micro
 import Lens.Micro.Extras (view)
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (bimapMHSMap, unionsHSMap)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.GovCert ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool ()

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
@@ -34,7 +34,7 @@ import Test.Cardano.Ledger.Conformance (
   hashToInteger,
  )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
 
 instance
   ( SpecRep (PParamsHKD Identity era) ~ Agda.PParams

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
@@ -33,8 +33,8 @@ import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance (
   hashToInteger,
  )
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 
 instance
   ( SpecRep (PParamsHKD Identity era) ~ Agda.PParams

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Gov.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Gov.hs
@@ -23,7 +23,7 @@ import qualified Data.Map.Strict as Map
 import Lens.Micro ((^.))
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
 
 instance
   ( SpecTranslate ctx (PParamsHKD Identity era)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Gov.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Gov.hs
@@ -22,8 +22,8 @@ import Data.Functor.Identity (Identity)
 import qualified Data.Map.Strict as Map
 import Lens.Micro ((^.))
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 
 instance
   ( SpecTranslate ctx (PParamsHKD Identity era)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
@@ -27,8 +27,8 @@ import Data.Map.Strict (Map, keysSet)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (mapMaybe)
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
 
 instance SpecTranslate ctx ConwayGovCert where
   type SpecRep ConwayGovCert = Agda.DCert

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
@@ -28,7 +28,7 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (mapMaybe)
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
 
 instance SpecTranslate ctx ConwayGovCert where
   type SpecRep ConwayGovCert = Agda.DCert

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
@@ -1,0 +1,276 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Ledger.Conformance.SpecTranslate.Core (
+  committeeCredentialToStrictMaybe,
+  vkeyToInteger,
+  vkeyFromInteger,
+  signatureToInteger,
+  signatureFromInteger,
+) where
+
+import Cardano.Crypto.DSIGN (DSIGNAlgorithm (..), SignedDSIGN (..))
+import Cardano.Crypto.Util (bytesToNatural, naturalToBytes)
+import Cardano.Ledger.Address (Addr (..), BootstrapAddress (..), RewardAccount (..))
+import Cardano.Ledger.BaseTypes (
+  EpochInterval (..),
+  EpochNo (..),
+  Network (..),
+  ProtVer (..),
+  SlotNo (..),
+  TxIx (..),
+  getVersion,
+ )
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway.Core (
+  ADDRHASH,
+  DataHash,
+  Era,
+  Hash,
+  KeyHash (..),
+  KeyRole (..),
+  PParams (..),
+  PParamsHKD,
+  PParamsUpdate (..),
+  SafeHash,
+  ScriptHash (..),
+  TxAuxDataHash (..),
+  extractHash,
+  hashAnnotated,
+ )
+import Cardano.Ledger.Conway.State
+import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
+import Cardano.Ledger.Keys (VKey (..))
+import Cardano.Ledger.Keys.WitVKey (WitVKey (..))
+import Cardano.Ledger.Plutus.CostModels (CostModels)
+import Cardano.Ledger.Plutus.Data (BinaryData, Data, Datum (..), hashBinaryData)
+import Cardano.Ledger.Plutus.ExUnits (ExUnits (..), Prices)
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Control.Monad.Except (throwError)
+import Data.Bifunctor (first)
+import Data.Functor.Identity (Identity (..))
+import Data.Map (Map)
+import Data.Maybe.Strict (StrictMaybe (..))
+import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
+  SpecTranslate (..),
+ )
+import Test.Cardano.Ledger.Conformance.Utils
+
+instance SpecTranslate ctx TxId where
+  type SpecRep TxId = Agda.TxId
+
+  toSpecRep (TxId x) = toSpecRep x
+
+instance SpecTranslate ctx TxIx where
+  type SpecRep TxIx = Integer
+
+  toSpecRep (TxIx x) = pure $ toInteger x
+
+instance SpecTranslate ctx TxIn where
+  type SpecRep TxIn = Agda.TxIn
+
+  toSpecRep (TxIn txId txIx) = toSpecRep (txId, txIx)
+
+instance SpecTranslate ctx (SafeHash a) where
+  type SpecRep (SafeHash a) = Agda.DataHash
+
+  toSpecRep = toSpecRep . extractHash
+
+instance SpecTranslate ctx StakeReference where
+  type SpecRep StakeReference = Maybe Agda.Credential
+
+  toSpecRep (StakeRefBase c) = Just <$> toSpecRep c
+  toSpecRep (StakeRefPtr _) = pure Nothing
+  toSpecRep StakeRefNull = pure Nothing
+
+instance SpecTranslate ctx BootstrapAddress where
+  type SpecRep BootstrapAddress = Agda.BootstrapAddr
+
+  toSpecRep _ = throwError "Cannot translate bootstrap addresses"
+
+instance SpecTranslate ctx Addr where
+  type SpecRep Addr = Agda.Addr
+
+  toSpecRep (Addr nw pc sr) =
+    Left
+      <$> (Agda.BaseAddr <$> toSpecRep nw <*> toSpecRep pc <*> toSpecRep sr)
+  toSpecRep (AddrBootstrap ba) = Right <$> toSpecRep ba
+
+instance SpecTranslate ctx (Hash a b) where
+  type SpecRep (Hash a b) = Integer
+
+  toSpecRep = pure . hashToInteger
+
+instance SpecTranslate ctx ScriptHash where
+  type SpecRep ScriptHash = Integer
+
+  toSpecRep (ScriptHash h) = toSpecRep h
+
+instance SpecTranslate ctx (KeyHash r) where
+  type SpecRep (KeyHash r) = Integer
+
+  toSpecRep (KeyHash h) = toSpecRep h
+
+instance SpecTranslate ctx (Credential k) where
+  type SpecRep (Credential k) = Agda.Credential
+
+  toSpecRep (KeyHashObj h) = Agda.KeyHashObj <$> toSpecRep h
+  toSpecRep (ScriptHashObj h) = Agda.ScriptObj <$> toSpecRep h
+
+instance SpecTranslate ctx Network where
+  type SpecRep Network = Integer
+
+  toSpecRep = pure . fromIntegral . fromEnum
+
+deriving instance SpecTranslate ctx Coin
+
+deriving instance SpecTranslate ctx SlotNo
+
+deriving instance SpecTranslate ctx EpochNo
+
+deriving instance SpecTranslate ctx EpochInterval
+
+instance SpecTranslate ctx ProtVer where
+  type SpecRep ProtVer = (Integer, Integer)
+
+  toSpecRep (ProtVer ver minor) = pure (getVersion ver, toInteger minor)
+
+instance SpecTranslate ctx CostModels where
+  type SpecRep CostModels = ()
+
+  toSpecRep _ = pure ()
+
+instance SpecTranslate ctx Prices where
+  type SpecRep Prices = ()
+
+  toSpecRep _ = pure ()
+
+instance SpecTranslate ctx ExUnits where
+  type SpecRep ExUnits = Agda.ExUnits
+
+  toSpecRep (ExUnits a b) = pure (toInteger a, toInteger b)
+
+instance SpecTranslate ctx RewardAccount where
+  type SpecRep RewardAccount = Agda.RwdAddr
+
+  toSpecRep (RewardAccount n c) = Agda.RwdAddr <$> toSpecRep n <*> toSpecRep c
+
+instance
+  ( SpecRep DataHash ~ Agda.DataHash
+  , Era era
+  ) =>
+  SpecTranslate ctx (BinaryData era)
+  where
+  type SpecRep (BinaryData era) = Agda.DataHash
+
+  toSpecRep = toSpecRep . hashBinaryData
+
+instance Era era => SpecTranslate ctx (Datum era) where
+  type SpecRep (Datum era) = Maybe (Either Agda.Datum Agda.DataHash)
+
+  toSpecRep NoDatum = pure Nothing
+  toSpecRep (Datum d) = Just . Left <$> toSpecRep d
+  toSpecRep (DatumHash h) = Just . Right <$> toSpecRep h
+
+instance Era era => SpecTranslate ctx (Data era) where
+  type SpecRep (Data era) = Agda.DataHash
+
+  toSpecRep = toSpecRep . hashAnnotated
+
+instance
+  SpecTranslate ctx (PParamsHKD Identity era) =>
+  SpecTranslate ctx (PParams era)
+  where
+  type SpecRep (PParams era) = SpecRep (PParamsHKD Identity era)
+
+  toSpecRep (PParams x) = toSpecRep x
+
+instance
+  SpecTranslate ctx (PParamsHKD StrictMaybe era) =>
+  SpecTranslate ctx (PParamsUpdate era)
+  where
+  type SpecRep (PParamsUpdate era) = SpecRep (PParamsHKD StrictMaybe era)
+
+  toSpecRep (PParamsUpdate ppu) = toSpecRep ppu
+
+vkeyToInteger :: VKey kd -> Integer
+vkeyToInteger = toInteger . bytesToNatural . rawSerialiseVerKeyDSIGN . unVKey
+
+vkeyFromInteger :: Integer -> Maybe (VKey kd)
+vkeyFromInteger = fmap VKey . rawDeserialiseVerKeyDSIGN . naturalToBytes 32 . fromInteger
+
+signatureToInteger :: DSIGNAlgorithm v => SigDSIGN v -> Integer
+signatureToInteger = toInteger . bytesToNatural . rawSerialiseSigDSIGN
+
+signatureFromInteger :: DSIGNAlgorithm v => Integer -> Maybe (SigDSIGN v)
+signatureFromInteger = rawDeserialiseSigDSIGN . naturalToBytes 64 . fromInteger
+
+instance SpecTranslate ctx (VKey k) where
+  type SpecRep (VKey k) = Agda.HSVKey
+
+  toSpecRep x = do
+    let hvkVKey = vkeyToInteger x
+    hvkStoredHash <- toSpecRep (hashVerKeyDSIGN @_ @ADDRHASH $ unVKey x)
+    pure Agda.MkHSVKey {..}
+
+instance DSIGNAlgorithm v => SpecTranslate ctx (SignedDSIGN v a) where
+  type SpecRep (SignedDSIGN v a) = Integer
+
+  toSpecRep (SignedDSIGN x) = pure $ signatureToInteger x
+
+instance SpecTranslate ctx (WitVKey k) where
+  type SpecRep (WitVKey k) = (SpecRep (VKey k), Integer)
+
+  toSpecRep (WitVKey vk sk) = toSpecRep (vk, sk)
+
+instance SpecTranslate ctx TxAuxDataHash where
+  type SpecRep TxAuxDataHash = Agda.DataHash
+
+  toSpecRep (TxAuxDataHash x) = toSpecRep x
+
+instance SpecTranslate ctx CommitteeAuthorization where
+  type
+    SpecRep CommitteeAuthorization =
+      SpecRep (Maybe (Credential 'HotCommitteeRole))
+
+  toSpecRep (CommitteeHotCredential c) = toSpecRep $ Just c
+  toSpecRep (CommitteeMemberResigned _) =
+    toSpecRep $
+      Nothing @(Credential 'HotCommitteeRole)
+
+instance SpecTranslate ctx (CommitteeState era) where
+  type
+    SpecRep (CommitteeState era) =
+      SpecRep (Map (Credential 'ColdCommitteeRole) CommitteeAuthorization)
+
+  toSpecRep = toSpecRep . csCommitteeCreds
+
+committeeCredentialToStrictMaybe ::
+  CommitteeAuthorization ->
+  StrictMaybe (Credential 'HotCommitteeRole)
+committeeCredentialToStrictMaybe (CommitteeHotCredential c) = SJust c
+committeeCredentialToStrictMaybe (CommitteeMemberResigned _) = SNothing
+
+instance SpecTranslate ctx IndividualPoolStake where
+  type SpecRep IndividualPoolStake = SpecRep Coin
+
+  toSpecRep (IndividualPoolStake _ c _) = toSpecRep c
+
+instance SpecTranslate ctx PoolDistr where
+  type SpecRep PoolDistr = Agda.HSMap Agda.VDeleg Agda.Coin
+
+  toSpecRep (PoolDistr ps _) = do
+    Agda.MkHSMap l <- toSpecRep ps
+    pure . Agda.MkHSMap $ first (Agda.CredVoter Agda.SPO . Agda.KeyHashObj) <$> l

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Utils.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Utils.hs
@@ -6,8 +6,14 @@ module Test.Cardano.Ledger.Conformance.Utils where
 
 import Cardano.Crypto.Hash (ByteString, Hash, HashAlgorithm, hashFromBytes, hashToBytes, sizeHash)
 import Cardano.Crypto.Util (bytesToNatural, naturalToBytes)
+import Data.Bifunctor (Bifunctor (..))
+import Data.Bitraversable (bimapM)
 import qualified Data.ByteString.Base16 as B16
+import Data.Containers.ListUtils (nubOrdOn)
 import Data.Data (Proxy (..))
+import Data.Foldable (Foldable (..))
+import Data.List (sortOn)
+import MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.TreeDiff (Expr, ToExpr (..))
 
 agdaHashToBytes :: Int -> Integer -> ByteString
@@ -21,3 +27,17 @@ hashToInteger = toInteger . bytesToNatural . hashToBytes
 
 integerToHash :: forall h a. HashAlgorithm h => Integer -> Maybe (Hash h a)
 integerToHash = hashFromBytes . naturalToBytes (fromIntegral . sizeHash $ Proxy @h) . fromInteger
+
+-- HSMap utils
+
+unionsHSMap :: Ord k => [Agda.HSMap k v] -> Agda.HSMap k v
+unionsHSMap = Agda.MkHSMap . sortOn fst . nubOrdOn fst . foldr' (\(Agda.MkHSMap x) y -> x <> y) []
+
+unionHSMap :: Ord k => Agda.HSMap k v -> Agda.HSMap k v -> Agda.HSMap k v
+unionHSMap x y = unionsHSMap [x, y]
+
+mapHSMapKey :: (k -> l) -> Agda.HSMap k v -> Agda.HSMap l v
+mapHSMapKey f (Agda.MkHSMap l) = Agda.MkHSMap $ first f <$> l
+
+bimapMHSMap :: Applicative m => (k -> m k') -> (v -> m v') -> Agda.HSMap k v -> m (Agda.HSMap k' v')
+bimapMHSMap f g (Agda.MkHSMap m) = Agda.MkHSMap <$> traverse (bimapM f g) m

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/ConformanceSpec.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/ConformanceSpec.hs
@@ -18,9 +18,10 @@ import Test.Cardano.Ledger.Conformance (
   hashToInteger,
   integerToHash,
   runSpecTransM,
+  vkeyFromInteger,
+  vkeyToInteger,
  )
 import Test.Cardano.Ledger.Conformance.Spec.Conway ()
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway (vkeyFromInteger, vkeyToInteger)
 
 hashDisplayProp ::
   forall a.

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
@@ -31,7 +31,7 @@ import Lens.Micro
 import MAlonzo.Code.Ledger.Foreign.API qualified as Agda
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway (ConwayLedgerExecContext (..))
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Core
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
 import Test.Cardano.Ledger.Constrained.Conway
 import Test.Cardano.Ledger.Conway.Imp.BbodySpec qualified as Bbody
 import Test.Cardano.Ledger.Conway.Imp.CertsSpec qualified as Certs


### PR DESCRIPTION
# Description

This PR:

- Renames the module `SpecTransalate.Core` to `SpecTranslate.Base`, so as to follow the naming structure of `formal-ledger-specifications`
- Moves `SpecTranslate` instances
    - from `Conway.Base` to `SpecTranslate.Base`, those which are (loosely) Ledger-independent
    -  from `Conway.Base` to `SpecTranslate.Core`, those which are era-independent
- Removes a stale link to fls in CONTRIBUTING.md
# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
