### PR TITLE
Add Dijkstra `CddlSpec` 

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -234,7 +234,7 @@ jobs:
 
       SECP_CACHE_VERSION: "2022-12-30"
 
-      packages-with-ruby-cddl-tests: '["cardano-protocol-tpraos", "cardano-ledger-shelley", "cardano-ledger-allegra", "cardano-ledger-mary", "cardano-ledger-alonzo", "cardano-ledger-babbage", "cardano-ledger-conway"]'
+      packages-with-ruby-cddl-tests: '["cardano-protocol-tpraos", "cardano-ledger-shelley", "cardano-ledger-allegra", "cardano-ledger-mary", "cardano-ledger-alonzo", "cardano-ledger-babbage", "cardano-ledger-conway", "cardano-ledger-dijkstra"]'
 
     defaults:
       run:

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -177,6 +177,7 @@ test-suite tests
   hs-source-dirs: test
   other-modules:
     Paths_cardano_ledger_dijkstra
+    Test.Cardano.Ledger.Dijkstra.Binary.CddlSpec
     Test.Cardano.Ledger.Dijkstra.GoldenSpec
 
   default-language: Haskell2010
@@ -194,7 +195,11 @@ test-suite tests
 
   build-depends:
     base,
+    cardano-ledger-allegra,
+    cardano-ledger-alonzo,
     cardano-ledger-babbage:testlib,
+    cardano-ledger-binary:testlib,
+    cardano-ledger-conway,
     cardano-ledger-core:{cardano-ledger-core, testlib},
     cardano-ledger-dijkstra:{cardano-ledger-dijkstra, testlib},
     cardano-ledger-shelley:testlib,

--- a/eras/dijkstra/impl/test/Main.hs
+++ b/eras/dijkstra/impl/test/Main.hs
@@ -9,6 +9,7 @@ import Test.Cardano.Ledger.Babbage.TxInfoSpec (txInfoSpec)
 import qualified Test.Cardano.Ledger.Babbage.TxInfoSpec as BabbageTxInfo
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Dijkstra.Binary.Annotator ()
+import qualified Test.Cardano.Ledger.Dijkstra.Binary.CddlSpec as Cddl
 import Test.Cardano.Ledger.Dijkstra.Binary.RoundTrip ()
 import qualified Test.Cardano.Ledger.Dijkstra.GoldenSpec as GoldenSpec
 import qualified Test.Cardano.Ledger.Dijkstra.Imp as Imp
@@ -19,6 +20,7 @@ main :: IO ()
 main =
   ledgerTestMain $
     describe "Dijkstra" $ do
+      Cddl.spec
       GoldenSpec.spec
       roundTripJsonShelleyEraSpec @DijkstraEra
       describe "Imp" $ do

--- a/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
+++ b/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
@@ -39,18 +39,23 @@ spec = do
     let v = eraProtVerHigh @DijkstraEra
     describe "Ruby-based" $ beforeAllCddlFile 3 readDijkstraCddlFiles $ do
       cddlRoundTripCborSpec @(Value DijkstraEra) v "positive_coin"
-      cddlRoundTripCborSpec @(Value DijkstraEra) v "value"
-      cddlRoundTripAnnCborSpec @(TxBody DijkstraEra) v "transaction_body"
-      cddlRoundTripCborSpec @(TxBody DijkstraEra) v "transaction_body"
-      cddlRoundTripAnnCborSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
-      cddlRoundTripCborSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
+      xdescribe "fix Multiasset" $ do
+        cddlRoundTripCborSpec @(Value DijkstraEra) v "value"
+      xdescribe "fix TxBody" $ do
+        cddlRoundTripAnnCborSpec @(TxBody DijkstraEra) v "transaction_body"
+        cddlRoundTripCborSpec @(TxBody DijkstraEra) v "transaction_body"
+      xdescribe "fix TxAuxData via annotator" $ do
+        cddlRoundTripAnnCborSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
+        cddlRoundTripCborSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
       cddlRoundTripAnnCborSpec @(NativeScript DijkstraEra) v "native_script"
       cddlRoundTripCborSpec @(NativeScript DijkstraEra) v "native_script"
       cddlRoundTripAnnCborSpec @(Data DijkstraEra) v "plutus_data"
       cddlRoundTripCborSpec @(Data DijkstraEra) v "plutus_data"
