### PR TITLE
Fix the flaky nightly tests

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -21,8 +21,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/constrained-generators.git
-  -- tag: 45559e07fe1651ddd257f2a1215dfd65e30a963f
-  tag: 9c72b29a43a604fd87238cf688a9ae624a32f4aa 
+  tag: 45559e07fe1651ddd257f2a1215dfd65e30a963f
+  commit: 9c72b29a43a604fd87238cf688a9ae624a32f4aa 
 
 -- NOTE: If you would like to update the above,
 -- see CONTRIBUTING.md#to-update-the-referenced-agda-ledger-spec

--- a/cabal.project
+++ b/cabal.project
@@ -21,7 +21,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/constrained-generators.git
-  tag: 45559e07fe1651ddd257f2a1215dfd65e30a963f
+  -- tag: 45559e07fe1651ddd257f2a1215dfd65e30a963f
+  tag: 9c72b29a43a604fd87238cf688a9ae624a32f4aa 
 
 -- NOTE: If you would like to update the above,
 -- see CONTRIBUTING.md#to-update-the-referenced-agda-ledger-spec

--- a/cabal.project
+++ b/cabal.project
@@ -21,7 +21,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/constrained-generators.git
-  tag: 6758e0e2c616ee612f80737323ce1f1ffd25f765
+  tag: 45559e07fe1651ddd257f2a1215dfd65e30a963f
 
 -- NOTE: If you would like to update the above,
 -- see CONTRIBUTING.md#to-update-the-referenced-agda-ledger-spec

--- a/cabal.project
+++ b/cabal.project
@@ -22,7 +22,7 @@ source-repository-package
   type: git
   location: https://github.com/input-output-hk/constrained-generators.git
   tag: 45559e07fe1651ddd257f2a1215dfd65e30a963f
-  commit: 9c72b29a43a604fd87238cf688a9ae624a32f4aa 
+  commit: 6758e0e2c616ee612f80737323ce1f1ffd25f765 
 
 -- NOTE: If you would like to update the above,
 -- see CONTRIBUTING.md#to-update-the-referenced-agda-ledger-spec

--- a/cabal.project
+++ b/cabal.project
@@ -21,7 +21,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/constrained-generators.git
-  tag: 6758e0e2c616ee612f80737323ce1f1ffd25f765 
+  tag: 6758e0e2c616ee612f80737323ce1f1ffd25f765
 
 -- NOTE: If you would like to update the above,
 -- see CONTRIBUTING.md#to-update-the-referenced-agda-ledger-spec

--- a/cabal.project
+++ b/cabal.project
@@ -21,8 +21,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/constrained-generators.git
-  tag: 45559e07fe1651ddd257f2a1215dfd65e30a963f
-  commit: 6758e0e2c616ee612f80737323ce1f1ffd25f765 
+  tag: 6758e0e2c616ee612f80737323ce1f1ffd25f765 
 
 -- NOTE: If you would like to update the above,
 -- see CONTRIBUTING.md#to-update-the-referenced-agda-ledger-spec

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
@@ -97,16 +97,13 @@ whoDelegatesSpec univ = constrained $ \m ->
   ]
 
 wdrlSpec ::
-  Era era =>
   Map (Credential 'DRepRole) (Set (Credential 'Staking)) ->
-  WitUniv era ->
   Specification (Map RewardAccount Coin)
-wdrlSpec whodelegates univ = constrained $ \m ->
+wdrlSpec whodelegates = constrained $ \m ->
   [ assert $ sizeOf_ (dom_ m) <=. lit 5
   , forAll' m $ \ [var|rewacct|] _ ->
       match rewacct $ \ [var|_network|] [var|credStake|] ->
         [ assert $ _network ==. lit Testnet
-        , witness univ credStake
         , assert $ member_ credStake (lit (delegators whodelegates))
         ]
   ]
@@ -137,7 +134,7 @@ type CertContext = (Map (Credential 'DRepRole) (Set (Credential 'Staking)), Map 
 genCertContext :: forall era. Era era => WitUniv era -> Gen CertContext
 genCertContext univ = do
   whodelegates <- genFromSpec (whoDelegatesSpec univ)
-  wdrl <- genFromSpec (wdrlSpec whodelegates univ)
+  wdrl <- genFromSpec (wdrlSpec whodelegates)
   pure (whodelegates, wdrl)
 
 -- This is a hack, neccessitated by the fact that conwayGovStateSpec,


### PR DESCRIPTION
The nightly tests have been failing on and off for a while. The problem is in the Specification wdrlSpec. It witnesses something that does not need to be witnessed, and the constraint occasionally fails. By removing this all the nightly tests now pass.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
