### PR TITLE
Enable epoch boundary hook in conformance

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
   subdir: hs
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `*-artifacts` BEFORE MERGE!
-  tag: d44548c8d1d718563175668baed75956d63293b3
+  tag: 61f0683c62adf1efe67f14e11dc0edfe884c348f
 
 source-repository-package
   type: git

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
@@ -604,7 +604,9 @@ proposalsSpec = do
           `shouldReturn` Node (SJust p212) []
         props <- getProposals
         proposalsSize props `shouldBe` 0
-      it "Subtrees are pruned for both enactment and expiry over multiple rounds" $ whenPostBootstrap $ do
+      -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/923
+      -- TODO: Re-enable after issues are resolved, by removing this override
+      disableInConformanceIt "Subtrees are pruned for both enactment and expiry over multiple rounds" $ whenPostBootstrap $ do
         committeeMembers' <- registerInitialCommittee
         (dRep, _, _) <- setupSingleDRep 1_000_000
         modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 4
@@ -790,7 +792,10 @@ votingSpec =
       submitTx_ $ mkBasicTx (mkBasicTxBody & certsTxBodyL .~ [UnRegDRepTxCert dRepCred deposit])
       gasAfterRemoval <- getGovActionState gaId
       gasDRepVotes gasAfterRemoval `shouldBe` []
-    it "expired gov-actions" $ do
+
+    -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/923
+    -- TODO: Re-enable after issues are resolved, by removing this override
+    disableInConformanceIt "expired gov-actions" $ do
       -- Voting for expired actions should fail
       modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
       (drep, _, _) <- setupSingleDRep 1_000_000
@@ -833,7 +838,9 @@ votingSpec =
           ]
     it "committee member mixed with other voters can not vote on UpdateCommittee action" $
       whenPostBootstrap ccVoteOnConstitutionFailsWithMultipleVotes
-    it "CC cannot ratify if below threshold" $ whenPostBootstrap $ do
+    -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/923
+    -- TODO: Re-enable after issues are resolved, by removing this override
+    disableInConformanceIt "CC cannot ratify if below threshold" $ whenPostBootstrap $ do
       modifyPParams $ \pp ->
         pp
           & ppGovActionLifetimeL .~ EpochInterval 3

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -693,7 +693,7 @@ disableImpInitPostEpochBoundaryHook ::
   SpecWith (ImpInit (LedgerSpec era)) ->
   SpecWith (ImpInit (LedgerSpec era))
 disableImpInitPostEpochBoundaryHook =
