### PR TITLE
Block body fields

### DIFF
--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/BbodySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/BbodySpec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -290,7 +291,7 @@ spec = do
       tryRunImpRule @"BBODY"
         (BbodyEnv pp (nes ^. chainAccountStateL))
         (BbodyState ls (BlocksMade Map.empty))
-        (Block bhView blockBody)
+        (Block {blockHeader = bhView, blockBody})
     isPostV10 protVer = pvMajor protVer >= natVersion @11
 
 -- Generate a list of integers such that the sum of their multiples by scale is greater than toExceed

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Block.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Block.hs
@@ -174,7 +174,7 @@ genBlockWithTxGen
         -- e.g. the KES period in which this key starts to be valid.
         <*> pure (fromIntegral (m * fromIntegral maxKESIterations))
         <*> pure oCert
-    let hView = makeHeaderView (bheader theBlock)
+    let hView = makeHeaderView (blockHeader theBlock)
     unless (bhviewBSize hView <= pp ^. ppMaxBBSizeL) $
       tracedDiscard $
         "genBlockWithTxGen: bhviewBSize too large"

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
@@ -14,10 +14,7 @@ module Test.Cardano.Ledger.Shelley.Rules.AdaPreservation (
 ) where
 
 import Cardano.Ledger.BaseTypes (ShelleyBase, StrictMaybe (..))
-import Cardano.Ledger.Block (
-  Block (..),
-  bbody,
- )
+import Cardano.Ledger.Block (Block (..))
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Credential
 import Cardano.Ledger.Shelley.API (LedgerState)
@@ -175,7 +172,7 @@ checkPreservation ::
   SourceSignalTarget (CHAIN era) ->
   Int ->
   Property
