### PR TITLE
5191 Rename PoolParams

### DIFF
--- a/docs/reward-calculation/HowRewardCalculationWorks.md
+++ b/docs/reward-calculation/HowRewardCalculationWorks.md
@@ -38,7 +38,7 @@ This is a Haskell Datatype (Map (Credential 'Staking)  (KeyHash StakePool)), whi
 Only registered credentials will receive rewards.
 
 3. Information about which pool operators are currently registered to operate pools, and the parameters under which the pools operate.
-This is a Haskell Datatype (Map (KeyHash StakePool) PoolParams), which we will call the `poolParamsMap` . Rewards for UTxO entries delegated
+This is a Haskell Datatype (Map (KeyHash StakePool) StakePoolParams), which we will call the `poolParamsMap` . Rewards for UTxO entries delegated
 to non registered Pools are distributed to either the Treasury or the Reserves.
 
 4. Information about which pools are currently scheduled to retire, and when.
@@ -193,7 +193,7 @@ The actual values are stored in internal maps found in the type family `CertStat
 
 Map (Credential 'Staking) (StrictMaybe (KeyHash 'StakePool)) -- The User registration map
 Map (Credential 'Staking) Coin                               -- The User Rewards map
-Map (KeyHash 'StakePool) PoolParams                          -- The StakePool registration map
+Map (KeyHash 'StakePool) StakePoolParams                          -- The StakePool registration map
 ```
 
 A `Reward` contains information about a computed reward, that has yet to be applied to the internal Rewards map.

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
@@ -75,7 +75,7 @@ import Cardano.Ledger.Plutus.Language (
   SLanguage (..),
  )
 import Cardano.Ledger.Plutus.TxInfo
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Rules.ValidationMode (Inject (..))
 import Cardano.Ledger.State (UTxO (..))
 import Cardano.Ledger.TxIn (TxIn (..), txInToText)
@@ -349,7 +349,7 @@ transTxCertCommon = \case
     Just $ PV1.DCertDelegDeRegKey (PV1.StakingHash (transCred stakeCred))
   DelegStakeTxCert stakeCred keyHash ->
     Just $ PV1.DCertDelegDelegate (PV1.StakingHash (transCred stakeCred)) (transKeyHash keyHash)
-  RegPoolTxCert (PoolParams {ppId, ppVrf}) ->
+  RegPoolTxCert (StakePoolParams {ppId, ppVrf}) ->
     Just $
       PV1.DCertPoolRegister
         (transKeyHash ppId)

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Invalid.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Invalid.hs
@@ -31,7 +31,7 @@ import Cardano.Ledger.Plutus (
   hashPlutusScript,
   withSLanguage,
  )
-import Cardano.Ledger.Shelley.LedgerState (epochStatePoolParamsL, nesEsL)
+import Cardano.Ledger.Shelley.LedgerState (epochStateStakePoolParamsL, nesEsL)
 import Cardano.Ledger.Shelley.Rules (ShelleyUtxowPredFailure (..))
 import qualified Data.Map.Strict as Map
 import Data.Maybe (isJust)
@@ -159,7 +159,7 @@ spec = describe "Invalid transactions" $ do
         it "No ExtraRedeemers on same script certificates" $ do
           Positive n <- arbitrary
           replicateM_ n $ freshKeyHash >>= registerPool
-          pools <- getsNES $ nesEsL . epochStatePoolParamsL
+          pools <- getsNES $ nesEsL . epochStateStakePoolParamsL
           poolId <- elements $ Map.keys pools
           let scriptHash = alwaysSucceedsNoDatumHash
               cred = ScriptHashObj scriptHash
@@ -256,7 +256,7 @@ spec = describe "Invalid transactions" $ do
               let scriptHash = alwaysSucceedsWithDatumHash
               Positive n <- arbitrary
               replicateM_ n $ freshKeyHash >>= registerPool
-              pools <- getsNES $ nesEsL . epochStatePoolParamsL
+              pools <- getsNES $ nesEsL . epochStateStakePoolParamsL
               poolId <- elements $ Map.keys pools
               let cred = ScriptHashObj scriptHash
                   certs =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -215,12 +215,12 @@ import Cardano.Ledger.Conway.Governance.Proposals
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential)
-import Cardano.Ledger.PoolParams (PoolParams (ppRewardAccount))
+import Cardano.Ledger.PoolParams (StakePoolParams (ppRewardAccount))
 import Cardano.Ledger.Shelley.LedgerState (
   EpochState (..),
   NewEpochState (..),
   epochStateGovStateL,
-  epochStatePoolParamsL,
+  epochStateStakePoolParamsL,
   esLStateL,
   lsCertState,
   lsUTxOState,
@@ -513,7 +513,7 @@ setFreshDRepPulsingState epochNo stakePoolDistr epochState = do
                     , dpProposals = proposalsActions props
                     , dpProposalDeposits = proposalsDeposits props
                     , dpGlobals = globals
-                    , dpPoolParams = epochState ^. epochStatePoolParamsL
+                    , dpStakePoolParams = epochState ^. epochStateStakePoolParamsL
                     }
                 )
   pure $ epochState & epochStateGovStateL .~ govState'
@@ -561,7 +561,7 @@ defaultStakePoolVote ::
   -- | Specify the key hash of the pool whose default vote should be returned.
   KeyHash 'StakePool ->
   -- | Registered Stake Pools
-  Map (KeyHash 'StakePool) PoolParams ->
+  Map (KeyHash 'StakePool) StakePoolParams ->
   -- | Delegations of staking credneitals to a DRep
   Accounts era ->
   DefaultVote

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/DRepPulser.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/DRepPulser.hs
@@ -71,7 +71,7 @@ import Cardano.Ledger.Conway.Governance.Procedures (GovActionState)
 import Cardano.Ledger.Conway.State hiding (balance)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..))
-import Cardano.Ledger.PoolParams (PoolParams)
+import Cardano.Ledger.PoolParams (StakePoolParams)
 import Control.DeepSeq (NFData (..), deepseq)
 import Control.Monad.Trans.Reader (Reader, runReader)
 import Control.State.Transition.Extended
