### PR TITLE
Fix wrong use of mempty deposit in pool registration test

### DIFF
--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -152,7 +152,7 @@ poolRegistrationProp
             conjoin
               [ counterexample
                   "New PoolParams are registered in pParams"
-                  (Map.lookup hk (psStakePools targetSt) === Just (mkStakePoolState mempty poolParams))
+                  ((stakePoolStateToPoolParams hk <$> Map.lookup hk (psStakePools targetSt)) === Just poolParams)
               , counterexample
                   "PoolParams are not present in 'future pool params'"
                   (eval (hk ∉ dom (psFutureStakePools targetSt)) :: Bool)


### PR DESCRIPTION
# Description

Test failures seen on Nightly CI:
- https://github.com/IntersectMBO/cardano-ledger/actions/runs/17258631252
- https://github.com/IntersectMBO/cardano-ledger/actions/runs/17229373236

There was a stray but suspicious `mempty` used to compare `PoolParams` with an expected `StakePoolState`, since we do not have access to the protocol parameters in that scope. Switching to comparing just `PoolParams` with `PoolParams` makes this test actually correct.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [ ] ~~`CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).~~
- [ ] ~~Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).~~
- [ ] ~~Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).~~
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