-checkPreservation SourceSignalTarget {source, target, signal} count =
+checkPreservation SourceSignalTarget {source, target, signal = block} count =
   counterexample
     ( mconcat
         ( [ "\ncount = " ++ show count ++ "\n"
@@ -278,7 +275,7 @@ checkPreservation SourceSignalTarget {source, target, signal} count =
                   <> toDeltaCoin (sumRewards prevPP (rs ru))
             ]
 
-    txs' = toList $ bbody signal ^. txSeqBlockBodyL
+    txs' = toList $ blockBody block ^. txSeqBlockBodyL
     txs = zipWith dispTx txs' [0 :: Int ..]
 
     dispTx tx ix =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -20,7 +21,7 @@ module Test.Cardano.Ledger.Shelley.Rules.ClassifyTraces (
 
 import Cardano.Ledger.BaseTypes (Globals, StrictMaybe (..), epochInfoPure)
 import Cardano.Ledger.Binary.Plain as Plain (serialize')
-import Cardano.Ledger.Block (Block (..), bheader)
+import Cardano.Ledger.Block (Block (..))
 import Cardano.Ledger.Shelley.API (
   Addr (..),
   Credential (..),
@@ -136,7 +137,7 @@ relevantCasesAreCoveredForTrace ::
   Property
 relevantCasesAreCoveredForTrace tr = do
   let blockTxs :: Block (BHeader MockCrypto) era -> [Tx era]
-      blockTxs (Block _ blockBody) = toList $ blockBody ^. txSeqBlockBodyL
+      blockTxs Block {blockBody} = toList $ blockBody ^. txSeqBlockBodyL
       bs = traceSignals OldestFirst tr
       txs = concatMap blockTxs bs
       certsByTx_ = certsByTx @era txs
@@ -421,7 +422,7 @@ epochsInTrace bs'
         EpochSize slotsPerEpoch =
           epochInfoSize (epochInfoPure testGlobals) $
             error "Impossible: Fixed epoch size does not care about current epoch number"
-        blockSlot = bheaderSlotNo . bhbody . bheader
+        blockSlot = bheaderSlotNo . bhbody . blockHeader
         atEpoch (SlotNo s) = s `div` slotsPerEpoch
        in
         fromIntegral $ toEpoch - fromEpoch + 1

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/CollisionFreeness.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/CollisionFreeness.hs
@@ -13,7 +13,7 @@ module Test.Cardano.Ledger.Shelley.Rules.CollisionFreeness (
 ) where
 
 import Cardano.Ledger.BaseTypes (ShelleyBase)
-import Cardano.Ledger.Block (bbody)
+import Cardano.Ledger.Block (blockBody)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Keys (witVKeyHash)
 import Cardano.Ledger.Shelley.LedgerState (
@@ -190,11 +190,11 @@ noDoubleSpend ::
   (ChainProperty era, EraGen era) =>
   SourceSignalTarget (CHAIN era) ->
   Property
-noDoubleSpend SourceSignalTarget {signal} =
+noDoubleSpend SourceSignalTarget {signal = block} =
   counterexample "noDoubleSpend" $
     [] === getDoubleInputs txs
   where
-    txs = toList $ bbody signal ^. txSeqBlockBodyL
+    txs = toList $ blockBody block ^. txSeqBlockBodyL
 
     getDoubleInputs :: [Tx era] -> [(Tx era, [Tx era])]
     getDoubleInputs [] = []

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -11,7 +11,7 @@ module Test.Cardano.Ledger.Shelley.Rules.Pool (
 ) where
 
 import Cardano.Ledger.BaseTypes (EpochInterval (..))
-import Cardano.Ledger.Block (bheader)
+import Cardano.Ledger.Block (blockHeader)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.LedgerState (
   NewEpochState (..),
@@ -89,7 +89,7 @@ poolRetirement SourceSignalTarget {source = chainSt, signal = block} =
     map (poolRetirementProp currentEpoch maxEpoch) (sourceSignalTargets poolTr)
   where
     (chainSt', poolTr) = poolTraceFromBlock chainSt block
-    bhb = bhbody $ bheader block
+    bhb = bhbody $ blockHeader block
     currentEpoch = (epochFromSlotNo . bheaderSlotNo) bhb
     maxEpoch = (view ppEMaxL . view curPParamsEpochStateL . nesEs . chainNes) chainSt'
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -25,7 +26,6 @@ module Test.Cardano.Ledger.Shelley.Rules.TestChain (
 import Cardano.Ledger.BaseTypes (Globals, SlotNo (..))
 import Cardano.Ledger.Block (
   Block (..),
-  bheader,
   neededTxInsForBlock,
  )
 import Cardano.Ledger.Core
@@ -252,14 +252,13 @@ ledgerTraceBase ::
   ChainState era ->
   Block (BHeader MockCrypto) era ->
   (ChainState era, LedgerEnv era, LedgerState era, [Tx era])
-ledgerTraceBase chainSt block =
+ledgerTraceBase chainSt Block {blockHeader = BHeader bhb _, blockBody} =
   ( tickedChainSt
   , LedgerEnv slot Nothing minBound pp_ (esChainAccountState nes)
   , esLState nes
   , txs
   )
   where
-    (Block (BHeader bhb _) blockBody) = block
     slot = bheaderSlotNo bhb
     tickedChainSt = tickChainState slot chainSt
     nes = (nesEs . chainNes) tickedChainSt
@@ -287,8 +286,7 @@ chainSstWithTick ledgerTr =
   map applyTick (sourceSignalTargets ledgerTr)
   where
     applyTick sst@SourceSignalTarget {source = chainSt, signal = block} =
-      let bh = bheader block
-          slot = (bheaderSlotNo . bhbody) bh
+      let slot = bheaderSlotNo (bhbody (blockHeader block))
        in sst {target = tickChainState @era slot chainSt}
 
 ---------------------------

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Utils.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Utils.hs
@@ -65,7 +65,7 @@ import Cardano.Ledger.BaseTypes (
   mkNonceFromOutputVRF,
  )
 import Cardano.Ledger.Binary (EncCBOR (..), hashWithEncoder, shelleyProtVer)
-import Cardano.Ledger.Block (Block, bheader)
+import Cardano.Ledger.Block (Block (blockHeader))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Keys (DSIGN, VKey (..))
 import Cardano.Ledger.Shelley.API (ApplyBlock)
@@ -266,4 +266,4 @@ mkHash i = coerce (hashWithEncoder @h shelleyProtVer encCBOR i)
 
 getBlockNonce :: forall era. Block (BHeader MockCrypto) era -> Nonce
 getBlockNonce =
-  mkNonceFromOutputVRF . certifiedOutput . bheaderEta . bhbody . bheader
+  mkNonceFromOutputVRF . certifiedOutput . bheaderEta . bhbody . blockHeader

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/GenesisDelegation.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/GenesisDelegation.hs
@@ -11,7 +11,7 @@ module Test.Cardano.Ledger.Shelley.Examples.GenesisDelegation (
 ) where
 
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
-import Cardano.Ledger.Block (Block, bheader)
+import Cardano.Ledger.Block (Block (blockHeader))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Keys (GenDelegPair (..), asWitness)
 import Cardano.Ledger.Shelley (ShelleyEra, Tx (..), TxBody (..))
@@ -188,7 +188,7 @@ genesisDelegation1 = CHAINExample initStGenesisDeleg blockEx1 (Right expectedStE
 blockEx2 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx2 =
   mkBlockFakeVRF @ShelleyEra
-    (bhHash $ bheader blockEx1)
+    (bhHash $ blockHeader blockEx1)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 50)
     []
     (SlotNo 50)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Mir.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Mir.hs
@@ -11,7 +11,7 @@ module Test.Cardano.Ledger.Shelley.Examples.Mir (
 ) where
 
 import Cardano.Ledger.BaseTypes (Mismatch (..), Nonce, StrictMaybe (..), mkCertIxPartial)
-import Cardano.Ledger.Block (Block, bheader)
+import Cardano.Ledger.Block (Block (blockHeader))
 import Cardano.Ledger.Coin (Coin (..), toDeltaCoin)
 import Cardano.Ledger.Credential (Ptr (..), SlotNo32 (..))
 import Cardano.Ledger.Keys (asWitness)
@@ -233,7 +233,7 @@ mirFailFunds pot treasury llNeeded llReceived =
 blockEx2 :: MIRPot -> Block (BHeader MockCrypto) ShelleyEra
 blockEx2 pot =
   mkBlockFakeVRF
-    (bhHash $ bheader (blockEx1 pot))
+    (bhHash $ blockHeader (blockEx1 pot))
     (coreNodeKeysBySchedule @ShelleyEra ppEx 50)
     []
     (SlotNo 50)
@@ -275,7 +275,7 @@ epoch1Nonce pot = chainCandidateNonce (expectedStEx2 pot)
 blockEx3 :: MIRPot -> Block (BHeader MockCrypto) ShelleyEra
 blockEx3 pot =
   mkBlockFakeVRF
-    (bhHash $ bheader (blockEx2 pot))
+    (bhHash $ blockHeader (blockEx2 pot))
     (coreNodeKeysBySchedule @ShelleyEra ppEx 110)
     []
     (SlotNo 110)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
@@ -27,7 +27,7 @@ import Cardano.Ledger.BaseTypes (
   mkCertIxPartial,
   (⭒),
  )
-import Cardano.Ledger.Block (Block, bheader)
+import Cardano.Ledger.Block (Block (blockHeader))
 import Cardano.Ledger.Coin (
   Coin (..),
   CompactForm (CompactCoin),
@@ -312,7 +312,7 @@ txEx2 =
 blockEx2 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx2 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx1)
+    (bhHash $ blockHeader blockEx1)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 90)
     [MkShelleyTx txEx2]
     (SlotNo 90)
@@ -371,7 +371,7 @@ epoch1Nonce = chainCandidateNonce expectedStEx2
 blockEx3 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx3 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx2)
+    (bhHash $ blockHeader blockEx2)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 110)
     []
     (SlotNo 110)
@@ -453,7 +453,7 @@ txEx4 =
 blockEx4 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx4 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx3)
+    (bhHash $ blockHeader blockEx3)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 190)
     [MkShelleyTx txEx4]
     (SlotNo 190)
@@ -499,7 +499,7 @@ poolLifetime4 = CHAINExample expectedStEx3 blockEx4 (Right (C.solidifyProposals 
 epoch2Nonce :: Nonce
 epoch2Nonce =
   chainCandidateNonce expectedStEx4
-    ⭒ hashHeaderToNonce (bhHash $ bheader blockEx2)
+    ⭒ hashHeaderToNonce (bhHash $ blockHeader blockEx2)
 
 --
 -- Block 5, Slot 220, Epoch 2
@@ -508,7 +508,7 @@ epoch2Nonce =
 blockEx5 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx5 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx4)
+    (bhHash $ blockHeader blockEx4)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 220)
     []
     (SlotNo 220)
@@ -575,7 +575,7 @@ poolLifetime5 = CHAINExample expectedStEx4 blockEx5 (Right expectedStEx5)
 blockEx6 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx6 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx5)
+    (bhHash $ blockHeader blockEx5)
     Cast.alicePoolKeys
     []
     (SlotNo 295) -- odd slots open for decentralization
@@ -622,12 +622,12 @@ poolLifetime6 = CHAINExample expectedStEx5 blockEx6 (Right (C.solidifyProposals 
 epoch3Nonce :: Nonce
 epoch3Nonce =
   chainCandidateNonce expectedStEx6
-    ⭒ hashHeaderToNonce (bhHash $ bheader blockEx4)
+    ⭒ hashHeaderToNonce (bhHash $ blockHeader blockEx4)
 
 blockEx7 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx7 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx6)
+    (bhHash $ blockHeader blockEx6)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 310)
     []
     (SlotNo 310)
@@ -663,7 +663,7 @@ poolLifetime7 = CHAINExample expectedStEx6 blockEx7 (Right expectedStEx7)
 blockEx8 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx8 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx7)
+    (bhHash $ blockHeader blockEx7)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 390)
     []
     (SlotNo 390)
@@ -759,12 +759,12 @@ poolLifetime8 = CHAINExample expectedStEx7 blockEx8 (Right (C.solidifyProposals 
 epoch4Nonce :: Nonce
 epoch4Nonce =
   chainCandidateNonce expectedStEx8
-    ⭒ hashHeaderToNonce (bhHash $ bheader blockEx6)
+    ⭒ hashHeaderToNonce (bhHash $ blockHeader blockEx6)
 
 blockEx9 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx9 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx8)
+    (bhHash $ blockHeader blockEx8)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 410)
     []
     (SlotNo 410)
@@ -842,7 +842,7 @@ txEx10 =
 blockEx10 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx10 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx9)
