### PR TITLE
Make Babbage `TxInfoSpec` tests work with newer Plutus versions

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.14.0.0
 
+* Add `PlutusTxInInfo` type family
+* Add `toPlutusTxInInfo` method to `EraPlutusTxInfo`
 * Replace `timelockScriptsAlonzoTxAuxDataL` with `nativeScriptsAlonzoTxAuxDataL`
 * Replace `atadTimelock` with `atadNativeScript` and `atadTimelock'` with `atadNativeScript'`
 * Replace `TimelockScript` constructor of `AlonzoScript` with a new constructor `NativeScript`

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
@@ -104,9 +104,7 @@ instance EraPlutusTxInfo 'PlutusV1 AlonzoEra where
   toPlutusTxInfo proxy LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} = do
     timeRange <-
       transValidityInterval ltiTx ltiEpochInfo ltiSystemStart (txBody ^. vldtTxBodyL)
-    txInsMaybes <- forM (Set.toList (txBody ^. inputsTxBodyL)) $ \txIn -> do
-      txOut <- transLookupTxOut ltiUTxO txIn
-      pure $ PV1.TxInInfo (transTxIn txIn) <$> transTxOut txOut
+    txInsMaybes <- forM (Set.toList (txBody ^. inputsTxBodyL)) $ toPlutusTxInInfo proxy ltiUTxO
     txCerts <- transTxBodyCerts proxy ltiProtVer txBody
     Right $
       PV1.TxInfo
@@ -127,6 +125,10 @@ instance EraPlutusTxInfo 'PlutusV1 AlonzoEra where
       txBody = ltiTx ^. bodyTxL
 
   toPlutusArgs = toPlutusV1Args
+
+  toPlutusTxInInfo _ utxo txIn = do
+    txOut <- transLookupTxOut utxo txIn
+    pure $ PV1.TxInInfo (transTxIn txIn) <$> transTxOut txOut
 
 toPlutusV1Args ::
   EraPlutusTxInfo 'PlutusV1 era =>

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
@@ -348,6 +348,8 @@ instance EraPlutusTxInfo 'PlutusV1 BabbageEra where
 
   toPlutusArgs = Alonzo.toPlutusV1Args
 
+  toPlutusTxInInfo _ = transTxInInfoV1
+
 instance EraPlutusTxInfo 'PlutusV2 BabbageEra where
   toPlutusTxCert _ _ = pure . Alonzo.transTxCert
 
@@ -384,6 +386,8 @@ instance EraPlutusTxInfo 'PlutusV2 BabbageEra where
       txBody = ltiTx ^. bodyTxL
 
   toPlutusArgs = toPlutusV2Args
+
+  toPlutusTxInInfo _ = transTxInInfoV2
 
 toPlutusV2Args ::
   EraPlutusTxInfo 'PlutusV2 era =>

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
@@ -431,6 +431,8 @@ instance EraPlutusTxInfo 'PlutusV1 ConwayEra where
 
   toPlutusArgs = Alonzo.toPlutusV1Args
 
+  toPlutusTxInInfo _ = transTxInInfoV1
+
 instance EraPlutusTxInfo 'PlutusV2 ConwayEra where
   toPlutusTxCert _ _ = transTxCertV1V2
 
@@ -468,6 +470,8 @@ instance EraPlutusTxInfo 'PlutusV2 ConwayEra where
       txBody = ltiTx ^. bodyTxL
 
   toPlutusArgs = Babbage.toPlutusV2Args
+
+  toPlutusTxInInfo _ = Babbage.transTxInInfoV2
 
 instance EraPlutusTxInfo 'PlutusV3 ConwayEra where
   toPlutusTxCert _ pv = pure . transTxCert pv
@@ -522,6 +526,8 @@ instance EraPlutusTxInfo 'PlutusV3 ConwayEra where
       txBody = ltiTx ^. bodyTxL
 
   toPlutusArgs = toPlutusV3Args
+
+  toPlutusTxInInfo _ = transTxInInfoV3
 
 transTxId :: TxId -> PV3.TxId
 transTxId txId = PV3.TxId (transSafeHash (unTxId txId))

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Spec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Spec.hs
@@ -121,4 +121,5 @@ spec =
     describe "TxInfo" $ do
       TxInfo.spec @era
       BabbageTxInfo.spec @era
-      describe "PlutusV3" $ BabbageTxInfo.txInfoSpecV2 @era SPlutusV3
+      describe "PlutusV3" $
+        BabbageTxInfo.txInfoSpec @era SPlutusV3

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Spec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Spec.hs
@@ -121,6 +121,4 @@ spec =
     describe "TxInfo" $ do
       TxInfo.spec @era
       BabbageTxInfo.spec @era
-      xdescribe "PlutusV3" $ do
-        -- TODO: https://github.com/IntersectMBO/cardano-ledger/issues/5209
-        BabbageTxInfo.txInfoSpecV2 @era SPlutusV3
+      describe "PlutusV3" $ BabbageTxInfo.txInfoSpecV2 @era SPlutusV3

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -194,7 +194,7 @@ test-suite tests
 
   build-depends:
     base,
-    cardano-ledger-core:testlib,
-    cardano-ledger-dijkstra:{cardano-ledger-dijkstra, testlib},
     cardano-ledger-babbage:testlib,