-      cddlRoundTripCborSpec @(TxOut DijkstraEra) v "transaction_output"
-      cddlRoundTripAnnCborSpec @(Script DijkstraEra) v "script"
-      cddlRoundTripCborSpec @(Script DijkstraEra) v "script"
+      xdescribe "fix TxOut" $ do
+        cddlRoundTripCborSpec @(TxOut DijkstraEra) v "transaction_output"
+      xdescribe "fix Script" $ do
+        cddlRoundTripAnnCborSpec @(Script DijkstraEra) v "script"
+        cddlRoundTripCborSpec @(Script DijkstraEra) v "script"
       cddlRoundTripCborSpec @(Datum DijkstraEra) v "datum_option"
       cddlRoundTripAnnCborSpec @(TxWits DijkstraEra) v "transaction_witness_set"
       cddlRoundTripCborSpec @(TxWits DijkstraEra) v "transaction_witness_set"
@@ -58,46 +63,54 @@ spec = do
       cddlRoundTripCborSpec @CostModels v "cost_models"
       cddlRoundTripAnnCborSpec @(Redeemers DijkstraEra) v "redeemers"
       cddlRoundTripCborSpec @(Redeemers DijkstraEra) v "redeemers"
-      cddlRoundTripAnnCborSpec @(Tx DijkstraEra) v "transaction"
-      cddlRoundTripCborSpec @(Tx DijkstraEra) v "transaction"
+      xdescribe "fix TxBody" $ do
+        cddlRoundTripAnnCborSpec @(Tx DijkstraEra) v "transaction"
+        cddlRoundTripCborSpec @(Tx DijkstraEra) v "transaction"
       cddlRoundTripCborSpec @(VotingProcedure DijkstraEra) v "voting_procedure"
       cddlRoundTripCborSpec @(ProposalProcedure DijkstraEra) v "proposal_procedure"
       cddlRoundTripCborSpec @(GovAction DijkstraEra) v "gov_action"
-      cddlRoundTripCborSpec @(TxCert DijkstraEra) v "certificate"
+      xdescribe "fix TxCert" $ do
+        cddlRoundTripCborSpec @(TxCert DijkstraEra) v "certificate"
       describe "DecCBOR instances equivalence via CDDL" $ do
         cddlDecoderEquivalenceSpec @(TxBody DijkstraEra) v "transaction_body"
-        cddlDecoderEquivalenceSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
+        xdescribe "Fix decoder equivalence of TxAuxData" $ do
+          cddlDecoderEquivalenceSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
         cddlDecoderEquivalenceSpec @(Timelock DijkstraEra) v "native_script"
         cddlDecoderEquivalenceSpec @(Data DijkstraEra) v "plutus_data"
         cddlDecoderEquivalenceSpec @(Script DijkstraEra) v "script"
         cddlDecoderEquivalenceSpec @(TxWits DijkstraEra) v "transaction_witness_set"
         cddlDecoderEquivalenceSpec @(Redeemers DijkstraEra) v "redeemers"
-        cddlDecoderEquivalenceSpec @(Tx DijkstraEra) v "transaction"
+        xdescribe "Fix decoder equivalence of Tx" $ do
+          cddlDecoderEquivalenceSpec @(Tx DijkstraEra) v "transaction"
     describe "Huddle" $ specWithHuddle dijkstraCDDL 100 $ do
       huddleRoundTripCborSpec @(Value DijkstraEra) v "positive_coin"
       huddleRoundTripArbitraryValidate @(Value DijkstraEra) v "value"
