### PR TITLE
Enable part of the remaining conformance imp tests

### DIFF
--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
@@ -146,7 +146,9 @@ dRepSpec ::
 dRepSpec =
   describe "DRep" $ do
     let submitParamChangeProposal = mkMinFeeUpdateGovAction SNothing >>= submitGovAction_
-    it "expiry is updated based on the number of dormant epochs" $ do
+    -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/923
+    -- TODO: Re-enable after issue is resolved, by removing this override
+    disableInConformanceIt "expiry is updated based on the number of dormant epochs" $ do
       modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
       (drep, _, _) <- setupSingleDRep 1_000_000
 
@@ -183,7 +185,9 @@ dRepSpec =
       passEpoch -- entering epoch 6
       expectNumDormantEpochs 0
       expectDRepExpiry drep $ offDRepActivity 103
-    it "expiry is not updated for inactive DReps" $ do
+    -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/923
+    -- TODO: Re-enable after issue is resolved, by removing this override
+    disableInConformanceIt "expiry is not updated for inactive DReps" $ do
       let
         drepActivity = 2
       modifyPParams $ \pp ->
@@ -232,7 +236,9 @@ dRepSpec =
       passEpoch -- entering epoch 6
       expectNumDormantEpochs 0
       expectDRepExpiry drep $ offDRepActivity 3
-    it "expiry updates are correct for a mixture of cases" $ do
+    -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/926
+    -- TODO: Re-enable after issue is resolved, by removing this override
+    disableInConformanceIt "expiry updates are correct for a mixture of cases" $ do
       let
         drepActivity = 4
       modifyPParams $ \pp ->

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
@@ -102,7 +102,9 @@ spec = do
             .~ Withdrawals
               [(ra, if hardforkConwayBootstrapPhase pv then mempty else balance)]
 
-  it "Withdraw from a key delegated to an unregistered DRep" $ do
+  -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/635
+  -- TODO: Re-enable after issue is resolved, by removing this override
+  disableInConformanceIt "Withdraw from a key delegated to an unregistered DRep" $ do
     modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
     kh <- freshKeyHash
     let cred = KeyHashObj kh
@@ -123,7 +125,9 @@ spec = do
     ifBootstrap (submitTx_ tx >> (getBalance cred `shouldReturn` mempty)) $ do
       submitFailingTx tx [injectFailure $ ConwayWdrlNotDelegatedToDRep [kh]]
 
-  it "Withdraw and unregister staking credential in the same transaction" $ do
+  -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/923
+  -- TODO: Re-enable after issue is resolved, by removing this override
+  disableInConformanceIt "Withdraw and unregister staking credential in the same transaction" $ do
     refund <- getsNES $ nesEsL . curPParamsEpochStateL . ppKeyDepositL
     (_, cred, _) <- setupSingleDRep 1_000_000
     ra <- getRewardAccountFor cred
@@ -171,7 +175,9 @@ spec = do
             .~ Withdrawals
               [(ra, balance)]
 
-  it "Withdraw from a key delegated to a DRep that expired after delegation" $ do
+  -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/635
+  -- TODO: Re-enable after issue is resolved, by removing this override
+  disableInConformanceIt "Withdraw from a key delegated to a DRep that expired after delegation" $ do
     modifyPParams $ \pp ->
       pp
         & ppGovActionLifetimeL .~ EpochInterval 4

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/RatifySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/RatifySpec.hs
@@ -667,7 +667,9 @@ votingSpec =
           passNEpochs 2
           -- The same vote should now successfully ratify the proposal
           getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)
-        it "Rewards contribute to active voting stake even in the absence of StakeDistr" $ whenPostBootstrap $ do
+        -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/926
+        -- TODO: Re-enable after issue is resolved, by removing this override
+        disableInConformanceIt "Rewards contribute to active voting stake even in the absence of StakeDistr" $ whenPostBootstrap $ do
           let govActionLifetime = 5
               govActionDeposit = Coin 1_000_000
               poolDeposit = Coin 858_000
