### PR TITLE
Remove `Deleg.conwayEraSpecificSpec`

### DIFF
--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -74,7 +74,6 @@ conwayEraGenericSpec = do
 conwayEraSpecificSpec :: SpecWith (ImpInit (LedgerSpec ConwayEra))
 conwayEraSpecificSpec = do
   describe "Conway era specific Imp spec" $ do
-    describe "DELEG" Deleg.conwayEraSpecificSpec
     describe "UTXO" Utxo.conwayEraSpecificSpec
 
 instance EraSpecificSpec ConwayEra where

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
@@ -50,5 +50,4 @@ shelleyEraSpecificSpec = do
       Deleg.shelleyEraSpecificSpec
 
 instance EraSpecificSpec ShelleyEra where
-  eraSpecificSpec =
-    describe "DELEG" Deleg.shelleyEraSpecificSpec
+  eraSpecificSpec = shelleyEraSpecificSpec

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/DelegSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/DelegSpec.hs
@@ -204,13 +204,13 @@ spec = do
     it "Register and delegate in the same transaction" $ do
       poolKh <- freshKeyHash
       registerPool poolKh
-      freshKeyHash >>= \kh -> do
-        regTxCert <- genRegTxCert (KeyHashObj kh)
-        submitTx_ $
-          mkBasicTx mkBasicTxBody
-            & bodyTxL . certsTxBodyL
-              .~ [regTxCert, delegStakeTxCert (KeyHashObj kh) poolKh]
-        expectDelegatedToPool (KeyHashObj kh) poolKh
+      cred <- KeyHashObj <$> freshKeyHash
+      regTxCert <- genRegTxCert cred
+      submitTx_ $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . certsTxBodyL
+            .~ [regTxCert, delegStakeTxCert cred poolKh]
+      expectDelegatedToPool cred poolKh
 
     it "Delegate unregistered stake credentials" $ do
       cred <- KeyHashObj <$> freshKeyHash


### PR DESCRIPTION
# Description
~Follow-up to #5220 and #5137~ @teodanciu addressed everything and then some that was originally part of this PR in https://github.com/IntersectMBO/cardano-ledger/pull/5330, so this PR is now reduced to a minor cleanup post-#5330.
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