-      huddleRoundTripCborSpec @(Value DijkstraEra) v "value"
-      huddleRoundTripAnnCborSpec @(TxBody DijkstraEra) v "transaction_body"
-      huddleRoundTripCborSpec @(TxBody DijkstraEra) v "transaction_body"
+      xdescribe "fix MultiAsset" $ do
+        huddleRoundTripCborSpec @(Value DijkstraEra) v "value"
+      xdescribe "fix TxBody" $ do
+        huddleRoundTripAnnCborSpec @(TxBody DijkstraEra) v "transaction_body"
+        huddleRoundTripCborSpec @(TxBody DijkstraEra) v "transaction_body"
       -- TODO enable this once map/list expansion has been optimized in cuddle
       xdescribe "hangs" $ huddleRoundTripArbitraryValidate @(TxBody DijkstraEra) v "transaction_body"
       huddleRoundTripAnnCborSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
       -- TODO fails because of plutus scripts
       xdescribe "fix plutus scripts" $ do
         huddleRoundTripArbitraryValidate @(TxAuxData DijkstraEra) v "auxiliary_data"
-      huddleRoundTripCborSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
+        huddleRoundTripCborSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
       huddleRoundTripAnnCborSpec @(NativeScript DijkstraEra) v "native_script"
       huddleRoundTripArbitraryValidate @(NativeScript DijkstraEra) v "native_script"
       huddleRoundTripCborSpec @(NativeScript DijkstraEra) v "native_script"
       huddleRoundTripAnnCborSpec @(Data DijkstraEra) v "plutus_data"
       huddleRoundTripArbitraryValidate @(Data DijkstraEra) v "plutus_data"
       huddleRoundTripCborSpec @(Data DijkstraEra) v "plutus_data"
-      huddleRoundTripCborSpec @(TxOut DijkstraEra) v "transaction_output"
+      xdescribe "fix TxOut" $ do
+        huddleRoundTripCborSpec @(TxOut DijkstraEra) v "transaction_output"
       -- TODO fails because of `address`
       xdescribe "fix address" $
         huddleRoundTripArbitraryValidate @(TxOut DijkstraEra) v "transaction_output"
-      huddleRoundTripAnnCborSpec @(Script DijkstraEra) v "script"
-      huddleRoundTripCborSpec @(Script DijkstraEra) v "script"
+      xdescribe "fix Script" $ do
+        huddleRoundTripAnnCborSpec @(Script DijkstraEra) v "script"
+        huddleRoundTripCborSpec @(Script DijkstraEra) v "script"
       -- TODO fails because of `plutus_v1_script`
       xdescribe "fix plutus_v1_script" $ huddleRoundTripArbitraryValidate @(Script DijkstraEra) v "script"
       huddleRoundTripCborSpec @(Datum DijkstraEra) v "datum_option"
@@ -132,13 +145,15 @@ spec = do
       huddleRoundTripCborSpec @(GovAction DijkstraEra) v "gov_action"
       -- TODO enable this once map/list expansion has been optimized in cuddle
       xdescribe "hangs" $ huddleRoundTripArbitraryValidate @(GovAction DijkstraEra) v "gov_action"
-      huddleRoundTripCborSpec @(TxCert DijkstraEra) v "certificate"
+      xdescribe "fix TxCert" $ do
+        huddleRoundTripCborSpec @(TxCert DijkstraEra) v "certificate"
       -- TODO this fails because of the hard-coded `unit_interval` in the CDDL
       xdescribe "fix unit_interval" $
         huddleRoundTripArbitraryValidate @(TxCert DijkstraEra) v "certificate"
       describe "DecCBOR instances equivalence via CDDL" $ do
         huddleDecoderEquivalenceSpec @(TxBody DijkstraEra) v "transaction_body"
-        huddleDecoderEquivalenceSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
+        xdescribe "Fix decoder equivalence of TxAuxData" $ do
+          huddleDecoderEquivalenceSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
         huddleDecoderEquivalenceSpec @(NativeScript DijkstraEra) v "native_script"
         huddleDecoderEquivalenceSpec @(Data DijkstraEra) v "plutus_data"
         huddleDecoderEquivalenceSpec @(Script DijkstraEra) v "script"

