### PR TITLE
Run Imp conformance tests at the epoch boundary

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
   subdir: hs
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `*-artifacts` BEFORE MERGE!
-  tag: d419ed67d4e5a5aa7b26f22785dd7b64f08de37a
+  tag: 33cc4c0dccad41875ccb46749983d4b2c38bffe9
 
 source-repository-package
   type: git

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
@@ -42,6 +42,7 @@ instance ShelleyEraImp AllegraEra where
 
   fixupTx = shelleyFixupTx
   expectTxSuccess = impShelleyExpectTxSuccess
+  modifyImpInitProtVer = shelleyModifyImpInitProtVer
 
 impAllegraSatisfyNativeScript ::
   ( AllegraEraScript era

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -431,6 +431,7 @@ instance ShelleyEraImp AlonzoEra where
   impSatisfyNativeScript = impAllegraSatisfyNativeScript
   fixupTx = alonzoFixupTx
   expectTxSuccess = impAlonzoExpectTxSuccess
+  modifyImpInitProtVer = shelleyModifyImpInitProtVer
 
 instance MaryEraImp AlonzoEra
 

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
@@ -53,6 +53,7 @@ instance ShelleyEraImp BabbageEra where
   impSatisfyNativeScript = impAllegraSatisfyNativeScript
   fixupTx = babbageFixupTx
   expectTxSuccess = impBabbageExpectTxSuccess
+  modifyImpInitProtVer = shelleyModifyImpInitProtVer
 
 babbageFixupTx ::
   ( HasCallStack

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -176,6 +176,7 @@ library testlib
 
   build-depends:
     FailT,
+    ImpSpec,
     aeson,
     base,
     bytestring,

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/DelegSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/DelegSpec.hs
@@ -490,7 +490,7 @@ spec = do
           setProtVer initialProtVer
           pure res
         (khSPO, _, _) <- setupPoolWithStake $ Coin 10_000_000
-        -- Using an irrefutable pattern here to prevent evaluation of tuple
+        -- Using a lazy pattern match here to prevent evaluation of tuple
         -- unless we actually need a value from it
         ~(drepCred, _, _) <-
           if initialProtVer > bootstrapVer

--- a/eras/dijkstra/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
+++ b/eras/dijkstra/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
@@ -55,6 +55,7 @@ instance ShelleyEraImp DijkstraEra where
 
   fixupTx = babbageFixupTx
   expectTxSuccess = impBabbageExpectTxSuccess
+  modifyImpInitProtVer = conwayModifyImpInitProtVer
 
 instance MaryEraImp DijkstraEra
 

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
@@ -27,6 +27,7 @@ instance ShelleyEraImp MaryEra where
   impSatisfyNativeScript = impAllegraSatisfyNativeScript
   fixupTx = shelleyFixupTx
   expectTxSuccess = impShelleyExpectTxSuccess
+  modifyImpInitProtVer = shelleyModifyImpInitProtVer
 
 class
   ( ShelleyEraImp era

--- a/flake.lock
+++ b/flake.lock
@@ -204,11 +204,11 @@
     "formal-ledger-specifications": {
       "flake": false,
       "locked": {
-        "lastModified": 1753368183,
-        "narHash": "sha256-F6mF5nM7NEOjFjITMZB89rirE4uHPY7RgrYBAsJAYVc=",
+        "lastModified": 1756178288,
+        "narHash": "sha256-YH+AZkJ3G7YY/JVMue5LOuR1QBb4I8eXvPuNREfLnAM=",
         "owner": "IntersectMBO",
         "repo": "formal-ledger-specifications",
-        "rev": "d419ed67d4e5a5aa7b26f22785dd7b64f08de37a",
+        "rev": "33cc4c0dccad41875ccb46749983d4b2c38bffe9",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
@@ -83,12 +83,23 @@ instance
   ) =>
   ToExpr (ConwayLedgerExecContext era)
 
-instance EraPParams era => EncCBOR (ConwayLedgerExecContext era) where
+instance
+  ( EraPParams era
+  , EraCertState era
+  , EncCBOR (TxOut era)
+  , EncCBOR (TxBody era)
+  , EncCBOR (TxAuxData era)
+  , EncCBOR (TxWits era)
+  , EncCBOR (Tx era)
+  ) =>
+  EncCBOR (ConwayLedgerExecContext era)
+  where
   encCBOR ConwayLedgerExecContext {..} =
     encode $
       Rec ConwayLedgerExecContext
         !> To clecPolicyHash
         !> To clecEnactState
+        !> To clecUtxoExecContext
 
 instance ExecSpecRule "LEDGER" ConwayEra where
   type ExecContext "LEDGER" ConwayEra = ConwayLedgerExecContext ConwayEra

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/NewEpoch.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/NewEpoch.hs
@@ -6,13 +6,10 @@
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.NewEpoch () where
 
 import Cardano.Ledger.Conway (ConwayEra)
-import Cardano.Ledger.Conway.Governance (GovActionState)
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance (ExecSpecRule (..), SpecTRC (..), unComputationResult_)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway ()
 import Test.Cardano.Ledger.Conway.ImpTest ()
 
 instance ExecSpecRule "NEWEPOCH" ConwayEra where
-  type ExecContext "NEWEPOCH" ConwayEra = [GovActionState ConwayEra]
-
   runAgdaRule (SpecTRC env st sig) = unComputationResult_ $ Agda.newEpochStep env st sig

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -96,7 +96,7 @@ instance NFData GovEnv
 
 instance NFData VDeleg
 
-instance NFData PoolParams
+instance NFData StakePoolParams
 
 instance NFData DCert
 
@@ -198,7 +198,7 @@ instance ToExpr EnactState
 
 instance ToExpr VDeleg
 
-instance ToExpr PoolParams
+instance ToExpr StakePoolParams
 
 instance ToExpr DCert
 
@@ -328,7 +328,7 @@ instance SpecNormalize DepositPurpose
 
 instance SpecNormalize DState
 
-instance SpecNormalize PoolParams
+instance SpecNormalize StakePoolParams
 
 instance SpecNormalize PState
 
@@ -367,7 +367,14 @@ instance SpecNormalize EpochState
 
 instance SpecNormalize Snapshots
 
-instance SpecNormalize Snapshot
+instance SpecNormalize Snapshot where
+  specNormalize (MkSnapshot s d p) =
+    MkSnapshot (specNormalize $ removeZero s) (specNormalize $ removeZero d) p
+    where
+      removeZero (MkHSMap l) = MkHSMap $ f l
+      f [] = []
+      f ((_, 0) : xs) = f xs
+      f (x : xs) = x : f xs
 
 instance SpecNormalize Acnt
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -589,10 +589,10 @@ instance SpecTranslate ctx RewardAccount where
   toSpecRep (RewardAccount n c) = Agda.RwdAddr <$> toSpecRep n <*> toSpecRep c
 
 instance SpecTranslate ctx PoolParams where
-  type SpecRep PoolParams = Agda.PoolParams
+  type SpecRep PoolParams = Agda.StakePoolParams
 
   toSpecRep PoolParams {..} =
-    Agda.PoolParams
+    Agda.StakePoolParams
       <$> toSpecRep ppOwners
       <*> toSpecRep ppCost
       <*> toSpecRep ppMargin


### PR DESCRIPTION
# Description

This PR adds the machinery to run conformance tests whenever an ImpTest crosses the epoch boundary. I could not yet enable this hook, because the snapshot computation is buggy in the spec and that causes the conformance test to fail in most test cases.

This is a revival of https://github.com/IntersectMBO/cardano-ledger/pull/4762

close https://github.com/IntersectMBO/cardano-ledger/issues/4751

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
