### PR TITLE
Add PlutusScript DijkstraEra

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -641,7 +641,7 @@ jobs:
       run: |
         PR_TARGET=${{ github.base_ref }}
         git fetch origin -n --refmap= +$PR_TARGET:pr-target
-        if git diff pr-target '*.hs' | grep '^\+.*undefined'; then
+        if git diff -U0 pr-target '*.hs' | grep '^\+.*undefined'; then
           echo 'The diff must not contain any `undefined` values'
           false
         fi

--- a/eras/dijkstra/cddl-files/dijkstra.cddl
+++ b/eras/dijkstra/cddl-files/dijkstra.cddl
@@ -286,6 +286,7 @@ script =
   // 1, plutus_v1_script
   // 2, plutus_v2_script
   // 3, plutus_v3_script
+  // 4, plutus_v4_script
   ]
 
 
@@ -336,6 +337,8 @@ distinct_VBytes =
 plutus_v2_script = distinct_VBytes
 
 plutus_v3_script = distinct_VBytes
+
+plutus_v4_script = distinct_VBytes
 
 certificates = nonempty_oset<certificate>
 
@@ -736,6 +739,7 @@ alonzo_auxiliary_data =
     , ? 2 : [* plutus_v1_script]
     , ? 3 : [* plutus_v2_script]
     , ? 4 : [* plutus_v3_script]
+    , ? 5 : [* plutus_v4_script]
     }
 
   )

--- a/eras/dijkstra/src/Cardano/Ledger/Dijkstra/TxInfo.hs
+++ b/eras/dijkstra/src/Cardano/Ledger/Dijkstra/TxInfo.hs
@@ -22,7 +22,6 @@ import Cardano.Ledger.Alonzo.Scripts (toAsItem)
 import qualified Cardano.Ledger.Babbage.TxInfo as Babbage
 import Cardano.Ledger.BaseTypes (ProtVer (..), strictMaybe)
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Conway.Scripts (PlutusScript (..))
 import Cardano.Ledger.Conway.TxInfo (
   ConwayContextError (..),
   ConwayEraPlutusTxInfo (..),
@@ -97,13 +96,11 @@ instance EraPlutusContext DijkstraEra where
   lookupTxInfoResult SPlutusV3 (DijkstraTxInfoResult _ _ tirPlutusV3 _) = tirPlutusV3
   lookupTxInfoResult SPlutusV4 (DijkstraTxInfoResult _ _ _ tirPlutusV4) = tirPlutusV4
 
-  mkPlutusWithContext =
-    ( \case
-        ConwayPlutusV1 p -> toPlutusWithContext $ Left p
-        ConwayPlutusV2 p -> toPlutusWithContext $ Left p
-        ConwayPlutusV3 p -> toPlutusWithContext $ Left p
-    )
-      . unDijkstraPlutusScript
+  mkPlutusWithContext = \case
+    DijkstraPlutusV1 p -> toPlutusWithContext $ Left p
+    DijkstraPlutusV2 p -> toPlutusWithContext $ Left p
+    DijkstraPlutusV3 p -> toPlutusWithContext $ Left p
+    DijkstraPlutusV4 p -> toPlutusWithContext $ Left p
 
 instance EraPlutusTxInfo 'PlutusV1 DijkstraEra where
   toPlutusTxCert _ _ = transTxCertV1V2

--- a/eras/dijkstra/testlib/Test/Cardano/Ledger/Dijkstra/CDDL.hs
+++ b/eras/dijkstra/testlib/Test/Cardano/Ledger/Dijkstra/CDDL.hs
@@ -402,7 +402,9 @@ cost_models =
         , 0 <+ asKey ((3 :: Integer) ... (255 :: Integer)) ==> arr [0 <+ a int64]
         ]
 
--- TODO: add entry for Plutus v4
+plutus_v4_script :: Rule
+plutus_v4_script = "plutus_v4_script" =:= distinct VBytes
+
 alonzo_auxiliary_data :: Rule
 alonzo_auxiliary_data =
   "alonzo_auxiliary_data"
@@ -414,6 +416,7 @@ alonzo_auxiliary_data =
           , opt (idx 2 ==> arr [0 <+ a plutus_v1_script])
           , opt (idx 3 ==> arr [0 <+ a plutus_v2_script])
           , opt (idx 4 ==> arr [0 <+ a plutus_v3_script])
+          , opt (idx 5 ==> arr [0 <+ a plutus_v4_script])
           ]
       )
 
@@ -424,7 +427,6 @@ auxiliary_data =
     / shelley_ma_auxiliary_data
     / alonzo_auxiliary_data
 
--- TODO: add entry for Plutus v4
 dijkstra_script :: Rule
 dijkstra_script =
   "script"
@@ -432,3 +434,4 @@ dijkstra_script =
     / arr [1, a plutus_v1_script]
     / arr [2, a plutus_v2_script]
     / arr [3, a plutus_v3_script]
+    / arr [4, a plutus_v4_script]


### PR DESCRIPTION
# Description

This PR adds PlutusV4 to Dijkstra era PlutusScripts.

resolve https://github.com/IntersectMBO/cardano-ledger/issues/5226

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
