### PR TITLE
Made predicate failures for `TICK` subrules `Void` in Shelley

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
@@ -83,12 +83,9 @@ import Cardano.Ledger.Shelley.Rewards ()
 import Cardano.Ledger.Shelley.Rules (
   ShelleyPOOLREAP,
   ShelleyPoolreapEvent,
-  ShelleyPoolreapPredFailure,
   ShelleyPoolreapState (..),
   ShelleySNAP,
-  ShelleySnapPredFailure,
   SnapEnv (..),
-  UpecPredFailure,
  )
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Cardano.Ledger.Slot (EpochNo)
@@ -164,8 +161,6 @@ instance
   , Environment (EraRule "POOLREAP" era) ~ ()
   , State (EraRule "POOLREAP" era) ~ ShelleyPoolreapState era
   , Signal (EraRule "POOLREAP" era) ~ EpochNo
-  , Eq (UpecPredFailure era)
-  , Show (UpecPredFailure era)
   , Embed (EraRule "RATIFY" era) (ConwayEPOCH era)
   , Environment (EraRule "RATIFY" era) ~ RatifyEnv era
   , GovState era ~ ConwayGovState era
@@ -258,8 +253,6 @@ epochTransition ::
   ( RunConwayRatify era
   , ConwayEraCertState era
   , EraTxOut era
-  , Eq (UpecPredFailure era)
-  , Show (UpecPredFailure era)
   , Environment (EraRule "SNAP" era) ~ SnapEnv era
   , State (EraRule "SNAP" era) ~ SnapShots
   , Signal (EraRule "SNAP" era) ~ ()
@@ -388,7 +381,6 @@ epochTransition = do
 instance
   ( Era era
   , STS (ShelleyPOOLREAP era)
-  , PredicateFailure (EraRule "POOLREAP" era) ~ ShelleyPoolreapPredFailure era
   , Event (EraRule "POOLREAP" era) ~ ShelleyPoolreapEvent era
   ) =>
   Embed (ShelleyPOOLREAP era) (ConwayEPOCH era)
@@ -400,7 +392,6 @@ instance
   ( EraTxOut era
   , EraStake era
   , EraCertState era
-  , PredicateFailure (EraRule "SNAP" era) ~ ShelleySnapPredFailure era
   , Event (EraRule "SNAP" era) ~ Shelley.SnapEvent era
   ) =>
   Embed (ShelleySNAP era) (ConwayEPOCH era)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/NewEpoch.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/NewEpoch.hs
@@ -47,7 +47,6 @@ import Cardano.Ledger.Shelley.Rules (
   RupdEvent (..),
   ShelleyTICK,
   ShelleyTickEvent (..),
-  ShelleyTickPredFailure (..),
  )
 import Cardano.Ledger.Slot (EpochNo (EpochNo))
 import Cardano.Ledger.State
@@ -221,7 +220,7 @@ instance
   ) =>
   Embed (ConwayNEWEPOCH era) (ShelleyTICK era)
   where
-  wrapFailed = NewEpochFailure
+  wrapFailed = \case {}
   wrapEvent = TickNewEpochEvent
 
 instance

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## 1.17.0.0
 
+* Remove:
+  * `ShelleyEpochPredFailure`
+  * `ShelleyMirPredFailure`
+  * `ShelleyNewEpochPredFailure`
+  * `ShelleyPoolreapPredFailure`
+  * `ShelleyRupdPredFailure`
+  * `ShelleySnapPredFailure`
+  * `ShelleyTickPredFailure`
+  * `ShelleyTickfPredFailure`
+  * `ShelleyUpecPredFailure`
+  * `TickTransitionError`
+  * `UpecPredFailure`
 * Remove `withCborRoundTripFailures` 
 * Refactor pool deposits to use `StakePoolState`. #5234
   * Update `Pool` rule to store deposits in individual `StakePoolState` records

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Validation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Validation.hs
@@ -21,7 +21,6 @@ module Cardano.Ledger.Shelley.API.Validation (
   applyBlockEitherNoEvents,
   applyBlockNoValidaton,
   applyTickNoEvents,
-  TickTransitionError (..),
   BlockTransitionError (..),
   chainChecks,
 ) where
@@ -222,22 +221,6 @@ updateNewEpochState ::
   NewEpochState era
 updateNewEpochState ss (STS.BbodyState ls bcur) =
   LedgerState.updateNES ss bcur ls