--- a/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
+++ b/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
@@ -1,0 +1,147 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Dijkstra.Binary.CddlSpec (spec) where
+
+import Cardano.Ledger.Allegra.Scripts
+import Cardano.Ledger.Alonzo.Scripts (CostModels)
+import Cardano.Ledger.Alonzo.TxWits (Redeemers)
+import Cardano.Ledger.Conway.Governance (GovAction, ProposalProcedure, VotingProcedure)
+import Cardano.Ledger.Core
+import Cardano.Ledger.Dijkstra (DijkstraEra)
+import Cardano.Ledger.Plutus.Data (Data, Datum)
+import Test.Cardano.Ledger.Binary.Cddl (
+  beforeAllCddlFile,
+  cddlDecoderEquivalenceSpec,
+  cddlRoundTripAnnCborSpec,
+  cddlRoundTripCborSpec,
+ )
+import Test.Cardano.Ledger.Binary.Cuddle (
+  huddleDecoderEquivalenceSpec,
+  huddleRoundTripAnnCborSpec,
+  huddleRoundTripArbitraryValidate,
+  huddleRoundTripCborSpec,
+  specWithHuddle,
+ )
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Dijkstra.Arbitrary ()
+import Test.Cardano.Ledger.Dijkstra.Binary.Annotator ()
+import Test.Cardano.Ledger.Dijkstra.Binary.Cddl (readDijkstraCddlFiles)
+import Test.Cardano.Ledger.Dijkstra.CDDL (dijkstraCDDL)
+
+spec :: Spec
+spec = do
+  describe "CDDL" $ do
+    let v = eraProtVerHigh @DijkstraEra
+    describe "Ruby-based" $ beforeAllCddlFile 3 readDijkstraCddlFiles $ do
+      cddlRoundTripCborSpec @(Value DijkstraEra) v "positive_coin"
+      cddlRoundTripCborSpec @(Value DijkstraEra) v "value"
+      cddlRoundTripAnnCborSpec @(TxBody DijkstraEra) v "transaction_body"
+      cddlRoundTripCborSpec @(TxBody DijkstraEra) v "transaction_body"
+      cddlRoundTripAnnCborSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
+      cddlRoundTripCborSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
+      cddlRoundTripAnnCborSpec @(NativeScript DijkstraEra) v "native_script"
+      cddlRoundTripCborSpec @(NativeScript DijkstraEra) v "native_script"
+      cddlRoundTripAnnCborSpec @(Data DijkstraEra) v "plutus_data"
+      cddlRoundTripCborSpec @(Data DijkstraEra) v "plutus_data"
+      cddlRoundTripCborSpec @(TxOut DijkstraEra) v "transaction_output"
+      cddlRoundTripAnnCborSpec @(Script DijkstraEra) v "script"
+      cddlRoundTripCborSpec @(Script DijkstraEra) v "script"
+      cddlRoundTripCborSpec @(Datum DijkstraEra) v "datum_option"
+      cddlRoundTripAnnCborSpec @(TxWits DijkstraEra) v "transaction_witness_set"
+      cddlRoundTripCborSpec @(TxWits DijkstraEra) v "transaction_witness_set"
+      cddlRoundTripCborSpec @(PParamsUpdate DijkstraEra) v "protocol_param_update"
+      cddlRoundTripCborSpec @CostModels v "cost_models"
+      cddlRoundTripAnnCborSpec @(Redeemers DijkstraEra) v "redeemers"
+      cddlRoundTripCborSpec @(Redeemers DijkstraEra) v "redeemers"
+      cddlRoundTripAnnCborSpec @(Tx DijkstraEra) v "transaction"
+      cddlRoundTripCborSpec @(Tx DijkstraEra) v "transaction"
+      cddlRoundTripCborSpec @(VotingProcedure DijkstraEra) v "voting_procedure"
+      cddlRoundTripCborSpec @(ProposalProcedure DijkstraEra) v "proposal_procedure"
+      cddlRoundTripCborSpec @(GovAction DijkstraEra) v "gov_action"
+      cddlRoundTripCborSpec @(TxCert DijkstraEra) v "certificate"
+      describe "DecCBOR instances equivalence via CDDL" $ do
+        cddlDecoderEquivalenceSpec @(TxBody DijkstraEra) v "transaction_body"
+        cddlDecoderEquivalenceSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
+        cddlDecoderEquivalenceSpec @(Timelock DijkstraEra) v "native_script"
+        cddlDecoderEquivalenceSpec @(Data DijkstraEra) v "plutus_data"
+        cddlDecoderEquivalenceSpec @(Script DijkstraEra) v "script"
+        cddlDecoderEquivalenceSpec @(TxWits DijkstraEra) v "transaction_witness_set"
+        cddlDecoderEquivalenceSpec @(Redeemers DijkstraEra) v "redeemers"
+        cddlDecoderEquivalenceSpec @(Tx DijkstraEra) v "transaction"
+    describe "Huddle" $ specWithHuddle dijkstraCDDL 100 $ do
+      huddleRoundTripCborSpec @(Value DijkstraEra) v "positive_coin"
+      huddleRoundTripArbitraryValidate @(Value DijkstraEra) v "value"
+      huddleRoundTripCborSpec @(Value DijkstraEra) v "value"
+      huddleRoundTripAnnCborSpec @(TxBody DijkstraEra) v "transaction_body"
+      huddleRoundTripCborSpec @(TxBody DijkstraEra) v "transaction_body"
+      -- TODO enable this once map/list expansion has been optimized in cuddle
+      xdescribe "hangs" $ huddleRoundTripArbitraryValidate @(TxBody DijkstraEra) v "transaction_body"
+      huddleRoundTripAnnCborSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
+      -- TODO fails because of plutus scripts
+      xdescribe "fix plutus scripts" $ do
+        huddleRoundTripArbitraryValidate @(TxAuxData DijkstraEra) v "auxiliary_data"
+      huddleRoundTripCborSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
+      huddleRoundTripAnnCborSpec @(NativeScript DijkstraEra) v "native_script"
+      huddleRoundTripArbitraryValidate @(NativeScript DijkstraEra) v "native_script"
+      huddleRoundTripCborSpec @(NativeScript DijkstraEra) v "native_script"
+      huddleRoundTripAnnCborSpec @(Data DijkstraEra) v "plutus_data"
+      huddleRoundTripArbitraryValidate @(Data DijkstraEra) v "plutus_data"
+      huddleRoundTripCborSpec @(Data DijkstraEra) v "plutus_data"
+      huddleRoundTripCborSpec @(TxOut DijkstraEra) v "transaction_output"
+      -- TODO fails because of `address`
+      xdescribe "fix address" $
+        huddleRoundTripArbitraryValidate @(TxOut DijkstraEra) v "transaction_output"
+      huddleRoundTripAnnCborSpec @(Script DijkstraEra) v "script"
+      huddleRoundTripCborSpec @(Script DijkstraEra) v "script"
+      -- TODO fails because of `plutus_v1_script`
+      xdescribe "fix plutus_v1_script" $ huddleRoundTripArbitraryValidate @(Script DijkstraEra) v "script"
+      huddleRoundTripCborSpec @(Datum DijkstraEra) v "datum_option"
+      -- TODO NoDatum is encoded as an empty bytestring
+      xdescribe "fix NoDatum" $ huddleRoundTripArbitraryValidate @(Datum DijkstraEra) v "datum_option"
+      huddleRoundTripAnnCborSpec @(TxWits DijkstraEra) v "transaction_witness_set"
+      -- TODO fails because of plutus_v1_script
+      xdescribe "fix plutus_v1_script" $
+        huddleRoundTripArbitraryValidate @(TxWits DijkstraEra) v "transaction_witness_set"
+      huddleRoundTripCborSpec @(TxWits DijkstraEra) v "transaction_witness_set"
+      huddleRoundTripCborSpec @(PParamsUpdate DijkstraEra) v "protocol_param_update"
+      -- TODO enable this once map/list expansion has been optimized in cuddle
+      xdescribe "hangs" $ do
+        huddleRoundTripArbitraryValidate @(PParamsUpdate DijkstraEra) v "protocol_param_update"
+      huddleRoundTripCborSpec @CostModels v "cost_models"
+      huddleRoundTripArbitraryValidate @CostModels v "cost_models"
+      huddleRoundTripAnnCborSpec @(Redeemers DijkstraEra) v "redeemers"
+      -- TODO arbitrary can generate empty redeemers, which is not allowed in the CDDL
+      xdescribe "fix redeemers" $ huddleRoundTripArbitraryValidate @(Redeemers DijkstraEra) v "redeemers"
+      huddleRoundTripCborSpec @(Redeemers DijkstraEra) v "redeemers"
+      xdescribe "fix Transaction" $ do
+        huddleRoundTripAnnCborSpec @(Tx DijkstraEra) v "transaction"
+        huddleRoundTripCborSpec @(Tx DijkstraEra) v "transaction"
+      -- TODO enable this once map/list expansion has been optimized in cuddle
+      xdescribe "hangs" $ huddleRoundTripArbitraryValidate @(Tx DijkstraEra) v "transaction"
+      huddleRoundTripCborSpec @(VotingProcedure DijkstraEra) v "voting_procedure"
+      huddleRoundTripArbitraryValidate @(VotingProcedure DijkstraEra) v "voting_procedure"
+      huddleRoundTripCborSpec @(ProposalProcedure DijkstraEra) v "proposal_procedure"
+      -- TODO This fails because of the hard-coded `reward_account` in the CDDL
+      xdescribe "fix reward_account" $
+        huddleRoundTripArbitraryValidate @(ProposalProcedure DijkstraEra) v "proposal_procedure"
+      huddleRoundTripCborSpec @(GovAction DijkstraEra) v "gov_action"
+      -- TODO enable this once map/list expansion has been optimized in cuddle
+      xdescribe "hangs" $ huddleRoundTripArbitraryValidate @(GovAction DijkstraEra) v "gov_action"
+      huddleRoundTripCborSpec @(TxCert DijkstraEra) v "certificate"
+      -- TODO this fails because of the hard-coded `unit_interval` in the CDDL
+      xdescribe "fix unit_interval" $
+        huddleRoundTripArbitraryValidate @(TxCert DijkstraEra) v "certificate"
+      describe "DecCBOR instances equivalence via CDDL" $ do
+        huddleDecoderEquivalenceSpec @(TxBody DijkstraEra) v "transaction_body"
+        huddleDecoderEquivalenceSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
+        huddleDecoderEquivalenceSpec @(NativeScript DijkstraEra) v "native_script"
+        huddleDecoderEquivalenceSpec @(Data DijkstraEra) v "plutus_data"
+        huddleDecoderEquivalenceSpec @(Script DijkstraEra) v "script"
+        huddleDecoderEquivalenceSpec @(TxWits DijkstraEra) v "transaction_witness_set"
+        huddleDecoderEquivalenceSpec @(Redeemers DijkstraEra) v "redeemers"
+        huddleDecoderEquivalenceSpec @(Tx DijkstraEra) v "transaction"