+    (bhHash $ blockHeader blockEx9)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 420)
     [MkShelleyTx txEx10]
     (SlotNo 420)
@@ -911,7 +911,7 @@ txEx11 =
 blockEx11 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx11 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx10)
+    (bhHash $ blockHeader blockEx10)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 490)
     [MkShelleyTx txEx11]
     (SlotNo 490)
@@ -980,12 +980,12 @@ poolLifetime11 = CHAINExample expectedStEx10 blockEx11 (Right (C.solidifyProposa
 epoch5Nonce :: Nonce
 epoch5Nonce =
   chainCandidateNonce expectedStEx11
-    ⭒ hashHeaderToNonce (bhHash $ bheader blockEx8)
+    ⭒ hashHeaderToNonce (bhHash $ blockHeader blockEx8)
 
 blockEx12 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx12 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx11)
+    (bhHash $ blockHeader blockEx11)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 510)
     []
     (SlotNo 510)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolReReg.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolReReg.hs
@@ -17,7 +17,7 @@ import Cardano.Ledger.BaseTypes (
   Nonce,
   StrictMaybe (..),
  )
-import Cardano.Ledger.Block (Block, bheader)
+import Cardano.Ledger.Block (Block (blockHeader))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Keys (asWitness)
 import Cardano.Ledger.Shelley (ShelleyEra, Tx (..), TxBody (..))