@@ -283,7 +283,7 @@ data DRepPulser era (m :: Type -> Type) ans where
     , dpProposalDeposits :: !(Map (Credential 'Staking) (CompactForm Coin))
     -- ^ Snapshot of the proposal-deposits per reward-account-staking-credential
     , dpGlobals :: !Globals
-    , dpPoolParams :: !(Map (KeyHash 'StakePool) PoolParams)
+    , dpStakePoolParams :: !(Map (KeyHash 'StakePool) StakePoolParams)
     -- ^ Snapshot of the parameters of stake pools -
     --   this is needed to get the reward account for SPO vote calculation
     } ->
@@ -339,7 +339,7 @@ instance
       , noThunks ctxt (dpProposals drp)
       , noThunks ctxt (dpProposalDeposits drp)
       , noThunks ctxt (dpGlobals drp)
-      , noThunks ctxt (dpPoolParams drp)
+      , noThunks ctxt (dpStakePoolParams drp)
       ]
 
 instance
@@ -411,7 +411,7 @@ finishDRepPulser (DRPulsing (DRepPulser {..})) =
         , reCurrentEpoch = dpCurrentEpoch
         , reCommitteeState = dpCommitteeState
         , reAccounts = dpAccounts
-        , rePoolParams = dpPoolParams
+        , reStakePoolParams = dpStakePoolParams
         }
     !ratifySig = RatifySignal dpProposals
     !ratifyState =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Internal.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Internal.hs
@@ -110,7 +110,7 @@ import Cardano.Ledger.Conway.PParams (
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..))
-import Cardano.Ledger.PoolParams (PoolParams)
+import Cardano.Ledger.PoolParams (StakePoolParams)
 import Cardano.Ledger.Shelley.LedgerState (epochStateStakeDistrL)
 import Control.DeepSeq (NFData (rnf), deepseq)
 import Data.Aeson (ToJSON (..), (.=))
@@ -568,7 +568,7 @@ data RatifyEnv era = RatifyEnv
   , reCurrentEpoch :: EpochNo
   , reCommitteeState :: CommitteeState era
   , reAccounts :: Accounts era
-  , rePoolParams :: Map (KeyHash 'StakePool) PoolParams
+  , reStakePoolParams :: Map (KeyHash 'StakePool) StakePoolParams
   }
   deriving (Generic)
 
@@ -652,7 +652,7 @@ instance
             !> To reCurrentEpoch
             !> To reCommitteeState
             !> To reAccounts
-            !> To rePoolParams
+            !> To reStakePoolParams
 
 instance
   (Era era, DecCBOR (InstantStake era), DecCBOR (Accounts era)) =>

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
@@ -220,7 +220,7 @@ certTransition = do
   TRC (CertEnv pp currentEpoch committee committeeProposals, certState, c) <- judgmentContext
   let
     certPState = certState ^. certPStateL
-    pools = psStakePoolParams certPState
+    pools = psStakeStakePoolParams certPState
   case c of
     ConwayTxCertDeleg delegCert -> do
       trans @(EraRule "DELEG" era) $ TRC (ConwayDelegEnv pp pools, certState, delegCert)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
@@ -54,7 +54,7 @@ import Cardano.Ledger.Conway.TxCert (
   Delegatee (DelegStake, DelegStakeVote, DelegVote),
  )
 import Cardano.Ledger.Credential (Credential)
-import Cardano.Ledger.PoolParams (PoolParams)
+import Cardano.Ledger.PoolParams (StakePoolParams)
 import Control.DeepSeq (NFData)
 import Control.Monad (forM_, guard, unless)
 import Control.State.Transition (
@@ -83,7 +83,7 @@ import NoThunks.Class (NoThunks)
 
 data ConwayDelegEnv era = ConwayDelegEnv
   { cdePParams :: PParams era
-  , cdePools :: Map (KeyHash 'StakePool) PoolParams
+  , cdePools :: Map (KeyHash 'StakePool) StakePoolParams
   }
   deriving (Generic)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
@@ -302,11 +302,11 @@ epochTransition = do
     trans @(EraRule "SNAP" era) $ TRC (SnapEnv ledgerState0 curPParams, snapshots0, ())
 
   -- Activate future StakePools
-  let newStakePoolParams = eval (psStakePoolParams pState0 ⨃ psFutureStakePoolParams pState0)
+  let newStakeStakePoolParams = eval (psStakeStakePoolParams pState0 ⨃ psFutureStakeStakePoolParams pState0)
       pState1 =
         pState0
-          { psStakePoolParams = newStakePoolParams
-          , psFutureStakePoolParams = Map.empty
+          { psStakeStakePoolParams = newStakeStakePoolParams
+          , psFutureStakeStakePoolParams = Map.empty
           }
   PoolreapState utxoState1 chainAccountState1 certState1 <-
     trans @(EraRule "POOLREAP" era) $

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -458,7 +458,7 @@ govTransition = do
       certDState = certState ^. certDStateL
       committeeState = vsCommitteeState certVState
       knownDReps = vsDReps certVState
-      knownStakePools = psStakePoolParams certPState
+      knownStakePools = psStakeStakePoolParams certPState
       knownCommitteeMembers = authorizedHotCommitteeCredentials committeeState
 
   expectedNetworkId <- liftSTS $ asks networkId

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ratify.hs
@@ -197,7 +197,7 @@ spoAcceptedRatio
   RatifyEnv
     { reStakePoolDistr = PoolDistr individualPoolStake (CompactCoin totalActiveStake)
     , reAccounts
-    , rePoolParams
+    , reStakePoolParams
     }
   GovActionState
     { gasStakePoolVotes
@@ -213,7 +213,7 @@ spoAcceptedRatio
               Nothing
                 | HardForkInitiation {} <- pProcGovAction -> (yes, abstain)
                 | hardforkConwayBootstrapPhase pv -> (yes, abstain + stake)
-                | otherwise -> case defaultStakePoolVote poolId rePoolParams reAccounts of
+                | otherwise -> case defaultStakePoolVote poolId reStakePoolParams reAccounts of
                     DefaultNoConfidence
                       | NoConfidence {} <- pProcGovAction -> (yes + stake, abstain)
                     DefaultAbstain -> (yes, abstain + stake)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/State/CertState.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/State/CertState.hs
@@ -119,7 +119,7 @@ conwayObligationCertState certState =
 conwayCertsTotalDepositsTxBody ::
   EraTxBody era => PParams era -> ConwayCertState era -> TxBody era -> Coin
 conwayCertsTotalDepositsTxBody pp ConwayCertState {conwayCertPState} =
-  getTotalDepositsTxBody pp (`Map.member` psStakePoolParams conwayCertPState)
+  getTotalDepositsTxBody pp (`Map.member` psStakeStakePoolParams conwayCertPState)
 
 conwayCertsTotalRefundsTxBody ::
   (EraTxBody era, EraAccounts era) => PParams era -> ConwayCertState era -> TxBody era -> Coin

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Transition.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Transition.hs
@@ -130,7 +130,7 @@ conwayRegisterInitialAccounts ShelleyGenesisStaking {sgsStake} nes =
     & nesEsL . esLStateL . lsCertStateL . certDStateL . accountsL %~ \initAccounts ->
       foldr registerAndDelegate initAccounts $ ListMap.toList sgsStake
   where
-    stakePools = nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL . psStakePoolParamsL
+    stakePools = nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL . psStakeStakePoolParamsL
     deposit = compactCoinOrError $ nes ^. nesEsL . curPParamsEpochStateL . ppKeyDepositL
     registerAndDelegate (stakeKeyHash, stakePool) !accounts
       | stakePool `Map.member` stakePools =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
@@ -545,7 +545,7 @@ transTxBodyWithdrawals txBody =
 transTxCert ::
   (ConwayEraTxCert era, TxCert era ~ ConwayTxCert era) => ProtVer -> TxCert era -> PV3.TxCert
 transTxCert pv = \case
-  RegPoolTxCert PoolParams {ppId, ppVrf} ->
+  RegPoolTxCert StakePoolParams {ppId, ppVrf} ->
     PV3.TxCertPoolRegister
       (transKeyHash ppId)
       (PV3.PubKeyHash (PV3.toBuiltin (hashToBytes (unVRFVerKeyHash ppVrf))))

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Examples.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Examples.hs
@@ -54,8 +54,8 @@ import Test.Cardano.Ledger.Mary.Examples (exampleMultiAssetValue)
 import Test.Cardano.Ledger.Shelley.Examples (
   LedgerExamples (..),
   examplePayKey,
-  examplePoolParams,
   exampleStakeKey,
+  exampleStakePoolParams,
   keyToCredential,
   mkKeyHash,
  )
@@ -115,7 +115,7 @@ exampleTxBodyConway =
 exampleConwayCerts :: OSet.OSet (ConwayTxCert era)
 exampleConwayCerts =
   OSet.fromList -- TODO add all possible certificates
-    [ConwayTxCertPool (RegPool examplePoolParams)]
+    [ConwayTxCertPool (RegPool exampleStakePoolParams)]
 
 exampleConwayGenesis :: ConwayGenesis
 exampleConwayGenesis = expectedConwayGenesis

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/DelegSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/DelegSpec.hs
@@ -643,7 +643,7 @@ spec = do
         expectDelegatedToPool cred poolKh
 
         -- when pool is retired and re-registered in the same transaction, delegations are kept
-        pps <- freshPoolParams poolKh rewardAccount
+        pps <- freshStakePoolParams poolKh rewardAccount
         poolExpiry >>= \pe ->
           submitTx_ $
             mkBasicTx mkBasicTxBody

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxoSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxoSpec.hs
@@ -63,7 +63,7 @@ spec = do
       cred3 <- KeyHashObj <$> freshKeyHash @'Staking
       cred4 <- KeyHashObj <$> freshKeyHash @'Staking
       poolId <- freshKeyHash
-      poolParams <- freshPoolParams poolId (RewardAccount Testnet cred0)
+      poolParams <- freshStakePoolParams poolId (RewardAccount Testnet cred0)
       dRepCred <- KeyHashObj <$> freshKeyHash @'DRepRole
       let delegatee = DelegStakeVote poolId (DRepCredential dRepCred)
       anchor <- arbitrary

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -176,11 +176,11 @@ import Cardano.Ledger.Conway.TxCert (Delegatee (..))
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.DRep
 import Cardano.Ledger.Plutus.Language (Language (..), SLanguage (..), hashPlutusScript)
-import Cardano.Ledger.PoolParams (PoolParams (..), ppRewardAccount)
+import Cardano.Ledger.PoolParams (StakePoolParams (..), ppRewardAccount)
 import Cardano.Ledger.Shelley.LedgerState (
   curPParamsEpochStateL,
   epochStateGovStateL,
-  epochStatePoolParamsL,
+  epochStateStakePoolParamsL,
   esLStateL,
   lsCertStateL,
   lsUTxOStateL,
@@ -977,7 +977,7 @@ getRatifyEnv = do
   drepState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certVStateL . vsDRepsL
   committeeState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certVStateL . vsCommitteeStateL
   accounts <- getsNES (nesEsL . esLStateL . lsCertStateL . certDStateL . accountsL)
-  poolPs <- getsNES $ nesEsL . epochStatePoolParamsL
+  poolPs <- getsNES $ nesEsL . epochStateStakePoolParamsL
   pure
     RatifyEnv
       { reStakePoolDistr = poolDistr
@@ -987,7 +987,7 @@ getRatifyEnv = do
       , reCurrentEpoch = eNo - 1
       , reCommitteeState = committeeState
       , reAccounts = accounts
-      , rePoolParams = poolPs
+      , reStakePoolParams = poolPs
       }
 
 ccShouldNotBeExpired ::
@@ -1694,7 +1694,7 @@ showConwayTxBalance pp certState utxo tx =
         (lookupDepositDState $ certState ^. certDStateL)
         (lookupDepositVState $ certState ^. certVStateL)
         txBody
-    isRegPoolId = (`Map.member` (certState ^. certPStateL . psStakePoolParamsL))
+    isRegPoolId = (`Map.member` (certState ^. certPStateL . psStakeStakePoolParamsL))
     withdrawals = fold . unWithdrawals $ txBody ^. withdrawalsTxBodyL
 
 logConwayTxBalance ::
@@ -1778,7 +1778,7 @@ delegateSPORewardAddressToDRep_ ::
   DRep ->
   ImpTestM era ()
 delegateSPORewardAddressToDRep_ kh stake drep = do
-  pp <- getRatifyEnv >>= expectJust . Map.lookup kh . rePoolParams
+  pp <- getRatifyEnv >>= expectJust . Map.lookup kh . reStakePoolParams
   void $
     delegateToDRep
       (raCredential . ppRewardAccount $ pp)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Types.hs
@@ -62,7 +62,7 @@ import Cardano.Ledger.Keys.Bootstrap as X (
  )
 import Cardano.Ledger.PoolParams as X (
   PoolMetadata (..),
-  PoolParams (..),
+  StakePoolParams (..),
   StakePoolRelay (..),
  )
 import Cardano.Ledger.Shelley.BlockBody as X

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -63,7 +63,7 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Keys (WitVKey (..))
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Shelley.AdaPots (
   AdaPots (..),
   totalAdaES,
@@ -156,7 +156,7 @@ getPools ::
   Set (KeyHash 'StakePool)
 getPools = Map.keysSet . f
   where
-    f nes = nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL . psStakePoolParamsL
+    f nes = nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL . psStakeStakePoolParamsL
 
 -- | Get the /current/ registered stake pool parameters for a given set of
 -- stake pools. The result map will contain entries for all the given stake
@@ -165,10 +165,10 @@ getPoolParameters ::
   EraCertState era =>
   NewEpochState era ->
   Set (KeyHash 'StakePool) ->
-  Map (KeyHash 'StakePool) PoolParams
+  Map (KeyHash 'StakePool) StakePoolParams
 getPoolParameters = Map.restrictKeys . f
   where
-    f nes = nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL . psStakePoolParamsL
+    f nes = nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL . psStakeStakePoolParamsL
 
 -- | Get pool sizes, but in terms of total stake
 --
@@ -263,7 +263,7 @@ getNonMyopicMemberRewards globals ss =
           let ostake = sumPoolOwnersStake pool stake
            in ppPledge poolp <= ostake
 
-sumPoolOwnersStake :: PoolParams -> EB.Stake -> Coin
+sumPoolOwnersStake :: StakePoolParams -> EB.Stake -> Coin
 sumPoolOwnersStake pool stake =
   let getStakeFor o =
         maybe mempty fromCompact $ VMap.lookup (KeyHashObj o) (EB.unStake stake)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
@@ -79,7 +79,7 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Genesis (EraGenesis (..))
 import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
 import Cardano.Ledger.Keys
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.PParams (ShelleyPParams (..))
 import Cardano.Ledger.Shelley.StabilityWindow
@@ -121,7 +121,7 @@ import NoThunks.Class (AllowThunksIn (..), NoThunks (..))
 -- For simplicity, pools defined in the genesis staking do not pay deposits for
 -- their registration.
 data ShelleyGenesisStaking = ShelleyGenesisStaking
-  { sgsPools :: LM.ListMap (KeyHash 'StakePool) PoolParams
+  { sgsPools :: LM.ListMap (KeyHash 'StakePool) StakePoolParams
   -- ^ Pools to register
   --
   --   The key in this map is the hash of the public key of the _pool_. This

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -102,7 +102,7 @@ module Cardano.Ledger.Shelley.LedgerState (
   utxosDonationL,
   epochStateGovStateL,
   epochStateStakeDistrL,
-  epochStatePoolParamsL,
+  epochStateStakePoolParamsL,
   epochStateDonationL,
   newEpochStateGovStateL,
   epochStateTreasuryL,
@@ -111,8 +111,8 @@ module Cardano.Ledger.Shelley.LedgerState (
   dsGenDelegsL,
   dsIRewardsL,
   dsFutureGenDelegsL,
-  psStakePoolParamsL,
-  psFutureStakePoolParamsL,
+  psStakeStakePoolParamsL,
+  psFutureStakeStakePoolParamsL,
   psRetiringL,
   psDepositsL,
 
@@ -125,7 +125,7 @@ module Cardano.Ledger.Shelley.LedgerState (
   ssStakeL,
   ssStakeDistrL,
   ssDelegationsL,
-  ssPoolParamsL,
+  ssStakePoolParamsL,
 ) where
 
 import Cardano.Ledger.Shelley.LedgerState.IncrementalStake

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/PulsingReward.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/PulsingReward.hs
@@ -39,7 +39,7 @@ import Cardano.Ledger.Coin (
   toDeltaCoin,
  )
 import Cardano.Ledger.Core
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Shelley.Era (hardforkBabbageForgoRewardPrefilter)
 import Cardano.Ledger.Shelley.LedgerState.Types
 import Cardano.Ledger.Shelley.PoolRank (

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
@@ -695,9 +695,9 @@ epochStateTreasuryL :: Lens' (EpochState era) Coin
 epochStateTreasuryL = treasuryL
 {-# DEPRECATED epochStateTreasuryL "In favor of `treasuryL`" #-}
 
-epochStatePoolParamsL ::
-  EraCertState era => Lens' (EpochState era) (Map (KeyHash 'StakePool) PoolParams)
-epochStatePoolParamsL = esLStateL . lsCertStateL . certPStateL . psStakePoolParamsL
+epochStateStakePoolParamsL ::
+  EraCertState era => Lens' (EpochState era) (Map (KeyHash 'StakePool) StakePoolParams)
+epochStateStakePoolParamsL = esLStateL . lsCertStateL . certPStateL . psStakeStakePoolParamsL
 
 epochStateStakeDistrL ::
   Lens' (EpochState era) (VMap VB VP (Credential 'Staking) (CompactForm Coin))

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/PoolRank.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/PoolRank.hs
@@ -57,7 +57,7 @@ import Cardano.Ledger.Binary (
 import Cardano.Ledger.Coin (Coin (..), coinToRational)
 import Cardano.Ledger.Core (EraPParams, PParams, ppA0L, ppNOptL)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Shelley.Rewards (StakeShare (..), memberRew)
 import Cardano.Ledger.State (maxPool)
 import Cardano.Slotting.Slot (EpochSize (..))
@@ -271,7 +271,7 @@ desirability ::
   NonNegativeInterval ->
   NonZero Word16 ->
   Coin ->
-  PoolParams ->
+  StakePoolParams ->
   PerformanceEstimate ->
   Coin ->
   Double
@@ -298,7 +298,7 @@ getTopRankedPools ::
   Coin ->
   Coin ->
   PParams era ->
-  Map (KeyHash 'StakePool) PoolParams ->
+  Map (KeyHash 'StakePool) StakePoolParams ->
   Map (KeyHash 'StakePool) PerformanceEstimate ->
   Set (KeyHash 'StakePool)
 getTopRankedPools rPot totalStake pp poolParams aps =
@@ -310,7 +310,7 @@ getTopRankedPoolsVMap ::
   Coin ->
   Coin ->
   PParams era ->
-  VMap.VMap VMap.VB VMap.VB (KeyHash 'StakePool) PoolParams ->
+  VMap.VMap VMap.VB VMap.VB (KeyHash 'StakePool) StakePoolParams ->
   Map (KeyHash 'StakePool) PerformanceEstimate ->
   Set (KeyHash 'StakePool)
 getTopRankedPoolsVMap rPot totalStake pp poolParams aps =
@@ -322,7 +322,7 @@ getTopRankedPoolsInternal ::
   Coin ->
   Coin ->
   PParams era ->
-  [(KeyHash 'StakePool, (PoolParams, PerformanceEstimate))] ->
+  [(KeyHash 'StakePool, (StakePoolParams, PerformanceEstimate))] ->
   Set (KeyHash 'StakePool)
 getTopRankedPoolsInternal rPot totalStake pp pdata =
   Set.fromList $
@@ -376,7 +376,7 @@ nonMyopicMemberRew ::
   EraPParams era =>
   PParams era ->
   Coin ->
-  PoolParams ->
+  StakePoolParams ->
   StakeShare ->
   StakeShare ->
   StakeShare ->

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/RewardProvenance.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/RewardProvenance.hs
@@ -14,7 +14,7 @@ import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Default (Default (..))
@@ -39,7 +39,7 @@ data RewardProvenancePool = RewardProvenancePool
   -- ^ The number of Lovelace owned by the stake pool owners.
   -- If this value is not at least as large as the 'pledgeRatioP',
   -- the stake pool will not earn any rewards for the given epoch.
-  , poolParamsP :: !PoolParams
+  , poolParamsP :: !StakePoolParams
   -- ^ The stake pool's registered parameters.
   , pledgeRatioP :: !Rational
   -- ^ The stake pool's pledge.
@@ -183,7 +183,7 @@ instance Show RewardProvenancePool where
         , "sigma = " ++ show (sigmaP t)
         , "sigmaA = " ++ show (sigmaAP t)
         , "ownerStake = " ++ show (ownerStakeP t)
-        , "poolParams = " ++ showPoolParams (poolParamsP t)
+        , "poolParams = " ++ showStakePoolParams (poolParamsP t)
         , "pledgeRatio = " ++ show (pledgeRatioP t)
         , "maxP = " ++ show (maxPP t)
         , "appPerf = " ++ show (appPerfP t)
@@ -191,9 +191,9 @@ instance Show RewardProvenancePool where
         , "lReward = " ++ show (lRewardP t)
         ]
 
-showPoolParams :: PoolParams -> String
-showPoolParams x =
-  "PoolParams\n"
+showStakePoolParams :: StakePoolParams -> String
+showStakePoolParams x =
+  "StakePoolParams\n"
     ++ mylines
       6
       [ "poolId = " ++ show (ppId x)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rewards.hs
@@ -48,7 +48,7 @@ import Cardano.Ledger.Coin (
 import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..))
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Shelley.Era (
   hardforkAllegraAggregatedRewards,
   hardforkBabbageForgoRewardPrefilter,
@@ -94,7 +94,7 @@ mkApparentPerformance d_ sigma blocksN blocksTotal
 -- | Calculate pool leader reward
 leaderRew ::
   Coin ->
-  PoolParams ->
+  StakePoolParams ->
   StakeShare ->
   StakeShare ->
   Coin
@@ -112,7 +112,7 @@ leaderRew f pool (StakeShare s) (StakeShare sigma)
 -- | Calculate pool member reward
 memberRew ::
   Coin ->
-  PoolParams ->
+  StakePoolParams ->
   StakeShare ->
   StakeShare ->
   Coin
@@ -214,7 +214,7 @@ data PoolRewardInfo = PoolRewardInfo
   -- ^ The stake pool's stake divided by the total stake
   , poolPot :: !Coin
   -- ^ The maximum rewards available for the entire pool
-  , poolPs :: !PoolParams
+  , poolPs :: !StakePoolParams
   -- ^ The stake pool parameters
   , poolBlocks :: !Natural
   -- ^ The number of blocks the stake pool produced
@@ -250,7 +250,7 @@ instance DecCBOR PoolRewardInfo where
       )
 
 notPoolOwner ::
-  PoolParams ->
+  StakePoolParams ->
   Credential 'Staking ->
   Bool
 notPoolOwner pps = \case
@@ -316,7 +316,7 @@ mkPoolRewardInfo ::
   Map (KeyHash 'StakePool) Coin ->
   Coin ->
   Coin ->
-  PoolParams ->
+  StakePoolParams ->
   Either StakeShare PoolRewardInfo
 mkPoolRewardInfo
   pp

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
@@ -250,7 +250,7 @@ validateStakePoolDelegateeRegistered ::
   KeyHash 'StakePool ->
   Test (KeyHash 'StakePool)
 validateStakePoolDelegateeRegistered pState targetPool =
-  let stPools = psStakePoolParams pState
+  let stPools = psStakeStakePoolParams pState
    in failureUnless (eval (targetPool ∈ dom stPools)) targetPool
 
 instance

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Epoch.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Epoch.hs
@@ -216,8 +216,8 @@ epochTransition = do
       ppp = eval (pParams ⨃ fPParams)
       pstate' =
         pstate
-          { psStakePoolParams = ppp
-          , psFutureStakePoolParams = Map.empty
+          { psStakeStakePoolParams = ppp
+          , psFutureStakeStakePoolParams = Map.empty
           }
   PoolreapState utxoSt' chainAccountState' adjustedCertState <-
     trans @(EraRule "POOLREAP" era) $

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/PoolReap.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/PoolReap.hs
@@ -141,7 +141,7 @@ poolReapTransition = do
       Map.partitionWithKey (\k _ -> Set.member k retired) (psDeposits ps)
     -- collect all accounts for stake pools that will retire
     retiredStakePoolAccounts :: Map.Map (KeyHash 'StakePool) RewardAccount
-    retiredStakePoolAccounts = Map.map ppRewardAccount $ eval (retired ◁ psStakePoolParams ps)
+    retiredStakePoolAccounts = Map.map ppRewardAccount $ eval (retired ◁ psStakeStakePoolParams ps)
     retiredStakePoolAccountsWithRefund :: Map.Map (KeyHash 'StakePool) (RewardAccount, CompactForm Coin)
     retiredStakePoolAccountsWithRefund = Map.intersectionWith (,) retiredStakePoolAccounts retiringDeposits
     -- collect all of the potential refunds
@@ -184,8 +184,8 @@ poolReapTransition = do
       ( cs
           & certDStateL . accountsL
             %~ removeStakePoolDelegations retired . addToBalanceAccounts refunds
-          & certPStateL . psStakePoolParamsL %~ (eval . (retired ⋪))
-          & certPStateL . psFutureStakePoolParamsL %~ (eval . (retired ⋪))
+          & certPStateL . psStakeStakePoolParamsL %~ (eval . (retired ⋪))
+          & certPStateL . psFutureStakeStakePoolParamsL %~ (eval . (retired ⋪))
           & certPStateL . psRetiringL %~ (eval . (retired ⋪))
           & certPStateL . psDepositsCompactL .~ remainingDeposits
       )

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/State/CertState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/State/CertState.hs
@@ -85,7 +85,7 @@ shelleyObligationCertState certState =
 shelleyCertsTotalDepositsTxBody ::
   EraTxBody era => PParams era -> ShelleyCertState era -> TxBody era -> Coin
 shelleyCertsTotalDepositsTxBody pp ShelleyCertState {shelleyCertPState} =
-  getTotalDepositsTxBody pp (`Map.member` psStakePoolParams shelleyCertPState)
+  getTotalDepositsTxBody pp (`Map.member` psStakeStakePoolParams shelleyCertPState)
 
 shelleyCertsTotalRefundsTxBody ::
   (EraTxBody era, EraAccounts era) => PParams era -> ShelleyCertState era -> TxBody era -> Coin

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Transition.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Transition.hs
@@ -394,7 +394,7 @@ registerInitialStakePools ::
   NewEpochState era
 registerInitialStakePools ShelleyGenesisStaking {sgsPools} nes =
   nes
-    & nesEsL . esLStateL . lsCertStateL . certPStateL . psStakePoolParamsL
+    & nesEsL . esLStateL . lsCertStateL . certPStateL . psStakeStakePoolParamsL
       .~ ListMap.toMap sgsPools
 
 -- | Register all staking credentials and apply delegations. Make sure StakePools that are bing
@@ -410,7 +410,7 @@ shelleyRegisterInitialAccounts ShelleyGenesisStaking {sgsStake} nes =
     & nesEsL . esLStateL . lsCertStateL . certDStateL . accountsL %~ \initAccounts ->
       foldr registerAndDelegate initAccounts $ zip (ListMap.toList sgsStake) ptrs
   where
-    stakePools = nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL . psStakePoolParamsL
+    stakePools = nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL . psStakeStakePoolParamsL
     deposit = compactCoinOrError $ nes ^. nesEsL . curPParamsEpochStateL . ppKeyDepositL
     registerAndDelegate ((stakeKeyHash, stakePool), ptr) !accounts
       | stakePool `Map.member` stakePools =

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
@@ -103,7 +103,7 @@ import Cardano.Ledger.Credential (
  )
 import Cardano.Ledger.Internal.Era (AllegraEra, AlonzoEra, BabbageEra, MaryEra)
 import Cardano.Ledger.Keys (asWitness)
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.PParams ()
 import Cardano.Ledger.Val ((<+>), (<×>))
@@ -619,7 +619,7 @@ shelleyTotalDepositsTxCerts pp isRegPoolRegistered certs =
     numKeys = getSum @Int $ foldMap' (\x -> if isRegStakeTxCert x then 1 else 0) certs
     numNewRegPoolCerts = Set.size (F.foldl' addNewPoolIds Set.empty certs)
     addNewPoolIds regPoolIds = \case
-      RegPoolTxCert (PoolParams {ppId})
+      RegPoolTxCert (StakePoolParams {ppId})
         -- We don't pay a deposit on a pool that is already registered or duplicated in the certs
         | not (isRegPoolRegistered ppId || Set.member ppId regPoolIds) -> Set.insert ppId regPoolIds
       _ -> regPoolIds

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -38,7 +38,7 @@ import Cardano.Ledger.Keys (
   asWitness,
   genDelegKeyHash,
  )
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (ProposedPPUpdates), Update (..))
 import Cardano.Ledger.Shelley.State ()
@@ -52,7 +52,7 @@ import Cardano.Ledger.State (
   EraCertState (..),
   dsGenDelegs,
   lookupDepositDState,
-  psStakePoolParamsL,
+  psStakeStakePoolParamsL,
  )
 import Cardano.Ledger.State as UTxO (
   CanGetUTxO (..),
@@ -141,7 +141,7 @@ produced ::
   TxBody era ->
   Value era
 produced pp certState =
-  getProducedValue pp (flip Map.member $ certState ^. certPStateL . psStakePoolParamsL)
+  getProducedValue pp (flip Map.member $ certState ^. certPStateL . psStakeStakePoolParamsL)
 
 shelleyProducedValue ::
   EraTxBody era =>

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/Golden.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/Golden.hs
@@ -83,5 +83,5 @@ goldenNewEpochStateExpectation
           [ E (TkListLen 3)
           , mapEnc (VMap.toMap (unStake ssStake))
           , Ev ver ssDelegations
-          , Ev ver ssPoolParams
+          , Ev ver ssStakePoolParams
           ]

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Examples.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Examples.hs
@@ -23,7 +23,7 @@ module Test.Cardano.Ledger.Shelley.Examples (
   exampleStakeKey,
   exampleNewEpochState,
   examplePoolDistr,
-  examplePoolParams,
+  exampleStakePoolParams,
   exampleTxIns,
   exampleProposedPPUpdates,
   exampleByronAddress,
@@ -364,7 +364,7 @@ exampleCerts ::
 exampleCerts =
   StrictSeq.fromList
     [ RegTxCert (keyToCredential exampleStakeKey)
-    , RegPoolTxCert examplePoolParams
+    , RegPoolTxCert exampleStakePoolParams
     , MirTxCert $
         MIRCert ReservesMIR $
           StakeAddressesMIR $
@@ -389,9 +389,9 @@ exampleProposedPPUpdates =
       (mkKeyHash 1)
       (emptyPParamsUpdate & ppuMaxBHSizeL .~ SJust 4000)
 
-examplePoolParams :: PoolParams
-examplePoolParams =
-  PoolParams
+exampleStakePoolParams :: StakePoolParams
+exampleStakePoolParams =
+  StakePoolParams
     { ppId = hashKey $ vKey $ mkDSIGNKeyPair 1
     , ppVrf = exampleVrfVerKeyHash
     , ppPledge = Coin 1

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -72,7 +72,7 @@ module Test.Cardano.Ledger.Shelley.ImpTest (
   getRewardAccountFor,
   getReward,
   lookupReward,
-  freshPoolParams,
+  freshStakePoolParams,
   registerPool,
   registerPoolWithRewardAccount,
   registerAndRetirePoolToMakeReward,
@@ -170,7 +170,7 @@ import Cardano.Ledger.Keys (
   makeBootstrapWitness,
   witVKeyHash,
  )
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.API.ByronTranslation (translateToShelleyLedgerStateFromUtxo)
 import Cardano.Ledger.Shelley.AdaPots (sumAdaPots, totalAdaPotsES)
@@ -1516,19 +1516,19 @@ getReward :: (HasCallStack, EraCertState era) => Credential 'Staking -> ImpTestM
 getReward = getBalance
 {-# DEPRECATED getReward "In favor of `getBalance`" #-}
 
-freshPoolParams ::
+freshStakePoolParams ::
   ShelleyEraImp era =>
   KeyHash 'StakePool ->
   RewardAccount ->
-  ImpTestM era PoolParams
-freshPoolParams khPool rewardAccount = do
+  ImpTestM era StakePoolParams
+freshStakePoolParams khPool rewardAccount = do
   vrfHash <- freshKeyHashVRF
   pp <- getsNES $ nesEsL . curPParamsEpochStateL
   let minCost = pp ^. ppMinPoolCostL
   poolCostExtra <- uniformRM (Coin 0, Coin 100_000_000)
   pledge <- uniformRM (Coin 0, Coin 100_000_000)
   pure
-    PoolParams
+    StakePoolParams
       { ppVrf = vrfHash
       , ppRewardAccount = rewardAccount
       , ppRelays = mempty
@@ -1552,7 +1552,7 @@ registerPoolWithRewardAccount ::
   RewardAccount ->
   ImpTestM era ()
 registerPoolWithRewardAccount khPool rewardAccount = do
-  pps <- freshPoolParams khPool rewardAccount
+  pps <- freshStakePoolParams khPool rewardAccount
   submitTxAnn_ "Registering a new stake pool" $
     mkBasicTx mkBasicTxBody
       & bodyTxL . certsTxBodyL .~ SSeq.singleton (RegPoolTxCert pps)

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/UnitTests/InstantStakeTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/UnitTests/InstantStakeTest.hs
@@ -11,7 +11,7 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Compactible (CompactForm, fromCompact)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential, StakeReference (..))
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Shelley.State hiding (balance)
 import Cardano.Ledger.TxIn (TxIn)
 import Data.Default (def)
@@ -26,7 +26,7 @@ import Test.Cardano.Ledger.Core.KeyPair (mkAddr)
 import Test.Cardano.Ledger.Shelley.Era
 import Test.Cardano.Ledger.Shelley.ImpTest
 
-ppIdL :: Lens' PoolParams (KeyHash 'StakePool)
+ppIdL :: Lens' StakePoolParams (KeyHash 'StakePool)
 ppIdL = lens ppId (\x y -> x {ppId = y})
 
 -- | Generate an arbitrary value and overwrite the specified value using the supplied lens.
@@ -37,7 +37,7 @@ arbitraryLens l b = (l .~ b) <$> arbitrary
 
 instantStakeIncludesRewards :: forall era. ShelleyEraImp era => Gen Property
 instantStakeIncludesRewards = do
-  (pool1, pool2) <- arbitrary @(TupleN 2 PoolParams)
+  (pool1, pool2) <- arbitrary @(TupleN 2 StakePoolParams)
   let
     poolId1 = pool1 ^. ppIdL
     poolId2 = pool2 ^. ppIdL
@@ -86,7 +86,7 @@ instantStakeIncludesRewards = do
 
     instantStake = addInstantStake utxo1 mempty
     poolparamMap = Map.fromList [(poolId1, pool1), (poolId2, pool2)]
-  pState <- arbitraryLens psStakePoolParamsL poolparamMap
+  pState <- arbitraryLens psStakeStakePoolParamsL poolparamMap
   let snapShot = snapShotFromInstantStake instantStake dState pState
       computedStakeDistr = VMap.toMap (unStake (ssStake snapShot))
 

--- a/eras/shelley/test-suite/bench/Cardano/Ledger/Shelley/Bench/Rewards.hs
+++ b/eras/shelley/test-suite/bench/Cardano/Ledger/Shelley/Bench/Rewards.hs
@@ -22,7 +22,7 @@ import Cardano.Ledger.BaseTypes (
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import Cardano.Ledger.Keys (KeyHash, KeyRole (Staking))
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.Genesis (ShelleyGenesisStaking (..))
 import qualified Cardano.Ledger.Shelley.LedgerState as LS
@@ -140,7 +140,7 @@ genChainInEpoch epoch = do
               [ (aikColdKeyHash, pp)
               | (AllIssuerKeys {aikVrf, aikColdKeyHash}, (owner : _)) <- stakeMap
               , let pp =
-                      PoolParams
+                      StakePoolParams
                         { ppId = aikColdKeyHash
                         , ppVrf = hashVerKeyVRF @MockCrypto $ vrfVerKey aikVrf
                         , ppPledge = Coin 1

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/BenchmarkFunctions.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/BenchmarkFunctions.hs
@@ -36,7 +36,7 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Keys (asWitness)
 import Cardano.Ledger.PoolParams (
-  PoolParams (..),
+  StakePoolParams (..),
   ppCost,
   ppId,
   ppMargin,
@@ -362,9 +362,9 @@ firstStakePoolKeyHash = mkPoolKeyHash firstStakePool
 vrfKeyHash :: VRFVerKeyHash 'StakePoolVRF
 vrfKeyHash = hashVerKeyVRF @MockCrypto . vrfVerKey . mkVRFKeyPair @MockCrypto $ RawSeed 0 0 0 0 0
 
-mkPoolParameters :: KeyPair 'StakePool -> PoolParams
+mkPoolParameters :: KeyPair 'StakePool -> StakePoolParams
 mkPoolParameters keys =
-  PoolParams
+  StakePoolParams
     { ppId = hashKey (vKey keys)
     , ppVrf = vrfKeyHash
     , ppPledge = Coin 0

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Cast.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Examples/Cast.hs
@@ -19,14 +19,14 @@ module Test.Cardano.Ledger.Shelley.Examples.Cast (
   aliceAddr,
   alicePtrAddr,
   alicePoolKeys,
-  alicePoolParams,
+  aliceStakePoolParams,
   aliceVRFKeyHash,
   bobPay,
   bobStake,
   bobSHK,
   bobAddr,
   bobPoolKeys,
-  bobPoolParams,
+  bobStakePoolParams,
   bobVRFKeyHash,
   carlPay,
   carlStake,
@@ -57,7 +57,7 @@ import Cardano.Ledger.Keys (
  )
 import Cardano.Ledger.PoolParams (
   PoolMetadata (..),
-  PoolParams (..),
+  StakePoolParams (..),
  )
 import Cardano.Protocol.Crypto (hashVerKeyVRF)
 import Cardano.Protocol.TPraos.OCert (KESPeriod (..))
@@ -120,9 +120,9 @@ alicePtrAddr :: Addr
 alicePtrAddr = mkAddr alicePHK (Ptr 10 minBound minBound)
 
 -- | Alice's stake pool parameters
-alicePoolParams :: PoolParams
-alicePoolParams =
-  PoolParams
+aliceStakePoolParams :: StakePoolParams
+aliceStakePoolParams =
+  StakePoolParams
     { ppId = hashKey . vKey $ aikCold alicePoolKeys
     , ppVrf = hashVerKeyVRF @MockCrypto . vrfVerKey $ aikVrf alicePoolKeys
     , ppPledge = Coin 1
@@ -175,9 +175,9 @@ bobPoolKeys =
     (skCold, vkCold) = mkKeyPair (RawSeed 2 0 0 0 1)
 
 -- | Bob's stake pool parameters
-bobPoolParams :: PoolParams
-bobPoolParams =
-  PoolParams
+bobStakePoolParams :: StakePoolParams
+bobStakePoolParams =
+  StakePoolParams
     { ppId = hashKey . vKey $ aikCold bobPoolKeys
     , ppVrf = hashVerKeyVRF @MockCrypto . vrfVerKey $ aikVrf bobPoolKeys
     , ppPledge = Coin 2

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/TxCert.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/TxCert.hs
@@ -239,7 +239,7 @@ genTxCerts
             (const Nothing)
             certs
 
-        deposits = getTotalDepositsTxCerts pp (`Map.member` psStakePoolParams certPState) certs
+        deposits = getTotalDepositsTxCerts pp (`Map.member` psStakeStakePoolParams certPState) certs
 
         certWits = concat (keyCredAsWitness <$> keyCreds')
         certScripts = extractScriptCred <$> scriptCreds

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rewards.hs
@@ -59,7 +59,7 @@ import Cardano.Ledger.Shelley (
   hardforkBabbageForgoRewardPrefilter,
  )
 import Cardano.Ledger.Shelley.API (NonMyopic)
-import Cardano.Ledger.Shelley.API.Types (PoolParams (..))
+import Cardano.Ledger.Shelley.API.Types (StakePoolParams (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (
   EpochState (..),
@@ -225,7 +225,7 @@ emptySetupArgs =
     }
 
 data PoolInfo = PoolInfo
-  { params :: PoolParams
+  { params :: StakePoolParams
   , coldKey :: KeyPair 'StakePool
   , ownerKey :: KeyPair 'Staking
   , ownerStake :: Coin
@@ -267,7 +267,7 @@ genPoolInfo PoolSetUpArgs {poolPledge, poolCost, poolMargin, poolMembers} = do
   -- here we are forcing the pool to meet the pledeg, later we may want flexibility
   let members = Map.insert (KeyHashObj . hashKey . vKey $ ownerKey) ownerStake members'
       params =
-        PoolParams
+        StakePoolParams
           { ppId = hashKey . vKey $ coldKey
           , ppVrf = hashVerKeyVRF @MockCrypto $ snd vrfKey
           , ppPledge = pledge
@@ -293,7 +293,7 @@ genRewardPPs = do
   where
     g xs = unsafeBoundRational <$> elements xs
 
-genBlocksMade :: [PoolParams] -> Gen BlocksMade
+genBlocksMade :: [StakePoolParams] -> Gen BlocksMade
 genBlocksMade pools = BlocksMade . Map.fromList <$> mapM f pools
   where
     f p = (ppId p,) <$> genNatural 0 maxPoolBlocks
@@ -376,7 +376,7 @@ rewardOnePool ::
   Coin ->
   Natural ->
   Natural ->
-  PoolParams ->
+  StakePoolParams ->
   Stake ->
   Rational ->
   Rational ->
@@ -450,7 +450,7 @@ rewardOld ::
   BlocksMade ->
   Coin ->
   Set.Set (Credential 'Staking) ->
-  VMap.VMap VMap.VB VMap.VB (KeyHash 'StakePool) PoolParams ->
+  VMap.VMap VMap.VB VMap.VB (KeyHash 'StakePool) StakePoolParams ->
   Stake ->
   VMap.VMap VMap.VB VMap.VB (Credential 'Staking) (KeyHash 'StakePool) ->
   Coin ->
@@ -743,7 +743,7 @@ reward ::
   BlocksMade ->
   Coin ->
   Set (Credential 'Staking) ->
-  VMap.VMap VMap.VB VMap.VB (KeyHash 'StakePool) PoolParams ->
+  VMap.VMap VMap.VB VMap.VB (KeyHash 'StakePool) StakePoolParams ->
   Stake ->
   VMap.VMap VMap.VB VMap.VB (Credential 'Staking) (KeyHash 'StakePool) ->
   Coin ->

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/IncrementalStake.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/IncrementalStake.hs
@@ -211,7 +211,7 @@ stakeDistr u ds ps =
     delegs :: Map.Map (Credential 'Staking) (KeyHash 'StakePool)
     delegs = Map.mapMaybe (^. stakePoolDelegationAccountStateL) accountsMap
     ptrs' = ds ^. accountsL . accountsPtrsMapG
-    PState {psStakePoolParams = poolParams} = ps
+    PState {psStakeStakePoolParams = poolParams} = ps
     stakeRelation :: Map (Credential 'Staking) (CompactForm Coin)
     stakeRelation = aggregateUtxoCoinByCredential ptrs' u rewards'
     activeDelegs :: Map.Map (Credential 'Staking) (KeyHash 'StakePool)

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -132,30 +132,30 @@ poolRegistrationProp
     , target = targetSt
     } =
     let hk = ppId poolParams
-        reRegistration = eval (hk ∈ dom (psStakePoolParams sourceSt))
+        reRegistration = eval (hk ∈ dom (psStakeStakePoolParams sourceSt))
      in if reRegistration
           then
             conjoin
               [ counterexample
-                  "Pre-existing PoolParams must still be registered in pParams"
-                  (eval (hk ∈ dom (psStakePoolParams targetSt)) :: Bool)
+                  "Pre-existing StakePoolParams must still be registered in pParams"
+                  (eval (hk ∈ dom (psStakeStakePoolParams targetSt)) :: Bool)
               , counterexample
-                  "New PoolParams are registered in future Params map"
-                  (Map.lookup hk (psFutureStakePoolParams targetSt) === Just poolParams)
+                  "New StakePoolParams are registered in future Params map"
+                  (Map.lookup hk (psFutureStakeStakePoolParams targetSt) === Just poolParams)
               , counterexample
-                  "PoolParams are removed in 'retiring'"
+                  "StakePoolParams are removed in 'retiring'"
                   (eval (hk ∉ dom (psRetiring targetSt)) :: Bool)
               ]
           else -- first registration
             conjoin
               [ counterexample
-                  "New PoolParams are registered in pParams"
-                  (Map.lookup hk (psStakePoolParams targetSt) === Just poolParams)
+                  "New StakePoolParams are registered in pParams"
+                  (Map.lookup hk (psStakeStakePoolParams targetSt) === Just poolParams)
               , counterexample
-                  "PoolParams are not present in 'future pool params'"
-                  (eval (hk ∉ dom (psFutureStakePoolParams targetSt)) :: Bool)
+                  "StakePoolParams are not present in 'future pool params'"
+                  (eval (hk ∉ dom (psFutureStakeStakePoolParams targetSt)) :: Bool)
               , counterexample
-                  "PoolParams are removed in 'retiring'"
+                  "StakePoolParams are removed in 'retiring'"
                   (eval (hk ∉ dom (psRetiring targetSt)) :: Bool)
               ]
 poolRegistrationProp _ = property ()
@@ -175,10 +175,10 @@ poolRetirementProp
           (currentEpoch < e && e < EpochNo (ce + fromIntegral maxEpoch))
       , counterexample
           "hk must be in source stPools"
-          (eval (hk ∈ dom (psStakePoolParams sourceSt)) :: Bool)
+          (eval (hk ∈ dom (psStakeStakePoolParams sourceSt)) :: Bool)
       , counterexample
           "hk must be in target stPools"
-          (eval (hk ∈ dom (psStakePoolParams targetSt)) :: Bool)
+          (eval (hk ∈ dom (psStakeStakePoolParams targetSt)) :: Bool)
       , counterexample
           "hk must be in target's retiring"
           (eval (hk ∈ dom (psRetiring targetSt)) :: Bool)
@@ -186,7 +186,7 @@ poolRetirementProp
 poolRetirementProp _ _ _ = property ()
 
 poolStateIsInternallyConsistentProp :: PState c -> Property
-poolStateIsInternallyConsistentProp PState {psStakePoolParams = pParams_, psRetiring = retiring_} = do
+poolStateIsInternallyConsistentProp PState {psStakeStakePoolParams = pParams_, psRetiring = retiring_} = do
   let poolKeys = Map.keysSet pParams_
       pParamKeys = Map.keysSet pParams_
       retiringKeys = Map.keysSet retiring_

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/PoolReap.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/PoolReap.hs
@@ -94,8 +94,8 @@ removedAfterPoolreap p p' e =
       && Set.null (eval (retire ∩ dom stp'))
       && Set.null (eval (retire ∩ dom retiring'))
   where
-    stp = psStakePoolParams p
-    stp' = psStakePoolParams p'
+    stp = psStakeStakePoolParams p
+    stp' = psStakeStakePoolParams p'
     retiring = psRetiring p
     retiring' = psRetiring p'
     retire :: Set.Set (KeyHash 'StakePool) -- This declaration needed to disambiguate 'eval'

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Combinators.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Combinators.hs
@@ -21,7 +21,7 @@ module Test.Cardano.Ledger.Shelley.Examples.Combinators (
   delegation,
   newPool,
   reregPool,
-  updatePoolParams,
+  updateStakePoolParams,
   stageRetirement,
   reapPool,
   mir,
@@ -59,7 +59,7 @@ import Cardano.Ledger.Coin (
 import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Credential (Credential (..), Ptr)
 import Cardano.Ledger.Hashes (GenDelegPair, GenDelegs (..))
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (
   EpochState (..),
@@ -152,7 +152,7 @@ addPoolDeposits ::
   forall era.
   (EraPParams era, EraCertState era) =>
   PParams era ->
-  [PoolParams] ->
+  [StakePoolParams] ->
   ChainState era ->
   ChainState era
 addPoolDeposits ppEx pools cs = cs {chainNes = nes}
@@ -265,7 +265,7 @@ delegation cred poolId cs = cs {chainNes = nes}
 newPool ::
   forall era.
   EraCertState era =>
-  PoolParams ->
+  StakePoolParams ->
   ChainState era ->
   ChainState era
 newPool pool cs = cs {chainNes = nes'}
@@ -277,7 +277,7 @@ newPool pool cs = cs {chainNes = nes'}
     ps = dps ^. certPStateL
     ps' =
       ps
-        { psStakePoolParams = Map.insert (ppId pool) pool (psStakePoolParams ps)
+        { psStakeStakePoolParams = Map.insert (ppId pool) pool (psStakeStakePoolParams ps)
         }
     dps' = dps & certPStateL .~ ps'
     ls' = ls {lsCertState = dps'}
@@ -288,7 +288,7 @@ newPool pool cs = cs {chainNes = nes'}
 reregPool ::
   forall era.
   EraCertState era =>
-  PoolParams ->
+  StakePoolParams ->
   ChainState era ->
   ChainState era
 reregPool pool cs = cs {chainNes = nes'}
@@ -300,7 +300,7 @@ reregPool pool cs = cs {chainNes = nes'}
     ps = dps ^. certPStateL
     ps' =
       ps
-        { psFutureStakePoolParams = Map.insert (ppId pool) pool (psStakePoolParams ps)
+        { psFutureStakeStakePoolParams = Map.insert (ppId pool) pool (psStakeStakePoolParams ps)
         }
     dps' = dps & certPStateL .~ ps'
     ls' = ls {lsCertState = dps'}
@@ -308,13 +308,13 @@ reregPool pool cs = cs {chainNes = nes'}
     nes' = nes {nesEs = es'}
 
 -- | = Re-Register Stake Pool
-updatePoolParams ::
+updateStakePoolParams ::
   forall era.
   EraCertState era =>
-  PoolParams ->
+  StakePoolParams ->
   ChainState era ->
   ChainState era
-updatePoolParams pool cs = cs {chainNes = nes'}
+updateStakePoolParams pool cs = cs {chainNes = nes'}
   where
     nes = chainNes cs
     es = nesEs nes
@@ -323,8 +323,8 @@ updatePoolParams pool cs = cs {chainNes = nes'}
     ps = dps ^. certPStateL
     ps' =
       ps
-        { psStakePoolParams = Map.insert (ppId pool) pool (psStakePoolParams ps)
-        , psFutureStakePoolParams = Map.delete (ppId pool) (psStakePoolParams ps)
+        { psStakeStakePoolParams = Map.insert (ppId pool) pool (psStakeStakePoolParams ps)
+        , psFutureStakeStakePoolParams = Map.delete (ppId pool) (psStakeStakePoolParams ps)
         }
     dps' = dps & certPStateL .~ ps'
     ls' = ls {lsCertState = dps'}
@@ -360,7 +360,7 @@ stageRetirement kh e cs = cs {chainNes = nes'}
 reapPool ::
   forall era.
   (EraGov era, EraCertState era) =>
-  PoolParams ->
+  StakePoolParams ->
   ChainState era ->
   ChainState era
 reapPool pool cs = cs {chainNes = nes'}
@@ -375,7 +375,7 @@ reapPool pool cs = cs {chainNes = nes'}
     ps' =
       ps
         { psRetiring = Map.delete poolId (psRetiring ps)
-        , psStakePoolParams = Map.delete poolId (psStakePoolParams ps)
+        , psStakeStakePoolParams = Map.delete poolId (psStakeStakePoolParams ps)
         , psDeposits = Map.delete poolId (psDeposits ps)
         }
     pp = es ^. curPParamsEpochStateL

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/NetworkID.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/NetworkID.hs
@@ -10,9 +10,9 @@ import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.API (
   Network (..),
   PoolEnv (..),
-  PoolParams (..),
   RewardAccount (..),
   ShelleyPOOL,
+  StakePoolParams (..),
  )
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Slot (EpochNo (..))
@@ -35,7 +35,7 @@ data Expectation = ExpectSuccess | ExpectFailure
 
 testPoolNetworkID ::
   ProtVer ->
-  PoolParams ->
+  StakePoolParams ->
   Expectation ->
   Assertion
 testPoolNetworkID pv poolParams e = do
@@ -54,15 +54,15 @@ testPoolNetworkID pv poolParams e = do
     (Right _, ExpectFailure) -> assertBool "We expected failure." False
     (Left _, ExpectSuccess) -> assertBool "We expected success." False
 
-matchingNetworkIDPoolParams :: PoolParams
-matchingNetworkIDPoolParams =
-  Cast.alicePoolParams {ppRewardAccount = RewardAccount Testnet Cast.aliceSHK}
+matchingNetworkIDStakePoolParams :: StakePoolParams
+matchingNetworkIDStakePoolParams =
+  Cast.aliceStakePoolParams {ppRewardAccount = RewardAccount Testnet Cast.aliceSHK}
 
 -- test globals use Testnet
 
-mismatchingNetworkIDPoolParams :: PoolParams
-mismatchingNetworkIDPoolParams =
-  Cast.alicePoolParams {ppRewardAccount = RewardAccount Mainnet Cast.aliceSHK}
+mismatchingNetworkIDStakePoolParams :: StakePoolParams
+mismatchingNetworkIDStakePoolParams =
+  Cast.aliceStakePoolParams {ppRewardAccount = RewardAccount Mainnet Cast.aliceSHK}
 
 -- test globals use Testnet
 
@@ -73,21 +73,21 @@ testPoolNetworkId =
     [ testCase "Incorrect Network ID is allowed pre-Alonzo" $
         testPoolNetworkID
           shelleyPV
-          mismatchingNetworkIDPoolParams
+          mismatchingNetworkIDStakePoolParams
           ExpectSuccess
     , testCase "Incorrect Network ID is NOT allowed in Alonzo" $
         testPoolNetworkID
           alonzoPV
-          mismatchingNetworkIDPoolParams
+          mismatchingNetworkIDStakePoolParams
           ExpectFailure
     , testCase "Correct Network ID is allowed pre-Alonzo" $
         testPoolNetworkID
           shelleyPV
-          matchingNetworkIDPoolParams
+          matchingNetworkIDStakePoolParams
           ExpectSuccess
     , testCase "Correct Network ID is allowed in Alonzo" $
         testPoolNetworkID
           alonzoPV
-          matchingNetworkIDPoolParams
+          matchingNetworkIDStakePoolParams
           ExpectSuccess
     ]

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
@@ -38,7 +38,7 @@ import Cardano.Ledger.Coin (
 import Cardano.Ledger.Compactible
 import Cardano.Ledger.Credential (Credential, Ptr (..), SlotNo32 (..))
 import Cardano.Ledger.Keys (asWitness, coerceKeyRole)
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Shelley (ShelleyEra, Tx (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (
@@ -177,7 +177,7 @@ txbodyEx1 =
         ( [ RegTxCert Cast.aliceSHK
           , RegTxCert Cast.bobSHK
           , RegTxCert Cast.carlSHK
-          , RegPoolTxCert Cast.alicePoolParams
+          , RegPoolTxCert Cast.aliceStakePoolParams
           ]
             ++ [ ShelleyTxCertMir
                    ( MIRCert
@@ -241,12 +241,12 @@ expectedStEx1 =
   C.evolveNonceUnfrozen (getBlockNonce blockEx1)
     . C.newLab blockEx1
     . C.addFees feeTx1
-    . C.addPoolDeposits ppEx [Cast.alicePoolParams]
+    . C.addPoolDeposits ppEx [Cast.aliceStakePoolParams]
     . C.newUTxO txbodyEx1
     . C.newStakeCred Cast.aliceSHK (Ptr (SlotNo32 10) minBound (mkCertIxPartial 0))
     . C.newStakeCred Cast.bobSHK (Ptr (SlotNo32 10) minBound (mkCertIxPartial 1))
     . C.newStakeCred Cast.carlSHK (Ptr (SlotNo32 10) minBound (mkCertIxPartial 2))
-    . C.newPool Cast.alicePoolParams
+    . C.newPool Cast.aliceStakePoolParams
     . C.mir Cast.carlSHK ReservesMIR carlMIR
     . C.mir Cast.dariaSHK ReservesMIR dariaMIR
     $ initStPoolLifetime
@@ -352,8 +352,8 @@ expectedStEx2 =
     . C.newLab blockEx2
     . C.addFees feeTx2
     . C.newUTxO txbodyEx2
-    . C.delegation Cast.aliceSHK (ppId Cast.alicePoolParams)
-    . C.delegation Cast.bobSHK (ppId Cast.alicePoolParams)
+    . C.delegation Cast.aliceSHK (ppId Cast.aliceStakePoolParams)
+    . C.delegation Cast.bobSHK (ppId Cast.aliceStakePoolParams)
     . C.pulserUpdate pulserEx2
     $ expectedStEx1
 
@@ -397,7 +397,7 @@ snapEx3 =
         [ (Cast.aliceSHK, aikColdKeyHash Cast.alicePoolKeys)
         , (Cast.bobSHK, aikColdKeyHash Cast.alicePoolKeys)
         ]
-    , ssPoolParams = [(aikColdKeyHash Cast.alicePoolKeys, Cast.alicePoolParams)]
+    , ssStakePoolParams = [(aikColdKeyHash Cast.alicePoolKeys, Cast.aliceStakePoolParams)]
     }
 
 expectedStEx3 :: ChainState ShelleyEra
@@ -486,7 +486,7 @@ expectedStEx4 =
     . C.newLab blockEx4
     . C.addFees feeTx4
     . C.newUTxO txbodyEx4
-    . C.delegation Cast.carlSHK (ppId Cast.alicePoolParams)
+    . C.delegation Cast.carlSHK (ppId Cast.aliceStakePoolParams)
     . C.pulserUpdate pulserEx4
     $ expectedStEx3
 
@@ -536,7 +536,7 @@ snapEx5 =
         , (Cast.carlSHK, aikColdKeyHash Cast.alicePoolKeys)
         , (Cast.bobSHK, aikColdKeyHash Cast.alicePoolKeys)
         ]
-    , ssPoolParams = [(aikColdKeyHash Cast.alicePoolKeys, Cast.alicePoolParams)]
+    , ssStakePoolParams = [(aikColdKeyHash Cast.alicePoolKeys, Cast.aliceStakePoolParams)]
     }
 
 pdEx5 :: PoolDistr
@@ -1019,7 +1019,7 @@ expectedStEx12 =
     . C.newSnapshot snapEx12 (Coin 11)
     . C.applyRewardUpdate rewardUpdateEx11
     . C.setOCertCounter coreNodeHK 3
-    . C.reapPool Cast.alicePoolParams
+    . C.reapPool Cast.aliceStakePoolParams
     $ expectedStEx11
   where
     coreNodeHK = coerceKeyRole . aikColdKeyHash $ coreNodeKeysBySchedule @ShelleyEra ppEx 510

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/TwoPools.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/TwoPools.hs
@@ -41,7 +41,7 @@ import Cardano.Ledger.Coin (
  )
 import Cardano.Ledger.Credential (Credential, Ptr (..), SlotNo32 (..))
 import Cardano.Ledger.Keys (asWitness, coerceKeyRole)
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Shelley
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (
@@ -164,11 +164,11 @@ aliceCoinEx1 =
 feeTx1 :: Coin
 feeTx1 = Coin 3
 
-alicePoolParams' :: PoolParams
-alicePoolParams' = Cast.alicePoolParams {ppRewardAccount = RewardAccount Testnet Cast.carlSHK}
+aliceStakePoolParams' :: StakePoolParams
+aliceStakePoolParams' = Cast.aliceStakePoolParams {ppRewardAccount = RewardAccount Testnet Cast.carlSHK}
 
-bobPoolParams' :: PoolParams
-bobPoolParams' = Cast.bobPoolParams {ppRewardAccount = RewardAccount Testnet Cast.carlSHK}
+bobStakePoolParams' :: StakePoolParams
+bobStakePoolParams' = Cast.bobStakePoolParams {ppRewardAccount = RewardAccount Testnet Cast.carlSHK}
 
 txbodyEx1 :: TxBody ShelleyEra
 txbodyEx1 =
@@ -179,8 +179,8 @@ txbodyEx1 =
         [ RegTxCert Cast.aliceSHK
         , RegTxCert Cast.bobSHK
         , RegTxCert Cast.carlSHK
-        , RegPoolTxCert alicePoolParams'
-        , RegPoolTxCert bobPoolParams'
+        , RegPoolTxCert aliceStakePoolParams'
+        , RegPoolTxCert bobStakePoolParams'
         , DelegStakeTxCert Cast.aliceSHK (aikColdKeyHash Cast.alicePoolKeys)
         , DelegStakeTxCert Cast.bobSHK (aikColdKeyHash Cast.bobPoolKeys)
         , DelegStakeTxCert Cast.carlSHK (aikColdKeyHash Cast.alicePoolKeys)
@@ -227,16 +227,16 @@ expectedStEx1 =
   C.evolveNonceUnfrozen (getBlockNonce blockEx1)
     . C.newLab blockEx1
     . C.addFees feeTx1
-    . C.addPoolDeposits ppEx [alicePoolParams', bobPoolParams']
+    . C.addPoolDeposits ppEx [aliceStakePoolParams', bobStakePoolParams']
     . C.newUTxO txbodyEx1
     . C.newStakeCred Cast.aliceSHK (Ptr (SlotNo32 10) minBound (mkCertIxPartial 0))
     . C.newStakeCred Cast.bobSHK (Ptr (SlotNo32 10) minBound (mkCertIxPartial 1))
     . C.newStakeCred Cast.carlSHK (Ptr (SlotNo32 10) minBound (mkCertIxPartial 2))
-    . C.newPool alicePoolParams'
-    . C.newPool bobPoolParams'
-    . C.delegation Cast.aliceSHK (ppId alicePoolParams')
-    . C.delegation Cast.bobSHK (ppId bobPoolParams')
-    . C.delegation Cast.carlSHK (ppId alicePoolParams')
+    . C.newPool aliceStakePoolParams'
+    . C.newPool bobStakePoolParams'
+    . C.delegation Cast.aliceSHK (ppId aliceStakePoolParams')
+    . C.delegation Cast.bobSHK (ppId bobStakePoolParams')
+    . C.delegation Cast.carlSHK (ppId aliceStakePoolParams')
     $ initStTwoPools
 
 -- === Block 1, Slot 10, Epoch 0
@@ -318,9 +318,9 @@ snapEx3 =
         , (Cast.bobSHK, aikColdKeyHash Cast.bobPoolKeys)
         , (Cast.carlSHK, aikColdKeyHash Cast.alicePoolKeys)
         ]
-    , ssPoolParams =
-        [ (aikColdKeyHash Cast.alicePoolKeys, alicePoolParams')
-        , (aikColdKeyHash Cast.bobPoolKeys, bobPoolParams')
+    , ssStakePoolParams =
+        [ (aikColdKeyHash Cast.alicePoolKeys, aliceStakePoolParams')
+        , (aikColdKeyHash Cast.bobPoolKeys, bobStakePoolParams')
         ]
     }
 
@@ -623,7 +623,7 @@ alicePoolRewards :: Coin
 alicePoolRewards = rationalToCoinViaFloor (appPerf * (fromIntegral . unCoin $ maxP))
   where
     appPerf = mkApparentPerformance (ppEx @ShelleyEra ^. ppDL) alicePoolStake 2 3
-    pledge = unCoin $ ppPledge alicePoolParams'
+    pledge = unCoin $ ppPledge aliceStakePoolParams'
     pr = pledge % circulation
     maxP = maxPool @ShelleyEra ppEx bigR aliceStakeShareTot pr
 
@@ -631,7 +631,7 @@ carlMemberRewardsFromAlice :: Coin
 carlMemberRewardsFromAlice =
   memberRew
     alicePoolRewards
-    alicePoolParams'
+    aliceStakePoolParams'
     (StakeShare $ unCoin carlInitCoin % circulation)
     (StakeShare aliceStakeShareTot)
 
@@ -639,7 +639,7 @@ carlLeaderRewardsFromAlice :: Coin
 carlLeaderRewardsFromAlice =
   leaderRew
     alicePoolRewards
-    alicePoolParams'
+    aliceStakePoolParams'
     (StakeShare $ unCoin aliceCoinEx1 % circulation)
     (StakeShare aliceStakeShareTot)
 
@@ -647,7 +647,7 @@ bobPoolRewards :: Coin
 bobPoolRewards = rationalToCoinViaFloor (appPerf * (fromIntegral . unCoin $ maxP))
   where
     appPerf = mkApparentPerformance (ppEx @ShelleyEra ^. ppDL) bobPoolStake 1 3
-    pledge = unCoin $ ppPledge bobPoolParams'
+    pledge = unCoin $ ppPledge bobStakePoolParams'
     pr = pledge % circulation
     maxP = maxPool @ShelleyEra ppEx bigR bobStakeShareTot pr
 
@@ -655,7 +655,7 @@ carlLeaderRewardsFromBob :: Coin
 carlLeaderRewardsFromBob =
   leaderRew
     bobPoolRewards
-    bobPoolParams'
+    bobStakePoolParams'
     (StakeShare $ unCoin bobInitCoin % circulation)
     (StakeShare bobStakeShareTot)
 

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
@@ -27,9 +27,9 @@ import Cardano.Ledger.Shelley (ShelleyEra, Tx (..), TxBody (..))
 import Cardano.Ledger.Shelley.API (
   Addr,
   Credential (..),
-  PoolParams (..),
   RewardAccount (..),
   ShelleyTxOut (..),
+  StakePoolParams (..),
   TxIn (..),
  )
 import Cardano.Ledger.Shelley.Scripts (
@@ -103,9 +103,9 @@ alicePool = KeyPair vk sk
 alicePoolKH :: KeyHash 'StakePool
 alicePoolKH = hashKey $ vKey alicePool
 
-alicePoolParams :: PoolParams
-alicePoolParams =
-  PoolParams
+aliceStakePoolParams :: StakePoolParams
+aliceStakePoolParams =
+  StakePoolParams
     { ppId = alicePoolKH
     , ppVrf = hashVerKeyVRF @StandardCrypto . vrfVerKey $ mkVRFKeyPair @StandardCrypto (RawSeed 0 0 0 0 3)
     , ppPledge = Coin 1
@@ -327,7 +327,7 @@ txbRegisterPool =
   ShelleyTxBody
     { stbInputs = Set.fromList [TxIn genesisId minBound]
     , stbOutputs = StrictSeq.fromList [ShelleyTxOut aliceAddr (Val.inject $ Coin 10)]
-    , stbCerts = StrictSeq.fromList [RegPoolTxCert alicePoolParams]
+    , stbCerts = StrictSeq.fromList [RegPoolTxCert aliceStakePoolParams]
     , stbWithdrawals = Withdrawals Map.empty
     , stbTxFee = Coin 94
     , stbTTL = SlotNo 10

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
@@ -71,7 +71,7 @@ import Cardano.Ledger.Keys (
  )
 import Cardano.Ledger.PoolParams (
   PoolMetadata (..),
-  PoolParams (..),
+  StakePoolParams (..),
   StakePoolRelay (..),
  )
 import Cardano.Ledger.Shelley (ShelleyEra)
@@ -521,7 +521,7 @@ tests =
             shelleyProtVer
             "register_pool"
             ( RegPoolTxCert @ShelleyEra
-                ( PoolParams
+                ( StakePoolParams
                     { ppId = hashKey $ vKey testStakePoolKey
                     , ppVrf = vrfKeyHash
                     , ppPledge = poolPledge

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Genesis.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Genesis.hs
@@ -142,7 +142,7 @@ golden_cbor_ShelleyGenesis =
         . TkMapLen 1 -- sgsPools
         . TkBytes
           "\245\131\164^IG\193\STX\t\ESC\150\ETB\SO\245\SO\240\207\142\219bfa\147\162\SYN2G\187"
-        . TkListLen 9 -- PoolParams
+        . TkListLen 9 -- StakePoolParams
         . TkBytes
           "N\DC3\f\v\222\183v\142\223.\143\133\NUL\DEL\213 s\227\220\CANq\244\196\DEL\157\252\169."
         . TkBytes
@@ -247,9 +247,9 @@ exampleShelleyGenesis =
         , L.SingleHostName L.SNothing (fromJust $ textToDns 64 "cool.domain.com")
         , L.MultiHostName (fromJust $ textToDns 64 "cool.domain.com")
         ]
-    poolParams :: L.PoolParams
+    poolParams :: L.StakePoolParams
     poolParams =
-      L.PoolParams
+      L.StakePoolParams
         { L.ppId = hashKey . snd $ mkKeyPair (RawSeed 1 0 0 0 1)
         , L.ppVrf =
             hashVerKeyVRF @StandardCrypto . vrfVerKey $ mkVRFKeyPair @StandardCrypto (RawSeed 1 0 0 0 2)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
@@ -21,7 +21,7 @@ import Cardano.Ledger.Credential (Credential (..), Ptr (..), SlotNo32 (..), Stak
 import Cardano.Ledger.Keys (asWitness)
 import Cardano.Ledger.PoolParams (
   PoolMetadata (..),
-  PoolParams (..),
+  StakePoolParams (..),
   pmHash,
   pmUrl,
   ppCost,
@@ -600,9 +600,9 @@ alicePoolColdKeys = KeyPair vk sk
   where
     (sk, vk) = mkKeyPair (RawSeed 0 0 0 0 1)
 
-alicePoolParamsSmallCost :: PoolParams
-alicePoolParamsSmallCost =
-  PoolParams
+aliceStakePoolParamsSmallCost :: StakePoolParams
+aliceStakePoolParamsSmallCost =
+  StakePoolParams
     { ppId = hashKey $ vKey alicePoolColdKeys
     , ppVrf = hashVerKeyVRF @MockCrypto vkVrf
     , ppPledge = Coin 1
@@ -628,7 +628,7 @@ testPoolCostTooSmall =
         DelplFailure $
           PoolFailure $
             StakePoolCostTooLowPOOL $
-              Mismatch (ppCost alicePoolParamsSmallCost) (pp @ShelleyEra ^. ppMinPoolCostL)
+              Mismatch (ppCost aliceStakePoolParamsSmallCost) (pp @ShelleyEra ^. ppMinPoolCostL)
     ]
     $ aliceGivesBobLovelace
     $ AliceToBob
@@ -637,7 +637,7 @@ testPoolCostTooSmall =
       , fee = Coin 997
       , deposits = Coin 250
       , refunds = Coin 0
-      , certs = [ShelleyTxCertPool $ RegPool alicePoolParamsSmallCost]
+      , certs = [ShelleyTxCertPool $ RegPool aliceStakePoolParamsSmallCost]
       , ttl = SlotNo 0
       , signers =
           ( [ asWitness alicePay

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -380,5 +380,5 @@ queryStakePoolDefaultVote ::
   KeyHash 'StakePool ->
   DefaultVote
 queryStakePoolDefaultVote nes poolId =
-  defaultStakePoolVote poolId (nes ^. nesEsL . epochStatePoolParamsL) $
+  defaultStakePoolVote poolId (nes ^. nesEsL . epochStateStakePoolParamsL) $
     nes ^. nesEsL . esLStateL . lsCertStateL . certDStateL . accountsL

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Body.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Body.hs
@@ -113,7 +113,7 @@ import Lens.Micro (Lens', lens)
 -- In case when full `Cardano.Ledger.CertState` is available then this can be simplified to:
 --
 -- > let lookupRefund = lookupDepositDState (certDState dpState)
--- > let isRegPoolId = (`Map.member` psStakePoolParams (certPState dpState))
+-- > let isRegPoolId = (`Map.member` psStakeStakePoolParams (certPState dpState))
 -- > evalBalanceTxBody pp lookupRefund isRegPoolId utxo txBody
 evalBalanceTxBody ::
   EraUTxO era =>

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/Tx/Body.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/Tx/Body.hs
@@ -37,7 +37,7 @@ totalTxDeposits pp dpstate txb =
   where
     certs = toList (txb ^. certsTxBodyL)
     numKeys = length $ filter isRegStakeTxCert certs
-    regpools = psStakePoolParams (dpstate ^. certPStateL)
+    regpools = psStakeStakePoolParams (dpstate ^. certPStateL)
     accum (!pools, !ans) (RegPoolTxCert poolparam) =
       -- We don't pay a deposit on a pool that is already registered
       if Map.member (ppId poolparam) pools
@@ -113,7 +113,7 @@ genTxBodyFrom certState (UTxO u) = do
   txBody <- arbitrary
   inputs <- sublistOf (Map.keys u)
   unDelegCreds <- sublistOf (Map.keys (certState ^. certDStateL . accountsL . accountsMapL))
-  deRegKeys <- sublistOf (Map.elems (certState ^. certPStateL . psStakePoolParamsL))
+  deRegKeys <- sublistOf (Map.elems (certState ^. certPStateL . psStakeStakePoolParamsL))
   certs <-
     shuffle $
       toList (txBody ^. certsTxBodyL)
@@ -138,7 +138,7 @@ propEvalBalanceTxBody pp certState utxo =
         `shouldBe` evaluateTransactionBalance pp certState utxo txBody
   where
     lookupKeyDeposit = lookupDepositDState (certState ^. certDStateL)
-    isRegPoolId = (`Map.member` psStakePoolParams (certState ^. certPStateL))
+    isRegPoolId = (`Map.member` psStakeStakePoolParams (certState ^. certPStateL))
 
 propEvalBalanceShelleyTxBody ::
   (EraUTxO era, ShelleyEraTxCert era, Arbitrary (TxBody era), EraCertState era) =>
@@ -153,7 +153,7 @@ propEvalBalanceShelleyTxBody pp certState utxo =
         `shouldBe` evaluateTransactionBalanceShelley pp certState utxo txBody
   where
     lookupKeyDeposit = lookupDepositDState (certState ^. certDStateL)
-    isRegPoolId = (`Map.member` psStakePoolParams (certState ^. certPStateL))
+    isRegPoolId = (`Map.member` psStakeStakePoolParams (certState ^. certPStateL))
 
 -- | NOTE: We cannot have this property pass for Conway and beyond because Conway changes this calculation.
 -- This property test only exists to confirm that the old and new implementations for the evalBalanceTxBody` API matched,

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -65,7 +65,7 @@ import Cardano.Ledger.Keys (VKey (..))
 import Cardano.Ledger.Keys.WitVKey (WitVKey (..))
 import Cardano.Ledger.Plutus (CostModels, ExUnits (..), Prices)
 import Cardano.Ledger.Plutus.Data (BinaryData, Data, Datum (..), hashBinaryData)
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Shelley.Rules (Identity)
 import Cardano.Ledger.Shelley.Scripts (
   pattern RequireAllOf,
@@ -591,10 +591,10 @@ instance SpecTranslate ctx RewardAccount where
 
   toSpecRep (RewardAccount n c) = Agda.RwdAddr <$> toSpecRep n <*> toSpecRep c
 
-instance SpecTranslate ctx PoolParams where
-  type SpecRep PoolParams = Agda.PoolParams
+instance SpecTranslate ctx StakePoolParams where
+  type SpecRep StakePoolParams = Agda.PoolParams
 
-  toSpecRep PoolParams {..} =
+  toSpecRep StakePoolParams {..} =
     Agda.PoolParams
       <$> toSpecRep ppOwners
       <*> toSpecRep ppCost
@@ -1029,7 +1029,7 @@ instance
       <*> dreps
       <*> toSpecRep reCommitteeState
       <*> toSpecRep treasury
-      <*> toSpecRep rePoolParams
+      <*> toSpecRep reStakePoolParams
       <*> toSpecRep (Map.mapMaybe (^. dRepDelegationAccountStateL) (reAccounts ^. accountsMapL))
 
 instance SpecTranslate ctx Bool where

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
@@ -37,13 +37,13 @@ instance SpecTranslate ctx (PState era) where
 
   toSpecRep PState {..} =
     Agda.MkPState
-      <$> toSpecRep psStakePoolParams
+      <$> toSpecRep psStakeStakePoolParams
       <*> toSpecRep psRetiring
 
 instance SpecTranslate ctx PoolCert where
   type SpecRep PoolCert = Agda.DCert
 
-  toSpecRep (RegPool p@PoolParams {ppId = KeyHash ppHash}) =
+  toSpecRep (RegPool p@StakePoolParams {ppId = KeyHash ppHash}) =
     Agda.Regpool
       <$> toSpecRep ppHash
       <*> toSpecRep p

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/TxCert.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/TxCert.hs
@@ -33,7 +33,7 @@ import Cardano.Ledger.Core.Translation
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Hashes (ScriptHash)
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..), asWitness)
-import Cardano.Ledger.PoolParams (PoolParams (ppId))
+import Cardano.Ledger.PoolParams (StakePoolParams (ppId))
 import Cardano.Ledger.Slot (EpochNo (..))
 import Control.DeepSeq (NFData (..), rwhnf)
 import Data.Aeson (ToJSON (..), (.=))
@@ -78,8 +78,8 @@ class
   -- | Return a ScriptHash for certificate types that require a witness
   getScriptWitnessTxCert :: TxCert era -> Maybe ScriptHash
 
-  mkRegPoolTxCert :: PoolParams -> TxCert era
-  getRegPoolTxCert :: TxCert era -> Maybe PoolParams
+  mkRegPoolTxCert :: StakePoolParams -> TxCert era
+  getRegPoolTxCert :: TxCert era -> Maybe StakePoolParams
 
   mkRetirePoolTxCert :: KeyHash 'StakePool -> EpochNo -> TxCert era
   getRetirePoolTxCert :: TxCert era -> Maybe (KeyHash 'StakePool, EpochNo)
@@ -110,7 +110,7 @@ class
     f (TxCert era) ->
     Coin
 
-pattern RegPoolTxCert :: EraTxCert era => PoolParams -> TxCert era
+pattern RegPoolTxCert :: EraTxCert era => StakePoolParams -> TxCert era
 pattern RegPoolTxCert d <- (getRegPoolTxCert -> Just d)
   where
     RegPoolTxCert d = mkRegPoolTxCert d
@@ -132,7 +132,7 @@ getPoolCertTxCert = \case
 
 data PoolCert
   = -- | A stake pool registration certificate.
-    RegPool !PoolParams
+    RegPool !StakePoolParams
   | -- | A stake pool retirement certificate.
     RetirePool !(KeyHash 'StakePool) !EpochNo
   deriving (Show, Generic, Eq, Ord)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/PoolParams.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/PoolParams.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Cardano.Ledger.PoolParams (
-  PoolParams (..),
+  StakePoolParams (..),
   PoolMetadata (..),
   StakePoolRelay (..),
   SizeOfPoolRelays (..),
@@ -191,7 +191,7 @@ instance DecCBOR StakePoolRelay where
       k -> invalidKey k
 
 -- | A stake pool.
-data PoolParams = PoolParams
+data StakePoolParams = StakePoolParams
   { ppId :: !(KeyHash 'StakePool)
   , ppVrf :: !(VRFVerKeyHash 'StakePoolVRF)
   , ppPledge :: !Coin
@@ -203,17 +203,17 @@ data PoolParams = PoolParams
   , ppMetadata :: !(StrictMaybe PoolMetadata)
   }
   deriving (Show, Generic, Eq, Ord)
-  deriving (EncCBOR) via CBORGroup PoolParams
-  deriving (DecCBOR) via CBORGroup PoolParams
+  deriving (EncCBOR) via CBORGroup StakePoolParams
+  deriving (DecCBOR) via CBORGroup StakePoolParams
 
-instance Default PoolParams where
-  def = PoolParams def def (Coin 0) (Coin 0) def def def def def
+instance Default StakePoolParams where
+  def = StakePoolParams def def (Coin 0) (Coin 0) def def def def def
 
-instance NoThunks PoolParams
+instance NoThunks StakePoolParams
 
-deriving instance NFData PoolParams
+deriving instance NFData StakePoolParams
 
-instance ToJSON PoolParams where
+instance ToJSON StakePoolParams where
   toJSON pp =
     Aeson.object
       [ "publicKey" .= ppId pp -- TODO publicKey is an unfortunate name, should be poolId
@@ -227,10 +227,10 @@ instance ToJSON PoolParams where
       , "metadata" .= ppMetadata pp
       ]
 
-instance FromJSON PoolParams where
+instance FromJSON StakePoolParams where
   parseJSON =
-    Aeson.withObject "PoolParams" $ \obj ->
-      PoolParams
+    Aeson.withObject "StakePoolParams" $ \obj ->
+      StakePoolParams
         <$> obj .: "publicKey" -- TODO publicKey is an unfortunate name, should be poolId
         <*> obj .: "vrf"
         <*> obj .: "pledge"
@@ -252,20 +252,20 @@ instance DecCBOR PoolMetadata where
     decodeRecordNamed "PoolMetadata" (const 2) (PoolMetadata <$> decCBOR <*> decCBOR)
 
 -- | The size of the 'ppOwners' 'Set'.  Only used to compute size of encoded
--- 'PoolParams'.
+-- 'StakePoolParams'.
 data SizeOfPoolOwners = SizeOfPoolOwners
 
 instance EncCBOR SizeOfPoolOwners where
   encCBOR = error "The `SizeOfPoolOwners` type cannot be encoded!"
 
 -- | The size of the 'ppRelays' 'Set'.  Only used to compute size of encoded
--- 'PoolParams'.
+-- 'StakePoolParams'.
 data SizeOfPoolRelays = SizeOfPoolRelays
 
 instance EncCBOR SizeOfPoolRelays where
   encCBOR = error "The `SizeOfPoolRelays` type cannot be encoded!"
 
-instance EncCBORGroup PoolParams where
+instance EncCBORGroup StakePoolParams where
   encCBORGroup poolParams =
     encCBOR (ppId poolParams)
       <> encCBOR (ppVrf poolParams)
@@ -302,7 +302,7 @@ instance EncCBORGroup PoolParams where
   listLen _ = 9
   listLenBound _ = 9
 
-instance DecCBORGroup PoolParams where
+instance DecCBORGroup StakePoolParams where
   decCBORGroup = do
     hk <- decCBOR
     vrf <- decCBOR
@@ -314,7 +314,7 @@ instance DecCBORGroup PoolParams where
     relays <- decCBOR
     md <- decodeNullMaybe decCBOR
     pure $
-      PoolParams
+      StakePoolParams
         { ppId = hk
         , ppVrf = vrf
         , ppPledge = pledge

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/CertState.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/CertState.hs
@@ -40,8 +40,8 @@ module Cardano.Ledger.State.CertState (
   dsGenDelegsL,
   dsIRewardsL,
   dsFutureGenDelegsL,
-  psStakePoolParamsL,
-  psFutureStakePoolParamsL,
+  psStakeStakePoolParamsL,
+  psFutureStakeStakePoolParamsL,
   psRetiringL,
   psDepositsL,
   psDepositsCompactL,
@@ -76,7 +76,7 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..), StakeCredential)
 import Cardano.Ledger.DRep (DRep (..), DRepState (..))
 import Cardano.Ledger.Hashes (GenDelegPair (..), GenDelegs (..))
-import Cardano.Ledger.PoolParams (PoolParams)
+import Cardano.Ledger.PoolParams (StakePoolParams)
 import Cardano.Ledger.Slot (EpochNo (..), SlotNo (..))
 import Cardano.Ledger.State.Account
 import Control.DeepSeq (NFData (..))
@@ -225,9 +225,9 @@ lookupRewardDState DState {dsAccounts} cred = do
 
 -- | The state used by the POOL rule, which tracks stake pool information.
 data PState era = PState
-  { psStakePoolParams :: !(Map (KeyHash 'StakePool) PoolParams)
+  { psStakeStakePoolParams :: !(Map (KeyHash 'StakePool) StakePoolParams)
   -- ^ The stake pool parameters.
-  , psFutureStakePoolParams :: !(Map (KeyHash 'StakePool) PoolParams)
+  , psFutureStakeStakePoolParams :: !(Map (KeyHash 'StakePool) StakePoolParams)
   -- ^ The future stake pool parameters.
   -- Changes to existing stake pool parameters are staged in order
   -- to give delegators time to react to changes.
@@ -252,19 +252,19 @@ instance Era era => EncCBOR (PState era) where
 instance DecShareCBOR (PState era) where
   type Share (PState era) = Interns (KeyHash 'StakePool)
   decSharePlusCBOR = decodeRecordNamedT "PState" (const 4) $ do
-    psStakePoolParams <- decSharePlusLensCBOR (toMemptyLens _1 id)
-    psFutureStakePoolParams <- decSharePlusLensCBOR (toMemptyLens _1 id)
+    psStakeStakePoolParams <- decSharePlusLensCBOR (toMemptyLens _1 id)
+    psFutureStakeStakePoolParams <- decSharePlusLensCBOR (toMemptyLens _1 id)
     psRetiring <- decSharePlusLensCBOR (toMemptyLens _1 id)
     psDeposits <- decSharePlusLensCBOR (toMemptyLens _1 id)
-    pure PState {psStakePoolParams, psFutureStakePoolParams, psRetiring, psDeposits}
+    pure PState {psStakeStakePoolParams, psFutureStakeStakePoolParams, psRetiring, psDeposits}
 
 instance (Era era, DecShareCBOR (PState era)) => DecCBOR (PState era) where
   decCBOR = decNoShareCBOR
 
 instance ToKeyValuePairs (PState era) where
   toKeyValuePairs PState {..} =
-    [ "stakePoolParams" .= psStakePoolParams
-    , "futureStakePoolParams" .= psFutureStakePoolParams
+    [ "stakeStakePoolParams" .= psStakeStakePoolParams
+    , "futureStakeStakePoolParams" .= psFutureStakeStakePoolParams
     , "retiring" .= psRetiring
     , "deposits" .= psDeposits
     ]
@@ -481,11 +481,11 @@ dsFutureGenDelegsL = lens dsFutureGenDelegs (\ds u -> ds {dsFutureGenDelegs = u}
 -- ===================================
 -- PState
 
-psStakePoolParamsL :: Lens' (PState era) (Map (KeyHash 'StakePool) PoolParams)
-psStakePoolParamsL = lens psStakePoolParams (\ds u -> ds {psStakePoolParams = u})
+psStakeStakePoolParamsL :: Lens' (PState era) (Map (KeyHash 'StakePool) StakePoolParams)
+psStakeStakePoolParamsL = lens psStakeStakePoolParams (\ds u -> ds {psStakeStakePoolParams = u})
 
-psFutureStakePoolParamsL :: Lens' (PState era) (Map (KeyHash 'StakePool) PoolParams)
-psFutureStakePoolParamsL = lens psFutureStakePoolParams (\ds u -> ds {psFutureStakePoolParams = u})
+psFutureStakeStakePoolParamsL :: Lens' (PState era) (Map (KeyHash 'StakePool) StakePoolParams)
+psFutureStakeStakePoolParamsL = lens psFutureStakeStakePoolParams (\ds u -> ds {psFutureStakeStakePoolParams = u})
 
 psRetiringL :: Lens' (PState era) (Map (KeyHash 'StakePool) EpochNo)
 psRetiringL = lens psRetiring (\ds u -> ds {psRetiring = u})

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/Stake.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/Stake.hs
@@ -84,11 +84,11 @@ class
 
 snapShotFromInstantStake ::
   forall era. EraStake era => InstantStake era -> DState era -> PState era -> SnapShot
-snapShotFromInstantStake iStake dState PState {psStakePoolParams} =
+snapShotFromInstantStake iStake dState PState {psStakeStakePoolParams} =
   SnapShot
     { ssStake = resolveInstantStake iStake accounts
     , ssDelegations = VMap.fromDistinctAscListN delegsCount delegsAscList
-    , ssPoolParams = VMap.fromMap psStakePoolParams
+    , ssStakePoolParams = VMap.fromMap psStakeStakePoolParams
     }
   where
     accounts = dsAccounts dState

--- a/libs/cardano-ledger-core/test/Test/Cardano/Ledger/JsonSpec.hs
+++ b/libs/cardano-ledger-core/test/Test/Cardano/Ledger/JsonSpec.hs
@@ -30,7 +30,7 @@ spec = do
     roundTripJsonSpec @CostModels
     roundTripJsonSpec @PoolMetadata
     roundTripJsonSpec @StakePoolRelay
-    roundTripJsonSpec @PoolParams
+    roundTripJsonSpec @StakePoolParams
     roundTripJsonSpec @Addr
     roundTripJsonSpec @RewardAccount
     roundTripJsonSpec @(Credential 'Witness)

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -97,9 +97,9 @@ import Cardano.Ledger.Plutus.ExUnits (ExUnits (..), Prices (..))
 import Cardano.Ledger.Plutus.Language (Language (..), nonNativeLanguages)
 import Cardano.Ledger.PoolParams (
   PoolMetadata (..),
-  PoolParams (..),
   SizeOfPoolOwners (..),
   SizeOfPoolRelays (..),
+  StakePoolParams (..),
   StakePoolRelay (..),
  )
 import Cardano.Ledger.State
@@ -457,12 +457,12 @@ instance Arbitrary Reward where
   shrink = genericShrink
 
 ------------------------------------------------------------------------------------------
--- Cardano.Ledger.PoolParams -------------------------------------------------------------
+-- Cardano.Ledger.StakePoolParams -------------------------------------------------------------
 ------------------------------------------------------------------------------------------
 
-instance Arbitrary PoolParams where
+instance Arbitrary StakePoolParams where
   arbitrary =
-    PoolParams
+    StakePoolParams
       <$> arbitrary
       <*> arbitrary
       <*> arbitrary

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
@@ -197,10 +197,10 @@ instance ToExpr Withdrawals
 
 instance ToExpr CompactAddr
 
--- PoolParams
+-- StakePoolParams
 instance ToExpr PoolMetadata
 
-instance ToExpr PoolParams
+instance ToExpr StakePoolParams
 
 instance ToExpr StakePoolRelay
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Cert.hs
@@ -111,7 +111,7 @@ conwayTxCertSpec univ (CertEnv pp ce cc cp) certState =
       (branchW 2 $ \govCert -> satisfies govCert $ govCertSpec univ govCertEnv certState)
   where
     certPState = certState ^. certPStateL
-    delegEnv = ConwayDelegEnv pp (psStakePoolParams certPState)
+    delegEnv = ConwayDelegEnv pp (psStakeStakePoolParams certPState)
     poolEnv = PoolEnv ce pp
     govCertEnv = ConwayGovCertEnv pp ce cc cp
 
@@ -174,7 +174,7 @@ shelleyTxCertSpec univ (CertEnv pp currEpoch _ _) (ShelleyCertState pstate dstat
             deleg
             ( shelleyDelegCertSpec @era
                 univ
-                (ConwayDelegEnv pp (psStakePoolParams pstate))
+                (ConwayDelegEnv pp (psStakeStakePoolParams pstate))
                 dstate
             )
       )

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
@@ -28,7 +28,7 @@ import Cardano.Ledger.Conway.TxCert
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential
 import Cardano.Ledger.Mary (MaryEra)
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.TxCert
 import Constrained.API
@@ -78,7 +78,7 @@ dRepMembershipPred dRepsMap dRep =
 
 -- | The DState needs a witnessed set of delegations to be usefull. Use this Spec to obtain a random one
 witnessedKeyHashPoolParamMapSpec ::
-  Era era => WitUniv era -> Specification (Map (KeyHash StakePool) PoolParams)
+  Era era => WitUniv era -> Specification (Map (KeyHash StakePool) StakePoolParams)
 witnessedKeyHashPoolParamMapSpec univ =
   constrained $ \keyPoolParamMap ->
     [witness univ (dom_ keyPoolParamMap), witness univ (rng_ keyPoolParamMap)]
@@ -86,7 +86,7 @@ witnessedKeyHashPoolParamMapSpec univ =
 conwayAccountsSpec ::
   Era era =>
   WitUniv era ->
-  Term (Map (KeyHash 'StakePool) PoolParams) ->
+  Term (Map (KeyHash 'StakePool) StakePoolParams) ->
   Specification (ConwayAccounts era)
 conwayAccountsSpec univ poolreg = constrained $ \ [var|conwayAccounts|] ->
   match conwayAccounts $ \ [var|accountmap|] ->

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Gov.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Gov.hs
@@ -297,7 +297,7 @@ govProceduresSpec ge@GovEnv {..} ps =
         ]
       committeeState = geCertState ^. certVStateL . vsCommitteeStateL
       knownDReps = Map.keysSet $ geCertState ^. certVStateL . vsDRepsL
-      knownStakePools = Map.keysSet $ geCertState ^. certPStateL . psStakePoolParamsL
+      knownStakePools = Map.keysSet $ geCertState ^. certPStateL . psStakeStakePoolParamsL
       knownCommitteeAuthorizations = authorizedHotCommitteeCredentials committeeState
       committeeVotableActionIds =
         actions (isCommitteeVotingAllowed geEpoch committeeState)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -672,9 +672,9 @@ instance HasSimpleRep PoolCert
 
 instance HasSpec PoolCert
 
-instance HasSimpleRep PoolParams
+instance HasSimpleRep StakePoolParams
 
-instance HasSpec PoolParams
+instance HasSpec StakePoolParams
 
 instance HasSimpleRep PoolMetadata
 
@@ -1442,7 +1442,7 @@ type DRepPulserTypes =
    , EnactState ConwayEra
    , StrictSeq (GovActionState ConwayEra)
    , Map (Credential 'Staking) (CompactForm Coin)
-   , Map (KeyHash 'StakePool) PoolParams
+   , Map (KeyHash 'StakePool) StakePoolParams
    ]
 
 instance
@@ -1466,7 +1466,7 @@ instance
       dpEnactState
       dpProposals
       dpProposalDeposits
-      dpPoolParams
+      dpStakePoolParams
   fromSimpleRep rep =
     algebra @'["DRepPulser" ::: DRepPulserTypes]
       rep

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Tests.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Tests.hs
@@ -15,7 +15,7 @@ import Cardano.Ledger.BaseTypes hiding (inject)
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Shelley.LedgerState (
   EpochState (..),
   LedgerState (..),
@@ -91,7 +91,7 @@ delegationsSpec ::
 delegationsSpec = (hasSize (rangeSize 8 12))
 
 poolRegSpec ::
-  forall era. Era era => WitUniv era -> Specification (Map (KeyHash 'StakePool) PoolParams)
+  forall era. Era era => WitUniv era -> Specification (Map (KeyHash 'StakePool) StakePoolParams)
 poolRegSpec univ = constrained $ \poolRegMap ->
   [ witness univ (dom_ poolRegMap)
   , witness univ (rng_ poolRegMap)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Pool.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Pool.hs
@@ -44,21 +44,21 @@ pStateSpec ::
   WitUniv era ->
   Specification (PState era)
 pStateSpec univ = constrained $ \ps ->
-  match ps $ \stakePoolParams futureStakePoolParams retiring deposits ->
-    [ witness univ (dom_ stakePoolParams)
-    , witness univ (rng_ stakePoolParams)
-    , witness univ (dom_ futureStakePoolParams)
-    , witness univ (rng_ futureStakePoolParams)
+  match ps $ \stakeStakePoolParams futureStakeStakePoolParams retiring deposits ->
+    [ witness univ (dom_ stakeStakePoolParams)
+    , witness univ (rng_ stakeStakePoolParams)
+    , witness univ (dom_ futureStakeStakePoolParams)
+    , witness univ (rng_ futureStakeStakePoolParams)
     , witness univ (dom_ retiring)
     , witness univ (dom_ deposits)
-    , assertExplain (pure "dom of retiring is a subset of dom of stakePoolParams") $
-        dom_ retiring `subset_` dom_ stakePoolParams
-    , assertExplain (pure "dom of deposits is dom of stakePoolParams") $
-        dom_ deposits ==. dom_ stakePoolParams
+    , assertExplain (pure "dom of retiring is a subset of dom of stakeStakePoolParams") $
+        dom_ retiring `subset_` dom_ stakeStakePoolParams
+    , assertExplain (pure "dom of deposits is dom of stakeStakePoolParams") $
+        dom_ deposits ==. dom_ stakeStakePoolParams
     , forAll' (rng_ deposits) $ \ [var|dep|] ->
         assertExplain (pure "all deposits are greater then (Coin 0)") $ dep >=. lit 0
-    , assertExplain (pure "dom of stakePoolParams is disjoint from futureStakePoolParams") $
-        dom_ stakePoolParams `disjoint_` dom_ futureStakePoolParams
+    , assertExplain (pure "dom of stakeStakePoolParams is disjoint from futureStakeStakePoolParams") $
+        dom_ stakeStakePoolParams `disjoint_` dom_ futureStakeStakePoolParams
     ]
 
 poolCertSpec ::
@@ -71,7 +71,7 @@ poolCertSpec ::
 poolCertSpec univ (PoolEnv e pp) ps =
   constrained $ \pc ->
     (caseOn pc)
-      -- RegPool !(PoolParams c)
+      -- RegPool !(StakePoolParams c)
       ( branchW 1 $ \poolParams ->
           match poolParams $ \_ _ _ cost _ rewAccnt _ _ mMetadata ->
             [ witness univ poolParams
@@ -93,5 +93,5 @@ poolCertSpec univ (PoolEnv e pp) ps =
   where
     EpochInterval maxEp = pp ^. ppEMaxL
     maxEpochNo = EpochNo (fromIntegral maxEp)
-    rpools = Map.keys $ psStakePoolParams ps
+    rpools = Map.keys $ psStakeStakePoolParams ps
     maxMetaLen = fromIntegral (Hash.sizeHash ([] @HASH))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/TxBodySpec.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/TxBodySpec.hs
@@ -90,7 +90,7 @@ getDepositRefund ::
   (EraTxCert era, ConwayEraCertState era) =>
   PParams era -> CertState era -> [TxCert era] -> (DeltaCoin, DeltaCoin)
 getDepositRefund pp certState certs =
-  ( delta $ getTotalDepositsTxCerts pp (`Map.member` psStakePoolParams ps) certs
+  ( delta $ getTotalDepositsTxCerts pp (`Map.member` psStakeStakePoolParams ps) certs
   , delta $ getTotalRefundsTxCerts pp (lookupDepositDState ds) (lookupDepositVState vs) certs
   )
   where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/WitnessUniverse.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/WitnessUniverse.hs
@@ -69,7 +69,7 @@ import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.Mary.Value ()
 import Cardano.Ledger.Plutus.Data (Data (..), hashData)
 import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.Scripts
 import Cardano.Ledger.Shelley.TxCert
@@ -407,14 +407,14 @@ witRewardAccountSpec univ =
         satisfies raCred (witCredSpec @era univ)
 
 owners_ ::
-  Term PoolParams -> Term (Set (KeyHash 'Staking))
+  Term StakePoolParams -> Term (Set (KeyHash 'Staking))
 owners_ = sel @6
 
-witPoolParamsSpec ::
+witStakePoolParamsSpec ::
   forall era.
-  WitUniv era -> Specification PoolParams
-witPoolParamsSpec univ =
-  explainWit "poolparams :: (PoolParams c)" univ $
+  WitUniv era -> Specification StakePoolParams
+witStakePoolParamsSpec univ =
+  explainWit "poolparams :: (StakePoolParams c)" univ $
     constrained $ \ [var|poolparams|] ->
       [ forAll (owners_ poolparams) $ \ [var|ownerKeyHash|] -> satisfies ownerKeyHash (witKeyHashSpec univ)
       , satisfies (owners_ poolparams) (hasSize (rangeSize 1 3))
@@ -445,7 +445,7 @@ witShelleyTxCert univ =
         )
         ( branchW 3 $ \poolcert ->
             (caseOn poolcert)
-              (branch $ \registerPoolParams -> satisfies registerPoolParams (witPoolParamsSpec univ))
+              (branch $ \registerStakePoolParams -> satisfies registerStakePoolParams (witStakePoolParamsSpec univ))
               (branch $ \retirePoolAuthor _ -> satisfies retirePoolAuthor (witKeyHashSpec univ))
         )
         ( branchW 1 $ \genesiscert -> match genesiscert $ \authorkey _ _ -> satisfies authorkey (witKeyHashSpec univ)
@@ -474,7 +474,7 @@ witConwayTxCert univ =
         )
         ( branch $ \poolcert ->
             (caseOn poolcert)
-              (branch $ \registerPoolParams -> satisfies registerPoolParams (witPoolParamsSpec univ))
+              (branch $ \registerStakePoolParams -> satisfies registerStakePoolParams (witStakePoolParamsSpec univ))
               (branch $ \retirePoolAuthor _ -> satisfies retirePoolAuthor (witKeyHashSpec univ))
         )
         ( branch $ \govcert ->
@@ -681,8 +681,8 @@ instance Era era => Witnessed era DRep where
 instance Era era => Witnessed era RewardAccount where
   witness univ t = satisfies t (witRewardAccountSpec univ)
 
-instance Era era => Witnessed era PoolParams where
-  witness univ t = satisfies t (witPoolParamsSpec univ)
+instance Era era => Witnessed era StakePoolParams where
+  witness univ t = satisfies t (witStakePoolParamsSpec univ)
 
 instance Era era => Witnessed era GenDelegPair where
   witness univ t = satisfies t (witGenDelegPairSpec univ)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
@@ -43,8 +43,8 @@ import Cardano.Ledger.PoolParams (PoolMetadata (..))
 import Cardano.Ledger.Shelley.API (
   GenDelegs (..),
   LedgerState (..),
-  PoolParams (..),
   ProtVer (..),
+  StakePoolParams (..),
  )
 import Cardano.Ledger.Shelley.LedgerState (smartUTxOState)
 import Cardano.Ledger.Shelley.Rules (
@@ -498,7 +498,7 @@ poolMDHTooBigTx =
       where
         tooManyBytes = BS.replicate (standardHashSize + 1) 0
         poolParams =
-          PoolParams
+          StakePoolParams
             { ppId = coerceKeyRole . hashKey $ vKey someKeys
             , ppVrf =
                 hashVerKeyVRF @MockCrypto . vrfVerKey @MockCrypto . mkVRFKeyPair @MockCrypto $

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Instances.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Instances.hs
@@ -31,7 +31,7 @@ import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Credential (Credential (..), Ptr (..))
 import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.Plutus (ExUnits (..), Language (..))
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.Scripts (pattern RequireAllOf, pattern RequireAnyOf)
 import Cardano.Ledger.Shelley.TxCert (ShelleyDelegCert (..), ShelleyTxCert (..))
@@ -116,7 +116,7 @@ applyShelleyCert model dcert = case dcert of
       }
   ShelleyTxCertPool (RegPool poolparams) ->
     model
-      { mPoolParams = Map.insert hk poolparams (mPoolParams model)
+      { mStakePoolParams = Map.insert hk poolparams (mStakePoolParams model)
       , mDeposited =
           if Map.member hk (mPoolDeposits model)
             then mDeposited model

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ModelState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ModelState.hs
@@ -40,7 +40,7 @@ import Cardano.Ledger.Coin (Coin (..), CompactForm (CompactCoin))
 import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Hashes (GenDelegs (..))
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (
   EpochState (..),
@@ -85,7 +85,7 @@ type MUtxo era = Map TxIn (TxOut era)
 
 data ModelNewEpochState era = ModelNewEpochState
   { -- PState fields
-    mPoolParams :: !(Map (KeyHash 'StakePool) PoolParams)
+    mStakePoolParams :: !(Map (KeyHash 'StakePool) StakePoolParams)
   , mPoolDeposits :: !(Map (KeyHash 'StakePool) Coin)
   , -- DState state fields
     mAccounts :: !(Accounts era)
@@ -112,7 +112,7 @@ data ModelNewEpochState era = ModelNewEpochState
   , mCount :: !Int
   , mIndex :: !(Map Int TxId)
   , -- below here NO EFFECT until we model EpochBoundary
-    mFPoolParams :: !(Map (KeyHash 'StakePool) PoolParams)
+    mFStakePoolParams :: !(Map (KeyHash 'StakePool) StakePoolParams)
   , mRetiring :: !(Map (KeyHash 'StakePool) EpochNo)
   , mSnapshots :: !SnapShots
   , mEL :: !EpochNo -- The current epoch,
@@ -162,8 +162,8 @@ dStateZero =
 pStateZero :: PState era
 pStateZero =
   PState
-    { psStakePoolParams = Map.empty
-    , psFutureStakePoolParams = Map.empty
+    { psStakeStakePoolParams = Map.empty
+    , psFutureStakeStakePoolParams = Map.empty
     , psRetiring = Map.empty
     , psDeposits = Map.empty
     }
@@ -222,7 +222,7 @@ stashedAVVMAddressesZero Allegra = ()
 mNewEpochStateZero :: (EraPParams era, EraAccounts era) => ModelNewEpochState era
 mNewEpochStateZero =
   ModelNewEpochState
-    { mPoolParams = Map.empty
+    { mStakePoolParams = Map.empty
     , mPoolDeposits = Map.empty
     , mAccounts = def
     , mUTxO = Map.empty
@@ -235,7 +235,7 @@ mNewEpochStateZero =
     , mCount = 0
     , mIndex = Map.empty
     , -- below here NO EFFECT until we model EpochBoundary
-      mFPoolParams = Map.empty
+      mFStakePoolParams = Map.empty
     , mRetiring = Map.empty
     , mSnapshots = emptySnapShots
     , mEL = EpochNo 0
@@ -264,7 +264,7 @@ instance Extract (DState era) era where
       instantaneousRewardsZero
 
 instance Extract (PState era) era where
-  extract x = PState (mPoolParams x) (mFPoolParams x) (mRetiring x) Map.empty
+  extract x = PState (mStakePoolParams x) (mFStakePoolParams x) (mRetiring x) Map.empty
 
 instance Extract (VState era) era where
   extract _ = VState def def (EpochNo 0)
@@ -319,7 +319,7 @@ instance forall era. Reflect era => Extract (NewEpochState era) era where
 abstract :: (EraGov era, EraCertState era) => NewEpochState era -> ModelNewEpochState era
 abstract x =
   ModelNewEpochState
-    { mPoolParams = (psStakePoolParams . certPState . lsCertState . esLState . nesEs) x
+    { mStakePoolParams = (psStakeStakePoolParams . certPState . lsCertState . esLState . nesEs) x
     , mPoolDeposits = (fmap fromCompact . psDeposits . certPState . lsCertState . esLState . nesEs) x
     , mAccounts = (dsAccounts . certDState . lsCertState . esLState . nesEs) x
     , mUTxO = (unUTxO . utxosUtxo . lsUTxOState . esLState . nesEs) x
@@ -332,7 +332,7 @@ abstract x =
     , mCount = 0
     , mIndex = Map.empty
     , -- below here NO EFFECT until we model EpochBoundary
-      mFPoolParams = (psFutureStakePoolParams . certPState . lsCertState . esLState . nesEs) x
+      mFStakePoolParams = (psFutureStakeStakePoolParams . certPState . lsCertState . esLState . nesEs) x
     , mRetiring = (psRetiring . certPState . lsCertState . esLState . nesEs) x
     , mSnapshots = esSnapshots (nesEs x)
     , mEL = nesEL x

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
@@ -209,14 +209,14 @@ raiseMockError ::
   GenState era ->
   String
 raiseMockError slot (SlotNo next) epochstate _pdfs _txs _ =
-  let _ssPoolParams = epochstate ^. esLStateL . lsCertStateL . certPStateL . psStakePoolParamsL
+  let _ssStakePoolParams = epochstate ^. esLStateL . lsCertStateL . certPStateL . psStakeStakePoolParamsL
       _pooldeposits = epochstate ^. esLStateL . lsCertStateL . certPStateL . psDepositsL
    in show
         [ toExpr $ adaPots reify epochstate
         , toExpr slot
         , toExpr next
         , -- ppString "===================================",
-          -- ppString "Real Pool Params\n" <> ppMap pcKeyHash pcPoolParams poolParams,
+          -- ppString "Real Pool Params\n" <> ppMap pcKeyHash pcStakePoolParams poolParams,
           toExpr (epochstate ^. curPParamsEpochStateL)
         ]
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
@@ -52,9 +52,9 @@ import Cardano.Ledger.Plutus.Data (Data, Datum (..), dataToBinaryData, hashData)
 import Cardano.Ledger.Shelley.API (
   Addr (..),
   Credential (..),
-  PoolParams (..),
   RewardAccount (..),
   ShelleyDelegCert (..),
+  StakePoolParams (..),
  )
 import Cardano.Ledger.Shelley.Scripts (
   MultiSig,
@@ -608,7 +608,7 @@ genTxCerts slot = do
           RetirePoolTxCert kh _ -> do
             -- We need to make sure that the pool is registered before
             -- we try to retire it
-            modelPools <- gets $ mPoolParams . gsModel
+            modelPools <- gets $ mStakePoolParams . gsModel
             case Map.lookup kh modelPools of
               Just _ -> pure (dc : dcs, ss, regCreds)
               Nothing -> pure (dcs, ss, regCreds)
@@ -782,13 +782,13 @@ getShelleyTxCertCredential = \case
       ShelleyDelegCert dk _ -> Just dk
   ShelleyTxCertPool pc ->
     case pc of
-      RegPool PoolParams {..} -> Just . coerceKeyRole $ KeyHashObj ppId
+      RegPool StakePoolParams {..} -> Just . coerceKeyRole $ KeyHashObj ppId
       RetirePool kh _ -> Just . coerceKeyRole $ KeyHashObj kh
   ShelleyTxCertGenesisDeleg _g -> Nothing
   ShelleyTxCertMir _m -> Nothing
 
 getConwayTxCertCredential :: ConwayTxCert era -> Maybe (Credential 'Staking)
-getConwayTxCertCredential (ConwayTxCertPool (RegPool PoolParams {..})) = Just . coerceKeyRole $ KeyHashObj ppId
+getConwayTxCertCredential (ConwayTxCertPool (RegPool StakePoolParams {..})) = Just . coerceKeyRole $ KeyHashObj ppId
 getConwayTxCertCredential (ConwayTxCertPool (RetirePool kh _)) = Just . coerceKeyRole $ KeyHashObj kh
 getConwayTxCertCredential (ConwayTxCertDeleg (ConwayRegCert _ _)) = Nothing
 getConwayTxCertCredential (ConwayTxCertDeleg (ConwayUnRegCert cred _)) = Just cred

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Tickf.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Tickf.hs
@@ -10,7 +10,7 @@ module Test.Cardano.Ledger.Tickf (oldCalculatePoolDistr, calcPoolDistOldEqualsNe
 import Cardano.Ledger.Coin (Coin (Coin), CompactForm (CompactCoin))
 import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (StakePool))
-import Cardano.Ledger.PoolParams (PoolParams (ppVrf))
+import Cardano.Ledger.PoolParams (StakePoolParams (ppVrf))
 import Cardano.Ledger.Shelley.Rules (calculatePoolDistr)
 import Cardano.Ledger.State (
   IndividualPoolStake (..),

--- a/libs/ledger-state/src/Cardano/Ledger/State/Orphans.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/Orphans.hs
@@ -19,7 +19,7 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Credential
 import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
 import Cardano.Ledger.Keys
-import Cardano.Ledger.PoolParams (PoolParams (..))
+import Cardano.Ledger.PoolParams (StakePoolParams (..))
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.PoolRank
 import Cardano.Ledger.State.UTxO
@@ -146,9 +146,9 @@ deriving via Enc GenDelegs instance PersistField GenDelegs
 
 deriving via Enc GenDelegs instance PersistFieldSql GenDelegs
 
-deriving via Enc PoolParams instance PersistField PoolParams
+deriving via Enc StakePoolParams instance PersistField StakePoolParams
 
-deriving via Enc PoolParams instance PersistFieldSql PoolParams
+deriving via Enc StakePoolParams instance PersistFieldSql StakePoolParams
 
 instance DecCBOR NonMyopic where
   decCBOR = decNoShareCBOR

--- a/libs/ledger-state/src/Cardano/Ledger/State/Query.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/Query.hs
@@ -148,7 +148,7 @@ insertSnapShot snapShotEpochStateId snapShotType State.SnapShot {..} = do
     credId <- insertGetKey (Credential (Keys.asWitness cred))
     keyHashId <- insertGetKey (KeyHash (Keys.asWitness spKeyHash))
     insert_ (SnapShotDelegation snapShotId credId keyHashId)
-  VG.forM_ (VMap.unVMap ssPoolParams) $ \(keyHash, pps) -> do
+  VG.forM_ (VMap.unVMap ssStakePoolParams) $ \(keyHash, pps) -> do
     keyHashId <- insertGetKey (KeyHash (Keys.asWitness keyHash))
     insert_ (SnapShotPool snapShotId keyHashId pps)
 
@@ -236,7 +236,7 @@ getSnapShotNoSharingM epochStateId snapShotType = do
     SnapShotM
       { ssStake = stake
       , ssDelegations = delegations
-      , ssPoolParams = poolParams
+      , ssStakePoolParams = poolParams
       }
 {-# INLINEABLE getSnapShotNoSharingM #-}
 
@@ -251,8 +251,8 @@ getSnapShotWithSharingM otherSnapShots epochStateId snapShotType = do
         interns
           (foldMap (internsFromMap . ssStake) otherSnapShots)
           . Keys.coerceKeyRole
-  let internOtherPoolParams =
-        interns (foldMap (internsFromMap . ssPoolParams) otherSnapShots)
+  let internOtherStakePoolParams =
+        interns (foldMap (internsFromMap . ssStakePoolParams) otherSnapShots)
           . Keys.coerceKeyRole
   let internOtherDelegations =
         interns (foldMap (internsFromMap . ssDelegations) otherSnapShots)
@@ -271,18 +271,18 @@ getSnapShotWithSharingM otherSnapShots epochStateId snapShotType = do
   poolParams <-
     selectMap [SnapShotPoolSnapShotId ==. snapShotId] $ \SnapShotPool {..} -> do
       KeyHash keyHash <- getJust snapShotPoolKeyHashId
-      pure (internOtherPoolParams keyHash, snapShotPoolParams)
-  let internPoolParams = interns (internsFromMap poolParams) . Keys.coerceKeyRole
+      pure (internOtherStakePoolParams keyHash, snapShotPoolParams)
+  let internStakePoolParams = interns (internsFromMap poolParams) . Keys.coerceKeyRole
   delegations <-
     selectMap [SnapShotDelegationSnapShotId ==. snapShotId] $ \SnapShotDelegation {..} -> do
       Credential credential <- getJust snapShotDelegationCredentialId
       KeyHash keyHash <- getJust snapShotDelegationKeyHash
-      pure (internOtherDelegations credential, internPoolParams keyHash)
+      pure (internOtherDelegations credential, internStakePoolParams keyHash)
   pure
     SnapShotM
       { ssStake = stake
       , ssDelegations = delegations
-      , ssPoolParams = poolParams
+      , ssStakePoolParams = poolParams
       }
 {-# INLINEABLE getSnapShotWithSharingM #-}
 
@@ -352,7 +352,7 @@ getSnapShotNoSharing epochStateId snapShotType = do
     State.SnapShot
       { ssStake = State.Stake stake
       , ssDelegations = delegations
-      , ssPoolParams = poolParams
+      , ssStakePoolParams = poolParams
       }
 {-# INLINEABLE getSnapShotNoSharing #-}
 
@@ -402,8 +402,8 @@ getSnapShotWithSharing otherSnapShots epochStateId snapShotType = do
         interns
           (foldMap (internsFromVMap . State.unStake . State.ssStake) otherSnapShots)
           . Keys.coerceKeyRole
-  let internOtherPoolParams =
-        interns (foldMap (internsFromVMap . State.ssPoolParams) otherSnapShots)
+  let internOtherStakePoolParams =
+        interns (foldMap (internsFromVMap . State.ssStakePoolParams) otherSnapShots)
           . Keys.coerceKeyRole
   let internOtherDelegations =
         interns (foldMap (internsFromVMap . State.ssDelegations) otherSnapShots)
@@ -422,18 +422,18 @@ getSnapShotWithSharing otherSnapShots epochStateId snapShotType = do
   poolParams <-
     selectVMap [SnapShotPoolSnapShotId ==. snapShotId] $ \SnapShotPool {..} -> do
       KeyHash keyHash <- getJust snapShotPoolKeyHashId
-      pure (internOtherPoolParams keyHash, snapShotPoolParams)
-  let internPoolParams = interns (internsFromVMap poolParams) . Keys.coerceKeyRole
+      pure (internOtherStakePoolParams keyHash, snapShotPoolParams)
+  let internStakePoolParams = interns (internsFromVMap poolParams) . Keys.coerceKeyRole
   delegations <-
     selectVMap [SnapShotDelegationSnapShotId ==. snapShotId] $ \SnapShotDelegation {..} -> do
       Credential credential <- getJust snapShotDelegationCredentialId
       KeyHash keyHash <- getJust snapShotDelegationKeyHash
-      pure (internOtherDelegations credential, internPoolParams keyHash)
+      pure (internOtherDelegations credential, internStakePoolParams keyHash)
   pure
     State.SnapShot
       { ssStake = State.Stake stake
       , ssDelegations = delegations
-      , ssPoolParams = poolParams
+      , ssStakePoolParams = poolParams
       }
 {-# INLINEABLE getSnapShotWithSharing #-}
 

--- a/libs/ledger-state/src/Cardano/Ledger/State/Schema.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/Schema.hs
@@ -91,7 +91,7 @@ SnapShotDelegation
 SnapShotPool
   snapShotId SnapShotId
   keyHashId KeyHashId
-  params Shelley.PoolParams
+  params Shelley.StakePoolParams
   UniqueSnapShotPool snapShotId keyHashId
 
 LedgerState

--- a/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
@@ -203,8 +203,8 @@ data SnapShotStats = SnapShotStats
   { sssStake :: !(Stat (Credential 'Staking))
   , sssDelegationCredential :: !(Stat (Credential 'Staking))
   , sssDelegationStakePool :: !(Stat (KeyHash 'StakePool))
-  , sssPoolParams :: !(Stat (KeyHash 'StakePool))
-  , sssPoolParamsStats :: !PoolParamsStats
+  , sssStakePoolParams :: !(Stat (KeyHash 'StakePool))
+  , sssStakePoolParamsStats :: !StakePoolParamsStats
   }
 
 instance Semigroup SnapShotStats where
@@ -226,15 +226,15 @@ instance Pretty SnapShotStats where
       [ "Stake" <:> sssStake
       , "DelegationCredential" <:> sssDelegationCredential
       , "DelegationStakePool" <:> sssDelegationStakePool
-      , "PoolParams" <:> sssPoolParams
-      , pretty sssPoolParamsStats
+      , "StakePoolParams" <:> sssStakePoolParams
+      , pretty sssStakePoolParamsStats
       ]
 
 instance AggregateStat SnapShotStats where
   aggregateStat SnapShotStats {..} =
-    (aggregateStat sssPoolParamsStats)
+    (aggregateStat sssStakePoolParamsStats)
       { gsCredentialStaking = sssStake <> sssDelegationCredential
-      , gsKeyHashStakePool = sssDelegationStakePool <> sssPoolParams
+      , gsKeyHashStakePool = sssDelegationStakePool <> sssStakePoolParams
       }
 
 countSnapShotStat :: SnapShot -> SnapShotStats
@@ -243,42 +243,42 @@ countSnapShotStat SnapShot {..} =
     { sssStake = statMapKeys (VMap.toMap (unStake ssStake))
     , sssDelegationCredential = statMapKeys (VMap.toMap ssDelegations)
     , sssDelegationStakePool = statFoldable (VMap.toMap ssDelegations)
-    , sssPoolParams = statMapKeys (VMap.toMap ssPoolParams)
-    , sssPoolParamsStats = VMap.foldMap countPoolParamsStats ssPoolParams
+    , sssStakePoolParams = statMapKeys (VMap.toMap ssStakePoolParams)
+    , sssStakePoolParamsStats = VMap.foldMap countStakePoolParamsStats ssStakePoolParams
     }
 
-data PoolParamsStats = PoolParamsStats
+data StakePoolParamsStats = StakePoolParamsStats
   { ppsPoolId :: !(Stat (KeyHash 'StakePool))
   , ppsRewardAccount :: !(Stat (Credential 'Staking))
   , ppsOwners :: !(Stat (KeyHash 'Staking))
   }
 
-instance Semigroup PoolParamsStats where
-  (<>) (PoolParamsStats x1 x2 x3) (PoolParamsStats y1 y2 y3) =
-    PoolParamsStats
+instance Semigroup StakePoolParamsStats where
+  (<>) (StakePoolParamsStats x1 x2 x3) (StakePoolParamsStats y1 y2 y3) =
+    StakePoolParamsStats
       (x1 <> y1)
       (x2 <> y2)
       (x3 <> y3)
 
-instance Monoid PoolParamsStats where
-  mempty = PoolParamsStats mempty mempty mempty
+instance Monoid StakePoolParamsStats where
+  mempty = StakePoolParamsStats mempty mempty mempty
 
-instance Pretty PoolParamsStats where
-  pretty PoolParamsStats {..} =
+instance Pretty StakePoolParamsStats where
+  pretty StakePoolParamsStats {..} =
     prettyRecord
-      "PoolParamsStats"
+      "StakePoolParamsStats"
       [ "PoolId" <:> ppsPoolId
       , "RewardAccount" <:> ppsRewardAccount
       , "Owners" <:> ppsOwners
       ]
 
-instance AggregateStat PoolParamsStats where
-  aggregateStat PoolParamsStats {..} =
+instance AggregateStat StakePoolParamsStats where
+  aggregateStat StakePoolParamsStats {..} =
     mempty {gsCredentialStaking = ppsRewardAccount, gsKeyHashStakePool = ppsPoolId}
 
-countPoolParamsStats :: PoolParams -> PoolParamsStats
-countPoolParamsStats PoolParams {..} =
-  PoolParamsStats
+countStakePoolParamsStats :: StakePoolParams -> StakePoolParamsStats
+countStakePoolParamsStats StakePoolParams {..} =
+  StakePoolParamsStats
     { ppsPoolId = statSingleton ppId
     , ppsRewardAccount = statSingleton (raCredential ppRewardAccount)
     , ppsOwners = statSet ppOwners
@@ -467,7 +467,7 @@ countDStateStats ds@DState {..} =
 
 data PStateStats = PStateStats
   { pssKeyHashStakePool :: !(Stat (KeyHash 'StakePool))
-  , pssPoolParamsStats :: !PoolParamsStats
+  , pssStakePoolParamsStats :: !StakePoolParamsStats
   }
 
 instance Pretty PStateStats where
@@ -475,23 +475,23 @@ instance Pretty PStateStats where
     prettyRecord
       "PStateStats"
       [ "KeyHashStakePool" <:> pssKeyHashStakePool
-      , pretty pssPoolParamsStats
+      , pretty pssStakePoolParamsStats
       ]
 
 instance AggregateStat PStateStats where
   aggregateStat PStateStats {..} =
-    (aggregateStat pssPoolParamsStats) {gsKeyHashStakePool = pssKeyHashStakePool}
+    (aggregateStat pssStakePoolParamsStats) {gsKeyHashStakePool = pssKeyHashStakePool}
 
 countPStateStats :: PState CurrentEra -> PStateStats
 countPStateStats PState {..} =
   PStateStats
     { pssKeyHashStakePool =
-        statMapKeys psStakePoolParams
-          <> statMapKeys psFutureStakePoolParams
+        statMapKeys psStakeStakePoolParams
+          <> statMapKeys psFutureStakeStakePoolParams
           <> statMapKeys psRetiring
-    , pssPoolParamsStats =
-        foldMap countPoolParamsStats psStakePoolParams
-          <> foldMap countPoolParamsStats psFutureStakePoolParams
+    , pssStakePoolParamsStats =
+        foldMap countStakePoolParamsStats psStakeStakePoolParams
+          <> foldMap countStakePoolParamsStats psFutureStakeStakePoolParams
     }
 
 data LedgerStateStats = LedgerStateStats

--- a/libs/ledger-state/src/Cardano/Ledger/State/Vector.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/Vector.hs
@@ -23,7 +23,7 @@ import Data.Map.Strict as Map
 data SnapShotM = SnapShotM
   { ssStake :: !(Map (Credential 'Staking) (CompactForm Coin))
   , ssDelegations :: !(Map (Credential 'Staking) (KeyHash 'StakePool))
-  , ssPoolParams :: !(Map (KeyHash 'StakePool) PoolParams)
+  , ssStakePoolParams :: !(Map (KeyHash 'StakePool) StakePoolParams)
   }
 
 instance NFData SnapShotM where


### PR DESCRIPTION
Rename PoolParams to StatekPoolParams, to avoid confusion with protocol parameters

# Description

This PR is for issue #5191, Rename PoolParams to StatekPoolParams, to avoid confusion with protocol parameters

# Checklist

- [x ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