@@ -829,7 +831,9 @@ votingSpec =
           -- AlwaysNoConfidence vote acts like 'Yes' for NoConfidence actions
           calculateDRepAcceptedRatio noConfidenceGovId `shouldReturn` 2 % 2
 
-        it "AlwaysNoConfidence" $ whenPostBootstrap $ do
+        -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/926
+        -- TODO: Re-enable after issue is resolved, by removing this override
+        disableInConformanceIt "AlwaysNoConfidence" $ whenPostBootstrap $ do
           (drep1, _, committeeGovId) <- electBasicCommittee
           initialMembers <- getCommitteeMembers
 
@@ -973,7 +977,9 @@ votingSpec =
           passNEpochs 2
           -- The same vote should now successfully ratify the proposal
           getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)
-        it "Rewards contribute to active voting stake even in the absence of StakeDistr" $
+        -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/926
+        -- TODO: Re-enable after issue is resolved, by removing this override
+        disableInConformanceIt "Rewards contribute to active voting stake even in the absence of StakeDistr" $
           whenPostBootstrap $ do
             let govActionLifetime = 5
                 govActionDeposit = Coin 1_000_000
@@ -1029,7 +1035,9 @@ votingSpec =
             passNEpochs 2
             getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)
         describe "Proposal deposits contribute to active voting stake" $ do
-          it "Directly" $ whenPostBootstrap $ do
+          -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/926
+          -- TODO: Re-enable after issue is resolved, by removing this override
+          disableInConformanceIt "Directly" $ whenPostBootstrap $ do
             -- Only modify the applicable thresholds
             modifyPParams $ \pp ->
               pp
@@ -1079,7 +1087,9 @@ votingSpec =
             passNEpochs 2
             -- The same vote should now successfully ratify the proposal
             getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)
-          it "After switching delegations" $ whenPostBootstrap $ do
+          -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/926
+          -- TODO: Re-enable after issue is resolved, by removing this override
+          disableInConformanceIt "After switching delegations" $ whenPostBootstrap $ do
             -- Only modify the applicable thresholds
             modifyPParams $ \pp ->
               pp
@@ -1533,7 +1543,9 @@ delayingActionsSpec =
         getLastEnactedParameterChange `shouldReturn` SJust (GovPurposeId pGai2)
         getParameterChangeProposals `shouldReturn` Map.empty
     describe "An action expires when delayed enough even after being ratified" $ do
-      it "Same lineage" $ whenPostBootstrap $ do
+      -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/923
+      -- TODO: Re-enable after issue is resolved, by removing this override
+      disableInConformanceIt "Same lineage" $ whenPostBootstrap $ do
         committeeMembers' <- registerInitialCommittee
         (dRep, _, _) <- setupSingleDRep 1_000_000
         modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
@@ -1558,7 +1570,9 @@ delayingActionsSpec =
         getConstitutionProposals `shouldReturn` Map.empty
         passEpoch
         getLastEnactedConstitution `shouldReturn` SJust (GovPurposeId gai2)
-      it "Other lineage" $ whenPostBootstrap $ do
+      -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/923
+      -- TODO: Re-enable after issue is resolved, by removing this override
+      disableInConformanceIt "Other lineage" $ whenPostBootstrap $ do
         committeeMembers' <- registerInitialCommittee
         (dRep, _, _) <- setupSingleDRep 1_000_000
         modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxoSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxoSpec.hs
@@ -55,7 +55,9 @@ spec ::
   SpecWith (ImpInit (LedgerSpec era))
 spec = do
   describe "Certificates" $ do