@@ -192,7 +192,7 @@ word64SlotToKesPeriodWord slot =
 blockEx2 :: Word64 -> Block (BHeader MockCrypto) ShelleyEra
 blockEx2 slot =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx1)
+    (bhHash $ blockHeader blockEx1)
     (coreNodeKeysBySchedule @ShelleyEra ppEx slot)
     [MkShelleyTx txEx2]
     (SlotNo slot)
@@ -257,7 +257,7 @@ epoch1Nonce = chainCandidateNonce expectedStEx2B
 blockEx3 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx3 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx2B)
+    (bhHash $ blockHeader blockEx2B)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 110)
     []
     (SlotNo 110)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/TwoPools.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/TwoPools.hs
@@ -30,7 +30,7 @@ import Cardano.Ledger.BaseTypes (
   natVersion,
   (⭒),
  )
-import Cardano.Ledger.Block (Block, bheader)
+import Cardano.Ledger.Block (Block (blockHeader))
 import Cardano.Ledger.Coin (
   Coin (..),
   CompactForm (CompactCoin),
@@ -262,7 +262,7 @@ twoPools1 = CHAINExample initStTwoPools blockEx1 (Right expectedStEx1)
 blockEx2 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx2 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx1)
+    (bhHash $ blockHeader blockEx1)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 90)
     []
     (SlotNo 90)
