### PR TITLE
Run Imp tests for every version of an era

### DIFF
--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Imp.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Imp.hs
@@ -23,5 +23,5 @@ spec ::
   Spec
 spec = do
   ShelleyImp.spec @era
-  describe "AllegraImpSpec" . withImpInit @(LedgerSpec era) $ do
+  describe "AllegraImpSpec" . withEachEraVersion @era $
     UtxowSpec.spec

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp.hs
@@ -21,7 +21,7 @@ import Cardano.Ledger.Shelley.Rules (
 import qualified Test.Cardano.Ledger.Alonzo.Imp.UtxoSpec as Utxo
 import qualified Test.Cardano.Ledger.Alonzo.Imp.UtxosSpec as Utxos
 import qualified Test.Cardano.Ledger.Alonzo.Imp.UtxowSpec as Utxow
-import Test.Cardano.Ledger.Alonzo.ImpTest (AlonzoEraImp, LedgerSpec)
+import Test.Cardano.Ledger.Alonzo.ImpTest
 import Test.Cardano.Ledger.Imp.Common
 import qualified Test.Cardano.Ledger.Mary.Imp as MaryImp
 
@@ -38,7 +38,7 @@ spec ::
   Spec
 spec = do
   MaryImp.spec @era
-  describe "AlonzoImpSpec" . withImpInit @(LedgerSpec era) $ do
+  describe "AlonzoImpSpec" . withEachEraVersion @era $ do
     Utxo.spec
     Utxos.spec
     Utxow.spec

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec.hs
@@ -3,9 +3,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 
 module Test.Cardano.Ledger.Alonzo.Imp.UtxowSpec (spec) where
 

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
@@ -23,7 +23,7 @@ import Cardano.Ledger.Shelley.Rules (
   ShelleyUtxowPredFailure,
  )
 import qualified Test.Cardano.Ledger.Alonzo.Imp as AlonzoImp
-import Test.Cardano.Ledger.Alonzo.ImpTest (AlonzoEraImp, LedgerSpec)
+import Test.Cardano.Ledger.Alonzo.ImpTest
 import qualified Test.Cardano.Ledger.Babbage.Imp.UtxoSpec as Utxo
 import qualified Test.Cardano.Ledger.Babbage.Imp.UtxosSpec as Utxos
 import qualified Test.Cardano.Ledger.Babbage.Imp.UtxowSpec as Utxow
@@ -46,7 +46,7 @@ spec ::
   Spec
 spec = do
   AlonzoImp.spec @era
-  withImpInit @(LedgerSpec era) $
+  withEachEraVersion @era $
     describe "BabbageImpSpec" $ do
       Utxo.spec
       Utxow.spec

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -57,13 +57,8 @@ import qualified Test.Cardano.Ledger.Conway.Imp.RatifySpec as Ratify
 import qualified Test.Cardano.Ledger.Conway.Imp.UtxoSpec as Utxo
 import qualified Test.Cardano.Ledger.Conway.Imp.UtxosSpec as Utxos
 import qualified Test.Cardano.Ledger.Conway.Imp.UtxowSpec as Utxow
-import Test.Cardano.Ledger.Conway.ImpTest (
-  ConwayEraImp,
-  LedgerSpec,
-  modifyImpInitProtVer,
- )
+import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Imp.Common
-import Test.Cardano.Ledger.Shelley.ImpTest (ImpInit)
 
 spec ::
   forall era.
@@ -101,11 +96,7 @@ spec ::
   Spec
 spec = do
   BabbageImp.spec @era
-  withImpInit @(LedgerSpec era) $
-    forM_ (eraProtVersions @era) $ \protVer ->
-      describe ("ConwayImpSpec - " <> show protVer) $
-        modifyImpInitProtVer protVer $
-          conwaySpec @era
+  withEachEraVersion @era $ conwaySpec @era
 
 conwaySpec ::
   forall era.

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Imp.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Imp.hs
@@ -12,8 +12,7 @@ import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure, ShelleyUtxowPredFai
 import qualified Test.Cardano.Ledger.Allegra.Imp as AllegraImp
 import Test.Cardano.Ledger.Imp.Common
 import qualified Test.Cardano.Ledger.Mary.Imp.UtxoSpec as Utxo
-import Test.Cardano.Ledger.Mary.ImpTest (MaryEraImp)
-import Test.Cardano.Ledger.Shelley.ImpTest (LedgerSpec)
+import Test.Cardano.Ledger.Mary.ImpTest
 
 spec ::
   forall era.
@@ -24,5 +23,6 @@ spec ::
   Spec
 spec = do
   AllegraImp.spec @era
-  describe "MaryImpSpec" $ withImpInit @(LedgerSpec era) $ do
-    Utxo.spec
+  describe "MaryImpSpec" $
+    withEachEraVersion @era $
+      Utxo.spec

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -68,6 +68,7 @@
 
 ### `testlib`
 
+* Added `withEachEraVersion`
 * Added `Examples` module with: `LedgerExamples`, `ledgerExamples`, `mkLedgerExamples`, `exampleCerts`,`exampleWithdrawals`, `exampleAuxDataMap`, `exampleNonMyopicRewards`, `exampleCoin`, `examplePayKey`, `exampleStakeKey`, `exampleNewEpochState`, `examplePoolDistr`, `examplePoolParams`, `exampleTxIns`, `exampleProposedPPUpdates`, `exampleByronAddress`, `testShelleyGenesis`, `keyToCredential`, `mkDSIGNKeyPair`, `mkKeyHash`, `mkScriptHash`, `mkWitnessesPreAlonzo`, `seedFromByte`, `seedFromWords`
 * Add `nativeAlwaysFails`, `nativeAlwaysSucceeds`
 * Deprecated `getRewardAccountAmount`, `lookupReward` and `getReward`

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
@@ -13,7 +13,7 @@ import qualified Test.Cardano.Ledger.Shelley.Imp.EpochSpec as Epoch
 import qualified Test.Cardano.Ledger.Shelley.Imp.LedgerSpec as Ledger
 import qualified Test.Cardano.Ledger.Shelley.Imp.UtxoSpec as Utxo
 import qualified Test.Cardano.Ledger.Shelley.Imp.UtxowSpec as Utxow
-import Test.Cardano.Ledger.Shelley.ImpTest (LedgerSpec, ShelleyEraImp)
+import Test.Cardano.Ledger.Shelley.ImpTest
 import qualified Test.Cardano.Ledger.Shelley.UnitTests.InstantStakeTest as Instant
 
 spec ::
@@ -24,7 +24,7 @@ spec ::
   ) =>
   Spec
 spec = do