-    it "Reg/UnReg collect and refund correct amounts" $ do
+    -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/926
+    -- TODO: Re-enable after issues are resolved, by removing this override
+    disableInConformanceIt "Reg/UnReg collect and refund correct amounts" $ do
       utxoStart <- getUTxO
       accountDeposit <- getsPParams ppKeyDepositL
       stakePoolDeposit <- getsPParams ppPoolDepositL

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Epoch.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Epoch.hs
@@ -15,4 +15,4 @@ import Test.Cardano.Ledger.Conway.ImpTest ()
 instance ExecSpecRule "EPOCH" ConwayEra where
   type ExecContext "EPOCH" ConwayEra = [GovActionState ConwayEra]
 
-  runAgdaRule (SpecTRC env st sig) = fmap fst . unComputationResult_ $ Agda.epochStep env st sig
+  runAgdaRuleWithDebug (SpecTRC env st sig) = unComputationResult_ $ Agda.epochStep env st sig

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/NewEpoch.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/NewEpoch.hs
@@ -12,4 +12,4 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway ()
 import Test.Cardano.Ledger.Conway.ImpTest ()
 
 instance ExecSpecRule "NEWEPOCH" ConwayEra where
-  runAgdaRule (SpecTRC env st sig) = fmap fst . unComputationResult_ $ Agda.newEpochStep env st sig
+  runAgdaRuleWithDebug (SpecTRC env st sig) = unComputationResult_ $ Agda.newEpochStep env st sig

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -133,6 +134,13 @@ class
     HasCallStack =>
     SpecTRC rule era ->
     Either Text (SpecState rule era)
+  runAgdaRule = fmap fst . runAgdaRuleWithDebug
+
+  runAgdaRuleWithDebug ::
+    HasCallStack =>
+    SpecTRC rule era ->
+    Either Text (SpecState rule era, Text)
+  runAgdaRuleWithDebug = fmap (,"") . runAgdaRule
 
   translateInputs ::
     HasCallStack =>

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
@@ -178,9 +178,7 @@ spec =
             describe "EPOCH" Epoch.spec
             describe "GOV" Gov.spec
             describe "GOVCERT" GovCert.spec
-            -- LEDGER tests pending on the dRep delegations cleanup in the spec:
-            -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/635
-            xdescribe "LEDGER" Ledger.spec
+            describe "LEDGER" Ledger.spec
             describe "RATIFY" Ratify.spec
             xdescribe "UTXO" Utxo.spec
             xdescribe "UTXOS" Utxos.spec

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
@@ -175,7 +175,7 @@ spec =
             describe "CERTS" Certs.spec
             describe "DELEG" Deleg.spec
             describe "ENACT" Enact.spec
-            xdescribe "EPOCH" Epoch.spec
+            describe "EPOCH" Epoch.spec
             describe "GOV" Gov.spec
             describe "GOVCERT" GovCert.spec
             -- LEDGER tests pending on the dRep delegations cleanup in the spec:

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
@@ -181,6 +181,6 @@ spec =
             -- LEDGER tests pending on the dRep delegations cleanup in the spec:
             -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/635
             xdescribe "LEDGER" Ledger.spec
-            xdescribe "RATIFY" Ratify.spec
+            describe "RATIFY" Ratify.spec
             xdescribe "UTXO" Utxo.spec
             xdescribe "UTXOS" Utxos.spec

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp.hs
@@ -180,5 +180,5 @@ spec =
             describe "GOVCERT" GovCert.spec
             describe "LEDGER" Ledger.spec
             describe "RATIFY" Ratify.spec
-            xdescribe "UTXO" Utxo.spec
+            describe "UTXO" Utxo.spec
             xdescribe "UTXOS" Utxos.spec


### PR DESCRIPTION
# Description

This PR 
- enables the Imp tests in conformance for EPOCH, LEDGER, UTXO and RATIFY and disables the failing tests selectively. It does not enable UTXOS as it has too many failing tests.
- Adds a new method to `SpecExecRule` to bring debugging info from the Agda side to Haskell.
- Adds a section to contributing about conformance testing

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
