### PR TITLE
Fixup random 1.3 compatibility

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -27,7 +27,7 @@ source-repository-package
 -- NOTE: If you would like to update the above,
 -- see CONTRIBUTING.md#to-update-the-referenced-agda-ledger-spec
 index-state:
-  , hackage.haskell.org 2025-06-11T21:55:55Z
+  , hackage.haskell.org 2025-09-09T23:37:25Z
   , cardano-haskell-packages 2025-06-11T08:32:56Z
 
 packages:

--- a/flake.lock
+++ b/flake.lock
@@ -275,11 +275,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1749687986,
-        "narHash": "sha256-cEt2Hhbc0w0SqiadjZg4TJyn2+rKxW/15nmu4an79wo=",
+        "lastModified": 1757523633,
+        "narHash": "sha256-nLzEuichc4tfUbzlJhMvAVi6EisQVyXMNwv4CKwRd1A=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "0949afe39e6d249b6db126a96646d3f51a4a4c11",
+        "rev": "1b9604d6c2f1d48e9e204e420103c0a5514a0be9",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-binary
-version: 1.7.0.0
+version: 1.7.0.1
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK
@@ -73,7 +73,7 @@ library
     nothunks,
     plutus-ledger-api >=1.27.0,
     primitive,
-    random,
+    random >=1.2,
     recursion-schemes,
     serialise,
     tagged,

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Arbitrary.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Arbitrary.hs
@@ -224,7 +224,11 @@ genLazyByteString :: Int -> Gen BSL.ByteString
 genLazyByteString n = BSL.fromStrict <$> genByteString n
 
 genShortByteString :: Int -> Gen SBS.ShortByteString
+#if MIN_VERSION_random(1,3,0)
+genShortByteString n = uniformShortByteStringM (fromIntegral n) QC
+#else
 genShortByteString n = uniformShortByteString (fromIntegral n) QC
+#endif
 
 genByteArray :: Int -> Gen Prim.ByteArray
 genByteArray n = do

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Random.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Random.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -33,9 +34,15 @@ instance StatefulGen QC Gen where
   {-# INLINE uniformWord32 #-}
   uniformWord64 QC = MkGen (\r _n -> runStateGen_ r uniformWord64)
   {-# INLINE uniformWord64 #-}
+#if MIN_VERSION_random(1,3,0)
+  uniformByteArrayM isPinned k QC =
+    MkGen (\r _n -> runStateGen_ r (uniformByteArrayM isPinned k))
+  {-# INLINE uniformByteArrayM #-}
+#else
   uniformShortByteString k QC =
     MkGen (\r _n -> runStateGen_ r (uniformShortByteString k))
   {-# INLINE uniformShortByteString #-}
+#endif
 
 -- | It is possible to use a hash of a binary representation of any type as a source of
 -- randomness, since hash value by its definiteion is uniformly distributed.

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -237,7 +237,7 @@ library testlib
     plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib},
     primitive,
     quickcheck-transformer,
-    random ^>=1.2,
+    random >=1.2,
     small-steps >=1.1,
     text,
     time,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -188,6 +189,9 @@ import NoThunks.Class (NoThunks (..))
 import Numeric.Natural (Natural)
 import Quiet (Quiet (Quiet))
 import System.Random.Stateful (Random, Uniform (..), UniformRange (..))
+#if MIN_VERSION_random(1,3,0)
+import System.Random.Stateful (isInRangeOrd)
+#endif
 
 maxDecimalsWord64 :: Int
 maxDecimalsWord64 = 19
@@ -874,6 +878,9 @@ instance Uniform CertIx where
 
 instance UniformRange CertIx where
   uniformRM r g = CertIx <$> uniformRM (coerce r) g
+#if MIN_VERSION_random(1,3,0)
+  isInRange = isInRangeOrd
+#endif
 
 -- | Construct a `CertIx` from a 16 bit unsigned integer
 mkCertIx :: Word16 -> CertIx

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -535,7 +535,7 @@ class
   -- | Every era, except Shelley, must be able to upgrade a `Script` from a previous era.
   --
   -- /Warning/ - Important to note that any memoized binary representation will not be
-  -- preserved, you need to retain underlying bytes you can use `translateEraThroughCBOR`
+  -- preserved. If you need to retain underlying bytes then you can use `translateEraThroughCBOR`
   upgradeScript :: EraScript (PreviousEra era) => Script (PreviousEra era) -> Script era
 
   scriptPrefixTag :: Script era -> BS.ByteString

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Language.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Language.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -117,7 +118,7 @@ import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusLedgerApi.V2 as PV2
 import qualified PlutusLedgerApi.V3 as PV3
 import Prettyprinter (Doc, Pretty (..), align, indent, line, vsep, (<+>))
-import System.Random.Stateful (Random, Uniform (..), UniformRange (..), uniformEnumM, uniformEnumRM)
+import System.Random.Stateful
 import qualified UntypedPlutusCore as UPLC
 
 -- | This is a deserialized version of the `Plutus` type that can be used directly with
@@ -239,6 +240,9 @@ instance Uniform Language where
 
 instance UniformRange Language where
   uniformRM = uniformEnumRM
+#if MIN_VERSION_random(1,3,0)
+  isInRange = isInRangeEnum
+#endif
 
 -- | Make a language from its `Enum` index.
 mkLanguageEnum :: Int -> Maybe Language

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/KeyPair.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/KeyPair.hs
@@ -257,11 +257,11 @@ mkBootKeyPairWithSeed = uncurry ByronKeyPair . Byron.deterministicKeyGen . ensur
 
 ensure32ByteSeed :: BS.ByteString -> BS.ByteString
 ensure32ByteSeed inputSeed
-  | BS.length inputSeed /= seedSize =
+  | BS.length inputSeed /= expectedSeedSize =
       hashToBytes $ Hash.hashWith @Hash.Blake2b_256 id inputSeed
   | otherwise = inputSeed
   where
-    seedSize = 32
+    expectedSeedSize = 32
 
 genByronVKeyAddr :: Gen (Byron.VerificationKey, Byron.Address)
 genByronVKeyAddr = do


### PR DESCRIPTION
# Description

This PR bumps up Hackage index-state (since there is a version of cuddle on Hackage that can handle random-1.3) and makes two ledger packages (`cardano-ledger-core` and `cardano-ledger-bianry`) compatible with random-1.3, while keeping compatibility with random-1.2 with some CPP. This is necessary to allow others for a graceful upgrade.

Depends on #5286

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
