### PR TITLE
Switch `AlonzoTxAuxData` to use `NativeScript`

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 * Replace `timelockScriptsTxAuxDataL` with `nativeScriptsTxAuxDataL`
 * Replace `timelockScriptsAllegraTxAuxDataL` with `nativeScriptsAllegraTxAuxDataL`
-* Add `upgradeNativeScript` method to `AllegraEraScript`
 * Changed `MaxTxSizeUTxO` to use `Word32`
 * Remove `TriesToForgeADA`
 * Change the type of `actualSize` and `PParameterMaxValue` fields in `OutputTooBigUTxO` to `Int`

--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.8.0.0
 
+* Replace `timelockScriptsTxAuxDataL` with `nativeScriptsTxAuxDataL`
+* Replace `timelockScriptsAllegraTxAuxDataL` with `nativeScriptsAllegraTxAuxDataL`
+* Add `upgradeNativeScript` method to `AllegraEraScript`
 * Changed `MaxTxSizeUTxO` to use `Word32`
 * Remove `TriesToForgeADA`
 * Change the type of `actualSize` and `PParameterMaxValue` fields in `OutputTooBigUTxO` to `Int`

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Scripts.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Scripts.hs
@@ -52,6 +52,7 @@ module Cardano.Ledger.Allegra.Scripts (
   encodeVI,
   decodeVI,
   translateTimelock,
+  upgradeMultiSig,
 ) where
 
 import Cardano.Ledger.Allegra.Era (AllegraEra)
@@ -156,8 +157,6 @@ class ShelleyEraScript era => AllegraEraScript era where
 
   mkTimeExpire :: SlotNo -> NativeScript era
   getTimeExpire :: NativeScript era -> Maybe SlotNo
-
-  upgradeNativeScript :: NativeScript (PreviousEra era) -> NativeScript era
 
 deriving instance Era era => NoThunks (TimelockRaw era)
 
@@ -289,8 +288,6 @@ instance AllegraEraScript AllegraEra where
 
   mkTimeExpire = mkTimeExpireTimelock
   getTimeExpire = getTimeExpireTimelock
-
-  upgradeNativeScript = upgradeMultiSig
 
 pattern RequireTimeExpire :: AllegraEraScript era => SlotNo -> NativeScript era
 pattern RequireTimeExpire mslot <- (getTimeExpire -> Just mslot)

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Binary/Annotator.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Binary/Annotator.hs
@@ -29,7 +29,13 @@ import Test.Cardano.Ledger.Shelley.Binary.Annotator
 
 deriving newtype instance DecCBOR (TxBody AllegraEra)
 
-instance Era era => DecCBOR (AllegraTxAuxDataRaw era) where
+instance
+  ( Era era
+  , AllegraEraScript era
+  , DecCBOR (NativeScript era)
+  ) =>
+  DecCBOR (AllegraTxAuxDataRaw era)
+  where
   decCBOR =
     peekTokenType >>= \case
       TypeMapLen -> decodeFromMap
@@ -53,7 +59,8 @@ instance Era era => DecCBOR (AllegraTxAuxDataRaw era) where
               <! From
           )
 
-deriving newtype instance Era era => DecCBOR (AllegraTxAuxData era)
+deriving newtype instance
+  (AllegraEraScript era, DecCBOR (NativeScript era)) => DecCBOR (AllegraTxAuxData era)
 
 instance Era era => DecCBOR (TimelockRaw era) where
   decCBOR = decode $ Summands "TimelockRaw" $ \case

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/TreeDiff.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/TreeDiff.hs
@@ -30,9 +30,9 @@ instance ToExpr (TimelockRaw era)
 instance ToExpr (Timelock era)
 
 -- TxAuxData
-instance ToExpr (AllegraTxAuxDataRaw era)
+instance ToExpr (NativeScript era) => ToExpr (AllegraTxAuxDataRaw era)
 
-instance ToExpr (AllegraTxAuxData era)
+instance ToExpr (NativeScript era) => ToExpr (AllegraTxAuxData era)
 
 -- TxBody
 instance

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.14.0.0
 
+* Replace `timelockScriptsAlonzoTxAuxDataL` with `nativeScriptsAlonzoTxAuxDataL`
+* Replace `atadTimelock` with `atadNative`
+* Replace `TimelockScript` constructor of `AlonzoScript` with a new constructor `NativeScript`
 * Changed `MaxTxSizeUTxO` to use `Word32`
 * Make `transValidityInterval` based on eras instead of protocol versions.
   * Remove `hardforkConwayTranslateUpperBoundForPlutusScripts` from `Cardano.Ledger.Alonzo.Era`.

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.14.0.0
 
 * Replace `timelockScriptsAlonzoTxAuxDataL` with `nativeScriptsAlonzoTxAuxDataL`
-* Replace `atadTimelock` with `atadNative`
+* Replace `atadTimelock` with `atadNativeScript` and `atadTimelock'` with `atadNativeScript'`
 * Replace `TimelockScript` constructor of `AlonzoScript` with a new constructor `NativeScript`
 * Changed `MaxTxSizeUTxO` to use `Word32`
 * Make `transValidityInterval` based on eras instead of protocol versions.

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -111,7 +111,6 @@ import Control.DeepSeq (NFData (..), deepseq)
 import Control.Monad (guard, (>=>))
 import Data.Aeson (ToJSON (..), Value (String), object, (.=))
 import qualified Data.ByteString as BS
-import Data.Coerce (coerce)
 import Data.Kind (Type)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromJust, isJust)
@@ -482,7 +481,7 @@ instance EraScript AlonzoEra where
   type Script AlonzoEra = AlonzoScript AlonzoEra
   type NativeScript AlonzoEra = Timelock AlonzoEra
 
-  upgradeScript = NativeScript . coerce
+  upgradeScript = NativeScript . translateTimelock
 
   scriptPrefixTag = alonzoScriptPrefixTag
 
@@ -519,6 +518,8 @@ instance AllegraEraScript AlonzoEra where
 
   mkTimeExpire = mkTimeExpireTimelock
   getTimeExpire = getTimeExpireTimelock
