### PR TITLE
Conway cleanup

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.8.0.0
 
+* Remove `TriesToForgeADA`
+* Change the type of `actualSize` and `PParameterMaxValue` fields in `OutputTooBigUTxO` to `Int`
 * Added `COMPLETE` pragma for `TxCert AllegraEra`
 * Added `COMPLETE` pragma for `NativeScript AllegraEra`
 * Move to `testlib` `DecCBOR` instances for: `TxBody AllegraEra`, `AllegraTxAuxDataRaw`, `AllegraTxAuxData`, `TimelockRaw`, `Timelock`

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
@@ -87,8 +87,6 @@ data AllegraUtxoPredFailure era
   | UpdateFailure (EraRuleFailure "PPUP" era) -- Subtransition Failures
   | OutputBootAddrAttrsTooBig
       [TxOut era] -- list of supplied bad transaction outputs
-  | -- Kept for backwards compatibility: no longer used because the `MultiAsset` type of mint doesn't allow for this possibility
-    TriesToForgeADA -- TODO: remove
   | OutputTooBigUTxO
       [TxOut era] -- list of supplied bad transaction outputs
   deriving (Generic)
@@ -361,7 +359,6 @@ instance
       WrongNetwork right wrongs -> Sum WrongNetwork 8 !> To right !> To wrongs
       WrongNetworkWithdrawal right wrongs -> Sum WrongNetworkWithdrawal 9 !> To right !> To wrongs
       OutputBootAddrAttrsTooBig outs -> Sum OutputBootAddrAttrsTooBig 10 !> To outs
-      TriesToForgeADA -> Sum TriesToForgeADA 11
       OutputTooBigUTxO outs -> Sum OutputTooBigUTxO 12 !> To outs
 
 instance
@@ -382,7 +379,6 @@ instance
     8 -> SumD WrongNetwork <! From <! From
     9 -> SumD WrongNetworkWithdrawal <! From <! From
     10 -> SumD OutputBootAddrAttrsTooBig <! From
-    11 -> SumD TriesToForgeADA
     12 -> SumD OutputTooBigUTxO <! From
     k -> Invalid k
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -370,18 +370,7 @@ alonzoToConwayUtxoPredFailure = \case
   Alonzo.OutputTooSmallUTxO x -> OutputTooSmallUTxO x
   Alonzo.UtxosFailure x -> UtxosFailure x
   Alonzo.OutputBootAddrAttrsTooBig xs -> OutputBootAddrAttrsTooBig xs
-  Alonzo.TriesToForgeADA ->
-    error
-      "Impossible case, soon to be removed. See: https://github.com/IntersectMBO/cardano-ledger/issues/4085"
-  Alonzo.OutputTooBigUTxO xs ->
-    let
-      -- TODO: Remove this once the other eras will make the switch from Integer to Int
-      -- as per #4015.
-      -- https://github.com/IntersectMBO/cardano-ledger/issues/4085
-      toRestricted :: (Integer, Integer, TxOut era) -> (Int, Int, TxOut era)
-      toRestricted (sz, mv, out) = (fromIntegral sz, fromIntegral mv, out)
-     in
-      OutputTooBigUTxO $ map toRestricted xs
+  Alonzo.OutputTooBigUTxO xs -> OutputTooBigUTxO xs
   Alonzo.InsufficientCollateral c1 c2 -> InsufficientCollateral c1 c2
   Alonzo.ScriptsNotPaidUTxO u -> ScriptsNotPaidUTxO u
   Alonzo.ExUnitsTooBigUTxO m -> ExUnitsTooBigUTxO m
@@ -408,7 +397,4 @@ allegraToConwayUtxoPredFailure = \case
   Allegra.OutputTooSmallUTxO x -> OutputTooSmallUTxO x
   Allegra.UpdateFailure x -> absurdEraRule @"PPUP" @era x
   Allegra.OutputBootAddrAttrsTooBig xs -> OutputBootAddrAttrsTooBig xs
-  Allegra.TriesToForgeADA ->
-    error
-      "Impossible case, soon to be removed. See: https://github.com/IntersectMBO/cardano-ledger/issues/4085"
   Allegra.OutputTooBigUTxO xs -> OutputTooBigUTxO (map (0,0,) xs)

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.17.0.0
 
+* Remove `withCborRoundTripFailures` 
 * Refactor pool deposits to use `StakePoolState`. #5234
   * Update `Pool` rule to store deposits in individual `StakePoolState` records
   * Add and export `prUTxOStateL`, `prChainAccountStateL`, and `prCertStateL` lenses for `ShelleyPoolreapState`


### PR DESCRIPTION
# Description

This PR cleans up some leftover code that was supposed to be removed once we enter `Conway`.

Addresses some points of https://github.com/IntersectMBO/cardano-ledger/issues/4085

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
