### PR TITLE
Add `undefined` check to Github Actions

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -630,3 +630,18 @@ jobs:
           echo "Commit $TAG was not found on the master-artifacts branch of formal-ledger-specifications."
           exit 1
         }
+  undefined-check:
+    name: Check that there are no additions of `undefined`s in the PR diff
+    runs-on: ubuntu-latest
+    if: ${{ github.base_ref != '' && github.ref != '' }}  # Only true for PRs
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Check for `undefined`s in the diffs
+      run: |
+        PR_TARGET=${{ github.base_ref }}
+        git fetch origin -n --refmap= +$PR_TARGET:pr-target
+        if git diff pr-target '*.hs' | grep '^\+.*undefined'; then
+          echo 'The diff must not contain any `undefined` values'
+          false
+        fi


### PR DESCRIPTION
# Description

This PR adds a Github Action that ensures that PRs don't add any `undefined` values.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
