### PR TITLE
Ts fix neil nightly take2

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -21,7 +21,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/constrained-generators.git
-  tag: 45559e07fe1651ddd257f2a1215dfd65e30a963f
+  tag: 6758e0e2c616ee612f80737323ce1f1ffd25f765
 
 -- NOTE: If you would like to update the above,
 -- see CONTRIBUTING.md#to-update-the-referenced-agda-ledger-spec

--- a/cabal.project
+++ b/cabal.project
@@ -21,7 +21,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/constrained-generators.git
-  tag: 6758e0e2c616ee612f80737323ce1f1ffd25f765
+  tag: 45559e07fe1651ddd257f2a1215dfd65e30a963f
 
 -- NOTE: If you would like to update the above,
 -- see CONTRIBUTING.md#to-update-the-referenced-agda-ledger-spec

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Epoch.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Epoch.hs
@@ -50,8 +50,8 @@ epochStateSpec epochNo = constrained $ \es ->
                   match pulser $ \_size _stakeMap _index _stakeDistr _stakePoolDistr _drepDistr _drepState pulseEpoch _committeeState _enactState pulseProposals _proposalDeposits _poolParams ->
                     [ assert $ pulseEpoch ==. epochNo
                     , forAll pulseProposals $ \gas ->
-                        match gas $ \gasId _ _ _ _ _ _ ->
-                          proposalExists gasId proposals
+                        match gas $ \gasIdPulse _ _ _ _ _ _ ->
+                          proposalExists gasIdPulse proposals
                     , -- TODO: something is wrong in this case and I haven't figured out what yet
                       assert False
                     ]
@@ -67,8 +67,9 @@ epochStateSpec epochNo = constrained $ \es ->
                             (expired ==. mempty)
                             (sizeOf_ expired <. sz)
                         ]
-                    , forAll expired $ \ [var| gasId |] ->
-                        proposalExists gasId proposals
+                    , assert $ sizeOf_ expired <=. 30
+                    , forAll expired $ \ [var| gasIdExpire |] ->
+                        proposalExists gasIdExpire proposals
                     , -- TODO: this isn't enough, we need to ensure it's at most
                       -- one of each type of action that's being enacted
                       forAll enacted $ \ [var|govact|] ->


### PR DESCRIPTION
Fixes another rare failure, by limiting the size of expired set, so that each can be found in the proposals.
If the size is too large, that all of the expired can't be found in the proposals (which is too small) 


<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
