### PR TITLE
Refactor the transaction validity interval test

### DIFF
--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -252,6 +252,5 @@ test-suite tests
     cardano-slotting,
     cardano-strict-containers,
     containers,
-    plutus-ledger-api,
     testlib,
     time,

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Era.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Era.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -30,6 +31,7 @@ class
   , ToExpr (PlutusPurpose AsIx era)
   , ToExpr (PlutusPurpose AsIxItem era)
   , Script era ~ AlonzoScript era
+  , EraPlutusTxInfo PlutusV1 era
   ) =>
   AlonzoEraTest era
 

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Era.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Era.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -6,6 +8,7 @@ module Test.Cardano.Ledger.Babbage.Era (
   BabbageEraTest,
 ) where
 
+import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusTxInfo)
 import Cardano.Ledger.Babbage
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Plutus (Language (..))
@@ -18,6 +21,7 @@ class
   ( AlonzoEraTest era
   , BabbageEraTxBody era
   , BabbageEraPParams era
+  , EraPlutusTxInfo PlutusV2 era
   ) =>
   BabbageEraTest era
 

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Era.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Era.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -9,6 +10,7 @@ module Test.Cardano.Ledger.Conway.Era (
   conwayAccountsToUMap,
 ) where
 
+import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusTxInfo)
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Conway
@@ -32,6 +34,7 @@ class
   , ConwayEraCertState era
   , ConwayEraGov era
   , ConwayEraAccounts era
+  , EraPlutusTxInfo PlutusV3 era
   ) =>
   ConwayEraTest era
 

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -8,10 +8,7 @@
 
 module Test.Cardano.Ledger.Conway.Imp (spec, conwaySpec) where
 
-import Cardano.Ledger.Alonzo.Plutus.Context (
-  EraPlutusContext (ContextError),
-  EraPlutusTxInfo,
- )
+import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext (ContextError))
 import Cardano.Ledger.Alonzo.Rules (
   AlonzoUtxoPredFailure,
   AlonzoUtxosPredFailure,
@@ -35,7 +32,6 @@ import Cardano.Ledger.Conway.Rules (
   ConwayUtxowPredFailure,
  )
 import Cardano.Ledger.Conway.TxInfo (ConwayContextError)
-import Cardano.Ledger.Plutus (Language (..))
 import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
 import Cardano.Ledger.Shelley.Rules (
   ShelleyDelegPredFailure,
@@ -94,7 +90,6 @@ spec ::
   , Eq (Event (EraRule "ENACT" era))
   , Typeable (Event (EraRule "ENACT" era))
   , ToExpr (Event (EraRule "BBODY" era))
-  , EraPlutusTxInfo PlutusV2 era
   ) =>
   Spec
 spec = do
@@ -128,7 +123,6 @@ conwaySpec ::
   , Eq (Event (EraRule "ENACT" era))
   , Typeable (Event (EraRule "ENACT" era))
   , ToExpr (Event (EraRule "BBODY" era))
-  , EraPlutusTxInfo PlutusV2 era
   ) =>
   SpecWith (ImpInit (LedgerSpec era))
 conwaySpec = do

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxowSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxowSpec.hs
@@ -9,7 +9,6 @@
 module Test.Cardano.Ledger.Conway.Imp.UtxowSpec (spec) where
 
 import Cardano.Ledger.Address (Addr (..))
-import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusTxInfo)
 import Cardano.Ledger.Babbage.Tx (ScriptIntegrity (..), getLanguageView)
 import Cardano.Ledger.BaseTypes (
   Inject (..),
@@ -47,7 +46,6 @@ spec ::
   forall era.
   ( ConwayEraImp era
   , InjectRuleFailure "LEDGER" ConwayUtxowPredFailure era
-  , EraPlutusTxInfo PlutusV2 era
   ) =>
   SpecWith (ImpInit (LedgerSpec era))
 spec = do

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Spec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Spec.hs
@@ -8,7 +8,7 @@
 
 module Test.Cardano.Ledger.Conway.Spec (spec) where
 
-import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext (..), EraPlutusTxInfo)
+import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext (..))
 import Cardano.Ledger.Alonzo.Rules (
   AlonzoUtxoPredFailure,
   AlonzoUtxosPredFailure,
@@ -45,7 +45,6 @@ import Cardano.Ledger.Conway.Rules (
  )
 import Cardano.Ledger.Conway.TxCert (ConwayTxCert)
 import Cardano.Ledger.Conway.TxInfo (ConwayContextError)
-import Cardano.Ledger.Plutus (Language (..))
 import Cardano.Ledger.Plutus.Language (SLanguage (..))
 import Cardano.Ledger.Shelley.API (ApplyTx)
 import Cardano.Ledger.Shelley.LedgerState (StashedAVVMAddresses)
@@ -75,10 +74,7 @@ import Test.Cardano.Ledger.Core.JSON (roundTripJsonEraSpec)
 
 spec ::
   forall era.
-  ( EraPlutusTxInfo PlutusV1 era
-  , EraPlutusTxInfo PlutusV2 era
-  , EraPlutusTxInfo PlutusV3 era
-  , RuleListEra era
+  ( RuleListEra era
   , ConwayEraImp era
   , ApplyTx era
   , DecCBOR (TxWits era)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TxInfoSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TxInfoSpec.hs
@@ -12,7 +12,6 @@ module Test.Cardano.Ledger.Conway.TxInfoSpec (spec) where
 
 import Cardano.Ledger.Alonzo.Plutus.Context (
   EraPlutusContext (ContextError),
-  EraPlutusTxInfo,
   toPlutusTxCert,
  )
 import Cardano.Ledger.BaseTypes
@@ -38,7 +37,6 @@ import Test.Cardano.Ledger.Conway.Genesis ()
 spec ::
   forall era.
   ( ConwayEraTest era
-  , EraPlutusTxInfo PlutusV3 era
   , TxCert era ~ ConwayTxCert era
   ) =>
   Spec


### PR DESCRIPTION
# Description

* Remove the incomplete, and now redundant `transVITimeUpperBoundIsClosed`.
* Use `toPlutusTxInfo` to comprehensively test for all protocol versions.
* The new test runs for all eras: alonzo, babbage and conway.

NOTE: This test only works for `PlutusV1` since we do not yet have common
accessors across common data types from different versions of Plutus.

Closes #5249 

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [ ] ~~`CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).~~
- [ ] ~~Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).~~
- [ ] ~~Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).~~
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