--- a/flake.nix
+++ b/flake.nix
@@ -188,6 +188,7 @@
                 packages.cardano-ledger-alonzo.components.tests.tests.build-tools = [pkgs.cddl pkgs.cbor-diag];
                 packages.cardano-ledger-babbage.components.tests.tests.build-tools = [pkgs.cddl pkgs.cbor-diag];
                 packages.cardano-ledger-conway.components.tests.tests.build-tools = [pkgs.cddl pkgs.cbor-diag];
+                packages.cardano-ledger-dijkstra.components.tests.tests.build-tools = [pkgs.cddl pkgs.cbor-diag];
                 packages.cardano-protocol-tpraos.components.tests.tests.build-tools = [pkgs.cddl pkgs.cbor-diag];
               })
             ({pkgs, ...}:
@@ -201,6 +202,7 @@
                 packages.cardano-ledger-alonzo.buildable = lib.mkForce false;
                 packages.cardano-ledger-babbage.buildable = lib.mkForce false;
                 packages.cardano-ledger-conway.buildable = lib.mkForce false;
+                packages.cardano-ledger-dijkstra.buildable = lib.mkForce false;
                 packages.cardano-protocol-tpraos.buildable = lib.mkForce false;
               })
           ];


### PR DESCRIPTION
# Description

DijkstraEra is missing `CddlSpec` - the test that is checking the deserialization of our types against the CDDL files.
This PR introduces  this test.
There are many test failures, so I disabled them.  To see which tests are failing only in Dijkstra but not in Conway, have a look at the second commit.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
