### PR TITLE
Remove redundant `NativeScript era ~ Timelock era` constraints

### DIFF
--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
@@ -32,6 +32,7 @@ import qualified Data.Map.Strict as Map
 import Data.Sequence.Strict (StrictSeq (..))
 import qualified Data.Set as Set
 import Lens.Micro ((^.))
+import Test.Cardano.Ledger.Allegra.Binary.Annotator ()
 import Test.Cardano.Ledger.Allegra.Era ()
 import Test.Cardano.Ledger.Allegra.TreeDiff ()
 import Test.Cardano.Ledger.Core.KeyPair (KeyPair)

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
@@ -23,7 +23,6 @@ module Test.Cardano.Ledger.Alonzo.Arbitrary (
   alwaysFailsLang,
   genEraLanguage,
   genAlonzoScript,
-  genNativeScript,
   genNonEmptyRedeemers,
   genNonEmptyTxDats,
   genPlutusScript,
@@ -33,7 +32,6 @@ module Test.Cardano.Ledger.Alonzo.Arbitrary (
   genAlonzoPlutusPurposePointer,
 ) where
 
-import Cardano.Ledger.Allegra.Scripts (Timelock)
 import Cardano.Ledger.Alonzo (AlonzoEra, Tx (..))
 import Cardano.Ledger.Alonzo.BlockBody (AlonzoBlockBody (AlonzoBlockBody))
 import Cardano.Ledger.Alonzo.Core
@@ -220,7 +218,7 @@ instance EraPlutusContext era => Arbitrary (SupportedLanguage era) where
 instance
   ( EraPlutusContext era
   , Script era ~ AlonzoScript era
-  , NativeScript era ~ Timelock era
+  , Arbitrary (NativeScript era)
   ) =>
   Arbitrary (AlonzoScript era)
   where
@@ -229,20 +227,15 @@ instance
 genAlonzoScript ::
   ( EraPlutusContext era
   , Script era ~ AlonzoScript era
-  , NativeScript era ~ Timelock era
+  , Arbitrary (NativeScript era)
   ) =>
   SupportedLanguage era ->
   Gen (AlonzoScript era)
 genAlonzoScript lang =
   frequency
     [ (2, fromPlutusScript <$> genPlutusScript lang)
-    , (8, fromNativeScript <$> genNativeScript)
+    , (8, fromNativeScript <$> arbitrary)
     ]
-
-genNativeScript ::
-  Arbitrary (NativeScript era) =>
-  Gen (NativeScript era)
-genNativeScript = arbitrary
 
 genPlutusScript ::
   SupportedLanguage era ->

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/TxWitsSpec.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/TxWitsSpec.hs
@@ -116,7 +116,7 @@ nativeScriptsProp = do
 
     genEncoding :: Bool -> Gen Encoding
     genEncoding duplicate = do
-      nativeScript <- genNativeScript @era
+      nativeScript <- arbitrary @(NativeScript era)
       let nativeScripts
             | duplicate = [nativeScript, nativeScript]
             | otherwise = [nativeScript]

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Era.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Era.hs
@@ -14,10 +14,12 @@ import Cardano.Ledger.Alonzo
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Plutus.Context
 import Cardano.Ledger.Alonzo.UTxO
+import Cardano.Ledger.MemoBytes (EqRaw)
 import Cardano.Ledger.Plutus (Language (..))
 import Data.TreeDiff
 import Test.Cardano.Ledger.Alonzo.Arbitrary ()
 import Test.Cardano.Ledger.Alonzo.TreeDiff ()
+import Test.Cardano.Ledger.Common (Arbitrary)
 import Test.Cardano.Ledger.Mary.Era
 import Test.Cardano.Ledger.Plutus (zeroTestingCostModels)
 
@@ -32,6 +34,10 @@ class
   , ToExpr (PlutusPurpose AsIxItem era)
   , Script era ~ AlonzoScript era
   , EraPlutusTxInfo PlutusV1 era
+  , Arbitrary (NativeScript era)
+  , EqRaw (NativeScript era)
+  , SafeToHash (NativeScript era)
+  , ToExpr (NativeScript era)
   ) =>
   AlonzoEraTest era
 

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Examples.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Examples.hs
@@ -13,7 +13,6 @@ module Test.Cardano.Ledger.Alonzo.Examples (
   exampleAlonzoGenesis,
 ) where
 
-import Cardano.Ledger.Allegra.Scripts (Timelock)
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
@@ -137,7 +136,6 @@ exampleTx ::
   , EraPlutusTxInfo 'PlutusV1 era
   , TxAuxData era ~ AlonzoTxAuxData era
   , Script era ~ AlonzoScript era
