### PR TITLE
Any era lenses

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -489,7 +489,7 @@ rdmrsAlonzoTxWitsL =
     \witsRaw rdmrsWits -> witsRaw {atwrRdmrsTxWits = rdmrsWits}
 {-# INLINEABLE rdmrsAlonzoTxWitsL #-}
 
-instance EraScript AlonzoEra => EraTxWits AlonzoEra where
+instance EraTxWits AlonzoEra where
   type TxWits AlonzoEra = AlonzoTxWits AlonzoEra
 
   mkBasicTxWits = mempty
@@ -508,7 +508,7 @@ class (EraTxWits era, AlonzoEraScript era) => AlonzoEraTxWits era where
 
   rdmrsTxWitsL :: Lens' (TxWits era) (Redeemers era)
 
-instance EraScript AlonzoEra => AlonzoEraTxWits AlonzoEra where
+instance AlonzoEraTxWits AlonzoEra where
   datsTxWitsL = datsAlonzoTxWitsL
   {-# INLINE datsTxWitsL #-}
 

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,12 +2,11 @@
 
 ## 1.12.1.0
 
+* Add `mkCollateralTxIn`
+
 ### `testlib`
 
 * Add `BabbageEraImp`
-
-### `testlib`
-
 * Removed `babbageEraSpecificSpec`
 
 ## 1.12.0.0

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Add `AnyEraScript`
 * Add `AnyEraSpendingPurpose`, `AnyEraMintingPurpose`, `AnyEraCertifyingPurpose`, `AnyEraRewardingPurpose`, `AnyEraVotingPurpose`, `AnyEraProposingPurpose`, `AnyEraGuardingPurpose` patterns
 * Re-export `DijkstraEraScript`, `toGuardingPurpose` and `GuardingPurpose` pattern
+* Add `AnyEraTxBody`
+* Add `ttlToValidityInterval`
+* Re-export `DijkstraEraTxBody`, `guardsTxBodyL`
 * Add `AnyEraTxCert`
 * Add `AnyEraTxWits`
 * Add `AnyEraTxOut` and `AnyEraTxAuxData`

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `AnyEraScript`
 * Add `AnyEraSpendingPurpose`, `AnyEraMintingPurpose`, `AnyEraCertifyingPurpose`, `AnyEraRewardingPurpose`, `AnyEraVotingPurpose`, `AnyEraProposingPurpose`, `AnyEraGuardingPurpose` patterns
 * Re-export `DijkstraEraScript`, `toGuardingPurpose` and `GuardingPurpose` pattern
+* Add `AnyEraTxCert`
 * Add `AnyEraTxWits`
 * Add `AnyEraTxOut` and `AnyEraTxAuxData`
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.0.0
 
+* Add `AnyEraTxWits`
 * Add `AnyEraTxOut` and `AnyEraTxAuxData`
 
 ### `testlib`

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.13.0.0
 
+* Add `AnyEraScript`
+* Add `AnyEraSpendingPurpose`, `AnyEraMintingPurpose`, `AnyEraCertifyingPurpose`, `AnyEraRewardingPurpose`, `AnyEraVotingPurpose`, `AnyEraProposingPurpose`, `AnyEraGuardingPurpose` patterns
+* Re-export `DijkstraEraScript`, `toGuardingPurpose` and `GuardingPurpose` pattern
 * Add `AnyEraTxWits`
 * Add `AnyEraTxOut` and `AnyEraTxAuxData`
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `AnyEraScript`
 * Add `AnyEraSpendingPurpose`, `AnyEraMintingPurpose`, `AnyEraCertifyingPurpose`, `AnyEraRewardingPurpose`, `AnyEraVotingPurpose`, `AnyEraProposingPurpose`, `AnyEraGuardingPurpose` patterns
 * Re-export `DijkstraEraScript`, `toGuardingPurpose` and `GuardingPurpose` pattern
+* Add `producedTxOuts` and `mkCollateralTxIn`
 * Add `AnyEraTx`
 * Add `AnyEraTxBody`
 * Add `ttlToValidityInterval`

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.13.0.0
 
-*
+* Add `AnyEraTxOut` and `AnyEraTxAuxData`
 
 ### `testlib`
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `AnyEraScript`
 * Add `AnyEraSpendingPurpose`, `AnyEraMintingPurpose`, `AnyEraCertifyingPurpose`, `AnyEraRewardingPurpose`, `AnyEraVotingPurpose`, `AnyEraProposingPurpose`, `AnyEraGuardingPurpose` patterns
 * Re-export `DijkstraEraScript`, `toGuardingPurpose` and `GuardingPurpose` pattern
+* Add `AnyEraTx`
 * Add `AnyEraTxBody`
 * Add `ttlToValidityInterval`
 * Re-export `DijkstraEraTxBody`, `guardsTxBodyL`

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -62,7 +62,7 @@ library
     cardano-data,
     cardano-ledger-allegra ^>=1.9,
     cardano-ledger-alonzo >=1.12,
-    cardano-ledger-babbage >=1.11,
+    cardano-ledger-babbage >=1.12.1,
     cardano-ledger-binary >=1.4,
     cardano-ledger-conway >=1.19,
     cardano-ledger-core:{cardano-ledger-core, internal} >=1.17,

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Era.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Era.hs
@@ -29,6 +29,7 @@ module Cardano.Ledger.Api.Era (
 
   -- ** Shelley
   ShelleyEra,
+  ttlToValidityInterval,
 
   -- ** Allegra
   AllegraEra,
@@ -262,9 +263,6 @@ instance EraApi AllegraEra where
         , Allegra.atbUpdate = upgradeUpdate () <$> (txBody ^. updateTxBodyL)
         , Allegra.atbAuxDataHash = txBody ^. auxDataHashTxBodyL
         }
-    where
-      ttlToValidityInterval :: SlotNo -> ValidityInterval
-      ttlToValidityInterval ttl = ValidityInterval SNothing (SJust ttl)
 
   upgradeTxAuxData (ShelleyTxAuxData md) = AllegraTxAuxData md mempty
 
@@ -275,6 +273,9 @@ instance EraApi AllegraEra where
       (bootWits stw)
 
   upgradeNativeScript = upgradeMultiSig
+
+ttlToValidityInterval :: SlotNo -> ValidityInterval
+ttlToValidityInterval ttl = ValidityInterval SNothing (SJust ttl)
 
 instance EraApi MaryEra where
   upgradeTx (MkAllegraTx (ShelleyTx txb txwits txAux)) =

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts.hs
@@ -1,4 +1,11 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Cardano.Ledger.Api.Scripts (
   module Cardano.Ledger.Api.Scripts.Data,
@@ -11,6 +18,16 @@ module Cardano.Ledger.Api.Scripts (
   validateNativeScript,
   isNativeScript,
   ValidityInterval (..),
+
+  -- * Any era
+  AnyEraScript (..),
+  pattern AnyEraSpendingPurpose,
+  pattern AnyEraMintingPurpose,
+  pattern AnyEraCertifyingPurpose,
+  pattern AnyEraRewardingPurpose,
+  pattern AnyEraVotingPurpose,
+  pattern AnyEraProposingPurpose,
+  pattern AnyEraGuardingPurpose,
 
   -- * Alonzo
   AlonzoEraScript (
@@ -35,8 +52,15 @@ module Cardano.Ledger.Api.Scripts (
   ),
   pattern VotingPurpose,
   pattern ProposingPurpose,
+
+  -- * Dijkstra
+  DijkstraEraScript (
+    toGuardingPurpose
+  ),
+  pattern GuardingPurpose,
 ) where
 
+import Cardano.Ledger.Address (RewardAccount)
 import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
 import Cardano.Ledger.Alonzo.Scripts (
   AlonzoEraScript (..),
@@ -47,12 +71,159 @@ import Cardano.Ledger.Alonzo.Scripts (
   pattern RewardingPurpose,
   pattern SpendingPurpose,
  )
-import Cardano.Ledger.Api.Era ()
+import Cardano.Ledger.Api.Era
 import Cardano.Ledger.Api.Scripts.Data
+import Cardano.Ledger.Conway.Governance (ProposalProcedure, Voter)
 import Cardano.Ledger.Conway.Scripts (
   ConwayEraScript (..),
   pattern ProposingPurpose,
   pattern VotingPurpose,
  )
-import Cardano.Ledger.Core (EraScript (..), hashScript, isNativeScript, validateNativeScript)
+import Cardano.Ledger.Core (
+  EraScript (..),
+  TxCert,
+  hashScript,
+  isNativeScript,
+  validateNativeScript,
+ )
+import Cardano.Ledger.Dijkstra.Scripts (
+  DijkstraEraScript (..),
+  pattern GuardingPurpose,
+ )
 import Cardano.Ledger.Hashes (ScriptHash)
+import Cardano.Ledger.Mary.Value (PolicyID)
+import Cardano.Ledger.Plutus (Language)
+import Cardano.Ledger.TxIn (TxIn)
+import Data.Word (Word32)
+
+class EraScript era => AnyEraScript era where
+  anyEraMaxLanguage :: Maybe Language
+  default anyEraMaxLanguage ::
+    AlonzoEraScript era => Maybe Language
+  anyEraMaxLanguage = Just (eraMaxLanguage @era)
+
+  anyEraToPlutusScript :: Script era -> Maybe (PlutusScript era)
+  default anyEraToPlutusScript ::
+    AlonzoEraScript era => Script era -> Maybe (PlutusScript era)
+  anyEraToPlutusScript = toPlutusScript
+
+  anyEraToSpendingPurpose :: PlutusPurpose f era -> Maybe (f Word32 TxIn)
+  default anyEraToSpendingPurpose ::
+    AlonzoEraScript era => PlutusPurpose f era -> Maybe (f Word32 TxIn)
+  anyEraToSpendingPurpose = toSpendingPurpose
+
+  anyEraToMintingPurpose :: PlutusPurpose f era -> Maybe (f Word32 PolicyID)
+  default anyEraToMintingPurpose ::
+    AlonzoEraScript era => PlutusPurpose f era -> Maybe (f Word32 PolicyID)
+  anyEraToMintingPurpose = toMintingPurpose
+
+  anyEraToCertifyingPurpose :: PlutusPurpose f era -> Maybe (f Word32 (TxCert era))
+  default anyEraToCertifyingPurpose ::
+    AlonzoEraScript era => PlutusPurpose f era -> Maybe (f Word32 (TxCert era))
+  anyEraToCertifyingPurpose = toCertifyingPurpose
+
+  anyEraToRewardingPurpose :: PlutusPurpose f era -> Maybe (f Word32 RewardAccount)
+  default anyEraToRewardingPurpose ::
+    AlonzoEraScript era => PlutusPurpose f era -> Maybe (f Word32 RewardAccount)
+  anyEraToRewardingPurpose = toRewardingPurpose
+
+  anyEraToVotingPurpose :: PlutusPurpose f era -> Maybe (f Word32 Voter)
+  default anyEraToVotingPurpose ::
+    ConwayEraScript era => PlutusPurpose f era -> Maybe (f Word32 Voter)
+  anyEraToVotingPurpose = toVotingPurpose
+
+  anyEraToProposingPurpose :: PlutusPurpose f era -> Maybe (f Word32 (ProposalProcedure era))
+  default anyEraToProposingPurpose ::
+    ConwayEraScript era => PlutusPurpose f era -> Maybe (f Word32 (ProposalProcedure era))
+  anyEraToProposingPurpose = toProposingPurpose
+
+  anyEraToGuardingPurpose :: PlutusPurpose f era -> Maybe (f Word32 ScriptHash)
+  default anyEraToGuardingPurpose ::
+    DijkstraEraScript era => PlutusPurpose f era -> Maybe (f Word32 ScriptHash)
+  anyEraToGuardingPurpose = toGuardingPurpose
+
+instance AnyEraScript ShelleyEra where
+  anyEraMaxLanguage = Nothing
+  anyEraToPlutusScript = const Nothing
+  anyEraToSpendingPurpose = const Nothing
+  anyEraToMintingPurpose = const Nothing
+  anyEraToCertifyingPurpose = const Nothing
+  anyEraToRewardingPurpose = const Nothing
+  anyEraToVotingPurpose = const Nothing
+  anyEraToProposingPurpose = const Nothing
+  anyEraToGuardingPurpose = const Nothing
+
+instance AnyEraScript AllegraEra where
+  anyEraMaxLanguage = Nothing
+  anyEraToPlutusScript = const Nothing
+  anyEraToSpendingPurpose = const Nothing
+  anyEraToMintingPurpose = const Nothing
+  anyEraToCertifyingPurpose = const Nothing
+  anyEraToRewardingPurpose = const Nothing
+  anyEraToVotingPurpose = const Nothing
+  anyEraToProposingPurpose = const Nothing
+  anyEraToGuardingPurpose = const Nothing
+
+instance AnyEraScript MaryEra where
+  anyEraMaxLanguage = Nothing
+  anyEraToPlutusScript = const Nothing
+  anyEraToSpendingPurpose = const Nothing
+  anyEraToMintingPurpose = const Nothing
+  anyEraToCertifyingPurpose = const Nothing
+  anyEraToRewardingPurpose = const Nothing
+  anyEraToVotingPurpose = const Nothing
+  anyEraToProposingPurpose = const Nothing
+  anyEraToGuardingPurpose = const Nothing
+
+instance AnyEraScript AlonzoEra where
+  anyEraToVotingPurpose = const Nothing
+  anyEraToProposingPurpose = const Nothing
+  anyEraToGuardingPurpose = const Nothing
+
+instance AnyEraScript BabbageEra where
+  anyEraToVotingPurpose = const Nothing
+  anyEraToProposingPurpose = const Nothing
+  anyEraToGuardingPurpose = const Nothing
+
+instance AnyEraScript ConwayEra where
+  anyEraToGuardingPurpose = const Nothing
+
+instance AnyEraScript DijkstraEra
+
+pattern AnyEraSpendingPurpose ::
+  AnyEraScript era => f Word32 TxIn -> PlutusPurpose f era
+pattern AnyEraSpendingPurpose c <- (anyEraToSpendingPurpose -> Just c)
+
+pattern AnyEraMintingPurpose ::
+  AnyEraScript era => f Word32 PolicyID -> PlutusPurpose f era
+pattern AnyEraMintingPurpose c <- (anyEraToMintingPurpose -> Just c)
+
+pattern AnyEraCertifyingPurpose ::
+  AnyEraScript era => f Word32 (TxCert era) -> PlutusPurpose f era
+pattern AnyEraCertifyingPurpose c <- (anyEraToCertifyingPurpose -> Just c)
+
+pattern AnyEraRewardingPurpose ::
+  AnyEraScript era => f Word32 RewardAccount -> PlutusPurpose f era
+pattern AnyEraRewardingPurpose c <- (anyEraToRewardingPurpose -> Just c)
+
+pattern AnyEraVotingPurpose ::
+  AnyEraScript era => f Word32 Voter -> PlutusPurpose f era
+pattern AnyEraVotingPurpose c <- (anyEraToVotingPurpose -> Just c)
+
+pattern AnyEraProposingPurpose ::
+  AnyEraScript era => f Word32 (ProposalProcedure era) -> PlutusPurpose f era
+pattern AnyEraProposingPurpose c <- (anyEraToProposingPurpose -> Just c)
+
+pattern AnyEraGuardingPurpose ::
+  AnyEraScript era => f Word32 ScriptHash -> PlutusPurpose f era
+pattern AnyEraGuardingPurpose c <- (anyEraToGuardingPurpose -> Just c)
+
+{-# COMPLETE
+  AnyEraSpendingPurpose
+  , AnyEraMintingPurpose
+  , AnyEraCertifyingPurpose
+  , AnyEraRewardingPurpose
+  , AnyEraVotingPurpose
+  , AnyEraProposingPurpose
+  , AnyEraGuardingPurpose
+  #-}

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/AuxData.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/AuxData.hs
@@ -1,9 +1,15 @@
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+
 module Cardano.Ledger.Api.Tx.AuxData (
   EraTxAuxData (TxAuxData),
   mkBasicTxAuxData,
   metadataTxAuxDataL,
   hashTxAuxData,
   validateTxAuxData,
+
+  -- * Any era
+  AnyEraTxAuxData (..),
 
   -- * Shelley
   ShelleyTxAuxData (..),
@@ -17,6 +23,8 @@ module Cardano.Ledger.Api.Tx.AuxData (
   -- * Alonzo
   AlonzoEraTxAuxData,
   plutusScriptsTxAuxDataL,
+  Language (..),
+  PlutusBinary (..),
   AlonzoTxAuxData (..),
   mkAlonzoTxAuxData,
   getAlonzoTxAuxDataScripts,
@@ -33,6 +41,43 @@ import Cardano.Ledger.Alonzo.TxAuxData (
   getAlonzoTxAuxDataScripts,
   mkAlonzoTxAuxData,
  )
-import Cardano.Ledger.Api.Era (EraApi (..))
-import Cardano.Ledger.Core (EraTxAuxData (..), binaryUpgradeTxAuxData, hashTxAuxData)
+import Cardano.Ledger.Api.Era
+import Cardano.Ledger.Core (EraTxAuxData (..), NativeScript, binaryUpgradeTxAuxData, hashTxAuxData)
+import Cardano.Ledger.Plutus.Language (Language (..), PlutusBinary (..))
 import Cardano.Ledger.Shelley.TxAuxData (Metadatum (..), ShelleyTxAuxData (..))
+import Data.List.NonEmpty (NonEmpty)
+import Data.Map (Map)
+import Data.Sequence.Strict (StrictSeq)
+import Lens.Micro
+
+class EraTxAuxData era => AnyEraTxAuxData era where
+  nativeScriptsTxAuxDataG :: SimpleGetter (TxAuxData era) (Maybe (StrictSeq (NativeScript era)))
+  default nativeScriptsTxAuxDataG ::
+    AllegraEraTxAuxData era =>
+    SimpleGetter (TxAuxData era) (Maybe (StrictSeq (NativeScript era)))
+  nativeScriptsTxAuxDataG = nativeScriptsTxAuxDataL . to Just
+
+  plutusScriptsTxAuxDataG ::
+    SimpleGetter (TxAuxData era) (Maybe (Map Language (NonEmpty PlutusBinary)))
+  default plutusScriptsTxAuxDataG ::
+    AlonzoEraTxAuxData era =>
+    SimpleGetter (TxAuxData era) (Maybe (Map Language (NonEmpty PlutusBinary)))
+  plutusScriptsTxAuxDataG = plutusScriptsTxAuxDataL . to Just
+
+instance AnyEraTxAuxData ShelleyEra where
+  nativeScriptsTxAuxDataG = to (const Nothing)
+  plutusScriptsTxAuxDataG = to (const Nothing)
+
+instance AnyEraTxAuxData AllegraEra where
+  plutusScriptsTxAuxDataG = to (const Nothing)
+
+instance AnyEraTxAuxData MaryEra where
+  plutusScriptsTxAuxDataG = to (const Nothing)
+
+instance AnyEraTxAuxData AlonzoEra
+
+instance AnyEraTxAuxData BabbageEra
+
+instance AnyEraTxAuxData ConwayEra
+
+instance AnyEraTxAuxData DijkstraEra

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Cert.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Cert.hs
@@ -323,8 +323,6 @@ instance AnyEraTxCert BabbageEra where
 instance AnyEraTxCert ConwayEra where
   anyEraToRegTxCert = getRegTxCert
   anyEraToUnRegTxCert = getUnRegTxCert
-  anyEraToGenesisDelegTxCert = const Nothing
-  anyEraToMirTxCert = const Nothing
 
 instance AnyEraTxCert DijkstraEra
 

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Cert.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Cert.hs
@@ -1,16 +1,43 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Cardano.Ledger.Api.Tx.Cert (
-  EraTxCert (TxCert, TxCertUpgradeError),
+  EraTxCert (
+    TxCert,
+    TxCertUpgradeError,
+    getRegPoolTxCert,
+    getRetirePoolTxCert,
+    lookupRegStakeTxCert,
+    lookupUnRegStakeTxCert
+  ),
   upgradeTxCert,
   getVKeyWitnessTxCert,
   getScriptWitnessTxCert,
   pattern RegPoolTxCert,
   pattern RetirePoolTxCert,
-  lookupRegStakeTxCert,
-  lookupUnRegStakeTxCert,
   isRegStakeTxCert,
   isUnRegStakeTxCert,
+
+  -- * Any Era
+  AnyEraTxCert (..),
+  pattern AnyEraRegPoolTxCert,
+  pattern AnyEraRetirePoolTxCert,
+  pattern AnyEraRegTxCert,
+  pattern AnyEraUnRegTxCert,
+  pattern AnyEraMirTxCert,
+  pattern AnyEraGenesisDelegTxCert,
+  pattern AnyEraRegDepositTxCert,
+  pattern AnyEraUnRegDepositTxCert,
+  pattern AnyEraDelegTxCert,
+  pattern AnyEraRegDepositDelegTxCert,
+  pattern AnyEraAuthCommitteeHotKeyTxCert,
+  pattern AnyEraResignCommitteeColdTxCert,
+  pattern AnyEraRegDRepTxCert,
+  pattern AnyEraUnRegDRepTxCert,
+  pattern AnyEraUpdateDRepTxCert,
 
   -- * Shelley Era
 
@@ -26,7 +53,13 @@ module Cardano.Ledger.Api.Tx.Cert (
   --   `MirTxCert`
   --   `GenesisDelegTxCert`
   -- @
-  ShelleyEraTxCert,
+  ShelleyEraTxCert (
+    getRegTxCert,
+    getUnRegTxCert,
+    getDelegStakeTxCert,
+    getGenesisDelegTxCert,
+    getMirTxCert
+  ),
   pattern MirTxCert,
   pattern GenesisDelegTxCert,
   pattern RegTxCert,
@@ -52,7 +85,16 @@ module Cardano.Ledger.Api.Tx.Cert (
   --   `RegDRepTxCert`
   --   `UnRegDRepTxCert`
   -- @
-  ConwayEraTxCert,
+  ConwayEraTxCert (
+    getRegDepositTxCert,
+    getUnRegDepositTxCert,
+    getDelegTxCert,
+    getRegDepositDelegTxCert,
+    getAuthCommitteeHotKeyTxCert,
+    getResignCommitteeColdTxCert,
+    getRegDRepTxCert,
+    getUpdateDRepTxCert
+  ),
   getDelegateeTxCert,
   Delegatee (..),
   getStakePoolDelegatee,
@@ -66,8 +108,21 @@ module Cardano.Ledger.Api.Tx.Cert (
   pattern UnRegDRepTxCert,
 ) where
 
+import Cardano.Ledger.Api.Era
+import Cardano.Ledger.BaseTypes (Anchor, EpochNo, StrictMaybe)
+import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway.TxCert (
-  ConwayEraTxCert,
+  ConwayEraTxCert (
+    getAuthCommitteeHotKeyTxCert,
+    getDelegTxCert,
+    getRegDRepTxCert,
+    getRegDepositDelegTxCert,
+    getRegDepositTxCert,
+    getResignCommitteeColdTxCert,
+    getUnRegDRepTxCert,
+    getUnRegDepositTxCert,
+    getUpdateDRepTxCert
+  ),
   Delegatee (..),
   getDelegateeTxCert,
   getStakePoolDelegatee,
@@ -84,22 +139,297 @@ import Cardano.Ledger.Core (
   EraTxCert (
     TxCert,
     TxCertUpgradeError,
+    getRegPoolTxCert,
+    getRetirePoolTxCert,
     getScriptWitnessTxCert,
     getVKeyWitnessTxCert,
     lookupRegStakeTxCert,
     lookupUnRegStakeTxCert,
     upgradeTxCert
   ),
+  KeyHash,
+  KeyRole (..),
+  KeyRoleVRF (GenDelegVRF),
+  VRFVerKeyHash,
   isRegStakeTxCert,
   isUnRegStakeTxCert,
   pattern RegPoolTxCert,
   pattern RetirePoolTxCert,
  )
+import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Shelley.TxCert (
-  ShelleyEraTxCert,
+  GenesisDelegCert (..),
+  MIRCert,
+  ShelleyEraTxCert (
+    getDelegStakeTxCert,
+    getGenesisDelegTxCert,
+    getMirTxCert,
+    getRegTxCert,
+    getUnRegTxCert
+  ),
   pattern DelegStakeTxCert,
   pattern GenesisDelegTxCert,
   pattern MirTxCert,
   pattern RegTxCert,
   pattern UnRegTxCert,
  )
+import Cardano.Ledger.State (PoolParams)
+
+class EraTxCert era => AnyEraTxCert era where
+  anyEraToRegTxCert :: TxCert era -> Maybe (Credential 'Staking)
+  anyEraToRegTxCert = const Nothing
+
+  anyEraToUnRegTxCert :: TxCert era -> Maybe (Credential 'Staking)
+  anyEraToUnRegTxCert = const Nothing
+
+  anyEraToGenesisDelegTxCert :: TxCert era -> Maybe GenesisDelegCert
+  anyEraToGenesisDelegTxCert = const Nothing
+
+  anyEraToMirTxCert :: TxCert era -> Maybe MIRCert
+  anyEraToMirTxCert = const Nothing
+
+  anyEraToRegDepositTxCert :: TxCert era -> Maybe (Credential 'Staking, Coin)
+  default anyEraToRegDepositTxCert ::
+    ConwayEraTxCert era => TxCert era -> Maybe (Credential 'Staking, Coin)
+  anyEraToRegDepositTxCert = getRegDepositTxCert
+
+  anyEraToUnRegDepositTxCert :: TxCert era -> Maybe (Credential 'Staking, Coin)
+  default anyEraToUnRegDepositTxCert ::
+    ConwayEraTxCert era => TxCert era -> Maybe (Credential 'Staking, Coin)
+  anyEraToUnRegDepositTxCert = getUnRegDepositTxCert
+
+  anyEraToDelegTxCert :: TxCert era -> Maybe (Credential 'Staking, Delegatee)
+  default anyEraToDelegTxCert ::
+    ConwayEraTxCert era => TxCert era -> Maybe (Credential 'Staking, Delegatee)
+  anyEraToDelegTxCert = getDelegTxCert
+
+  anyEraToRegDepositDelegTxCert :: TxCert era -> Maybe (Credential 'Staking, Delegatee, Coin)
+  default anyEraToRegDepositDelegTxCert ::
+    ConwayEraTxCert era => TxCert era -> Maybe (Credential 'Staking, Delegatee, Coin)
+  anyEraToRegDepositDelegTxCert = getRegDepositDelegTxCert
+
+  anyEraToAuthCommitteeHotKeyTxCert ::
+    TxCert era -> Maybe (Credential 'ColdCommitteeRole, Credential 'HotCommitteeRole)
+  default anyEraToAuthCommitteeHotKeyTxCert ::
+    ConwayEraTxCert era =>
+    TxCert era ->
+    Maybe (Credential 'ColdCommitteeRole, Credential 'HotCommitteeRole)
+  anyEraToAuthCommitteeHotKeyTxCert = getAuthCommitteeHotKeyTxCert
+
+  anyEraToResignCommitteeColdTxCert ::
+    TxCert era -> Maybe (Credential 'ColdCommitteeRole, StrictMaybe Anchor)
+  default anyEraToResignCommitteeColdTxCert ::
+    ConwayEraTxCert era =>
+    TxCert era ->
+    Maybe (Credential 'ColdCommitteeRole, StrictMaybe Anchor)
+  anyEraToResignCommitteeColdTxCert = getResignCommitteeColdTxCert
+
+  anyEraToRegDRepTxCert ::
+    TxCert era -> Maybe (Credential 'DRepRole, Coin, StrictMaybe Anchor)
+  default anyEraToRegDRepTxCert ::
+    ConwayEraTxCert era =>
+    TxCert era ->
+    Maybe (Credential 'DRepRole, Coin, StrictMaybe Anchor)
+  anyEraToRegDRepTxCert = getRegDRepTxCert
+
+  anyEraToUnRegDRepTxCert :: TxCert era -> Maybe (Credential 'DRepRole, Coin)
+  default anyEraToUnRegDRepTxCert ::
+    ConwayEraTxCert era => TxCert era -> Maybe (Credential 'DRepRole, Coin)
+  anyEraToUnRegDRepTxCert = getUnRegDRepTxCert
+
+  anyEraToUpdateDRepTxCert ::
+    TxCert era -> Maybe (Credential 'DRepRole, StrictMaybe Anchor)
+  default anyEraToUpdateDRepTxCert ::
+    ConwayEraTxCert era =>
+    TxCert era ->
+    Maybe (Credential 'DRepRole, StrictMaybe Anchor)
+  anyEraToUpdateDRepTxCert = getUpdateDRepTxCert
+
+instance AnyEraTxCert ShelleyEra where
+  anyEraToRegTxCert = getRegTxCert
+  anyEraToUnRegTxCert = getUnRegTxCert
+  anyEraToGenesisDelegTxCert = getGenesisDelegTxCert
+  anyEraToMirTxCert = getMirTxCert
+  anyEraToRegDepositTxCert = const Nothing
+  anyEraToUnRegDepositTxCert = const Nothing
+  anyEraToDelegTxCert = const Nothing
+  anyEraToRegDepositDelegTxCert = const Nothing
+  anyEraToAuthCommitteeHotKeyTxCert = const Nothing
+  anyEraToResignCommitteeColdTxCert = const Nothing
+  anyEraToRegDRepTxCert = const Nothing
+  anyEraToUnRegDRepTxCert = const Nothing
+  anyEraToUpdateDRepTxCert = const Nothing
+
+instance AnyEraTxCert AllegraEra where
+  anyEraToRegTxCert = getRegTxCert
+  anyEraToUnRegTxCert = getUnRegTxCert
+  anyEraToGenesisDelegTxCert = getGenesisDelegTxCert
+  anyEraToMirTxCert = getMirTxCert
+  anyEraToRegDepositTxCert = const Nothing
+  anyEraToUnRegDepositTxCert = const Nothing
+  anyEraToDelegTxCert = const Nothing
+  anyEraToRegDepositDelegTxCert = const Nothing
+  anyEraToAuthCommitteeHotKeyTxCert = const Nothing
+  anyEraToResignCommitteeColdTxCert = const Nothing
+  anyEraToRegDRepTxCert = const Nothing
+  anyEraToUnRegDRepTxCert = const Nothing
+  anyEraToUpdateDRepTxCert = const Nothing
+
+instance AnyEraTxCert MaryEra where
+  anyEraToRegTxCert = getRegTxCert
+  anyEraToUnRegTxCert = getUnRegTxCert
+  anyEraToGenesisDelegTxCert = getGenesisDelegTxCert
+  anyEraToMirTxCert = getMirTxCert
+  anyEraToRegDepositTxCert = const Nothing
+  anyEraToUnRegDepositTxCert = const Nothing
+  anyEraToDelegTxCert = const Nothing
+  anyEraToRegDepositDelegTxCert = const Nothing
+  anyEraToAuthCommitteeHotKeyTxCert = const Nothing
+  anyEraToResignCommitteeColdTxCert = const Nothing
+  anyEraToRegDRepTxCert = const Nothing
+  anyEraToUnRegDRepTxCert = const Nothing
+  anyEraToUpdateDRepTxCert = const Nothing
+
+instance AnyEraTxCert AlonzoEra where
+  anyEraToRegTxCert = getRegTxCert
+  anyEraToUnRegTxCert = getUnRegTxCert
+  anyEraToGenesisDelegTxCert = getGenesisDelegTxCert
+  anyEraToMirTxCert = getMirTxCert
+  anyEraToRegDepositTxCert = const Nothing
+  anyEraToUnRegDepositTxCert = const Nothing
+  anyEraToDelegTxCert = const Nothing
+  anyEraToRegDepositDelegTxCert = const Nothing
+  anyEraToAuthCommitteeHotKeyTxCert = const Nothing
+  anyEraToResignCommitteeColdTxCert = const Nothing
+  anyEraToRegDRepTxCert = const Nothing
+  anyEraToUnRegDRepTxCert = const Nothing
+  anyEraToUpdateDRepTxCert = const Nothing
+
+instance AnyEraTxCert BabbageEra where
+  anyEraToRegTxCert = getRegTxCert
+  anyEraToUnRegTxCert = getUnRegTxCert
+  anyEraToGenesisDelegTxCert = getGenesisDelegTxCert
+  anyEraToMirTxCert = getMirTxCert
+  anyEraToRegDepositTxCert = const Nothing
+  anyEraToUnRegDepositTxCert = const Nothing
+  anyEraToDelegTxCert = const Nothing
+  anyEraToRegDepositDelegTxCert = const Nothing
+  anyEraToAuthCommitteeHotKeyTxCert = const Nothing
+  anyEraToResignCommitteeColdTxCert = const Nothing
+  anyEraToRegDRepTxCert = const Nothing
+  anyEraToUnRegDRepTxCert = const Nothing
+  anyEraToUpdateDRepTxCert = const Nothing
+
+instance AnyEraTxCert ConwayEra where
+  anyEraToRegTxCert = getRegTxCert
+  anyEraToUnRegTxCert = getUnRegTxCert
+  anyEraToGenesisDelegTxCert = const Nothing
+  anyEraToMirTxCert = const Nothing
+
+instance AnyEraTxCert DijkstraEra
+
+pattern AnyEraRegPoolTxCert :: EraTxCert era => PoolParams -> TxCert era
+pattern AnyEraRegPoolTxCert poolParams = RegPoolTxCert poolParams
+
+pattern AnyEraRetirePoolTxCert ::
+  EraTxCert era => KeyHash 'StakePool -> EpochNo -> TxCert era
+pattern AnyEraRetirePoolTxCert keyHash epochNo = RetirePoolTxCert keyHash epochNo
+
+pattern AnyEraRegTxCert :: AnyEraTxCert era => Credential 'Staking -> TxCert era
+pattern AnyEraRegTxCert c <- (anyEraToRegTxCert -> Just c)
+
+pattern AnyEraUnRegTxCert :: AnyEraTxCert era => Credential 'Staking -> TxCert era
+pattern AnyEraUnRegTxCert c <- (anyEraToUnRegTxCert -> Just c)
+
+pattern AnyEraMirTxCert :: AnyEraTxCert era => MIRCert -> TxCert era
+pattern AnyEraMirTxCert d <- (anyEraToMirTxCert -> Just d)
+
+pattern AnyEraGenesisDelegTxCert ::
+  AnyEraTxCert era =>
+  KeyHash 'Genesis ->
+  KeyHash 'GenesisDelegate ->
+  VRFVerKeyHash 'GenDelegVRF ->
+  TxCert era
+pattern AnyEraGenesisDelegTxCert genKey genDelegKey vrfKeyHash <-
+  (anyEraToGenesisDelegTxCert -> Just (GenesisDelegCert genKey genDelegKey vrfKeyHash))
+
+pattern AnyEraRegDepositTxCert ::
+  AnyEraTxCert era =>
+  Credential 'Staking ->
+  Coin ->
+  TxCert era
+pattern AnyEraRegDepositTxCert cred c <- (anyEraToRegDepositTxCert -> Just (cred, c))
+
+pattern AnyEraUnRegDepositTxCert ::
+  AnyEraTxCert era =>
+  Credential 'Staking ->
+  Coin ->
+  TxCert era
+pattern AnyEraUnRegDepositTxCert cred c <- (anyEraToUnRegDepositTxCert -> Just (cred, c))
+
+pattern AnyEraDelegTxCert ::
+  AnyEraTxCert era =>
+  Credential 'Staking ->
+  Delegatee ->
+  TxCert era
+pattern AnyEraDelegTxCert cred d <- (anyEraToDelegTxCert -> Just (cred, d))
+
+pattern AnyEraRegDepositDelegTxCert ::
+  AnyEraTxCert era =>
+  Credential 'Staking ->
+  Delegatee ->
+  Coin ->
+  TxCert era
+pattern AnyEraRegDepositDelegTxCert cred d c <- (anyEraToRegDepositDelegTxCert -> Just (cred, d, c))
+
+pattern AnyEraAuthCommitteeHotKeyTxCert ::
+  AnyEraTxCert era =>
+  Credential 'ColdCommitteeRole ->
+  Credential 'HotCommitteeRole ->
+  TxCert era
+pattern AnyEraAuthCommitteeHotKeyTxCert ck hk <- (anyEraToAuthCommitteeHotKeyTxCert -> Just (ck, hk))
+
+pattern AnyEraResignCommitteeColdTxCert ::
+  AnyEraTxCert era =>
+  Credential 'ColdCommitteeRole ->
+  StrictMaybe Anchor ->
+  TxCert era
+pattern AnyEraResignCommitteeColdTxCert ck a <- (anyEraToResignCommitteeColdTxCert -> Just (ck, a))
+
+pattern AnyEraRegDRepTxCert ::
+  AnyEraTxCert era =>
+  Credential 'DRepRole ->
+  Coin ->
+  StrictMaybe Anchor ->
+  TxCert era
+pattern AnyEraRegDRepTxCert cred deposit mAnchor <- (anyEraToRegDRepTxCert -> Just (cred, deposit, mAnchor))
+
+pattern AnyEraUnRegDRepTxCert ::
+  AnyEraTxCert era =>
+  Credential 'DRepRole ->
+  Coin ->
+  TxCert era
+pattern AnyEraUnRegDRepTxCert cred deposit <- (anyEraToUnRegDRepTxCert -> Just (cred, deposit))
+
+pattern AnyEraUpdateDRepTxCert ::
+  AnyEraTxCert era =>
+  Credential 'DRepRole ->
+  StrictMaybe Anchor ->
+  TxCert era
+pattern AnyEraUpdateDRepTxCert cred mAnchor <- (anyEraToUpdateDRepTxCert -> Just (cred, mAnchor))
+
+{-# COMPLETE
+  AnyEraRegPoolTxCert
+  , AnyEraRetirePoolTxCert
+  , AnyEraRegTxCert
+  , AnyEraUnRegTxCert
+  , AnyEraRegDepositTxCert
+  , AnyEraUnRegDepositTxCert
+  , AnyEraDelegTxCert
+  , AnyEraRegDepositDelegTxCert
+  , AnyEraAuthCommitteeHotKeyTxCert
+  , AnyEraResignCommitteeColdTxCert
+  , AnyEraRegDRepTxCert
+  , AnyEraUnRegDRepTxCert
+  , AnyEraUpdateDRepTxCert
+  #-}

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/In.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/In.hs
@@ -1,10 +1,11 @@
 module Cardano.Ledger.Api.Tx.In (
   -- * Transaction input
   TxIn (..),
+  mkTxInPartial,
+  mkCollateralTxIn,
 
   -- ** Transaction ID
   TxId (..),
-  mkTxInPartial,
 
   -- ** Transaction index
   TxIx,
@@ -14,6 +15,7 @@ module Cardano.Ledger.Api.Tx.In (
   mkTxIxPartial,
 ) where
 
+import Cardano.Ledger.Babbage.Collateral (mkCollateralTxIn)
 import Cardano.Ledger.BaseTypes (
   TxIx,
   mkTxIx,

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Wits.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Wits.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+
 module Cardano.Ledger.Api.Tx.Wits (
   -- * Shelley onwards
   EraTxWits (TxWits),
@@ -18,6 +21,9 @@ module Cardano.Ledger.Api.Tx.Wits (
   -- ** Script witness
   scriptTxWitsL,
   hashScriptTxWitsL,
+
+  -- * Any era
+  AnyEraTxWits (..),
 
   -- * Alonzo onwards
   AlonzoEraTxWits,
@@ -61,9 +67,40 @@ import Cardano.Ledger.Alonzo.TxWits (
   unTxDats,
   unTxDatsL,
  )
-import Cardano.Ledger.Api.Era (EraApi (..))
+import Cardano.Ledger.Api.Era
+import Cardano.Ledger.Api.Scripts (AnyEraScript)
 import Cardano.Ledger.Conway.Scripts (ConwayPlutusPurpose (..))
 import Cardano.Ledger.Core (EraTxWits (..), binaryUpgradeTxWits, hashScriptTxWitsL)
 import Cardano.Ledger.Keys (KeyRole (Witness))
 import Cardano.Ledger.Keys.Bootstrap (BootstrapWitness)
 import Cardano.Ledger.Keys.WitVKey (WitVKey (WitVKey), witVKeyHash)
+import Lens.Micro
+
+class (EraTxWits era, AnyEraScript era) => AnyEraTxWits era where
+  datsTxWitsG :: SimpleGetter (TxWits era) (Maybe (TxDats era))
+  default datsTxWitsG :: AlonzoEraTxWits era => SimpleGetter (TxWits era) (Maybe (TxDats era))
+  datsTxWitsG = datsTxWitsL . to Just
+
+  rdmrsTxWitsG :: SimpleGetter (TxWits era) (Maybe (Redeemers era))
+  default rdmrsTxWitsG :: AlonzoEraTxWits era => SimpleGetter (TxWits era) (Maybe (Redeemers era))
+  rdmrsTxWitsG = rdmrsTxWitsL . to Just
+
+instance AnyEraTxWits ShelleyEra where
+  datsTxWitsG = to (const Nothing)
+  rdmrsTxWitsG = to (const Nothing)
+
+instance AnyEraTxWits AllegraEra where
+  datsTxWitsG = to (const Nothing)
+  rdmrsTxWitsG = to (const Nothing)
+
+instance AnyEraTxWits MaryEra where
+  datsTxWitsG = to (const Nothing)
+  rdmrsTxWitsG = to (const Nothing)
+
+instance AnyEraTxWits AlonzoEra
+
+instance AnyEraTxWits BabbageEra
+
+instance AnyEraTxWits ConwayEra
+
+instance AnyEraTxWits DijkstraEra


### PR DESCRIPTION
# Description

This PR adds interface for downstream users that allows accessing parts of any transaction starting with ShelleyEra without type system restricting access to features that were not available in earlier eras. In other words whenever features that are not available (eg collateral) will result in `Nothing` being returned instead of a compiler failure.

This interface does not provide modifiers, since those would either have to be partial or ignore value being set. Neither of these options is acceptable, since safety is not an acceptable trade-off.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