@@ -297,7 +297,7 @@ epoch1Nonce = chainCandidateNonce expectedStEx2
 blockEx3 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx3 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx2)
+    (bhHash $ blockHeader blockEx2)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 110)
     []
     (SlotNo 110)
@@ -349,7 +349,7 @@ twoPools3 = CHAINExample expectedStEx2 blockEx3 (Right expectedStEx3)
 blockEx4 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx4 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx3)
+    (bhHash $ blockHeader blockEx3)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 190)
     []
     (SlotNo 190)
@@ -391,7 +391,7 @@ twoPools4 = CHAINExample expectedStEx3 blockEx4 (Right expectedStEx4)
 epoch2Nonce :: Nonce
 epoch2Nonce =
   chainCandidateNonce expectedStEx4
-    ⭒ hashHeaderToNonce (bhHash $ bheader blockEx2)
+    ⭒ hashHeaderToNonce (bhHash $ blockHeader blockEx2)
 
 --
 -- Block 5, Slot 221, Epoch 2
@@ -400,7 +400,7 @@ epoch2Nonce =
 blockEx5 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx5 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx4)
+    (bhHash $ blockHeader blockEx4)
     Cast.alicePoolKeys
     []
     (SlotNo 221) -- odd slots open for decentralization
@@ -467,7 +467,7 @@ twoPools5 = CHAINExample expectedStEx4 blockEx5 (Right expectedStEx5)
 blockEx6 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx6 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx5)
+    (bhHash $ blockHeader blockEx5)
     Cast.alicePoolKeys
     []
     (SlotNo 295) -- odd slots open for decentralization
@@ -501,7 +501,7 @@ twoPools6 = CHAINExample expectedStEx5 blockEx6 (Right expectedStEx6)
 blockEx7 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx7 =
   mkBlockFakeVRF
-    (bhHash $ bheader @(BHeader MockCrypto) blockEx6)
+    (bhHash $ blockHeader @(BHeader MockCrypto) blockEx6)
     Cast.bobPoolKeys
     []
     (SlotNo 297) -- odd slots open for decentralization
@@ -534,12 +534,12 @@ twoPools7 = CHAINExample expectedStEx6 blockEx7 (Right expectedStEx7)
 epoch3Nonce :: Nonce
 epoch3Nonce =
   chainCandidateNonce expectedStEx7
-    ⭒ hashHeaderToNonce (bhHash $ bheader blockEx4)
+    ⭒ hashHeaderToNonce (bhHash $ blockHeader blockEx4)
 
 blockEx8 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx8 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx7)
+    (bhHash $ blockHeader blockEx7)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 310)
     []
     (SlotNo 310)
@@ -574,7 +574,7 @@ twoPools8 = CHAINExample expectedStEx7 blockEx8 (Right expectedStEx8)
 blockEx9 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx9 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx8)
+    (bhHash $ blockHeader blockEx8)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 390)
     []
     (SlotNo 390)

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Updates.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Updates.hs
@@ -18,7 +18,7 @@ import Cardano.Ledger.BaseTypes (
   mkNonceFromNumber,
   (⭒),
  )