+
+  upgradeNativeScript = translateTimelock
 
 instance AlonzoEraScript AlonzoEra where
   newtype PlutusScript AlonzoEra = AlonzoPlutusV1 (Plutus 'PlutusV1)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -519,8 +519,6 @@ instance AllegraEraScript AlonzoEra where
   mkTimeExpire = mkTimeExpireTimelock
   getTimeExpire = getTimeExpireTimelock
 
-  upgradeNativeScript = translateTimelock
-
 instance AlonzoEraScript AlonzoEra where
   newtype PlutusScript AlonzoEra = AlonzoPlutusV1 (Plutus 'PlutusV1)
     deriving newtype (Eq, Ord, Show, NFData, NoThunks, SafeToHash, Generic)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
@@ -29,7 +29,7 @@ module Cardano.Ledger.Alonzo.TxAuxData (
     atadNativeScripts,
     atadPlutus,
     atadMetadata',
-    atadNativeScript',
+    atadNativeScripts',
     atadPlutus'
   ),
   AlonzoEraTxAuxData (..),
@@ -374,5 +374,5 @@ pattern AlonzoTxAuxData' ::
   StrictSeq (NativeScript era) ->
   Map Language (NE.NonEmpty PlutusBinary) ->
   AlonzoTxAuxData era
-pattern AlonzoTxAuxData' {atadMetadata', atadNative', atadPlutus'} <-
-  (getMemoRawType -> AlonzoTxAuxDataRaw atadMetadata' atadNative' atadPlutus')
+pattern AlonzoTxAuxData' {atadMetadata', atadNativeScripts', atadPlutus'} <-
+  (getMemoRawType -> AlonzoTxAuxDataRaw atadMetadata' atadNativeScripts' atadPlutus')

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
@@ -29,7 +29,7 @@ module Cardano.Ledger.Alonzo.TxAuxData (
     atadNativeScripts,
     atadPlutus,
     atadMetadata',
-    atadNative',
+    atadNativeScript',
     atadPlutus'
   ),
   AlonzoEraTxAuxData (..),

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
@@ -114,8 +114,8 @@ import Test.Cardano.Ledger.Plutus (alwaysFailsPlutus, alwaysSucceedsPlutus)
 
 instance
   ( Arbitrary (AlonzoScript era)
+  , Arbitrary (NativeScript era)
   , AlonzoEraScript era
-  , NativeScript era ~ Timelock era
   ) =>
   Arbitrary (AlonzoTxAuxData era)
   where

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Examples.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Examples.hs
@@ -159,7 +159,7 @@ exampleTx txBody scriptPurpose =
       .~ SJust
         ( mkAlonzoTxAuxData
             exampleAuxDataMap
-            [alwaysFails @'PlutusV1 2, TimelockScript $ RequireAllOf @era mempty]
+            [alwaysFails @'PlutusV1 2, NativeScript $ RequireAllOf @era mempty]
         )
 
 exampleTxBodyAlonzo :: TxBody AlonzoEra

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
@@ -37,7 +37,7 @@ import Test.Cardano.Ledger.Mary.TreeDiff
 -- Scripts
 instance ToExpr (PlutusScript AlonzoEra)
 
-instance ToExpr (PlutusScript era) => ToExpr (AlonzoScript era)
+instance (ToExpr (PlutusScript era), ToExpr (NativeScript era)) => ToExpr (AlonzoScript era)
 
 instance ToExpr (AlonzoPlutusPurpose AsIx era)
 
@@ -57,9 +57,9 @@ instance ToExpr (TxCert era) => ToExpr (AlonzoPlutusPurpose AsIxItem era)
 deriving newtype instance ToExpr CoinPerWord
 
 -- TxAuxData
-instance ToExpr (AlonzoTxAuxDataRaw era)
+instance ToExpr (NativeScript era) => ToExpr (AlonzoTxAuxDataRaw era)
 
-instance ToExpr (AlonzoTxAuxData era)
+instance ToExpr (NativeScript era) => ToExpr (AlonzoTxAuxData era)
 
 -- PParams
 deriving newtype instance ToExpr OrdExUnits

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -17,7 +17,6 @@ import Cardano.Ledger.Address (Addr (..))
 import Cardano.Ledger.Allegra.Scripts (
   AllegraEraScript,
   Timelock (..),
-  translateTimelock,
   pattern RequireTimeExpire,
   pattern RequireTimeStart,
  )
@@ -83,6 +82,7 @@ import Cardano.Ledger.State (
 import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Ledger.Val (Val (isAdaOnly, (<+>), (<×>)))
 import Control.Monad (replicateM)
+import Data.Coerce (coerce)
 import Data.Foldable as F
 import qualified Data.List as List
 import Data.Map.Strict (Map)
@@ -265,23 +265,23 @@ genAux constants = do
   maybeAux <- genEraAuxiliaryData @MaryEra constants
   pure $
     fmap
-      (\(AllegraTxAuxData x y) -> mkAlonzoTxAuxData x (TimelockScript . translateTimelock <$> y))
+      (\(AllegraTxAuxData x y) -> mkAlonzoTxAuxData x (NativeScript . coerce <$> y))
       maybeAux
 
 instance ScriptClass AlonzoEra where
   basescript = someLeaf
-  isKey _ (TimelockScript x) = isKey (Proxy @MaryEra) $ translateTimelock x
+  isKey _ (NativeScript x) = isKey (Proxy @MaryEra) $ coerce x
   isKey _ (PlutusScript _) = Nothing
-  isOnePhase _ (TimelockScript _) = True
+  isOnePhase _ (NativeScript _) = True
   isOnePhase _ (PlutusScript _) = False
-  quantify _ (TimelockScript x) = fmap (TimelockScript . translateTimelock) (quantify (Proxy @MaryEra) (translateTimelock x))
+  quantify _ (NativeScript x) = fmap (NativeScript . coerce) (quantify (Proxy @MaryEra) (coerce x))
   quantify _ x = Leaf x
   unQuantify _ quant =
-    TimelockScript . translateTimelock $
-      unQuantify (Proxy @MaryEra) (fmap (translateTimelock . unTime) quant)
+    NativeScript . coerce $
+      unQuantify (Proxy @MaryEra) (fmap (coerce . unTime) quant)
 
-unTime :: AlonzoScript era -> Timelock era
-unTime (TimelockScript x) = x
+unTime :: AlonzoScript era -> NativeScript era
+unTime (NativeScript x) = x
 unTime (PlutusScript _) = error "Plutus in Timelock"
 
 okAsCollateral :: UTxO AlonzoEra -> TxIn -> Bool
@@ -331,7 +331,7 @@ genAlonzoTxBody _genenv utxo pparams currentslot input txOuts certs withdrawals 
         )
         auxDHash
         netid
-    , List.map TimelockScript scriptsFromPolicies <> plutusScripts
+    , List.map NativeScript scriptsFromPolicies <> plutusScripts
     )
 
 genSlotAfter :: SlotNo -> Gen SlotNo
@@ -632,9 +632,9 @@ someLeaf _proxy keyHash =
    in
     case mode of
       0 ->
-        TimelockScript $
+        NativeScript $
           (RequireAnyOf . Seq.fromList) [RequireTimeStart slot, RequireTimeExpire slot]
-      _ -> TimelockScript $ RequireSignature keyHash
+      _ -> NativeScript $ RequireSignature keyHash
 
 -- | given the "txscripts" field of the TxWits, compute the set of languages used in a transaction
 langsUsed ::

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
@@ -33,6 +33,7 @@ import Cardano.Ledger.Babbage.TxCert ()
 import Cardano.Ledger.Plutus.Language
 import Cardano.Ledger.Shelley.Scripts (ShelleyEraScript (..))
 import Control.DeepSeq (NFData (..), rwhnf)
+import Data.Coerce (coerce)
 import Data.MemPack
 import GHC.Generics
 import NoThunks.Class (NoThunks (..))
@@ -42,16 +43,16 @@ instance EraScript BabbageEra where
   type NativeScript BabbageEra = Timelock BabbageEra
 
   upgradeScript = \case
-    TimelockScript ts -> TimelockScript $ translateTimelock ts
+    NativeScript ts -> NativeScript $ coerce ts
     PlutusScript (AlonzoPlutusV1 ps) -> PlutusScript $ BabbagePlutusV1 ps
 
   scriptPrefixTag = alonzoScriptPrefixTag
 
   getNativeScript = \case
-    TimelockScript ts -> Just ts
+    NativeScript ts -> Just ts
     _ -> Nothing
 
-  fromNativeScript = TimelockScript
+  fromNativeScript = NativeScript
 
 instance AlonzoEraScript BabbageEra where
   data PlutusScript BabbageEra

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
@@ -123,8 +123,6 @@ instance AllegraEraScript BabbageEra where
   mkTimeExpire = mkTimeExpireTimelock
   getTimeExpire = getTimeExpireTimelock
 
-  upgradeNativeScript = translateTimelock
-
 instance NFData (PlutusScript BabbageEra) where
   rnf = rwhnf
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
@@ -33,7 +33,6 @@ import Cardano.Ledger.Babbage.TxCert ()
 import Cardano.Ledger.Plutus.Language
 import Cardano.Ledger.Shelley.Scripts (ShelleyEraScript (..))
 import Control.DeepSeq (NFData (..), rwhnf)
-import Data.Coerce (coerce)
 import Data.MemPack
 import GHC.Generics
 import NoThunks.Class (NoThunks (..))
@@ -43,7 +42,7 @@ instance EraScript BabbageEra where
   type NativeScript BabbageEra = Timelock BabbageEra
 
   upgradeScript = \case
-    NativeScript ts -> NativeScript $ coerce ts
+    NativeScript ts -> NativeScript $ translateTimelock ts
     PlutusScript (AlonzoPlutusV1 ps) -> PlutusScript $ BabbagePlutusV1 ps
 
   scriptPrefixTag = alonzoScriptPrefixTag
@@ -123,6 +122,8 @@ instance AllegraEraScript BabbageEra where
 
   mkTimeExpire = mkTimeExpireTimelock
   getTimeExpire = getTimeExpireTimelock
+
+  upgradeNativeScript = translateTimelock
 
 instance NFData (PlutusScript BabbageEra) where
   rnf = rwhnf

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxAuxData.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxAuxData.hs
@@ -7,8 +7,8 @@ import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.TxAuxData (
   AlonzoTxAuxData (..),
   metadataAlonzoTxAuxDataL,
+  nativeScriptsAlonzoTxAuxDataL,
   plutusScriptsAllegraTxAuxDataL,
-  timelockScriptsAlonzoTxAuxDataL,
   validateAlonzoTxAuxData,
  )
 import Cardano.Ledger.Babbage.Era
@@ -23,7 +23,7 @@ instance EraTxAuxData BabbageEra where
   validateTxAuxData = validateAlonzoTxAuxData
 
 instance AllegraEraTxAuxData BabbageEra where
-  timelockScriptsTxAuxDataL = timelockScriptsAlonzoTxAuxDataL
+  nativeScriptsTxAuxDataL = nativeScriptsAlonzoTxAuxDataL
 
 instance AlonzoEraTxAuxData BabbageEra where
   plutusScriptsTxAuxDataL = plutusScriptsAllegraTxAuxDataL

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
@@ -55,6 +55,7 @@ import Cardano.Ledger.Shelley.Scripts (ShelleyEraScript (..))
 import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData (..), rwhnf)
 import Data.Aeson (ToJSON (..), (.=))
+import Data.Coerce (coerce)
 import Data.MemPack
 import Data.Typeable
 import Data.Word (Word16, Word32, Word8)
@@ -75,17 +76,17 @@ instance EraScript ConwayEra where
   type NativeScript ConwayEra = Timelock ConwayEra
 
   upgradeScript = \case
-    TimelockScript ts -> TimelockScript $ translateTimelock ts
+    NativeScript ts -> NativeScript $ coerce ts
     PlutusScript (BabbagePlutusV1 ps) -> PlutusScript $ ConwayPlutusV1 ps
     PlutusScript (BabbagePlutusV2 ps) -> PlutusScript $ ConwayPlutusV2 ps
 
   scriptPrefixTag = alonzoScriptPrefixTag
 
   getNativeScript = \case
-    TimelockScript ts -> Just ts
+    NativeScript ts -> Just ts
     _ -> Nothing
 
-  fromNativeScript = TimelockScript
+  fromNativeScript = NativeScript
 
 instance AlonzoEraScript ConwayEra where
   data PlutusScript ConwayEra

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
@@ -55,7 +55,6 @@ import Cardano.Ledger.Shelley.Scripts (ShelleyEraScript (..))
 import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData (..), rwhnf)
 import Data.Aeson (ToJSON (..), (.=))
-import Data.Coerce (coerce)
 import Data.MemPack
 import Data.Typeable
 import Data.Word (Word16, Word32, Word8)
@@ -76,7 +75,7 @@ instance EraScript ConwayEra where
   type NativeScript ConwayEra = Timelock ConwayEra
 
   upgradeScript = \case
-    NativeScript ts -> NativeScript $ coerce ts
+    NativeScript ts -> NativeScript $ translateTimelock ts
     PlutusScript (BabbagePlutusV1 ps) -> PlutusScript $ ConwayPlutusV1 ps
     PlutusScript (BabbagePlutusV2 ps) -> PlutusScript $ ConwayPlutusV2 ps
 
@@ -174,6 +173,8 @@ instance AllegraEraScript ConwayEra where
 
   mkTimeExpire = mkTimeExpireTimelock
   getTimeExpire = getTimeExpireTimelock
+
+  upgradeNativeScript = translateTimelock
 
 instance NFData (PlutusScript ConwayEra) where
   rnf = rwhnf

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
@@ -174,8 +174,6 @@ instance AllegraEraScript ConwayEra where
   mkTimeExpire = mkTimeExpireTimelock
   getTimeExpire = getTimeExpireTimelock
 
-  upgradeNativeScript = translateTimelock
-
 instance NFData (PlutusScript ConwayEra) where
   rnf = rwhnf
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxAuxData.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxAuxData.hs
@@ -7,8 +7,8 @@ import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.TxAuxData (
   AlonzoTxAuxData (..),
   metadataAlonzoTxAuxDataL,
+  nativeScriptsAlonzoTxAuxDataL,
   plutusScriptsAllegraTxAuxDataL,
-  timelockScriptsAlonzoTxAuxDataL,
   validateAlonzoTxAuxData,
  )
 import Cardano.Ledger.Conway.Era
@@ -24,7 +24,7 @@ instance EraTxAuxData ConwayEra where
   validateTxAuxData = validateAlonzoTxAuxData
 
 instance AllegraEraTxAuxData ConwayEra where
-  timelockScriptsTxAuxDataL = timelockScriptsAlonzoTxAuxDataL
+  nativeScriptsTxAuxDataL = nativeScriptsAlonzoTxAuxDataL
 
 instance AlonzoEraTxAuxData ConwayEra where
   plutusScriptsTxAuxDataL = plutusScriptsAllegraTxAuxDataL

--- a/eras/dijkstra/src/Cardano/Ledger/Dijkstra/Scripts.hs
+++ b/eras/dijkstra/src/Cardano/Ledger/Dijkstra/Scripts.hs
@@ -337,8 +337,6 @@ instance AllegraEraScript DijkstraEra where
   mkTimeExpire = mkTimeExpireTimelock
   getTimeExpire = getTimeExpireTimelock
 
-  upgradeNativeScript = translateTimelock
-
 instance ConwayEraScript DijkstraEra where
   mkVotingPurpose = DijkstraVoting
 

--- a/eras/dijkstra/src/Cardano/Ledger/Dijkstra/Scripts.hs
+++ b/eras/dijkstra/src/Cardano/Ledger/Dijkstra/Scripts.hs
@@ -39,7 +39,6 @@ import Cardano.Ledger.Allegra.Scripts (
   mkRequireSignatureTimelock,
   mkTimeExpireTimelock,
   mkTimeStartTimelock,
-  translateTimelock,
  )
 import Cardano.Ledger.Alonzo (AlonzoScript)
 import Cardano.Ledger.Alonzo.Scripts (
@@ -82,6 +81,7 @@ import Cardano.Ledger.Shelley.Scripts (ShelleyEraScript (..))
 import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData (..), rwhnf)
 import Data.Aeson (KeyValue (..), ToJSON (..))
+import Data.Coerce (coerce)
 import Data.MemPack (MemPack (..), packTagM, packedTagByteCount, unknownTagM, unpackTagM)
 import Data.Typeable (Proxy (..), Typeable)
 import Data.Word (Word16, Word32, Word8)
@@ -221,17 +221,17 @@ instance EraScript DijkstraEra where
   type NativeScript DijkstraEra = Timelock DijkstraEra
 
   upgradeScript = \case
-    TimelockScript ts -> TimelockScript $ translateTimelock ts
+    NativeScript ts -> NativeScript $ coerce ts
     PlutusScript (ConwayPlutusV1 s) -> PlutusScript $ DijkstraPlutusV1 s
     PlutusScript (ConwayPlutusV2 s) -> PlutusScript $ DijkstraPlutusV2 s
     PlutusScript (ConwayPlutusV3 s) -> PlutusScript $ DijkstraPlutusV3 s
 
   scriptPrefixTag = alonzoScriptPrefixTag
 
-  getNativeScript (TimelockScript ts) = Just ts
+  getNativeScript (NativeScript ts) = Just ts
   getNativeScript _ = Nothing
 
-  fromNativeScript = TimelockScript
+  fromNativeScript = NativeScript
 
 instance MemPack (PlutusScript DijkstraEra) where
   packedByteCount = \case

--- a/eras/dijkstra/src/Cardano/Ledger/Dijkstra/Scripts.hs
+++ b/eras/dijkstra/src/Cardano/Ledger/Dijkstra/Scripts.hs
@@ -39,11 +39,10 @@ import Cardano.Ledger.Allegra.Scripts (
   mkRequireSignatureTimelock,
   mkTimeExpireTimelock,
   mkTimeStartTimelock,
+  translateTimelock,
  )
-import Cardano.Ledger.Alonzo (AlonzoScript)
 import Cardano.Ledger.Alonzo.Scripts (
   AlonzoEraScript (..),
-  AlonzoScript (..),
   AsItem,
   AsIx (..),
   AsIxItem,
@@ -60,11 +59,7 @@ import Cardano.Ledger.Binary (
   encodeWord8,
  )
 import Cardano.Ledger.Conway.Governance (ProposalProcedure, Voter)
-import Cardano.Ledger.Conway.Scripts (
-  ConwayEraScript (..),
-  ConwayPlutusPurpose (..),
-  PlutusScript (..),
- )
+import Cardano.Ledger.Conway.Scripts
 import Cardano.Ledger.Core (
   EraPParams,
   EraScript (..),
@@ -81,7 +76,6 @@ import Cardano.Ledger.Shelley.Scripts (ShelleyEraScript (..))
 import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData (..), rwhnf)
 import Data.Aeson (KeyValue (..), ToJSON (..))
-import Data.Coerce (coerce)
 import Data.MemPack (MemPack (..), packTagM, packedTagByteCount, unknownTagM, unpackTagM)
 import Data.Typeable (Proxy (..), Typeable)
 import Data.Word (Word16, Word32, Word8)
@@ -221,7 +215,7 @@ instance EraScript DijkstraEra where
   type NativeScript DijkstraEra = Timelock DijkstraEra
 
   upgradeScript = \case
-    NativeScript ts -> NativeScript $ coerce ts
+    NativeScript ts -> NativeScript $ translateTimelock ts
     PlutusScript (ConwayPlutusV1 s) -> PlutusScript $ DijkstraPlutusV1 s
     PlutusScript (ConwayPlutusV2 s) -> PlutusScript $ DijkstraPlutusV2 s
     PlutusScript (ConwayPlutusV3 s) -> PlutusScript $ DijkstraPlutusV3 s
@@ -342,6 +336,8 @@ instance AllegraEraScript DijkstraEra where
 
   mkTimeExpire = mkTimeExpireTimelock
   getTimeExpire = getTimeExpireTimelock
+
+  upgradeNativeScript = translateTimelock
 
 instance ConwayEraScript DijkstraEra where
   mkVotingPurpose = DijkstraVoting

--- a/eras/dijkstra/src/Cardano/Ledger/Dijkstra/TxAuxData.hs
+++ b/eras/dijkstra/src/Cardano/Ledger/Dijkstra/TxAuxData.hs
@@ -6,8 +6,8 @@ module Cardano.Ledger.Dijkstra.TxAuxData () where
 import Cardano.Ledger.Alonzo.TxAuxData (
   AlonzoTxAuxData (..),
   metadataAlonzoTxAuxDataL,
+  nativeScriptsAlonzoTxAuxDataL,
   plutusScriptsAllegraTxAuxDataL,
-  timelockScriptsAlonzoTxAuxDataL,
   validateAlonzoTxAuxData,
  )
 import Cardano.Ledger.Conway.Core (
@@ -28,7 +28,7 @@ instance EraTxAuxData DijkstraEra where
   validateTxAuxData = validateAlonzoTxAuxData
 
 instance AllegraEraTxAuxData DijkstraEra where
-  timelockScriptsTxAuxDataL = timelockScriptsAlonzoTxAuxDataL
+  nativeScriptsTxAuxDataL = nativeScriptsAlonzoTxAuxDataL
 
 instance AlonzoEraTxAuxData DijkstraEra where
   plutusScriptsTxAuxDataL = plutusScriptsAllegraTxAuxDataL

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Scripts.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Scripts.hs
@@ -21,8 +21,6 @@ instance EraScript MaryEra where
   type Script MaryEra = Timelock MaryEra
   type NativeScript MaryEra = Timelock MaryEra
 
-  upgradeScript = translateTimelock
-
   scriptPrefixTag _script = nativeMultiSigTag -- "\x00"
 
   getNativeScript = Just

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Scripts.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Scripts.hs
@@ -48,5 +48,3 @@ instance AllegraEraScript MaryEra where
 
   mkTimeExpire = mkTimeExpireTimelock
   getTimeExpire = getTimeExpireTimelock
-
-  upgradeNativeScript = translateTimelock

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Scripts.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Scripts.hs
@@ -27,6 +27,8 @@ instance EraScript MaryEra where
 
   fromNativeScript = id
 
+  upgradeScript = translateTimelock
+
 instance ShelleyEraScript MaryEra where
   mkRequireSignature = mkRequireSignatureTimelock
   getRequireSignature = getRequireSignatureTimelock
@@ -46,3 +48,5 @@ instance AllegraEraScript MaryEra where
 
   mkTimeExpire = mkTimeExpireTimelock
   getTimeExpire = getTimeExpireTimelock
+
+  upgradeNativeScript = translateTimelock

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Translation.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Translation.hs
@@ -17,7 +17,7 @@ import Cardano.Ledger.Binary (DecoderError)
 import Cardano.Ledger.Genesis (NoGenesis (..))
 import Cardano.Ledger.Mary.Core
 import Cardano.Ledger.Mary.Era (MaryEra)
-import Cardano.Ledger.Mary.Scripts (Timelock, translateTimelock)
+import Cardano.Ledger.Mary.Scripts (Timelock)
 import Cardano.Ledger.Mary.State
 import Cardano.Ledger.Mary.TxAuxData (AllegraTxAuxData (..))
 import Cardano.Ledger.Shelley.LedgerState (
@@ -163,7 +163,7 @@ instance TranslateEra MaryEra Update where
   translateEra _ (Update pp en) = pure $ Update (coerce pp) en
 
 instance TranslateEra MaryEra Timelock where
-  translateEra _ = pure . translateTimelock
+  translateEra _ = pure . coerce
 
 instance TranslateEra MaryEra AllegraTxAuxData where
   translateEra ctx (AllegraTxAuxData md as) =

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Translation.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Translation.hs
@@ -17,7 +17,7 @@ import Cardano.Ledger.Binary (DecoderError)
 import Cardano.Ledger.Genesis (NoGenesis (..))
 import Cardano.Ledger.Mary.Core
 import Cardano.Ledger.Mary.Era (MaryEra)
-import Cardano.Ledger.Mary.Scripts (Timelock)
+import Cardano.Ledger.Mary.Scripts (Timelock, translateTimelock)
 import Cardano.Ledger.Mary.State
 import Cardano.Ledger.Mary.TxAuxData (AllegraTxAuxData (..))
 import Cardano.Ledger.Shelley.LedgerState (
@@ -163,7 +163,7 @@ instance TranslateEra MaryEra Update where
   translateEra _ (Update pp en) = pure $ Update (coerce pp) en
 
 instance TranslateEra MaryEra Timelock where
-  translateEra _ = pure . coerce
+  translateEra _ = pure . translateTimelock
 
 instance TranslateEra MaryEra AllegraTxAuxData where
   translateEra ctx (AllegraTxAuxData md as) =

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxAuxData.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxAuxData.hs
@@ -15,7 +15,7 @@ import Cardano.Ledger.Allegra.TxAuxData (
   AllegraEraTxAuxData (..),
   AllegraTxAuxData (..),
   metadataAllegraTxAuxDataL,
-  timelockScriptsAllegraTxAuxDataL,
+  nativeScriptsAllegraTxAuxDataL,
  )
 import Cardano.Ledger.Core
 import Cardano.Ledger.Mary.Era (MaryEra)
@@ -35,4 +35,4 @@ instance EraTxAuxData MaryEra where
   validateTxAuxData _ (AllegraTxAuxData md as) = as `deepseq` all validMetadatum md
 
 instance AllegraEraTxAuxData MaryEra where
-  timelockScriptsTxAuxDataL = timelockScriptsAllegraTxAuxDataL
+  nativeScriptsTxAuxDataL = nativeScriptsAllegraTxAuxDataL

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/ShelleyMA/Serialisation/Golden/Encoding.hs
@@ -15,7 +15,6 @@ import Cardano.Ledger.Address (Addr (..), RewardAccount (..))
 import Cardano.Ledger.Allegra (AllegraEra)
 import Cardano.Ledger.Allegra.Scripts (
   AllegraEraScript,
-  Timelock (..),
   pattern RequireTimeExpire,
   pattern RequireTimeStart,
  )
@@ -173,7 +172,8 @@ scriptGoldenTest =
               )
         )
 
-metadataNoScriptsGoldenTest :: forall era. Era era => TestTree
+metadataNoScriptsGoldenTest ::
+  forall era. (AllegraEraScript era, DecCBOR (NativeScript era)) => TestTree
 metadataNoScriptsGoldenTest =
   checkEncodingCBORAnnotated
     (eraProtVerHigh @era)
@@ -191,7 +191,7 @@ metadataNoScriptsGoldenTest =
 -- CONTINUE also Scripts
 metadataWithScriptsGoldenTest ::
   forall era.
-  (ShelleyEraScript era, NativeScript era ~ Timelock era) =>
+  (AllegraEraScript era, DecCBOR (NativeScript era)) =>
   TestTree
 metadataWithScriptsGoldenTest =
   checkEncodingCBORAnnotated

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.12.0.0
 
+* Add `upgradeNativeScript` method to `EraApi`
 * Replace `timelockScriptsTxAuxDataL` with `nativeScriptsTxAuxDataL`
 * Changed the type of `translateAlonzoTxAuxData` to only work with consecutive eras
 * Add `EraHasName` type class and add `EraName` type family to the `Era` type class.

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.12.0.0
 
+* Replace `timelockScriptsTxAuxDataL` with `nativeScriptsTxAuxDataL`
+* Changed the type of `translateAlonzoTxAuxData` to only work with consecutive eras
 * Add `EraHasName` type class and add `EraName` type family to the `Era` type class.
 * Add `queryPoolState` and bring back `queryPoolParameters` state query.
 * Add `queryDRepDelegations` state query

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Era.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Era.hs
@@ -69,7 +69,7 @@ module Cardano.Ledger.Api.Era (
 ) where
 
 import Cardano.Ledger.Allegra (AllegraEra)
-import Cardano.Ledger.Allegra.Scripts (AllegraEraScript (..))
+import Cardano.Ledger.Allegra.Scripts (translateTimelock, upgradeMultiSig)
 import Cardano.Ledger.Allegra.TxAuxData (AllegraTxAuxData (..))
 import Cardano.Ledger.Allegra.TxBody (AllegraEraTxBody (..), ValidityInterval (..))
 import qualified Cardano.Ledger.Allegra.TxBody as Allegra (TxBody (..))
@@ -215,6 +215,9 @@ class
   -- Use `binaryUpgradeTxWits` instead, if you need to preserve the serialised form.
   upgradeTxWits :: EraTxWits (PreviousEra era) => TxWits (PreviousEra era) -> TxWits era
 
+  -- | Upgrade a native script from the previous era.
+  upgradeNativeScript :: NativeScript (PreviousEra era) -> NativeScript era
+
 instance EraApi ShelleyEra where
   upgradeTx =
     error
@@ -232,6 +235,10 @@ instance EraApi ShelleyEra where
   upgradeTxWits =
     error
       "Calling this function will cause a compilation error, since there is no TxWits instance for ByronEra"
+
+  upgradeNativeScript =
+    error
+      "Calling this function will cause a compilation error, since there is no `NativeScript` in the ByronEra"
 
 instance EraApi AllegraEra where
   upgradeTx (MkShelleyTx (ShelleyTx txb txwits txAux)) =
@@ -266,6 +273,8 @@ instance EraApi AllegraEra where
       (upgradeScript <$> scriptWits stw)
       (bootWits stw)
 
+  upgradeNativeScript = upgradeMultiSig
+
 instance EraApi MaryEra where
   upgradeTx (MkAllegraTx (ShelleyTx txb txwits txAux)) =
     fmap MkMaryTx $
@@ -296,6 +305,8 @@ instance EraApi MaryEra where
       (addrWits stw)
       (upgradeScript <$> scriptWits stw)
       (bootWits stw)
+
+  upgradeNativeScript = translateTimelock
 
 newtype AlonzoTxUpgradeError = ATUEBodyUpgradeError AlonzoTxBodyUpgradeError
   deriving (Show)
@@ -384,6 +395,8 @@ instance EraApi AlonzoEra where
   upgradeTxWits (ShelleyTxWits {addrWits, scriptWits, bootWits}) =
     AlonzoTxWits addrWits bootWits (upgradeScript <$> scriptWits) mempty (Redeemers mempty)
 
+  upgradeNativeScript = translateTimelock
+
 -- | Upgrade redeemers from one era to another. The underlying data structure
 -- will remain identical, but the memoised serialisation may change to reflect
 -- the versioned serialisation of the new era.
@@ -408,7 +421,7 @@ upgradeTxDats ::
 upgradeTxDats (TxDats datMap) = TxDats $ fmap upgradeData datMap
 
 translateAlonzoTxAuxData ::
-  (AlonzoEraScript (PreviousEra era), AlonzoEraScript era) =>
+  (AlonzoEraScript (PreviousEra era), AlonzoEraScript era, EraApi era) =>
   AlonzoTxAuxData (PreviousEra era) ->
   AlonzoTxAuxData era
 translateAlonzoTxAuxData AlonzoTxAuxData {atadMetadata, atadNativeScripts, atadPlutus} =
@@ -506,6 +519,8 @@ instance EraApi BabbageEra where
       , txrdmrs = upgradeRedeemers (txrdmrs atw)
       }
 
+  upgradeNativeScript = translateTimelock
+
 data ConwayTxBodyUpgradeError
   = CTBUETxCert ConwayTxCertUpgradeError
   | -- | The TxBody contains an update proposal from a pre-Conway era. Since
@@ -566,6 +581,8 @@ instance EraApi ConwayEra where
       , txrdmrs = upgradeRedeemers (txrdmrs atw)
       }
 
+  upgradeNativeScript = translateTimelock
+
 newtype DijkstraTxBodyUpgradeError = DTBUETxCert DijkstraTxCertUpgradeError
   deriving (Eq, Show)
 
@@ -615,3 +632,5 @@ instance EraApi DijkstraEra where
       }
 
   upgradeTxAuxData = translateAlonzoTxAuxData
