### PR TITLE
Dijkstra Native Scripts

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 * Remove deprecated `timelockScriptsTxAuxDataL`
 
+### `testlib`
+
+* Add `impSatisfyMNativeScripts`
+* Add `impSatisfySignature`
+
 ## 1.8.0.0
 
 * Replace `timelockScriptsTxAuxDataL` with `nativeScriptsTxAuxDataL`

--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-allegra`
 
-## 1.8.0.1
+## 1.9.0.0
 
-*
+* Remove deprecated `timelockScriptsTxAuxDataL`
 
 ## 1.8.0.0
 

--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-allegra
-version: 1.8.0.0
+version: 1.9.0.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Scripts.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Scripts.hs
@@ -53,6 +53,8 @@ module Cardano.Ledger.Allegra.Scripts (
   decodeVI,
   translateTimelock,
   upgradeMultiSig,
+  lteNegInfty,
+  ltePosInfty,
 ) where
 
 import Cardano.Ledger.Allegra.Era (AllegraEra)

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
@@ -29,7 +29,7 @@ module Cardano.Ledger.Allegra.TxAuxData (
 ) where
 
 import Cardano.Ledger.Allegra.Era (AllegraEra)
-import Cardano.Ledger.Allegra.Scripts (AllegraEraScript, Timelock)
+import Cardano.Ledger.Allegra.Scripts (AllegraEraScript)
 import Cardano.Ledger.Binary (
   Annotator,
   DecCBOR (..),
@@ -89,13 +89,6 @@ deriving instance Eq (NativeScript era) => Eq (AllegraTxAuxDataRaw era)
 
 class EraTxAuxData era => AllegraEraTxAuxData era where
   nativeScriptsTxAuxDataL :: Lens' (TxAuxData era) (StrictSeq (NativeScript era))
-
-  timelockScriptsTxAuxDataL :: Lens' (TxAuxData era) (StrictSeq (Timelock era))
-  default timelockScriptsTxAuxDataL ::
-    NativeScript era ~ Timelock era => Lens' (TxAuxData era) (StrictSeq (Timelock era))
-  timelockScriptsTxAuxDataL = nativeScriptsTxAuxDataL
-
-{-# DEPRECATED timelockScriptsTxAuxDataL "In favor of `nativeScriptsTxAuxDataL`" #-}
 
 instance EraTxAuxData AllegraEra where
   type TxAuxData AllegraEra = AllegraTxAuxData AllegraEra

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Arbitrary.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Arbitrary.hs
@@ -68,7 +68,7 @@ sizedTimelock n =
 instance
   forall era.
   ( AllegraEraScript era
-  , NativeScript era ~ Timelock era
+  , Arbitrary (NativeScript era)
   , Arbitrary (Script era)
   , Era era
   ) =>

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Era.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Era.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -9,9 +10,11 @@ module Test.Cardano.Ledger.Allegra.Era (
 import Cardano.Ledger.Allegra
 import Cardano.Ledger.Allegra.Core
 import Cardano.Ledger.Allegra.Scripts
+import Cardano.Ledger.MemoBytes (EqRaw)
 import Cardano.Ledger.Plutus (emptyCostModels)
 import Test.Cardano.Ledger.Allegra.Arbitrary ()
 import Test.Cardano.Ledger.Allegra.TreeDiff ()
+import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Shelley.Era
 
 class
@@ -19,6 +22,10 @@ class
   , AllegraEraTxBody era
   , AllegraEraTxAuxData era
   , AllegraEraScript era
+  , Arbitrary (NativeScript era)
+  , EqRaw (NativeScript era)
+  , SafeToHash (NativeScript era)
+  , ToExpr (NativeScript era)
   ) =>
   AllegraEraTest era
 

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Add `PlutusTxInInfo` type family
 * Add `toPlutusTxInInfo` method to `EraPlutusTxInfo`
 
+### `testlib`
+
+* Add `NativeScript` parameter to `exampleTx`
+
 ## 1.14.0.0
 
 * Replace `timelockScriptsAlonzoTxAuxDataL` with `nativeScriptsAlonzoTxAuxDataL`

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -85,7 +85,7 @@ library
     bytestring,
     cardano-crypto-class,
     cardano-data ^>=1.2.1,
-    cardano-ledger-allegra ^>=1.8,
+    cardano-ledger-allegra ^>=1.9,
     cardano-ledger-binary ^>=1.7,
     cardano-ledger-core:{cardano-ledger-core, internal} ^>=1.19,
     cardano-ledger-mary ^>=1.9,

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
@@ -33,7 +33,6 @@ module Test.Cardano.Ledger.Alonzo.Arbitrary (
   genAlonzoPlutusPurposePointer,
 ) where
 
-import Cardano.Ledger.Allegra.Scripts (Timelock)
 import Cardano.Ledger.Alonzo (AlonzoEra, Tx (..))
 import Cardano.Ledger.Alonzo.BlockBody (AlonzoBlockBody (AlonzoBlockBody))
 import Cardano.Ledger.Alonzo.Core
@@ -220,7 +219,7 @@ instance EraPlutusContext era => Arbitrary (SupportedLanguage era) where
 instance
   ( EraPlutusContext era
   , Script era ~ AlonzoScript era
-  , NativeScript era ~ Timelock era
+  , Arbitrary (NativeScript era)
   ) =>
   Arbitrary (AlonzoScript era)
   where
@@ -229,7 +228,7 @@ instance
 genAlonzoScript ::
   ( EraPlutusContext era
   , Script era ~ AlonzoScript era
-  , NativeScript era ~ Timelock era
+  , Arbitrary (NativeScript era)
   ) =>
   SupportedLanguage era ->
   Gen (AlonzoScript era)

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Examples.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Examples.hs
@@ -13,7 +13,6 @@ module Test.Cardano.Ledger.Alonzo.Examples (
   exampleAlonzoGenesis,
 ) where
 
-import Cardano.Ledger.Allegra.Scripts (Timelock)
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
@@ -129,7 +128,11 @@ exampleAlonzoNewEpochState =
     (emptyPParams & ppCoinsPerUTxOWordL .~ CoinPerWord (Coin 1))
 
 exampleTxAlonzo :: Tx AlonzoEra
-exampleTxAlonzo = exampleTx exampleTxBodyAlonzo (AlonzoSpending $ AsIx 0)
+exampleTxAlonzo =
+  exampleTx
+    exampleTxBodyAlonzo
+    (AlonzoSpending $ AsIx 0)
+    (RequireAllOf @AlonzoEra mempty)
 
 exampleTx ::
   forall era.
@@ -137,10 +140,9 @@ exampleTx ::
   , EraPlutusTxInfo 'PlutusV1 era
   , TxAuxData era ~ AlonzoTxAuxData era
   , Script era ~ AlonzoScript era
-  , NativeScript era ~ Timelock era
   ) =>
-  TxBody era -> PlutusPurpose AsIx era -> Tx era
-exampleTx txBody scriptPurpose =
+  TxBody era -> PlutusPurpose AsIx era -> NativeScript era -> Tx era
+exampleTx txBody scriptPurpose nativeScript =
   mkBasicTx @era txBody
     & witsTxL
       .~ ( mkBasicTxWits
@@ -159,7 +161,7 @@ exampleTx txBody scriptPurpose =
       .~ SJust
         ( mkAlonzoTxAuxData
             exampleAuxDataMap
-            [alwaysFails @'PlutusV1 2, NativeScript $ RequireAllOf @era mempty]
+            [alwaysFails @'PlutusV1 2, NativeScript nativeScript]
         )
 
 exampleTxBodyAlonzo :: TxBody AlonzoEra

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -80,7 +80,7 @@ library
     base >=4.18 && <5,
     bytestring,
     cardano-data >=1.2,
-    cardano-ledger-allegra ^>=1.8,
+    cardano-ledger-allegra ^>=1.9,
     cardano-ledger-alonzo ^>=1.15,
     cardano-ledger-binary >=1.6,
     cardano-ledger-core:{cardano-ledger-core, internal} >=1.19,

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Examples.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Examples.hs
@@ -36,6 +36,7 @@ import Cardano.Ledger.Shelley.API (
   Update (..),
  )
 import Cardano.Ledger.Shelley.Rules (ShelleyDelegsPredFailure (..), ShelleyLedgerPredFailure (..))
+import Cardano.Ledger.Shelley.Scripts
 import Cardano.Ledger.TxIn (mkTxInPartial)
 import Cardano.Slotting.Slot (EpochNo (..), SlotNo (..))
 import qualified Data.Map.Strict as Map
@@ -82,7 +83,11 @@ exampleBabbageNewEpochState =
     (emptyPParams & ppCoinsPerUTxOByteL .~ CoinPerByte (Coin 1))
 
 exampleTxBabbage :: Tx BabbageEra
-exampleTxBabbage = exampleTx exampleTxBodyBabbage (AlonzoSpending $ AsIx 0)
+exampleTxBabbage =
+  exampleTx
+    exampleTxBodyBabbage
+    (AlonzoSpending $ AsIx 0)
+    (RequireAllOf @BabbageEra mempty)
 
 exampleTxBodyBabbage :: TxBody BabbageEra
 exampleTxBodyBabbage =

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -96,7 +96,7 @@ library
     base >=4.18 && <5,
     cardano-crypto-class,
     cardano-data >=1.2.3,
-    cardano-ledger-allegra ^>=1.8,
+    cardano-ledger-allegra ^>=1.9,
     cardano-ledger-alonzo ^>=1.15,
     cardano-ledger-babbage ^>=1.12,
     cardano-ledger-binary ^>=1.7,

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/BinarySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/BinarySpec.hs
@@ -40,6 +40,7 @@ import Test.Cardano.Ledger.Core.Binary.RoundTrip (RuleListEra, roundTripEraSpec)
 spec ::
   forall era.
   ( ConwayEraImp era
+  , DecCBOR (NativeScript era)
   , DecCBOR (TxAuxData era)
   , DecCBOR (TxWits era)
   , DecCBOR (TxBody era)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Examples.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Examples.hs
@@ -32,6 +32,7 @@ import Cardano.Ledger.Shelley.API (
   RewardAccount (..),
   TxId (..),
  )
+import Cardano.Ledger.Shelley.Scripts
 import Cardano.Ledger.TxIn (mkTxInPartial)
 import Control.State.Transition.Extended (Embed (..))
 import qualified Data.Map.Strict as Map
@@ -72,7 +73,11 @@ ledgerExamples =
     exampleConwayGenesis
 
 exampleTxConway :: Tx ConwayEra
-exampleTxConway = exampleTx exampleTxBodyConway (ConwaySpending $ AsIx 0)
+exampleTxConway =
+  exampleTx
+    exampleTxBodyConway
+    (ConwaySpending $ AsIx 0)
+    (RequireAllOf @ConwayEra mempty)
 
 exampleTxBodyConway :: TxBody ConwayEra
 exampleTxBodyConway =

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -141,7 +141,6 @@ module Test.Cardano.Ledger.Conway.ImpTest (
 ) where
 
 import Cardano.Ledger.Address (RewardAccount (..))
-import Cardano.Ledger.Allegra.Scripts (Timelock)
 import Cardano.Ledger.BaseTypes (
   EpochInterval (..),
   EpochNo (..),
@@ -342,7 +341,6 @@ class
   , State (EraRule "ENACT" era) ~ EnactState era
   , Signal (EraRule "ENACT" era) ~ EnactSignal era
   , Environment (EraRule "ENACT" era) ~ ()
-  , NativeScript era ~ Timelock era
   , GovState era ~ ConwayGovState era
   ) =>
   ConwayEraImp era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Spec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Spec.hs
@@ -66,6 +66,7 @@ spec ::
   , ConwayEraImp era
   , EraSpecificSpec era
   , ApplyTx era
+  , DecCBOR (NativeScript era)
   , DecCBOR (TxWits era)
   , DecCBOR (TxBody era)
   , DecCBOR (Tx era)

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -1,8 +1,19 @@
 # Revision history for cardano-ledger-dijkstra
 
-## 0.1.0.1
+## 0.2.0.0
 
-*
+* Add `DijkstraNativeScript` and `DijkstraNativeScriptRaw` along with type instances
+* Change `NativeScript` type family to `DijkstraNativeScript`
+* Add `evalDijkstraNativeScript` to `Scripts` module
+* Add `upgradeTimelock` to `Scripts` module
+* Add `validateDijkstraNativeScript` to `Tx` module
+* Add `RequireGuard` pattern to `Scripts` module
+* Add `ConwayEraScript` constraint to `DijkstraEraScript`
+
+### `testlib`
+
+* Add `impDijkstraSatisfyNativeScript`
+* Add `DijkstraEraTxBody` and `DijkstraEraScript` constraints to `DijkstraEraTest`
 
 ## 0.1.0.0
 

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -115,6 +115,7 @@ library testlib
     Test.Cardano.Ledger.Dijkstra.Era
     Test.Cardano.Ledger.Dijkstra.Examples
     Test.Cardano.Ledger.Dijkstra.Imp
+    Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec
     Test.Cardano.Ledger.Dijkstra.ImpTest
     Test.Cardano.Ledger.Dijkstra.TreeDiff
 

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -133,6 +133,7 @@ library testlib
     base,
     bytestring,
     cardano-data,
+    cardano-ledger-allegra:{cardano-ledger-allegra, testlib},
     cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
     cardano-ledger-babbage:{cardano-ledger-babbage, testlib},
     cardano-ledger-binary,

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-dijkstra
-version: 0.1.0.1
+version: 0.2.0.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/eras/dijkstra/impl/cddl-files/dijkstra.cddl
+++ b/eras/dijkstra/impl/cddl-files/dijkstra.cddl
@@ -297,6 +297,7 @@ native_script =
   // script_n_of_k
   // invalid_before
   // invalid_hereafter
+  // script_require_guard
   ]
 
 
@@ -315,6 +316,10 @@ int64 = -9223372036854775808 .. 9223372036854775807
 invalid_before = (4, slot_no)
 
 invalid_hereafter = (5, slot_no)
+
+script_require_guard = (6, credential)
+
+credential = [0, addr_keyhash// 1, script_hash]
 
 ; The real type of plutus_v1_script, plutus_v2_script and
 ; plutus_v3_script is bytes. However, because we enforce
@@ -345,8 +350,6 @@ certificates = nonempty_oset<certificate>
 nonempty_oset<a0> = #6.258([+ a0])/ [+ a0]
 
 stake_credential = credential
-
-credential = [0, addr_keyhash// 1, script_hash]
 
 pool_keyhash = hash28
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Scripts.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Scripts.hs
@@ -17,6 +17,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -434,7 +435,7 @@ instance ConwayEraScript DijkstraEra where
   toProposingPurpose (DijkstraProposing i) = Just i
   toProposingPurpose _ = Nothing
 
-class DijkstraEraScript era where
+class ConwayEraScript era => DijkstraEraScript era where
   mkGuardingPurpose :: f Word32 ScriptHash -> PlutusPurpose f era
   toGuardingPurpose :: PlutusPurpose f era -> Maybe (f Word32 ScriptHash)
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
@@ -15,7 +15,6 @@ module Cardano.Ledger.Dijkstra.Tx (
   validateDijkstraNativeScript,
 ) where
 
-import Cardano.Ledger.Allegra.Scripts
 import Cardano.Ledger.Allegra.TxBody (AllegraEraTxBody (..))
 import Cardano.Ledger.Alonzo.Tx (
   AlonzoEraTx,
@@ -32,9 +31,13 @@ import Cardano.Ledger.Binary (Annotator, DecCBOR (..), EncCBOR, ToCBOR)
 import Cardano.Ledger.Conway.Tx (AlonzoEraTx (..), Tx (..), getConwayMinFeeTx)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
-import Cardano.Ledger.Dijkstra.Scripts (DijkstraNativeScript, evalDijkstraNativeScript)
+import Cardano.Ledger.Dijkstra.Scripts (
+  DijkstraEraScript,
+  DijkstraNativeScript,
+  evalDijkstraNativeScript,
+ )
 import Cardano.Ledger.Dijkstra.TxAuxData ()
-import Cardano.Ledger.Dijkstra.TxBody ()
+import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody (..))
 import Cardano.Ledger.Dijkstra.TxWits ()
 import Cardano.Ledger.Keys.WitVKey (witVKeyHash)
 import Cardano.Ledger.MemoBytes (EqRaw (..))
@@ -83,12 +86,13 @@ instance DecCBOR (Annotator (Tx DijkstraEra)) where
 
 validateDijkstraNativeScript ::
   ( EraTx era
-  , AllegraEraTxBody era
-  , AllegraEraScript era
+  , DijkstraEraTxBody era
+  , DijkstraEraScript era
   , NativeScript era ~ DijkstraNativeScript era
   ) =>
   Tx era -> NativeScript era -> Bool
-validateDijkstraNativeScript tx = evalDijkstraNativeScript vhks (tx ^. bodyTxL . vldtTxBodyL)
+validateDijkstraNativeScript tx =
+  evalDijkstraNativeScript vhks (tx ^. bodyTxL . vldtTxBodyL) (tx ^. bodyTxL . guardsTxBodyL)
   where
     vhks = Set.map witVKeyHash (tx ^. witsTxL . addrTxWitsL)
 {-# INLINEABLE validateDijkstraNativeScript #-}

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -11,16 +11,17 @@ module Test.Cardano.Ledger.Dijkstra.Arbitrary () where
 
 import Cardano.Ledger.BaseTypes (StrictMaybe)
 import Cardano.Ledger.Dijkstra (DijkstraEra)
-import Cardano.Ledger.Dijkstra.Core (Era, EraTx (..), EraTxBody (..))
+import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Genesis (DijkstraGenesis (..))
 import Cardano.Ledger.Dijkstra.PParams (DijkstraPParams, UpgradeDijkstraPParams)
-import Cardano.Ledger.Dijkstra.Scripts (DijkstraPlutusPurpose)
+import Cardano.Ledger.Dijkstra.Scripts (DijkstraNativeScript, DijkstraPlutusPurpose)
 import Cardano.Ledger.Dijkstra.Transition (TransitionConfig (..))
 import Cardano.Ledger.Dijkstra.Tx (Tx (..))
 import Cardano.Ledger.Dijkstra.TxBody (TxBody (..))
 import Cardano.Ledger.Dijkstra.TxCert
 import Data.Functor.Identity (Identity)
 import Generic.Random (genericArbitraryU)
+import Test.Cardano.Ledger.Allegra.Arbitrary (maxTimelockDepth, sizedTimelock)
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Conway.Arbitrary ()
 
@@ -67,6 +68,9 @@ instance
   Arbitrary (DijkstraPlutusPurpose f DijkstraEra)
   where
   arbitrary = genericArbitraryU
+
+instance Arbitrary (DijkstraNativeScript DijkstraEra) where
+  arbitrary = sizedTimelock maxTimelockDepth
 
 deriving newtype instance Arbitrary (Tx DijkstraEra)
 

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -9,21 +10,29 @@
 
 module Test.Cardano.Ledger.Dijkstra.Arbitrary () where
 
+import Cardano.Ledger.Allegra.Scripts (
+  pattern RequireTimeExpire,
+  pattern RequireTimeStart,
+ )
 import Cardano.Ledger.BaseTypes (StrictMaybe)
 import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Genesis (DijkstraGenesis (..))
 import Cardano.Ledger.Dijkstra.PParams (DijkstraPParams, UpgradeDijkstraPParams)
-import Cardano.Ledger.Dijkstra.Scripts (DijkstraNativeScript, DijkstraPlutusPurpose)
+import Cardano.Ledger.Dijkstra.Scripts
 import Cardano.Ledger.Dijkstra.Transition (TransitionConfig (..))
 import Cardano.Ledger.Dijkstra.Tx (Tx (..))
 import Cardano.Ledger.Dijkstra.TxBody (TxBody (..))
 import Cardano.Ledger.Dijkstra.TxCert
+import Cardano.Ledger.Shelley.Scripts (
+  pattern RequireSignature,
+ )
 import Data.Functor.Identity (Identity)
 import Generic.Random (genericArbitraryU)
-import Test.Cardano.Ledger.Allegra.Arbitrary (maxTimelockDepth, sizedTimelock)
+import Test.Cardano.Ledger.Allegra.Arbitrary (maxTimelockDepth)
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Conway.Arbitrary ()
+import Test.Cardano.Ledger.Shelley.Arbitrary (sizedNativeScriptGens)
 
 instance Arbitrary (DijkstraPParams Identity DijkstraEra) where
   arbitrary = genericArbitraryU
@@ -70,7 +79,20 @@ instance
   arbitrary = genericArbitraryU
 
 instance Arbitrary (DijkstraNativeScript DijkstraEra) where
-  arbitrary = sizedTimelock maxTimelockDepth
+  arbitrary = sizedDijkstraNativeScript maxTimelockDepth
+
+sizedDijkstraNativeScript ::
+  DijkstraEraScript era =>
+  Int ->
+  Gen (NativeScript era)
+sizedDijkstraNativeScript 0 = RequireSignature <$> arbitrary
+sizedDijkstraNativeScript n =
+  oneof $
+    sizedNativeScriptGens n
+      <> [ RequireTimeStart <$> arbitrary
+         , RequireTimeExpire <$> arbitrary
+         , RequireGuard <$> arbitrary
+         ]
 
 deriving newtype instance Arbitrary (Tx DijkstraEra)
 

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
@@ -30,6 +30,7 @@ instance Era era => DecCBOR (DijkstraNativeScriptRaw era) where
     3 -> SumD DijkstraRequireMOf <! From <! From
     4 -> SumD DijkstraTimeStart <! From
     5 -> SumD DijkstraTimeExpire <! From
+    6 -> SumD DijkstraRequireGuard <! From
     n -> Invalid n
 
 instance Era era => DecCBOR (DijkstraNativeScript era) where

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -8,12 +10,29 @@ module Test.Cardano.Ledger.Dijkstra.Binary.Annotator (
 
 ) where
 
-import Cardano.Ledger.Binary (DecCBOR)
+import Cardano.Ledger.Binary
+import Cardano.Ledger.Binary.Coders
+import Cardano.Ledger.Core
 import Cardano.Ledger.Dijkstra (DijkstraEra)
+import Cardano.Ledger.Dijkstra.Scripts
 import Cardano.Ledger.Dijkstra.Tx (Tx (..))
 import Cardano.Ledger.Dijkstra.TxBody (TxBody (..))
+import Cardano.Ledger.MemoBytes (decodeMemoized)
 import Test.Cardano.Ledger.Conway.Binary.Annotator ()
 
 deriving newtype instance DecCBOR (TxBody DijkstraEra)
+
+instance Era era => DecCBOR (DijkstraNativeScriptRaw era) where
+  decCBOR = decode $ Summands "DijkstraNativeScriptRaw" $ \case
+    0 -> SumD DijkstraRequireSignature <! From
+    1 -> SumD DijkstraRequireAllOf <! From
+    2 -> SumD DijkstraRequireAnyOf <! From
+    3 -> SumD DijkstraRequireMOf <! From <! From
+    4 -> SumD DijkstraTimeStart <! From
+    5 -> SumD DijkstraTimeExpire <! From
+    n -> Invalid n
+
+instance Era era => DecCBOR (DijkstraNativeScript era) where
+  decCBOR = MkDijkstraNativeScript <$> decodeMemoized decCBOR
 
 deriving newtype instance DecCBOR (Tx DijkstraEra)

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/CDDL.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/CDDL.hs
@@ -30,6 +30,7 @@ import Test.Cardano.Ledger.Conway.CDDL hiding (
   header,
   header_body,
   language,
+  native_script,
   parameter_change_action,
   proposal_procedure,
   proposal_procedures,
@@ -368,7 +369,7 @@ transaction_witness_set =
   "transaction_witness_set"
     =:= mp
       [ opt $ idx 0 ==> nonempty_set vkeywitness
-      , opt $ idx 1 ==> nonempty_set native_script
+      , opt $ idx 1 ==> nonempty_set dijkstra_native_script
       , opt $ idx 2 ==> nonempty_set bootstrap_witness
       , opt $ idx 3 ==> nonempty_set plutus_v1_script
       , opt $ idx 4 ==> nonempty_set plutus_data
@@ -421,6 +422,20 @@ cost_models =
 plutus_v4_script :: Rule
 plutus_v4_script = "plutus_v4_script" =:= distinct VBytes
 
+script_require_guard :: Named Group
+script_require_guard = "script_require_guard" =:~ grp [6, a credential]
+
+dijkstra_native_script :: Rule
+dijkstra_native_script =
+  "native_script"
+    =:= arr [a script_pubkey]
+    / arr [a script_all]
+    / arr [a script_any]
+    / arr [a script_n_of_k]
+    / arr [a invalid_before]
+    / arr [a invalid_hereafter]
+    / arr [a script_require_guard]
+
 alonzo_auxiliary_data :: Rule
 alonzo_auxiliary_data =
   "alonzo_auxiliary_data"
@@ -428,7 +443,7 @@ alonzo_auxiliary_data =
       259
       ( mp
           [ opt (idx 0 ==> metadata)
-          , opt (idx 1 ==> arr [0 <+ a native_script])
+          , opt (idx 1 ==> arr [0 <+ a dijkstra_native_script])
           , opt (idx 2 ==> arr [0 <+ a plutus_v1_script])
           , opt (idx 3 ==> arr [0 <+ a plutus_v2_script])
           , opt (idx 4 ==> arr [0 <+ a plutus_v3_script])
@@ -446,7 +461,7 @@ auxiliary_data =
 dijkstra_script :: Rule
 dijkstra_script =
   "script"
-    =:= arr [0, a native_script]
+    =:= arr [0, a dijkstra_native_script]
     / arr [1, a plutus_v1_script]
     / arr [2, a plutus_v2_script]
     / arr [3, a plutus_v3_script]

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Era.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Era.hs
@@ -7,7 +7,9 @@ module Test.Cardano.Ledger.Dijkstra.Era (
 ) where
 
 import Cardano.Ledger.Dijkstra (DijkstraEra)
+import Cardano.Ledger.Dijkstra.Scripts (DijkstraEraScript)
 import Cardano.Ledger.Dijkstra.State
+import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody)
 import Cardano.Ledger.Plutus (Language (..))
 import Data.Coerce
 import Test.Cardano.Ledger.Conway.Era
@@ -23,7 +25,10 @@ instance EraTest DijkstraEra where
   accountsFromAccountsMap = coerce
 
 class
-  ConwayEraTest era =>
+  ( ConwayEraTest era
+  , DijkstraEraTxBody era
+  , DijkstraEraScript era
+  ) =>
   DijkstraEraTest era
 
 instance ShelleyEraTest DijkstraEra

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Examples.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Examples.hs
@@ -32,6 +32,7 @@ import Cardano.Ledger.Shelley.API (
   RewardAccount (..),
   TxId (..),
  )
+import Cardano.Ledger.Shelley.Scripts
 import Cardano.Ledger.TxIn (mkTxInPartial)
 import Control.State.Transition.Extended (Embed (..))
 import qualified Data.Map.Strict as Map
@@ -73,7 +74,11 @@ ledgerExamples =
     exampleDijkstraGenesis
 
 exampleTxDijkstra :: Tx DijkstraEra
-exampleTxDijkstra = exampleTx exampleTxBodyDijkstra (DijkstraSpending $ AsIx 0)
+exampleTxDijkstra =
+  exampleTx
+    exampleTxBodyDijkstra
+    (DijkstraSpending $ AsIx 0)
+    (RequireAllOf @DijkstraEra mempty)
 
 exampleTxBodyDijkstra :: TxBody DijkstraEra
 exampleTxBodyDijkstra =

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
@@ -22,6 +22,7 @@ import Cardano.Ledger.Shelley.Rules
 import Data.Typeable (Typeable)
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Conway.Imp as ConwayImp
+import qualified Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec as Utxow
 import Test.Cardano.Ledger.Dijkstra.ImpTest
 
 spec ::
@@ -58,6 +59,17 @@ spec ::
   , ToExpr (Event (EraRule "BBODY" era))
   ) =>
   Spec
-spec = ConwayImp.spec @era
+spec = do
+  ConwayImp.spec @era
+  withEachEraVersion @era $ dijkstraEraGenericSpec @era
+
+dijkstraEraGenericSpec ::
+  forall era.
+  ( DijkstraEraImp era
+  , InjectRuleFailure "LEDGER" ConwayUtxowPredFailure era
+  ) =>
+  SpecWith (ImpInit (LedgerSpec era))
+dijkstraEraGenericSpec = do
+  describe "UTXOW" Utxow.spec
 
 instance EraSpecificSpec DijkstraEra

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxowSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxowSpec.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec (spec) where
+
+import Cardano.Ledger.Conway.Rules
+import Cardano.Ledger.Core
+import Cardano.Ledger.Credential
+import Cardano.Ledger.Dijkstra.Core
+import Cardano.Ledger.Dijkstra.Scripts
+import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody (..))
+import Cardano.Ledger.Shelley.LedgerState
+import Cardano.Ledger.Shelley.Scripts
+import Lens.Micro
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Dijkstra.ImpTest
+
+spec ::
+  forall era.
+  ( DijkstraEraImp era
+  , InjectRuleFailure "LEDGER" ConwayUtxowPredFailure era
+  ) =>
+  SpecWith (ImpInit (LedgerSpec era))
+spec =
+  describe "RequireGuard native scripts" $ do
+    it "Spending inputs locked by script requiring a keyhash guard" $ do
+      guardKeyHash <- KeyHashObj <$> freshKeyHash
+      scriptHash <- impAddNativeScript (RequireGuard guardKeyHash)
+      txIn <- produceScript scriptHash
+      let tx = mkBasicTx (mkBasicTxBody & inputsTxBodyL .~ [txIn])
+      submitFailingTx tx [injectFailure $ ScriptWitnessNotValidatingUTXOW [scriptHash]]
+      submitTx_ $ tx & bodyTxL . guardsTxBodyL .~ [guardKeyHash]
+
+    it "A native script required as guard needs to be witnessed " $ do
+      let guardScript = RequireAllOf []
+      let guardScriptHash = hashScript @era $ fromNativeScript guardScript
+      scriptHash <- impAddNativeScript $ RequireGuard (ScriptHashObj guardScriptHash)
+      tx <- mkTokenMintingTx scriptHash
+      submitFailingTx tx [injectFailure $ ScriptWitnessNotValidatingUTXOW [scriptHash]]
+
+      let txWithGuards = tx & bodyTxL . guardsTxBodyL .~ [ScriptHashObj guardScriptHash]
+      submitFailingTx txWithGuards [injectFailure $ MissingScriptWitnessesUTXOW [guardScriptHash]]
+      submitTx_ $ txWithGuards & witsTxL . hashScriptTxWitsL .~ [fromNativeScript guardScript]
+
+    it "A failing native script required as guard results in a predicate failure" $ do
+      let guardScriptFailing = RequireAnyOf []
+      let guardScriptHash = hashScript @era $ fromNativeScript guardScriptFailing
+      scriptHash <- impAddNativeScript $ RequireGuard (ScriptHashObj guardScriptHash)
+      expectedDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppKeyDepositL
+      let tx =
+            mkBasicTx mkBasicTxBody
+              & bodyTxL . certsTxBodyL .~ [RegDepositTxCert (ScriptHashObj scriptHash) expectedDeposit]
+              & bodyTxL . guardsTxBodyL .~ [ScriptHashObj guardScriptHash]
+              & witsTxL . hashScriptTxWitsL .~ [fromNativeScript guardScriptFailing]
+      submitFailingTx tx [injectFailure $ ScriptWitnessNotValidatingUTXOW [guardScriptHash]]
+
+    it "A redundant guard is ignored" $ do
+      guardKeyHash <- KeyHashObj <$> freshKeyHash
+      let tx =
+            mkBasicTx mkBasicTxBody
+              & bodyTxL . guardsTxBodyL .~ [guardKeyHash]
+      submitTx_ tx
+
+    it "Nested RequiredGuard scripts" $ do
+      guardKeyHash <- KeyHashObj <$> freshKeyHash
+      let guardScript = RequireGuard guardKeyHash
+      let guardScriptHash = hashScript @era $ fromNativeScript guardScript
+
+      scriptHash <- impAddNativeScript $ RequireGuard (ScriptHashObj guardScriptHash)
+
+      tx <- mkTokenMintingTx scriptHash
+      submitFailingTx tx [injectFailure $ ScriptWitnessNotValidatingUTXOW [scriptHash]]
+      submitTx_ $
+        tx
+          & bodyTxL . guardsTxBodyL .~ [ScriptHashObj guardScriptHash, guardKeyHash]
+          & witsTxL . hashScriptTxWitsL .~ [fromNativeScript guardScript]

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
@@ -12,7 +12,11 @@ import Cardano.Ledger.BaseTypes (StrictMaybe)
 import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Core (EraTx (..), EraTxBody (..), PlutusScript)
 import Cardano.Ledger.Dijkstra.PParams (DijkstraPParams)
-import Cardano.Ledger.Dijkstra.Scripts (DijkstraPlutusPurpose)
+import Cardano.Ledger.Dijkstra.Scripts (
+  DijkstraNativeScript,
+  DijkstraNativeScriptRaw,
+  DijkstraPlutusPurpose,
+ )
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraTxBodyRaw)
 import Cardano.Ledger.Dijkstra.TxCert
 import Data.Functor.Identity (Identity)
@@ -23,6 +27,10 @@ instance
   ToExpr (DijkstraPlutusPurpose f DijkstraEra)
 
 instance ToExpr (PlutusScript DijkstraEra)
+
+instance ToExpr (DijkstraNativeScript era)
+
+instance ToExpr (DijkstraNativeScriptRaw era)
 
 instance ToExpr (DijkstraPParams Identity DijkstraEra)
 

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -126,7 +126,7 @@ library testlib
     bytestring,
     cardano-crypto-class,
     cardano-data:testlib,
-    cardano-ledger-allegra:{cardano-ledger-allegra, testlib},
+    cardano-ledger-allegra:testlib,
     cardano-ledger-binary:{cardano-ledger-binary, testlib},
     cardano-ledger-core:{cardano-ledger-core, testlib},
     cardano-ledger-mary,

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-mary
-version: 1.9.0.0
+version: 1.9.0.1
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK
@@ -78,7 +78,7 @@ library
     bytestring,
     cardano-crypto-class,
     cardano-data ^>=1.2,
-    cardano-ledger-allegra ^>=1.8,
+    cardano-ledger-allegra ^>=1.9,
     cardano-ledger-binary >=1.4,
     cardano-ledger-core:{cardano-ledger-core, internal} >=1.19,
     cardano-ledger-shelley ^>=1.17,

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
@@ -12,7 +12,6 @@ module Test.Cardano.Ledger.Mary.ImpTest (
   mkTokenMintingTx,
 ) where
 
-import Cardano.Ledger.Allegra.Scripts
 import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.Mary.Core
 import Cardano.Ledger.Mary.Value
@@ -32,7 +31,6 @@ instance ShelleyEraImp MaryEra where
 class
   ( ShelleyEraImp era
   , MaryEraTest era
-  , NativeScript era ~ Timelock era
   , Value era ~ MaryValue
   ) =>
   MaryEraImp era

--- a/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
+++ b/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-shelley-ma-test
-version: 1.4.0.0
+version: 1.4.0.1
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK
@@ -44,7 +44,7 @@ library
     QuickCheck,
     base >=4.18 && <5,
     bytestring,
-    cardano-ledger-allegra:{cardano-ledger-allegra, testlib} ^>=1.8,
+    cardano-ledger-allegra:{cardano-ledger-allegra, testlib} ^>=1.9,
     cardano-ledger-binary:{cardano-ledger-binary, testlib} ^>=1.7,
     cardano-ledger-core >=1.17,
     cardano-ledger-mary:{cardano-ledger-mary, testlib} ^>=1.9,

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -60,7 +60,7 @@ library
     base >=4.18 && <5,
     bytestring,
     cardano-data,
-    cardano-ledger-allegra ^>=1.8,
+    cardano-ledger-allegra ^>=1.9,
     cardano-ledger-alonzo >=1.12,
     cardano-ledger-babbage >=1.11,
     cardano-ledger-binary >=1.4,

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -66,7 +66,7 @@ library
     cardano-ledger-binary >=1.4,
     cardano-ledger-conway >=1.19,
     cardano-ledger-core:{cardano-ledger-core, internal} >=1.17,
-    cardano-ledger-dijkstra >=0.1,
+    cardano-ledger-dijkstra >=0.2,
     cardano-ledger-mary ^>=1.9,
     cardano-ledger-shelley ^>=1.17,
     cardano-strict-containers,

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Era.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Era.hs
@@ -92,6 +92,7 @@ import Cardano.Ledger.Conway.TxCert (ConwayTxCertUpgradeError)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Dijkstra (DijkstraEra)
+import Cardano.Ledger.Dijkstra.Scripts
 import Cardano.Ledger.Dijkstra.Tx (Tx (..))
 import Cardano.Ledger.Dijkstra.TxBody (TxBody (..), upgradeProposals)
 import Cardano.Ledger.Dijkstra.TxCert (DijkstraTxCertUpgradeError)
@@ -633,4 +634,4 @@ instance EraApi DijkstraEra where
 
   upgradeTxAuxData = translateAlonzoTxAuxData
 
-  upgradeNativeScript = translateTimelock
+  upgradeNativeScript = upgradeTimelock


### PR DESCRIPTION
# Description

For CIP 112,  we need a new type of NativeScript: RequireGuard. 
This means that we cannot reuse `Timelock` as NativeScript  in Dijkstra. 

A big part of the PR is just replacing the Timelock with a similar structure in Dijkstra. 
For the actual differences between the NativeScripts in Dijkstra in contrast to Conway, have a look at the last two commits.

Closes https://github.com/IntersectMBO/cardano-ledger/issues/5225

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