-import Cardano.Ledger.Block (Block, bheader)
+import Cardano.Ledger.Block (Block (blockHeader))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Keys (asWitness)
 import Cardano.Ledger.Shelley (ShelleyEra, Tx (..))
@@ -224,7 +224,7 @@ txEx2 =
 blockEx2 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx2 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx1)
+    (bhHash $ blockHeader blockEx1)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 20)
     [MkShelleyTx txEx2]
     (SlotNo 20)
@@ -296,7 +296,7 @@ txEx3 =
 blockEx3 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx3 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx2)
+    (bhHash $ blockHeader blockEx2)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 80)
     [MkShelleyTx txEx3]
     (SlotNo 80)
@@ -338,7 +338,7 @@ epoch1Nonce = chainCandidateNonce expectedStEx3 ⭒ mkNonceFromNumber 123
 blockEx4 :: Block (BHeader MockCrypto) ShelleyEra
 blockEx4 =
   mkBlockFakeVRF
-    (bhHash $ bheader blockEx3)
+    (bhHash $ blockHeader blockEx3)
     (coreNodeKeysBySchedule @ShelleyEra ppEx 110)
     []
     (SlotNo 110)

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * Remove the `UMap` module and the `umap` benchmarks cabal target.
 * Export `dRepToText`
+* Deprecated `bheader` and `bbody`
+* Add field accessors to `Block`: `blockHeader` and `blockBody`.
+* Expose `dRepToText`
 * Modify `withdrawalsThatDoNotDrainAccounts` to return `Maybe (Withdrawals, Withdrawals)` where the `fst` are either missing accounts or in the wrong network and `snd` are incomplete withdrawals.
 * Add `FromJSON` instance for `PParamUpdate`
 

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.19.0.0
 
 * Remove the `UMap` module and the `umap` benchmarks cabal target.
+* Export `dRepToText`
 * Modify `withdrawalsThatDoNotDrainAccounts` to return `Maybe (Withdrawals, Withdrawals)` where the `fst` are either missing accounts or in the wrong network and `snd` are incomplete withdrawals.
 * Add `FromJSON` instance for `PParamUpdate`
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/DRep.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/DRep.hs
@@ -12,6 +12,7 @@ module Cardano.Ledger.DRep (
   DRep (DRepCredential, DRepKeyHash, DRepScriptHash, DRepAlwaysAbstain, DRepAlwaysNoConfidence),
   DRepState (..),
   credToDRep,
+  dRepToText,
   dRepToCred,
   drepExpiryL,
   drepAnchorL,

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -594,7 +595,7 @@ coldKeys = KeyPair vk sk
 
 makeNaiveBlock ::
   forall era. EraBlockBody era => [Tx era] -> Block BHeaderView era
-makeNaiveBlock txs = Block bhView blockBody
+makeNaiveBlock txs = Block {blockHeader = bhView, blockBody}
   where
     bhView =
       BHeaderView

--- a/libs/cardano-protocol-tpraos/testlib/Test/Cardano/Protocol/TPraos/Create.hs
+++ b/libs/cardano-protocol-tpraos/testlib/Test/Cardano/Protocol/TPraos/Create.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TupleSections #-}
@@ -278,8 +279,8 @@ mkBlock prev pKeys txns slotNo blockNo enonce kesPeriod keyRegKesPeriod oCert =
       bodySize = fromIntegral $ bBodySize protVer blockBody
       bodyHash = hashBlockBody @era blockBody
       bhBody = mkBHBody protVer prev pKeys slotNo blockNo enonce oCert bodySize bodyHash
-      bHeader = mkBHeader pKeys kesPeriod keyRegKesPeriod bhBody
-   in Block bHeader blockBody
+      blockHeader = mkBHeader pKeys kesPeriod keyRegKesPeriod bhBody
+   in Block {blockHeader, blockBody}
 
 -- | Create a block with a faked VRF result.
 mkBlockFakeVRF ::


### PR DESCRIPTION
# Description

* Deprecated `bheader` and `bbody`
* Add field accessors to `Block`: `blockHeader` and `blockBody`.
* Expose `dRepToText`

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