+
+  upgradeNativeScript = translateTimelock

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Era.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Era.hs
@@ -69,7 +69,7 @@ module Cardano.Ledger.Api.Era (
 ) where
 
 import Cardano.Ledger.Allegra (AllegraEra)
-import Cardano.Ledger.Allegra.Scripts (translateTimelock)
+import Cardano.Ledger.Allegra.Scripts (AllegraEraScript (..))
 import Cardano.Ledger.Allegra.TxAuxData (AllegraTxAuxData (..))
 import Cardano.Ledger.Allegra.TxBody (AllegraEraTxBody (..), ValidityInterval (..))
 import qualified Cardano.Ledger.Allegra.TxBody as Allegra (TxBody (..))
@@ -374,10 +374,10 @@ instance EraApi AlonzoEra where
               m
 
   upgradeTxAuxData (AllegraTxAuxData md scripts) =
-    mkMemoizedEra @AlonzoEra $
+    mkMemoizedEra @AllegraEra $
       AlonzoTxAuxDataRaw
         { atadrMetadata = md
-        , atadrTimelock = translateTimelock <$> scripts
+        , atadrNativeScripts = upgradeNativeScript <$> scripts
         , atadrPlutus = mempty
         }
 
@@ -408,13 +408,13 @@ upgradeTxDats ::
 upgradeTxDats (TxDats datMap) = TxDats $ fmap upgradeData datMap
 
 translateAlonzoTxAuxData ::
