### PR TITLE
Update crypto-details.tex with kes construction info

### DIFF
--- a/eras/shelley/formal-spec/crypto-details.tex
+++ b/eras/shelley/formal-spec/crypto-details.tex
@@ -40,7 +40,7 @@ use Ed25519. See \cite{rfcEdDSA}.
 The \fun{sign_{ev}} and \fun{verify_{ev}} functions from Figure~\ref{fig:kes-defs-shelley}
 use the iterated sum construction from Section 3.1 of \cite{cryptoeprint:2001:034}.
 We allow up to $2^7$ key evolutions, which is larger than the maximum number
-of evolutions allow by the spec, \MaxKESEvo, which will be set to $90$.
+of evolutions allow by the spec, \MaxKESEvo, which will be set to $62$.
 See Figure~\ref{fig:rules:ocert}.
 The sum construction uses the combination of the signature scheme Ed25519 and
 hash function BLAKE2b-256.

--- a/eras/shelley/formal-spec/crypto-details.tex
+++ b/eras/shelley/formal-spec/crypto-details.tex
@@ -42,6 +42,8 @@ use the iterated sum construction from Section 3.1 of \cite{cryptoeprint:2001:03
 We allow up to $2^7$ key evolutions, which is larger than the maximum number
 of evolutions allow by the spec, \MaxKESEvo, which will be set to $90$.
 See Figure~\ref{fig:rules:ocert}.
+The sum construction uses the combination of the signature scheme Ed25519 and
+hash function BLAKE2b-256.
 
 \subsection{VRF}
 \label{sec:app-vrf}


### PR DESCRIPTION
Hi,

An auditor pointed out that it would be good to add the clarification of which signature scheme and hash function are used in the sum construction of the key evolution scheme (similar to how we do [it](https://github.com/IntersectMBO/cardano-ledger/blob/dc318d971f7e6a3a9e487620903955dd0885e4cc/eras/shelley/formal-spec/crypto-details.tex#L37) for addresses).

As per, for example, [this](https://github.com/IntersectMBO/cardano-ledger/blob/dc318d971f7e6a3a9e487620903955dd0885e4cc/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs#L647) line, we use Ed25519 and the BLAKE2b-256.

And given https://github.com/IntersectMBO/ouroboros-network/pull/2403 I also corrected the `MaxKesEvo` value to match mainnet
```bash
[thomas@nixos:~]$ curl https://book.world.dev.cardano.org/environments/mainnet/shelley-genesis.json | grep KES
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2486  100  2486    0     0  21255      0 --:--:-- --:--:-- --:--:-- 21431
  "slotsPerKESPeriod": 129600,
  "maxKESEvolutions": 62,


```