-  , NativeScript era ~ Timelock era
   ) =>
   TxBody era -> PlutusPurpose AsIx era -> Tx era
 exampleTx txBody scriptPurpose =

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -616,9 +616,7 @@ addMaybeDataHashToTxOut (AlonzoTxOut addr val _) = AlonzoTxOut addr val (dataFro
 
 someLeaf ::
   forall era.
-  ( AllegraEraScript era
-  , NativeScript era ~ Timelock era
-  ) =>
+  AllegraEraScript era =>
   Proxy era ->
   KeyHash 'Witness ->
   AlonzoScript era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -141,7 +141,6 @@ module Test.Cardano.Ledger.Conway.ImpTest (
 ) where
 
 import Cardano.Ledger.Address (RewardAccount (..))
-import Cardano.Ledger.Allegra.Scripts (Timelock)
 import Cardano.Ledger.BaseTypes (
   EpochInterval (..),
   EpochNo (..),
@@ -342,7 +341,6 @@ class
   , State (EraRule "ENACT" era) ~ EnactState era
   , Signal (EraRule "ENACT" era) ~ EnactSignal era
   , Environment (EraRule "ENACT" era) ~ ()
-  , NativeScript era ~ Timelock era
   , GovState era ~ ConwayGovState era
   ) =>
   ConwayEraImp era

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -126,7 +126,7 @@ library testlib
     bytestring,
     cardano-crypto-class,
     cardano-data:testlib,
-    cardano-ledger-allegra:{cardano-ledger-allegra, testlib},
+    cardano-ledger-allegra:testlib,
     cardano-ledger-binary:{cardano-ledger-binary, testlib},
     cardano-ledger-core:{cardano-ledger-core, testlib},
     cardano-ledger-mary,

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
@@ -12,7 +12,6 @@ module Test.Cardano.Ledger.Mary.ImpTest (
   mkTokenMintingTx,
 ) where
 
-import Cardano.Ledger.Allegra.Scripts
 import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.Mary.Core
 import Cardano.Ledger.Mary.Value
@@ -32,7 +31,6 @@ instance ShelleyEraImp MaryEra where
 class
   ( ShelleyEraImp era
   , MaryEraTest era
-  , NativeScript era ~ Timelock era
   , Value era ~ MaryValue
   ) =>
   MaryEraImp era

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/AllegraEraGen.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/AllegraEraGen.hs
@@ -189,7 +189,7 @@ genValidityInterval cs@(SlotNo currentSlot) =
 -- valid sub-branch of script.
 someLeaf ::
   forall era.
-  (AllegraEraScript era, NativeScript era ~ Timelock era) =>
+  (AllegraEraScript era) =>
   KeyHash 'Witness ->
   NativeScript era
 someLeaf x =

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -269,6 +269,7 @@ import Test.Cardano.Ledger.Core.Rational ((%!))
 import Test.Cardano.Ledger.Core.Utils (mkDummySafeHash, txInAt)
 import Test.Cardano.Ledger.Imp.Common
 import Test.Cardano.Ledger.Plutus (PlutusArgs, ScriptTestContext)
+import Test.Cardano.Ledger.Shelley.Binary.Annotator ()
 import Test.Cardano.Ledger.Shelley.Era
 import Test.Cardano.Ledger.Shelley.TreeDiff (Expr (..))
 import Test.Cardano.Slotting.Numeric ()
@@ -439,6 +440,7 @@ class
   , Environment (EraRule "NEWEPOCH" era) ~ ()
   , State (EraRule "NEWEPOCH" era) ~ NewEpochState era
   , Signal (EraRule "NEWEPOCH" era) ~ EpochNo
+  , DecCBOR (NativeScript era)
   ) =>
   ShelleyEraImp era
   where

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -176,7 +176,6 @@ instance Era era => SpecTranslate ctx (Datum era) where
 
 instance
   ( AlonzoEraScript era
-  , NativeScript era ~ Timelock era
   , Script era ~ AlonzoScript era
   ) =>
   SpecTranslate ctx (Timelock era)
@@ -208,7 +207,6 @@ instance
 
 instance
   ( AlonzoEraScript era
-  , NativeScript era ~ Timelock era
   , Script era ~ AlonzoScript era
   ) =>
   SpecTranslate ctx (PlutusScript era)
@@ -223,7 +221,6 @@ instance
 instance
   ( AlonzoEraScript era
   , Script era ~ AlonzoScript era
-  , NativeScript era ~ Timelock era
   ) =>
   SpecTranslate ctx (AlonzoScript era)
   where
@@ -537,7 +534,6 @@ instance
   , SpecTranslate ctx (PlutusPurpose AsIx era)
   , SpecRep (PlutusPurpose AsIx era) ~ Agda.RdmrPtr
   , Script era ~ AlonzoScript era
-  , NativeScript era ~ Timelock era
   ) =>
   SpecTranslate ctx (AlonzoTxWits era)
   where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -466,7 +466,7 @@ instance (Era era, Typeable (NativeScript era)) => HasSimpleRep (AlonzoScript er
 instance
   ( AlonzoEraScript era
   , Script era ~ AlonzoScript era
-  , NativeScript era ~ Timelock era
+  , HasSpec (NativeScript era)
   ) =>
   HasSpec (AlonzoScript era)
 
@@ -525,9 +525,7 @@ instance Era era => HasSimpleRep (Timelock era) where
 -}
 
 instance
-  ( AllegraEraScript era
-  , NativeScript era ~ Timelock era
-  ) =>
+  AllegraEraScript era =>
   HasSpec (Timelock era)
   where
   type TypeSpec (Timelock era) = ()
@@ -1575,7 +1573,6 @@ instance AlonzoEraScript era => HasSimpleRep (AlonzoTxAuxData era) where
 instance
   ( Era era
   , AlonzoEraScript era
-  , NativeScript era ~ Timelock era
   ) =>
   HasSpec (AlonzoTxAuxData era)
 
@@ -1603,7 +1600,6 @@ instance
 instance
   ( Era era
   , AllegraEraScript era
-  , NativeScript era ~ Timelock era
   ) =>
   HasSpec (AllegraTxAuxData era)
 
@@ -1625,7 +1621,6 @@ instance Era era => HasSimpleRep (ShelleyTxAuxData era) where
 instance
   ( Era era
   , AllegraEraScript era
-  , NativeScript era ~ Timelock era
   ) =>
   HasSpec (ShelleyTxAuxData era)
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
@@ -726,7 +726,7 @@ genScript tag = case reify @era of
 -- Adds to gsScripts
 genTimelockScript ::
   forall era.
-  (AllegraEraScript era, NativeScript era ~ Timelock era) =>
+  (AllegraEraScript era) =>
   GenRS era ScriptHash
 genTimelockScript = do
   vi@(ValidityInterval mBefore mAfter) <- gets gsValidityInterval


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
