### PR TITLE
Added a new test Plutus script

### DIFF
--- a/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor/Binary/V3.hs
+++ b/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor/Binary/V3.hs
@@ -29,6 +29,7 @@ $datumIsWellformedQ
 $inputsOutputsAreNotEmptyNoDatumQ
 $inputsOutputsAreNotEmptyWithDatumQ
 $inputsOverlapsWithRefInputsQ
+$ensureTreasuryReserveQ
 
 -- ================================================================
 -- Compile and serialize the real functions as Plutus scripts.
@@ -116,4 +117,10 @@ inputsOverlapsWithRefInputsBytes :: (Q [Dec], PlutusBinary)
 inputsOverlapsWithRefInputsBytes =
   ( inputsOverlapsWithRefInputsQ
   , PlutusBinary $ PV3.serialiseCompiledCode $$(P.compile [||inputsOverlapsWithRefInputs||])
+  )
+
+ensureTreasuryReserveBytes :: (Q [Dec], PlutusBinary)
+ensureTreasuryReserveBytes =
+  ( ensureTreasuryReserveQ
+  , PlutusBinary $ PV3.serialiseCompiledCode $$(P.compile [||ensureTreasuryReserve||])
   )


### PR DESCRIPTION
# Description

Implements a script that prohibits a single treasury withdrawal from withdrawing too much ADA from the treasury.

This addresses the second point in https://github.com/IntersectMBO/cardano-ledger/issues/4382

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