-
-newtype TickTransitionError era
-  = TickTransitionError (NonEmpty (STS.PredicateFailure (EraRule "TICK" era)))
-  deriving (Generic)
-
-instance
-  NoThunks (STS.PredicateFailure (EraRule "TICK" era)) =>
-  NoThunks (TickTransitionError era)
-
-deriving stock instance
-  Eq (STS.PredicateFailure (EraRule "TICK" era)) =>
-  Eq (TickTransitionError era)
-
-deriving stock instance
-  Show (STS.PredicateFailure (EraRule "TICK" era)) =>
-  Show (TickTransitionError era)
 
 newtype BlockTransitionError era
   = BlockTransitionError (NonEmpty (STS.PredicateFailure (EraRule "BBODY" era)))

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Mir.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Mir.hs
@@ -14,7 +14,6 @@
 module Cardano.Ledger.Shelley.Rules.Mir (
   ShelleyMIR,
   PredicateFailure,
-  ShelleyMirPredFailure,
   ShelleyMirEvent (..),
   emptyInstantaneousRewards,
 ) where
@@ -51,14 +50,9 @@ import Control.State.Transition (
 import Data.Default (Default)
 import Data.Foldable (fold)
 import qualified Data.Map.Strict as Map
+import Data.Void (Void)
 import GHC.Generics (Generic)
 import Lens.Micro
-import NoThunks.Class (NoThunks (..))
-
-data ShelleyMirPredFailure era
-  deriving (Show, Generic, Eq)
-
-instance NFData (ShelleyMirPredFailure era)
 
 data ShelleyMirEvent era
   = MirTransfer InstantaneousRewards
@@ -72,8 +66,6 @@ deriving instance Eq (ShelleyMirEvent era)
 
 instance NFData (ShelleyMirEvent era)
 
-instance NoThunks (ShelleyMirPredFailure era)
-
 instance
   ( Default (EpochState era)
   , EraGov era
@@ -86,7 +78,7 @@ instance
   type Environment (ShelleyMIR era) = ()
   type BaseM (ShelleyMIR era) = ShelleyBase
   type Event (ShelleyMIR era) = ShelleyMirEvent era
-  type PredicateFailure (ShelleyMIR era) = ShelleyMirPredFailure era
+  type PredicateFailure (ShelleyMIR era) = Void
 
   transitionRules = [mirTransition]
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/PoolReap.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/PoolReap.hs
@@ -20,7 +20,6 @@ module Cardano.Ledger.Shelley.Rules.PoolReap (
   prChainAccountStateL,
   prUTxOStateL,
   PredicateFailure,
-  ShelleyPoolreapPredFailure,
 ) where
 
 import Cardano.Ledger.Address
@@ -55,9 +54,9 @@ import qualified Data.Map.Merge.Strict as Map
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
+import Data.Void (Void)
 import GHC.Generics (Generic)
 import Lens.Micro
-import NoThunks.Class (NoThunks (..))
 
 data ShelleyPoolreapState era = PoolreapState
   { prUTxOSt :: UTxOState era
@@ -77,11 +76,6 @@ prChainAccountStateL = lens prChainAccountState $ \sprs x -> sprs {prChainAccoun
 prCertStateL :: Lens' (ShelleyPoolreapState era) (CertState era)
 prCertStateL = lens prCertState $ \sprs x -> sprs {prCertState = x}
 
-data ShelleyPoolreapPredFailure era -- No predicate failures
-  deriving (Show, Eq, Generic)
-
-instance NFData (ShelleyPoolreapPredFailure era)
-
 data ShelleyPoolreapEvent era = RetiredPools
   { refundPools ::
       Map.Map (Credential 'Staking) (Map.Map (KeyHash 'StakePool) (CompactForm Coin))
@@ -94,8 +88,6 @@ data ShelleyPoolreapEvent era = RetiredPools
 deriving instance Eq (ShelleyPoolreapEvent era)
 
 instance NFData (ShelleyPoolreapEvent era)
-
-instance NoThunks (ShelleyPoolreapPredFailure era)
 
 instance (Default (UTxOState era), Default (CertState era)) => Default (ShelleyPoolreapState era) where
   def = PoolreapState def def def
@@ -114,7 +106,7 @@ instance
   type Signal (ShelleyPOOLREAP era) = EpochNo
   type Environment (ShelleyPOOLREAP era) = ()
   type BaseM (ShelleyPOOLREAP era) = ShelleyBase
-  type PredicateFailure (ShelleyPOOLREAP era) = ShelleyPoolreapPredFailure era
+  type PredicateFailure (ShelleyPOOLREAP era) = Void
   type Event (ShelleyPOOLREAP era) = ShelleyPoolreapEvent era
   transitionRules = [poolReapTransition]
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Rupd.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Rupd.hs
@@ -11,7 +11,6 @@ module Cardano.Ledger.Shelley.Rules.Rupd (
   ShelleyRUPD,
   RupdEnv (..),
   PredicateFailure,
-  ShelleyRupdPredFailure,
   epochInfoRange,
   PulsingRewUpdate (..),
   startStep,
@@ -70,18 +69,11 @@ import Control.State.Transition (
  )
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
+import Data.Void (Void)
 import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks (..))
 
 data RupdEnv era
   = RupdEnv BlocksMade (EpochState era)
-
-data ShelleyRupdPredFailure era -- No predicate failures
-  deriving (Show, Eq, Generic)
-
-instance NoThunks (ShelleyRupdPredFailure era)
-
-instance NFData (ShelleyRupdPredFailure era)
 
 instance
   ( Era era
@@ -94,7 +86,7 @@ instance
   type Signal (ShelleyRUPD era) = SlotNo
   type Environment (ShelleyRUPD era) = RupdEnv era
   type BaseM (ShelleyRUPD era) = ShelleyBase
-  type PredicateFailure (ShelleyRUPD era) = ShelleyRupdPredFailure era
+  type PredicateFailure (ShelleyRUPD era) = Void
   type Event (ShelleyRUPD era) = RupdEvent
 
   initialRules = [pure SNothing]

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Snap.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Snap.hs
@@ -12,7 +12,6 @@
 module Cardano.Ledger.Shelley.Rules.Snap (
   ShelleySNAP,
   PredicateFailure,
-  ShelleySnapPredFailure,
   SnapEvent (..),
   SnapEnv (..),
 ) where
@@ -39,18 +38,11 @@ import Control.State.Transition (
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.VMap as VMap
+import Data.Void (Void)
 import GHC.Generics (Generic)
 import Lens.Micro
-import NoThunks.Class (NoThunks (..))
 
 -- ======================================================
-
-data ShelleySnapPredFailure era -- No predicate failures
-  deriving (Show, Generic, Eq)
-
-instance NFData (ShelleySnapPredFailure era)
-
-instance NoThunks (ShelleySnapPredFailure era)
 
 newtype SnapEvent era
   = StakeDistEvent
@@ -68,7 +60,7 @@ instance (EraTxOut era, EraStake era, EraCertState era) => STS (ShelleySNAP era)
   type Signal (ShelleySNAP era) = ()
   type Environment (ShelleySNAP era) = SnapEnv era
   type BaseM (ShelleySNAP era) = ShelleyBase
-  type PredicateFailure (ShelleySNAP era) = ShelleySnapPredFailure era
+  type PredicateFailure (ShelleySNAP era) = Void
   type Event (ShelleySNAP era) = SnapEvent era
   initialRules = [pure emptySnapShots]
   transitionRules = [snapTransition]

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Upec.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Upec.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -18,7 +20,6 @@
 module Cardano.Ledger.Shelley.Rules.Upec (
   ShelleyUPEC,
   UpecState (..),
-  ShelleyUpecPredFailure (..),
 ) where
 
 import Cardano.Ledger.BaseTypes (ShelleyBase)
@@ -35,7 +36,6 @@ import Cardano.Ledger.Shelley.Rules.Newpp (
   ShelleyNEWPP,
   ShelleyNewppState (..),
  )
-import Control.DeepSeq (NFData)
 import Control.State.Transition (
   Embed (..),
   STS (..),
@@ -44,8 +44,7 @@ import Control.State.Transition (
   trans,
  )
 import Data.Default (Default)
-import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks (..))
+import Data.Void (Void)
 
 data UpecState era = UpecState
   { usCurPParams :: !(PParams era)
@@ -57,14 +56,6 @@ data UpecState era = UpecState
 deriving stock instance
   (Show (PParams era), Show (PParamsUpdate era)) =>
   Show (UpecState era)
-
-newtype ShelleyUpecPredFailure era
-  = NewPpFailure (PredicateFailure (ShelleyNEWPP era))
-  deriving (Eq, Show, Generic)
-
-instance NoThunks (ShelleyUpecPredFailure era)
-
-instance NFData (ShelleyUpecPredFailure era)
 
 instance
   ( EraGov era
@@ -78,7 +69,7 @@ instance
   type Signal (ShelleyUPEC era) = ()
   type Environment (ShelleyUPEC era) = LedgerState era
   type BaseM (ShelleyUPEC era) = ShelleyBase
-  type PredicateFailure (ShelleyUPEC era) = ShelleyUpecPredFailure era
+  type PredicateFailure (ShelleyUPEC era) = Void
   initialRules = []
   transitionRules =
     [ do
@@ -101,4 +92,4 @@ instance
   (Era era, STS (ShelleyNEWPP era)) =>
   Embed (ShelleyNEWPP era) (ShelleyUPEC era)
   where
-  wrapFailed = NewPpFailure
+  wrapFailed = \case {}

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
@@ -295,33 +295,4 @@ instance
   ToExpr (State (EraRule "LEDGERS" era)) =>
   ToExpr (ShelleyBbodyState era)
 
-instance
-  ( ToExpr (PredicateFailure (EraRule "NEWEPOCH" era))
-  , ToExpr (PredicateFailure (EraRule "RUPD" era))
-  ) =>
-  ToExpr (ShelleyTickPredFailure era)
-
-instance
-  ( ToExpr (PredicateFailure (EraRule "EPOCH" era))
-  , ToExpr (PredicateFailure (EraRule "MIR" era))
-  ) =>
-  ToExpr (ShelleyNewEpochPredFailure era)
-
-instance
-  ( ToExpr (UpecPredFailure era)
-  , ToExpr (PredicateFailure (EraRule "POOLREAP" era))
-  , ToExpr (PredicateFailure (EraRule "SNAP" era))
-  ) =>
-  ToExpr (ShelleyEpochPredFailure era)
-
-instance ToExpr (ShelleyUpecPredFailure era)
-
-instance ToExpr (ShelleyPoolreapPredFailure era)
-
-instance ToExpr (ShelleySnapPredFailure era)
-
-instance ToExpr (ShelleyMirPredFailure era)
-
-instance ToExpr (ShelleyRupdPredFailure era)
-
 instance ToExpr (Tx ShelleyEra)

--- a/eras/shelley/test-suite/CHANGELOG.md
+++ b/eras/shelley/test-suite/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.7.0.0
 
+* Removed `MockChainFromTickFailure` constructor from `MockChainFailure`
 * Removed `Test.Cardano.Ledger.Shelley.Examples.Consensus` (moved to `cardano-ledger-api` testlib)
 * Remove `EncCBOR` instance for `RawSeed` (moved to `cardano-ledger-shelley` testlib)
 * Remove `Test.Cardano.Ledger.Shelley.LaxBlock` as unused

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -69,7 +71,6 @@ import Cardano.Ledger.Shelley.Rules (
   ShelleyBbodyState (..),
   ShelleyTICK,
   ShelleyTickEvent,
-  ShelleyTickPredFailure,
  )
 import Cardano.Ledger.Shelley.State
 import Cardano.Ledger.Slot (EpochNo)
@@ -142,7 +143,6 @@ chainStateNesL = lens chainNes $ \x y -> x {chainNes = y}
 data TestChainPredicateFailure era
   = RealChainPredicateFailure ChainPredicateFailure
   | BbodyFailure (PredicateFailure (EraRule "BBODY" era)) -- Subtransition Failures
-  | TickFailure (PredicateFailure (EraRule "TICK" era)) -- Subtransition Failures
   | TicknFailure (PredicateFailure (EraRule "TICKN" era)) -- Subtransition Failures
   | PrtclFailure (PredicateFailure (PRTCL MockCrypto)) -- Subtransition Failures
   | PrtclSeqFailure PrtlSeqFailure -- Subtransition Failures
@@ -409,12 +409,11 @@ instance
   ( Era era
   , Era era
   , STS (ShelleyTICK era)
-  , PredicateFailure (EraRule "TICK" era) ~ ShelleyTickPredFailure era
   , Event (EraRule "TICK" era) ~ ShelleyTickEvent era
   ) =>
   Embed (ShelleyTICK era) (CHAIN era)
   where
-  wrapFailed = TickFailure
+  wrapFailed = \case {}
   wrapEvent = TickEvent
 
 instance Era era => Embed (PRTCL MockCrypto) (CHAIN era) where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
@@ -294,8 +294,6 @@ instance
   , Reflect era
   , EraTest era
   , ToExpr (PredicateFailure (EraRule "LEDGER" era))
-  , ToExpr (PredicateFailure (EraRule "NEWEPOCH" era))
-  , ToExpr (PredicateFailure (EraRule "RUPD" era))
   ) =>
   HasTrace (MOCKCHAIN era) (Gen1 era)
   where


### PR DESCRIPTION
# Description

This PR removes predicate failure types from all the subrules of `TICK`, since we can't have any predicate failures when crossing the epoch.

close https://github.com/IntersectMBO/cardano-ledger/issues/4158

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