+    cardano-ledger-core:{cardano-ledger-core, testlib},
+    cardano-ledger-dijkstra:{cardano-ledger-dijkstra, testlib},
     cardano-ledger-shelley:testlib,

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -196,4 +196,5 @@ test-suite tests
     base,
     cardano-ledger-core:testlib,
     cardano-ledger-dijkstra:{cardano-ledger-dijkstra, testlib},
+    cardano-ledger-babbage:testlib,
     cardano-ledger-shelley:testlib,

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
@@ -33,7 +33,12 @@ import Cardano.Ledger.BaseTypes (Inject (..), ProtVer (..), strictMaybe)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Scripts (ConwayPlutusPurpose (..))
 import Cardano.Ledger.Conway.TxCert (Delegatee (..))
-import Cardano.Ledger.Conway.TxInfo (ConwayContextError (..), ConwayEraPlutusTxInfo (..))
+import Cardano.Ledger.Conway.TxInfo (
+  ConwayContextError (..),
+  ConwayEraPlutusTxInfo (..),
+  transTxInInfoV1,
+  transTxInInfoV3,
+ )
 import qualified Cardano.Ledger.Conway.TxInfo as Conway
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
@@ -175,6 +180,8 @@ instance EraPlutusTxInfo 'PlutusV1 DijkstraEra where
 
   toPlutusArgs = Alonzo.toPlutusV1Args
 
+  toPlutusTxInInfo _ = transTxInInfoV1
+
 transTxCertV1V2 ::
   ( ConwayEraTxCert era
   , Inject (ConwayContextError era) (ContextError era)
@@ -235,6 +242,8 @@ instance EraPlutusTxInfo 'PlutusV2 DijkstraEra where
 
   toPlutusArgs = Babbage.toPlutusV2Args
 
+  toPlutusTxInInfo _ = Babbage.transTxInInfoV2
+
 instance EraPlutusTxInfo 'PlutusV3 DijkstraEra where
   toPlutusTxCert _ _ = pure . transTxCert
 
@@ -288,6 +297,8 @@ instance EraPlutusTxInfo 'PlutusV3 DijkstraEra where
       txBody = ltiTx ^. bodyTxL
 
   toPlutusArgs = Conway.toPlutusV3Args
+
+  toPlutusTxInInfo _ = transTxInInfoV3
 
 transTxCert ::
   (ConwayEraTxCert era, TxCert era ~ DijkstraTxCert era) => TxCert era -> PV3.TxCert
@@ -382,6 +393,8 @@ instance EraPlutusTxInfo 'PlutusV4 DijkstraEra where
       txBody = ltiTx ^. bodyTxL
 
   toPlutusArgs = toPlutusV4Args
+
+  toPlutusTxInInfo _ = transTxInInfoV3
 
 toPlutusV4Args ::
   EraPlutusTxInfo 'PlutusV4 era =>

--- a/eras/dijkstra/impl/test/Main.hs
+++ b/eras/dijkstra/impl/test/Main.hs
@@ -4,6 +4,9 @@ module Main where
 
 import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Rules ()
+import Cardano.Ledger.Plutus (SLanguage (..))
+import Test.Cardano.Ledger.Babbage.TxInfoSpec (txInfoSpec)
+import qualified Test.Cardano.Ledger.Babbage.TxInfoSpec as BabbageTxInfo
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Dijkstra.Binary.Annotator ()
 import Test.Cardano.Ledger.Dijkstra.Binary.RoundTrip ()
@@ -11,7 +14,6 @@ import qualified Test.Cardano.Ledger.Dijkstra.GoldenSpec as GoldenSpec
 import qualified Test.Cardano.Ledger.Dijkstra.Imp as Imp
 import Test.Cardano.Ledger.Dijkstra.ImpTest ()
 import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
-import qualified Test.Cardano.Ledger.Babbage.TxInfoSpec as BabbageTxInfo
 
 main :: IO ()
 main =
@@ -23,3 +25,5 @@ main =
         Imp.spec @DijkstraEra
       describe "TxInfo" $ do
         BabbageTxInfo.spec @DijkstraEra
+        txInfoSpec @DijkstraEra SPlutusV3
+        txInfoSpec @DijkstraEra SPlutusV4

--- a/eras/dijkstra/impl/test/Main.hs
+++ b/eras/dijkstra/impl/test/Main.hs
@@ -11,6 +11,7 @@ import qualified Test.Cardano.Ledger.Dijkstra.GoldenSpec as GoldenSpec
 import qualified Test.Cardano.Ledger.Dijkstra.Imp as Imp
 import Test.Cardano.Ledger.Dijkstra.ImpTest ()
 import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
+import qualified Test.Cardano.Ledger.Babbage.TxInfoSpec as BabbageTxInfo
 
 main :: IO ()
 main =
@@ -20,3 +21,5 @@ main =
       roundTripJsonShelleyEraSpec @DijkstraEra
       describe "Imp" $ do
         Imp.spec @DijkstraEra
+      describe "TxInfo" $ do
+        BabbageTxInfo.spec @DijkstraEra


### PR DESCRIPTION
# Description

This PR makes some `TxInfoSpec` tests run with newer Plutus versions by generalizing their helper funcions over the plutus version.

close #5209

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