-  (AlonzoEraScript era1, AlonzoEraScript era2) =>
-  AlonzoTxAuxData era1 ->
-  AlonzoTxAuxData era2
-translateAlonzoTxAuxData AlonzoTxAuxData {atadMetadata, atadTimelock, atadPlutus} =
+  (AlonzoEraScript (PreviousEra era), AlonzoEraScript era) =>
+  AlonzoTxAuxData (PreviousEra era) ->
+  AlonzoTxAuxData era
+translateAlonzoTxAuxData AlonzoTxAuxData {atadMetadata, atadNativeScripts, atadPlutus} =
   AlonzoTxAuxData
     { atadMetadata = atadMetadata
-    , atadTimelock = translateTimelock <$> atadTimelock
+    , atadNativeScripts = upgradeNativeScript <$> atadNativeScripts
     , atadPlutus = atadPlutus
     }
 

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/AuxData.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/AuxData.hs
@@ -11,7 +11,7 @@ module Cardano.Ledger.Api.Tx.AuxData (
 
   -- * Allegra
   AllegraEraTxAuxData,
-  timelockScriptsTxAuxDataL,
+  nativeScriptsTxAuxDataL,
   AllegraTxAuxData (..),
 
   -- * Alonzo

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -186,7 +186,7 @@ instance
   toSpecRep tl =
     Agda.HSTimelock
       <$> timelockToSpecRep tl
-      <*> toSpecRep (hashScript @era $ TimelockScript tl)
+      <*> toSpecRep (hashScript @era $ NativeScript tl)
       <*> pure (fromIntegral $ originalBytesSize tl)
     where
       timelockToSpecRep x =
@@ -229,7 +229,7 @@ instance
   where
   type SpecRep (AlonzoScript era) = Agda.Script
 
-  toSpecRep (TimelockScript s) = Left <$> toSpecRep s
+  toSpecRep (NativeScript s) = Left <$> toSpecRep s
   toSpecRep (PlutusScript s) = Right <$> toSpecRep s
 
 instance

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -115,7 +115,6 @@ import Control.Monad.Trans.Fail.String (errorFail)
 import Data.Aeson (ToJSON)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
-import Data.Coerce (Coercible, coerce)
 import Data.Kind (Type)
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
@@ -538,9 +537,6 @@ class
   -- /Warning/ - Important to note that any memoized binary representation will not be
   -- preserved, you need to retain underlying bytes you can use `translateEraThroughCBOR`
   upgradeScript :: EraScript (PreviousEra era) => Script (PreviousEra era) -> Script era
-  default upgradeScript ::
-    Coercible (Script (PreviousEra era)) (Script era) => Script (PreviousEra era) -> Script era
-  upgradeScript = coerce
 
   scriptPrefixTag :: Script era -> BS.ByteString
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -114,6 +115,7 @@ import Control.Monad.Trans.Fail.String (errorFail)
 import Data.Aeson (ToJSON)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
+import Data.Coerce (Coercible, coerce)
 import Data.Kind (Type)
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
@@ -536,6 +538,9 @@ class
   -- /Warning/ - Important to note that any memoized binary representation will not be
   -- preserved, you need to retain underlying bytes you can use `translateEraThroughCBOR`
   upgradeScript :: EraScript (PreviousEra era) => Script (PreviousEra era) -> Script era
+  default upgradeScript ::
+    Coercible (Script (PreviousEra era)) (Script era) => Script (PreviousEra era) -> Script era
+  upgradeScript = coerce
 
   scriptPrefixTag :: Script era -> BS.ByteString
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes/Internal.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes/Internal.hs
@@ -19,6 +19,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_HADDOCK not-home #-}
+{-# LANGUAGE RoleAnnotations #-}
 
 -- | Provides MemoBytes internals
 --
@@ -115,6 +116,9 @@ data MemoBytes t = MemoBytes
   }
   deriving (Generic)
   deriving (NoThunks) via AllowThunksIn '["mbBytes", "mbHash"] (MemoBytes t)
+
+-- | Prevent coercion on MemoBytes because it does not preserve the invariants
+type role MemoBytes nominal
 
 pattern Memo :: t -> ShortByteString -> MemoBytes t
 pattern Memo memoType memoBytes <-

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes/Internal.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes/Internal.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
@@ -19,7 +20,6 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_HADDOCK not-home #-}
-{-# LANGUAGE RoleAnnotations #-}
 
 -- | Provides MemoBytes internals
 --

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -457,11 +457,11 @@ instance Typeable era => HasSimpleRep (Datum era)
 instance (Era era, HasSpec (Data era)) => HasSpec (Datum era)
 
 -- TODO: here we are cheating to get out of having to deal with Plutus scripts
-instance Typeable era => HasSimpleRep (AlonzoScript era) where
-  type SimpleRep (AlonzoScript era) = Timelock era
-  toSimpleRep (TimelockScript tl) = tl
+instance (Era era, Typeable (NativeScript era)) => HasSimpleRep (AlonzoScript era) where
+  type SimpleRep (AlonzoScript era) = NativeScript era
+  toSimpleRep (NativeScript tl) = tl
   toSimpleRep (PlutusScript _) = error "toSimpleRep for AlonzoScript on a PlutusScript"
-  fromSimpleRep = TimelockScript
+  fromSimpleRep = NativeScript
 
 instance
   ( AlonzoEraScript era
@@ -1557,7 +1557,7 @@ instance HasSpec IsValid
 -- NOTE: we don't generate or talk about plutus scripts (yet!)
 type AlonzoTxAuxDataTypes era =
   '[ Map Word64 Metadatum
-   , StrictSeq (Timelock era)
+   , StrictSeq (NativeScript era)
    ]
 
 instance AlonzoEraScript era => HasSimpleRep (AlonzoTxAuxData era) where
@@ -1582,10 +1582,13 @@ instance
 -- NOTE: we don't generate or talk about plutus scripts (yet!)
 type AllegraTxAuxDataTypes era =
   '[ Map Word64 Metadatum
-   , StrictSeq (Timelock era)
+   , StrictSeq (NativeScript era)
    ]
 
-instance Era era => HasSimpleRep (AllegraTxAuxData era) where
+instance
+  (Era era, Typeable (NativeScript era), EncCBOR (NativeScript era)) =>
+  HasSimpleRep (AllegraTxAuxData era)
+  where
   type
     TheSop (AllegraTxAuxData era) =
       '["AllegraTxOutData" ::: AllegraTxAuxDataTypes era]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/TxGen.hs
@@ -211,13 +211,13 @@ genGenericScriptWitness mTag script =
     Allegra -> mkTimelockWit mTag script
     Mary -> mkTimelockWit mTag script
     Alonzo -> case script of
-      TimelockScript timelock -> mkTimelockWit mTag timelock
+      NativeScript timelock -> mkTimelockWit mTag timelock
       PlutusScript _ -> pure (const id)
     Babbage -> case script of
-      TimelockScript timelock -> mkTimelockWit mTag timelock
+      NativeScript timelock -> mkTimelockWit mTag timelock
       PlutusScript _ -> pure (const id)
     Conway -> case script of
-      TimelockScript timelock -> mkTimelockWit mTag timelock
+      NativeScript timelock -> mkTimelockWit mTag timelock
       PlutusScript _ -> pure (const id)
 
 -- | Generate a TxWits producing function. We handle TxWits come from Keys and Scripts


### PR DESCRIPTION
# Description

This PR changes `AlonzoTxAuxData` and `AllegraTxAuxData` to use `NativeScript` instead of `Timelock`. This allows us to reuse `AlonzoTxAuxData` in Dijkstra, where we'll be using a new type for `NativeScript`.

close https://github.com/IntersectMBO/cardano-ledger/issues/5255

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