-  describe "ShelleyImpSpec" $ withImpInit @(LedgerSpec era) $ do
+  describe "ShelleyImpSpec" $ withEachEraVersion @era $ do
     Ledger.spec
     Epoch.spec
     Utxow.spec

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -115,6 +115,7 @@ module Test.Cardano.Ledger.Shelley.ImpTest (
   whenMajorVersionAtMost,
   unlessMajorVersion,
   getsPParams,
+  withEachEraVersion,
 
   -- * Logging
   Doc,
@@ -568,6 +569,17 @@ defaultInitImpTestState nes = do
       , impGlobals = globals
       , impEvents = mempty
       }
+
+withEachEraVersion ::
+  forall era.
+  ShelleyEraImp era =>
+  SpecWith (ImpInit (LedgerSpec era)) ->
+  Spec
+withEachEraVersion specWith =
+  withImpInit @(LedgerSpec era) $ do
+    forM_ (eraProtVersions @era) $ \protVer ->
+      describe (show protVer) $
+        modifyImpInitProtVer protVer specWith
 
 modifyImpInitProtVer ::
   forall era.


### PR DESCRIPTION
# Description

With these changes, each era will run Imp tests for each version from its @eraProtVerLow to its @eraProtVerLow.
(We're already doing this in Conway, but not for the other eras). 
Since each era includes the Imp tests of the previous era, it means that, for example, a test added in Mary will run with version 9, 10 and 11 when ran in Conway. 

This will increase the number of tests we are running (and possibly the build time), but I see no reason to restrict the tests to one version - we might be missing testing logic under certain flags in this way. 


<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