-  modifyImpInitPostSubmitTxHook $ \_ _ _ -> pure ()
+  modifyImpInitPostEpochBoundaryHook $ \_ _ _ -> pure ()
 
 impLedgerEnv :: EraGov era => NewEpochState era -> ImpTestM era (LedgerEnv era)
 impLedgerEnv nes = do

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -111,6 +111,7 @@ module Test.Cardano.Ledger.Shelley.ImpTest (
   disableImpInitPostSubmitTxHook,
   modifyImpInitPostEpochBoundaryHook,
   disableImpInitPostEpochBoundaryHook,
+  disableInConformanceIt,
   minorFollow,
   majorFollow,
   cantFollow,
@@ -694,6 +695,16 @@ disableImpInitPostEpochBoundaryHook ::
   SpecWith (ImpInit (LedgerSpec era))
 disableImpInitPostEpochBoundaryHook =
   modifyImpInitPostEpochBoundaryHook $ \_ _ _ -> pure ()
+
+disableInConformanceIt ::
+  ShelleyEraImp era =>
+  String ->
+  ImpTestM era () ->
+  SpecWith (ImpInit (LedgerSpec era))
+disableInConformanceIt s =
+  disableImpInitPostSubmitTxHook
+    . disableImpInitPostEpochBoundaryHook
+    . it (s ++ " [disabled in conformance]")
 
 impLedgerEnv :: EraGov era => NewEpochState era -> ImpTestM era (LedgerEnv era)
 impLedgerEnv nes = do

--- a/flake.lock
+++ b/flake.lock
@@ -204,11 +204,11 @@
     "formal-ledger-specifications": {
       "flake": false,
       "locked": {
-        "lastModified": 1757603684,
-        "narHash": "sha256-fT4F/DzZEjc/jkTVhQUge+3K8rZR8evam0janNGp04Q=",
+        "lastModified": 1758124240,
+        "narHash": "sha256-WDOqa3EuAxGhbcJee6WRaHv8haQTH6nsNh5A3mik8ik=",
         "owner": "IntersectMBO",
         "repo": "formal-ledger-specifications",
-        "rev": "d44548c8d1d718563175668baed75956d63293b3",
+        "rev": "61f0683c62adf1efe67f14e11dc0edfe884c348f",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
@@ -144,7 +144,7 @@ submitTxConformanceHook globals trc@(TRC (env, state, signal)) =
               }
         }
 
-_epochBoundaryConformanceHook ::
+epochBoundaryConformanceHook ::
   forall era t.
   ( ShelleyEraImp era
   , ExecSpecRule "NEWEPOCH" era
@@ -155,7 +155,7 @@ _epochBoundaryConformanceHook ::
   TRC (EraRule "NEWEPOCH" era) ->
   State (EraRule "NEWEPOCH" era) ->
   ImpM t ()
-_epochBoundaryConformanceHook globals trc res =
+epochBoundaryConformanceHook globals trc res =
   conformanceHook @"NEWEPOCH" @era globals () trc $ Right (res, [])
 
 spec :: Spec
@@ -163,25 +163,24 @@ spec =
   withImpInit @(LedgerSpec ConwayEra) $
     modifyImpInitProtVer @ConwayEra (natVersion @10) $
       modifyImpInitPostSubmitTxHook submitTxConformanceHook $ do
-        -- TODO enable epoch boundary conformance tests once the specs have been fixed
-        -- modifyImpInitPostEpochBoundaryHook epochBoundaryConformanceHook $ do
-        describe "Basic imp conformance" $ do
-          it "Submit constitution" $ do
-            _ <- submitConstitution @ConwayEra SNothing
-            passNEpochs 2
-          it "Can elect a basic committee" $ do
-            void $ evaluateDeep =<< electBasicCommittee
-        describe "Conway Imp conformance" $ do
-          describe "BBODY" Bbody.spec
-          describe "CERTS" Certs.spec
-          describe "DELEG" Deleg.spec
-          describe "ENACT" Enact.spec
-          xdescribe "EPOCH" Epoch.spec
-          describe "GOV" Gov.spec
-          describe "GOVCERT" GovCert.spec
-          -- LEDGER tests pending on the dRep delegations cleanup in the spec:
-          -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/635
-          xdescribe "LEDGER" Ledger.spec
-          xdescribe "RATIFY" Ratify.spec
-          xdescribe "UTXO" Utxo.spec
-          xdescribe "UTXOS" Utxos.spec
+        modifyImpInitPostEpochBoundaryHook epochBoundaryConformanceHook $ do
+          describe "Basic imp conformance" $ do
+            it "Submit constitution" $ do
+              _ <- submitConstitution @ConwayEra SNothing
+              passNEpochs 2
+            it "Can elect a basic committee" $ do
+              void $ evaluateDeep =<< electBasicCommittee
+          describe "Conway Imp conformance" $ do
+            describe "BBODY" Bbody.spec
+            describe "CERTS" Certs.spec
+            describe "DELEG" Deleg.spec
+            describe "ENACT" Enact.spec
+            xdescribe "EPOCH" Epoch.spec
+            describe "GOV" Gov.spec
+            describe "GOVCERT" GovCert.spec
+            -- LEDGER tests pending on the dRep delegations cleanup in the spec:
+            -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/635
+            xdescribe "LEDGER" Ledger.spec
+            xdescribe "RATIFY" Ratify.spec
+            xdescribe "UTXO" Utxo.spec
+            xdescribe "UTXOS" Utxos.spec


### PR DESCRIPTION
# Description

This PR enables `_epochBoundaryConformanceHook` in conformance testing. 

Enabling the hook causes 7 test failures (against the updated fls), and thus this PR also disables those test selectively. 

To that end it adds a new combinator `disableInConformanceIt` to replace `hspec`'s `it` in those test for which we want to disable conformance testing. For instance:

```haskell
      -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/916
      -- TODO: Re-enable after issue is resolved, by removing this override
      disableInConformanceIt "Delegate vote and undelegate after delegating to some stake pools" $ do
```

In addition, this PR:

1. fixes the implementation of `disableImpInitPostEpochBoundaryHook`
2. updates fls
3. restructures a couple of (conformance failing) test following the aforementioned structure

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
