### PR TITLE
Store delegators in pool state

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0.0
 
+* Expose `conwayRegisterInitialAccounts`
 * Add `TxLevel` argument to `Tx` and `TxBody`
 * Add `HasEraTxLevel` instances for `Tx` and `TxBody`
 * Add `EraTxLevel` instance

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0.0
 
+* Add `unDelegReDelegDRep` to `VState` module
 * Expose `conwayRegisterInitialAccounts`
 * Add `TxLevel` argument to `Tx` and `TxBody`
 * Add `HasEraTxLevel` instances for `Tx` and `TxBody`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
@@ -67,6 +67,7 @@ import Control.State.Transition (
   State,
   TRC (TRC),
   TransitionRule,
+  failBecause,
   failOnJust,
   judgmentContext,
   transitionRules,
@@ -201,10 +202,6 @@ conwayDelegTransition = do
             else IncorrectDepositDELEG deposit
     checkStakeKeyNotRegistered stakeCred =
       not (isAccountRegistered stakeCred accounts) ?! StakeKeyRegisteredDELEG stakeCred
-    checkStakeKeyIsRegistered stakeCred = do
-      let mAccountState = lookupAccountState stakeCred accounts
-      isJust mAccountState ?! StakeKeyNotRegisteredDELEG stakeCred
-      pure $ mAccountState >>= accountStateDelegatee
     checkStakeDelegateeRegistered =
       let checkPoolRegistered targetPool =
             targetPool `Map.member` pools ?! DelegateeStakePoolNotRegisteredDELEG targetPool
@@ -253,18 +250,23 @@ conwayDelegTransition = do
             guard (balanceCompact /= mempty)
             Just $ fromCompact balanceCompact
       failOnJust checkInvalidRefund id
-      isJust mAccountState ?! StakeKeyNotRegisteredDELEG stakeCred
       failOnJust checkStakeKeyHasZeroRewardBalance StakeKeyHasNonZeroRewardAccountBalanceDELEG
-      pure $
-        certState
-          & certDStateL . accountsL .~ newAccounts
-          & certVStateL %~ unDelegDRep stakeCred mCurDelegatee
-          & certPStateL %~ unDelegStakePool stakeCred mCurDelegatee Nothing
+      case mAccountState of
+        Nothing -> do
+          failBecause $ StakeKeyNotRegisteredDELEG stakeCred
+          pure certState
+        Just accountState ->
+          pure $
+            certState
+              & certDStateL . accountsL .~ newAccounts
+              & certVStateL %~ unDelegDRep stakeCred mCurDelegatee
+              & certPStateL %~ unDelegReDelegStakePool stakeCred accountState Nothing
     ConwayDelegCert stakeCred delegatee -> do
-      mCurDelegatee <- checkStakeKeyIsRegistered stakeCred
+      let mAccountState = lookupAccountState stakeCred accounts
+      isJust mAccountState ?! StakeKeyNotRegisteredDELEG stakeCred
       checkStakeDelegateeRegistered delegatee
       pure $
-        processDelegationInternal (pvMajor pv < natVersion @10) stakeCred mCurDelegatee delegatee certState
+        processDelegationInternal (pvMajor pv < natVersion @10) stakeCred mAccountState delegatee certState
     ConwayRegDelegCert stakeCred delegatee deposit -> do
       checkDepositAgainstPParams deposit
       checkStakeKeyNotRegistered stakeCred
@@ -287,9 +289,8 @@ processDelegation ::
   CertState era
 processDelegation stakeCred newDelegatee !certState = certState'
   where
-    !certState' = processDelegationInternal False stakeCred mCurDelegatee newDelegatee certState
+    !certState' = processDelegationInternal False stakeCred mAccountState newDelegatee certState
     mAccountState = Map.lookup stakeCred (certState ^. certDStateL . accountsL . accountsMapL)
-    mCurDelegatee = mAccountState >>= accountStateDelegatee
 
 -- | Same as `processDelegation`, except it expects the current delegation supplied as an
 -- argument, because in ledger rules we already have it readily available.
@@ -299,23 +300,27 @@ processDelegationInternal ::
   Bool ->
   -- | Delegator
   Credential 'Staking ->
-  -- | Current delegatee for the above stake credential that needs to be cleaned up.
-  Maybe Delegatee ->
+  -- | Account state for the above stake credential
+  Maybe (AccountState era) ->
   -- | New delegatee
   Delegatee ->
   CertState era ->
   CertState era
-processDelegationInternal preserveIncorrectDelegation stakeCred mCurDelegatee newDelegatee =
+processDelegationInternal preserveIncorrectDelegation stakeCred mAccountState newDelegatee =
   case newDelegatee of
     DelegStake sPool -> delegStake sPool
     DelegVote dRep -> delegVote dRep
     DelegStakeVote sPool dRep -> delegVote dRep . delegStake sPool
   where
+    mCurDelegatee = mAccountState >>= accountStateDelegatee
     delegStake stakePool cState =
       cState
         & certDStateL . accountsL
           %~ adjustAccountState (stakePoolDelegationAccountStateL ?~ stakePool) stakeCred
-        & certPStateL %~ adjustPState stakePool
+        & maybe
+          (certPStateL . psStakePoolsL %~ Map.adjust (spsDelegatorsL %~ Set.insert stakeCred) stakePool)
+          (\accountState -> certPStateL %~ unDelegReDelegStakePool stakeCred accountState (Just stakePool))
+          mAccountState
     delegVote dRep cState =
       let cState' =
             cState
@@ -331,26 +336,6 @@ processDelegationInternal preserveIncorrectDelegation stakeCred mCurDelegatee ne
                   let dRepState' = dRepState {drepDelegs = Set.insert stakeCred (drepDelegs dRepState)}
                    in cState' & certVStateL . vsDRepsL .~ Map.insert targetDRep dRepState' dReps
             _ -> cState'
-    adjustPState newPool =
-      (psStakePoolsL %~ Map.adjust (spsDelegatorsL %~ Set.insert stakeCred) newPool)
-        . unDelegStakePool stakeCred mCurDelegatee (Just newPool)
-
-unDelegStakePool ::
-  Credential 'Staking ->
-  Maybe Delegatee ->
-  Maybe (KeyHash 'StakePool) ->
-  PState era ->
-  PState era
-unDelegStakePool stakeCred mCurDelegatee mNewPool =
-  maybe
-    id
-    (\oldPool -> psStakePoolsL %~ Map.adjust (spsDelegatorsL %~ Set.delete stakeCred) oldPool)
-    (mCurDelegatee >>= stakePoolToUnDeleg)
-  where
-    stakePoolToUnDeleg = \case
-      DelegStake oldPool | Just oldPool /= mNewPool -> Just oldPool
-      DelegStakeVote oldPool _ | Just oldPool /= mNewPool -> Just oldPool
-      _ -> Nothing
 
 unDelegDRep ::
   Credential 'Staking ->

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.18.0.0
 
+* Change state of `ShelleyDELEG` rule from `DState` to `CertState`
+* Add `EraCertState` constraint to `STS` instance for `ShelleyDELEG`
 * Add `TxLevel` argument to `Tx` and `TxBody`
 * Add `HasEraTxLevel` instances for `Tx` and `TxBody`
 * Add `EraTxLevel` instance

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
@@ -120,7 +120,7 @@ instance
   , EraCertState era
   , Embed (EraRule "DELEG" era) (ShelleyDELPL era)
   , Environment (EraRule "DELEG" era) ~ DelegEnv era
-  , State (EraRule "DELEG" era) ~ DState era
+  , State (EraRule "DELEG" era) ~ CertState era
   , Embed (EraRule "POOL" era) (ShelleyDELPL era)
   , Environment (EraRule "POOL" era) ~ PoolEnv era
   , State (EraRule "POOL" era) ~ PState era
@@ -183,7 +183,7 @@ delplTransition ::
   forall era.
   ( Embed (EraRule "DELEG" era) (ShelleyDELPL era)
   , Environment (EraRule "DELEG" era) ~ DelegEnv era
-  , State (EraRule "DELEG" era) ~ DState era
+  , State (EraRule "DELEG" era) ~ CertState era
   , State (EraRule "POOL" era) ~ PState era
   , Signal (EraRule "DELEG" era) ~ TxCert era
   , Embed (EraRule "POOL" era) (ShelleyDELPL era)
@@ -201,20 +201,14 @@ delplTransition = do
         trans @(EraRule "POOL" era) $ TRC (PoolEnv eNo pp, d ^. certPStateL, poolCert)
       pure $ d & certPStateL .~ ps
     ShelleyTxCertGenesisDeleg GenesisDelegCert {} -> do
-      ds <-
-        trans @(EraRule "DELEG" era) $
-          TRC (DelegEnv slot eNo ptr chainAccountState pp, d ^. certDStateL, c)
-      pure $ d & certDStateL .~ ds
+      trans @(EraRule "DELEG" era) $
+        TRC (DelegEnv slot eNo ptr chainAccountState pp, d, c)
     ShelleyTxCertDelegCert _ -> do
-      ds <-
-        trans @(EraRule "DELEG" era) $
-          TRC (DelegEnv slot eNo ptr chainAccountState pp, d ^. certDStateL, c)
-      pure $ d & certDStateL .~ ds
+      trans @(EraRule "DELEG" era) $
+        TRC (DelegEnv slot eNo ptr chainAccountState pp, d, c)
     ShelleyTxCertMir _ -> do
-      ds <-
-        trans @(EraRule "DELEG" era) $
-          TRC (DelegEnv slot eNo ptr chainAccountState pp, d ^. certDStateL, c)
-      pure $ d & certDStateL .~ ds
+      trans @(EraRule "DELEG" era) $
+        TRC (DelegEnv slot eNo ptr chainAccountState pp, d, c)
 
 instance
   ( Era era
@@ -230,6 +224,7 @@ instance
 instance
   ( ShelleyEraAccounts era
   , ShelleyEraTxCert era
+  , EraCertState era
   , EraPParams era
   , AtMostEra "Babbage" era
   , PredicateFailure (EraRule "DELEG" era) ~ ShelleyDelegPredFailure era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -260,7 +260,8 @@ poolDelegationTransition = do
           tellEvent $ RegisterPool sppId
           pure $
             ps
-              & psStakePoolsL %~ Map.insert sppId (mkStakePoolState (pp ^. ppPoolDepositCompactL) stakePoolParams)
+              & psStakePoolsL
+                %~ Map.insert sppId (mkStakePoolState (pp ^. ppPoolDepositCompactL) mempty stakePoolParams)
               & psVRFKeyHashesL %~ updateVRFKeyHash
         -- re-register Pool
         Just stakePoolState -> do
@@ -293,10 +294,15 @@ poolDelegationTransition = do
           -- has been removed from the registered pools).  does it need to pay a
           -- new deposit (at the current deposit amount). But of course, if that
           -- has happened, we cannot be in this branch of the case statement.
+          let futureStakePoolState =
+                mkStakePoolState
+                  (stakePoolState ^. spsDepositL)
+                  (stakePoolState ^. spsDelegatorsL)
+                  stakePoolParams
           pure $
             ps
               & psFutureStakePoolsL
-                %~ Map.insert sppId (mkStakePoolState (stakePoolState ^. spsDepositL) stakePoolParams)
+                %~ Map.insert sppId futureStakePoolState
               & psRetiringL %~ Map.delete sppId
               & psVRFKeyHashesL %~ updateFutureVRFKeyHash
     RetirePool sppId e -> do

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -277,7 +277,7 @@ poolDelegationTransition = do
                       Nothing -> Map.insert sppVrf (knownNonZeroBounded @1)
                       Just futureStakePoolState
                         | futureStakePoolState ^. spsVrfL /= sppVrf ->
-                            (Map.insert sppVrf (knownNonZeroBounded @1))
+                            Map.insert sppVrf (knownNonZeroBounded @1)
                               . Map.delete (futureStakePoolState ^. spsVrfL)
                         | otherwise -> id
                 | otherwise = id
@@ -297,7 +297,9 @@ poolDelegationTransition = do
           let futureStakePoolState =
                 mkStakePoolState
                   (stakePoolState ^. spsDepositL)
-                  (stakePoolState ^. spsDelegatorsL)
+                  -- delegators are set in PoolReap,
+                  -- in order to capture delegations that happened after re-registration but before the end of the epoch
+                  mempty
                   stakePoolParams
           pure $
             ps

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/PoolReap.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/PoolReap.hs
@@ -152,7 +152,11 @@ poolReapTransition = do
     -- activate future stakePools
     ps =
       ps0
-        { psStakePools = Map.union (ps0 ^. psFutureStakePoolsL) (ps0 ^. psStakePoolsL)
+        { psStakePools =
+            Map.unionWith
+              (\newPoolState oldPoolState -> newPoolState {spsDelegators = spsDelegators oldPoolState})
+              (ps0 ^. psFutureStakePoolsL)
+              (ps0 ^. psStakePoolsL)
         , psFutureStakePools = Map.empty
         }
     cs = cs0 & certPStateL .~ ps
@@ -226,7 +230,6 @@ poolReapTransition = do
     removeVRFKeyHashOccurrence =
       -- Removes the key from the map if the value drops to 0
       Map.update (mapNonZero (\n -> n - 1))
-
     delegsToClear cState pools =
       foldMap spsDelegators $
         Map.restrictKeys (cState ^. certPStateL . psStakePoolsL) pools

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Transition.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Transition.hs
@@ -395,11 +395,11 @@ registerInitialStakePools ::
 registerInitialStakePools ShelleyGenesisStaking {sgsPools} nes =
   nes
     & nesEsL . esLStateL . lsCertStateL . certPStateL . psStakePoolsL
-      .~ ListMap.toMap (mkStakePoolState deposit <$> sgsPools)
+      .~ ListMap.toMap (mkStakePoolState deposit mempty <$> sgsPools)
   where
     deposit = nes ^. nesEsL . curPParamsEpochStateL . ppPoolDepositCompactL
 
--- | Register all staking credentials and apply delegations. Make sure StakePools that are bing
+-- | Register all staking credentials and apply delegations. Make sure StakePools that are being
 -- delegated to are already registered, which can be done with `registerInitialStakePools`.
 shelleyRegisterInitialAccounts ::
   forall era.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Transition.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Transition.hs
@@ -75,6 +75,7 @@ import Data.Default
 import Data.Kind
 import qualified Data.ListMap as ListMap
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import Data.Typeable
 import Data.Void (Void)
 import GHC.Generics (Generic)
@@ -409,14 +410,20 @@ shelleyRegisterInitialAccounts ::
   NewEpochState era
 shelleyRegisterInitialAccounts ShelleyGenesisStaking {sgsStake} nes =
   nes
-    & nesEsL . esLStateL . lsCertStateL . certDStateL . accountsL %~ \initAccounts ->
-      foldr registerAndDelegate initAccounts $ zip (ListMap.toList sgsStake) ptrs
+    & nesEsL . esLStateL . lsCertStateL . certDStateL . accountsL .~ updatedAccounts
+    & nesEsL . esLStateL . lsCertStateL . certPStateL . psStakePoolsL .~ updatedStakePoolStates
   where
     stakePools = nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL . psStakePoolsL
+    initialAccounts = nes ^. nesEsL . esLStateL . lsCertStateL . certDStateL . accountsL
     deposit = compactCoinOrError $ nes ^. nesEsL . curPParamsEpochStateL . ppKeyDepositL
-    registerAndDelegate ((stakeKeyHash, stakePool), ptr) !accounts
+
+    !(!updatedAccounts, !updatedStakePoolStates) =
+      foldr registerAndDelegate (initialAccounts, stakePools) (zip (ListMap.toList sgsStake) ptrs)
+    registerAndDelegate ((stakeKeyHash, stakePool), ptr) (!accounts, !stakePoolMap)
       | stakePool `Map.member` stakePools =
-          registerShelleyAccount (KeyHashObj stakeKeyHash) ptr deposit (Just stakePool) accounts
+          ( registerShelleyAccount (KeyHashObj stakeKeyHash) ptr deposit (Just stakePool) accounts
+          , Map.adjust (spsDelegatorsL %~ Set.insert (KeyHashObj stakeKeyHash)) stakePool stakePoolMap
+          )
       | otherwise =
           error $
             "Invariant of a delegation of "

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
@@ -10,6 +10,7 @@ module Test.Cardano.Ledger.Shelley.Imp (spec, shelleyEraSpecificSpec) where
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.Rules
+import Cardano.Ledger.Shelley.State (ShelleyEraAccounts)
 import Test.Cardano.Ledger.Imp.Common
 import qualified Test.Cardano.Ledger.Shelley.Imp.DelegSpec as Deleg
 import qualified Test.Cardano.Ledger.Shelley.Imp.EpochSpec as Epoch
@@ -41,6 +42,7 @@ spec = do
 shelleyEraSpecificSpec ::
   forall era.
   ( ShelleyEraImp era
+  , ShelleyEraAccounts era
   , InjectRuleFailure "LEDGER" ShelleyDelegsPredFailure era
   ) =>
   SpecWith (ImpInit (LedgerSpec era))

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/DelegSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/DelegSpec.hs
@@ -54,7 +54,7 @@ shelleyEraSpecificSpec = do
           & bodyTxL . certsTxBodyL .~ [delegStakeTxCert cred poolKh]
       )
       [injectFailure $ DelegateeNotRegisteredDELEG poolKh]
-    expectNotDelegatedToPool cred
+    expectNotDelegatedToAnyPool cred
 
   it "Deregistering returns the deposit" $ do
     let keyDeposit = Coin 2
@@ -228,6 +228,7 @@ spec = do
               else StakeKeyNotRegisteredDELEG cred
         ]
       expectStakeCredNotRegistered cred
+      expectNotDelegatedToAnyPool cred
 
     it "Delegate already delegated credentials" $ do
       cred <- KeyHashObj <$> freshKeyHash
@@ -251,6 +252,7 @@ spec = do
           & bodyTxL . certsTxBodyL
             .~ [delegStakeTxCert cred poolKh1]
       expectDelegatedToPool cred poolKh1
+      expectNotDelegatedToPool cred poolKh
 
       poolKh2 <- freshKeyHash
       registerPool poolKh2
@@ -265,6 +267,8 @@ spec = do
                ]
 
       expectDelegatedToPool cred poolKh3
+      expectNotDelegatedToPool cred poolKh2
+      expectNotDelegatedToPool cred poolKh
 
     it "Delegate and unregister" $ do
       cred <- KeyHashObj <$> freshKeyHash
@@ -277,3 +281,4 @@ spec = do
           & bodyTxL . certsTxBodyL
             .~ [regTxCert, delegStakeTxCert cred poolKh, unRegTxCert]
       expectStakeCredNotRegistered cred
+      expectNotDelegatedToAnyPool cred

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/UnitTests/InstantStakeTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/UnitTests/InstantStakeTest.hs
@@ -85,7 +85,7 @@ instantStakeIncludesRewards = do
 
     instantStake = addInstantStake utxo1 mempty
     poolparamMap = Map.fromList [(poolId1, pool1), (poolId2, pool2)]
-  pState <- arbitraryLens psStakePoolsL $ mkStakePoolState mempty <$> poolparamMap
+  pState <- arbitraryLens psStakePoolsL $ mkStakePoolState mempty mempty <$> poolparamMap
   let snapShot = snapShotFromInstantStake instantStake dState pState
       computedStakeDistr = VMap.toMap (unStake (ssStake snapShot))
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -134,7 +134,7 @@ poolRegistrationProp
               , counterexample
                   "New StakePoolParams are registered in future Params map"
                   ( Map.lookup hk (psFutureStakePools targetSt)
-                      === Just (mkStakePoolState (sps ^. spsDepositL) stakePoolParams)
+                      === Just (mkStakePoolState (sps ^. spsDepositL) (sps ^. spsDelegatorsL) stakePoolParams)
                   )
               , counterexample
                   "StakePoolParams are removed in 'retiring'"

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -220,7 +220,7 @@ delegTraceFromBlock ::
 delegTraceFromBlock chainSt block =
   ( delegEnv
   , runShelleyBase $
-      Trace.closure @(ShelleyDELEG era) delegEnv delegSt0 blockCerts
+      Trace.closure @(ShelleyDELEG era) delegEnv (ledgerSt0 ^. lsCertStateL) blockCerts
   )
   where
     (_tickedChainSt, ledgerEnv, ledgerSt0, txs) = ledgerTraceBase chainSt block
@@ -231,8 +231,6 @@ delegTraceFromBlock chainSt block =
           dummyCertIx = minBound
           ptr = Ptr (SlotNo32 (fromIntegral slot64)) txIx dummyCertIx
        in DelegEnv slot (epochFromSlotNo slot) ptr reserves pp
-    delegSt0 =
-      ledgerSt0 ^. lsCertStateL . certDStateL
     delegCert (RegTxCert _) = True
     delegCert (UnRegTxCert _) = True
     delegCert (DelegStakeTxCert _ _) = True

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Combinators.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Combinators.hs
@@ -260,7 +260,7 @@ regPool pool cs = cs {chainNes = nes'}
             { psStakePools =
                 Map.insert
                   (sppId pool)
-                  (mkStakePoolState poolDeposit pool)
+                  (mkStakePoolState poolDeposit mempty pool)
                   (psStakePools ps)
             }
         Just sps ->
@@ -268,7 +268,7 @@ regPool pool cs = cs {chainNes = nes'}
             { psFutureStakePools =
                 Map.insert
                   (sppId pool)
-                  (mkStakePoolState (spsDeposit sps) pool)
+                  (mkStakePoolState (spsDeposit sps) mempty pool)
                   (psFutureStakePools ps)
             }
     dps' = dps & certPStateL .~ ps'
@@ -301,7 +301,7 @@ updatePoolParams pool cs = cs {chainNes = nes'}
         { psStakePools =
             Map.insert
               (sppId pool)
-              (mkStakePoolState (es ^. curPParamsEpochStateL . ppPoolDepositCompactL) pool)
+              (mkStakePoolState (es ^. curPParamsEpochStateL . ppPoolDepositCompactL) mempty pool)
               (psStakePools ps)
         , psFutureStakePools = Map.delete (sppId pool) (psStakePools ps)
         }

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Combinators.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Combinators.hs
@@ -95,7 +95,6 @@ import Data.Foldable (fold)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromJust)
-import qualified Data.Set as Set
 import Data.Word (Word64)
 import GHC.Stack (HasCallStack)
 import Lens.Micro
@@ -369,7 +368,10 @@ reapPool pool cs = cs {chainNes = nes'}
            in ( accounts & accountsMapL %~ Map.insert poolAccountCred accountState'
               , mempty
               )
-    ds' = ds {dsAccounts = removeStakePoolDelegations (Set.singleton poolId) accounts'}
+    delegsToClear =
+      foldMap spsDelegators $
+        Map.lookup poolId (dps ^. certPStateL . psStakePoolsL)
+    ds' = ds {dsAccounts = removeStakePoolDelegations delegsToClear accounts'}
     chainAccountState = esChainAccountState es
     chainAccountState' = chainAccountState {casTreasury = casTreasury chainAccountState <+> fromCompact unclaimed}
     utxoSt = lsUTxOState ls

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Add `unDelegReDelegStakePool` to `CertState` module
 * Add `iRReservesL`, `iRTreasuryL`, `iRDeltaReservesL`, `iRDeltaTreasuryL`
 * Add `spsDelegators` field to `StakePool`
 * Add `spsDelegatorsL`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `spsDelegators` field to `StakePool`
 * Add `spsDelegatorsL`
+* Change parameter type of `removeStakePoolDelegations` from `Set (KeyHash 'StakePool)` to `Set (Credential 'Staking)`
 * Add `fromStrictMaybeL`, `toStrictMaybeL`
 * Add `memoRawTypeL`
 * Remove `getterMemoRawType`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.19.0.0
 
+* Add `spsDelegators` field to `StakePool`
+* Add `spsDelegatorsL`
 * Add `fromStrictMaybeL`, `toStrictMaybeL`
 * Add `memoRawTypeL`
 * Remove `getterMemoRawType`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Add `iRReservesL`, `iRTreasuryL`, `iRDeltaReservesL`, `iRDeltaTreasuryL`
 * Add `spsDelegators` field to `StakePool`
 * Add `spsDelegatorsL`
 * Change parameter type of `removeStakePoolDelegations` from `Set (KeyHash 'StakePool)` to `Set (Credential 'Staking)`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/CertState.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/CertState.hs
@@ -34,6 +34,7 @@ module Cardano.Ledger.State.CertState (
   lookupRewardDState,
   Obligations (..),
   sumObligation,
+  unDelegReDelegStakePool,
   -- Lenses
   iRReservesL,
   dsIRewardsL,
@@ -80,7 +81,7 @@ import Cardano.Ledger.DRep (DRep (..), DRepState (..))
 import Cardano.Ledger.Hashes (GenDelegPair (..), GenDelegs (..))
 import Cardano.Ledger.Slot (EpochNo (..), SlotNo (..))
 import Cardano.Ledger.State.Account
-import Cardano.Ledger.State.StakePool (StakePoolState (..))
+import Cardano.Ledger.State.StakePool (StakePoolState (..), spsDelegatorsL)
 import Control.DeepSeq (NFData (..))
 import Control.Monad.Trans
 import Data.Aeson (ToJSON (..), object, (.=))
@@ -89,6 +90,7 @@ import qualified Data.Foldable as F
 import Data.Kind (Type)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
 import Data.Word (Word64)
 import GHC.Generics (Generic)
@@ -272,6 +274,30 @@ instance ToKeyValuePairs (PState era) where
     , "futureStakePools" .= psFutureStakePools
     , "retiring" .= psRetiring
     ]
+
+-- | Reverses stake pool delegation.
+-- To be called when a stake credential is unregistered or its delegation target changes.
+-- If the new delegation matches the previous one, this is a noop.
+unDelegReDelegStakePool ::
+  EraAccounts era =>
+  Credential 'Staking ->
+  -- | Account that is losing its current delegation and/or acquiring a new one
+  AccountState era ->
+  -- | Optional new delegation target. Use 'Nothing' when the stake credential unregisters.
+  Maybe (KeyHash 'StakePool) ->
+  PState era ->
+  PState era
+unDelegReDelegStakePool stakeCred accountState mNewStakePool =
+  fromMaybe (psStakePoolsL %~ addNewDelegation) $ do
+    curStakePool <- accountState ^. stakePoolDelegationAccountStateL
+    pure $
+      -- no need to update the set of delegations if the delegation is unchanged
+      if Just curStakePool == mNewStakePool
+        then id
+        else
+          psStakePoolsL %~ addNewDelegation . Map.adjust (spsDelegatorsL %~ Set.delete stakeCred) curStakePool
+  where
+    addNewDelegation = maybe id (Map.adjust (spsDelegatorsL %~ Set.insert stakeCred)) mNewStakePool
 
 data CommitteeAuthorization
   = -- | Member authorized with a Hot credential acting on behalf of their Cold credential

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/CertState.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/CertState.hs
@@ -35,8 +35,12 @@ module Cardano.Ledger.State.CertState (
   Obligations (..),
   sumObligation,
   -- Lenses
-  dsGenDelegsL,
+  iRReservesL,
   dsIRewardsL,
+  dsGenDelegsL,
+  iRTreasuryL,
+  iRDeltaReservesL,
+  iRDeltaTreasuryL,
   dsFutureGenDelegsL,
   psStakePoolsL,
   psFutureStakePoolsL,
@@ -433,6 +437,18 @@ dsGenDelegsL = lens dsGenDelegs (\ds u -> ds {dsGenDelegs = u})
 
 dsIRewardsL :: Lens' (DState era) InstantaneousRewards
 dsIRewardsL = lens dsIRewards (\ds u -> ds {dsIRewards = u})
+
+iRReservesL :: Lens' InstantaneousRewards (Map (Credential 'Staking) Coin)
+iRReservesL = lens iRReserves (\ir m -> ir {iRReserves = m})
+
+iRTreasuryL :: Lens' InstantaneousRewards (Map (Credential 'Staking) Coin)
+iRTreasuryL = lens iRTreasury (\ir m -> ir {iRTreasury = m})
+
+iRDeltaReservesL :: Lens' InstantaneousRewards DeltaCoin
+iRDeltaReservesL = lens deltaReserves (\ir d -> ir {deltaReserves = d})
+
+iRDeltaTreasuryL :: Lens' InstantaneousRewards DeltaCoin
+iRDeltaTreasuryL = lens deltaTreasury (\ir d -> ir {deltaTreasury = d})
 
 dsFutureGenDelegsL ::
   Lens' (DState era) (Map FutureGenDeleg GenDelegPair)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/StakePool.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/StakePool.hs
@@ -86,8 +86,10 @@ import Cardano.Ledger.Binary (
   DecShareCBOR (..),
   EncCBOR (..),
   EncCBORGroup (..),
+  Interns,
   decodeNullStrictMaybe,
   decodeRecordNamed,
+  decodeRecordNamedT,
   decodeRecordSum,
   encodeListLen,
   encodeNullStrictMaybe,
@@ -106,6 +108,7 @@ import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..), KeyRoleVRF (StakePoolVRF
 import Cardano.Ledger.Orphans ()
 import Control.DeepSeq (NFData)
 import Control.Monad (unless)
+import Control.Monad.Trans (lift)
 import Data.Aeson (FromJSON (..), ToJSON (..), Value, (.!=), (.:), (.:?), (.=))
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (Parser, explicitParseField)
@@ -211,7 +214,20 @@ instance DecCBOR StakePoolState where
         <! From
 
 instance DecShareCBOR StakePoolState where
-  decShareCBOR _ = decCBOR
+  type Share StakePoolState = Interns (Credential 'Staking)
+  decSharePlusCBOR =
+    decodeRecordNamedT "StakePoolState" (const 10) $
+      StakePoolState
+        <$> lift decCBOR
+        <*> lift decCBOR
+        <*> lift decCBOR
+        <*> lift decCBOR
+        <*> lift decCBOR
+        <*> lift decCBOR
+        <*> lift decCBOR
+        <*> lift decCBOR
+        <*> lift decCBOR
+        <*> decSharePlusCBOR
 
 instance Default StakePoolState where
   def =

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/StakePool.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/StakePool.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | This module provides the 'StakePoolState' data type, which represents the
@@ -36,6 +37,7 @@ module Cardano.Ledger.State.StakePool (
   spsOwnersL,
   spsRelaysL,
   spsMetadataL,
+  spsDelegatorsL,
   spsDepositL,
 
   -- * Conversions
@@ -99,6 +101,7 @@ import Cardano.Ledger.Binary.Coders (
   (<!),
  )
 import Cardano.Ledger.Coin (Coin (..), CompactForm)
+import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..), KeyRoleVRF (StakePoolVRF), VRFVerKeyHash)
 import Cardano.Ledger.Orphans ()
 import Control.DeepSeq (NFData)
@@ -142,6 +145,8 @@ data StakePoolState = StakePoolState
   -- ^ Optional metadata (URL and hash)
   , spsDeposit :: !(CompactForm Coin)
   -- ^ Deposit for each pool
+  , spsDelegators :: !(Set (Credential 'Staking))
+  -- ^ Credentials that have delegated to the pool
   }
   deriving (Show, Generic, Eq, Ord, NoThunks, NFData, FromJSON, ToJSON)
 
@@ -172,6 +177,9 @@ spsMetadataL = lens spsMetadata $ \sps md -> sps {spsMetadata = md}
 spsDepositL :: Lens' StakePoolState (CompactForm Coin)
 spsDepositL = lens spsDeposit $ \sps d -> sps {spsDeposit = d}
 
+spsDelegatorsL :: Lens' StakePoolState (Set (Credential 'Staking))
+spsDelegatorsL = lens spsDelegators $ \sps delegators -> sps {spsDelegators = delegators}
+
 instance EncCBOR StakePoolState where
   encCBOR sps =
     encode $
@@ -185,11 +193,13 @@ instance EncCBOR StakePoolState where
         !> To (spsRelays sps)
         !> To (spsMetadata sps)
         !> To (spsDeposit sps)
+        !> To (spsDelegators sps)
 
 instance DecCBOR StakePoolState where
   decCBOR =
     decode $
       RecD StakePoolState
+        <! From
         <! From
         <! From
         <! From
@@ -215,13 +225,15 @@ instance Default StakePoolState where
       , spsRelays = def
       , spsMetadata = def
       , spsDeposit = mempty
+      , spsDelegators = def
       }
 
 -- | Convert 'StakePoolParams' to 'StakePoolState' by dropping the pool ID.
 -- This is the primary way to create a 'StakePoolState' from registration
 -- or update parameters.
-mkStakePoolState :: CompactForm Coin -> StakePoolParams -> StakePoolState
-mkStakePoolState deposit spp =
+mkStakePoolState ::
+  CompactForm Coin -> Set (Credential 'Staking) -> StakePoolParams -> StakePoolState
+mkStakePoolState deposit delegators spp =
   StakePoolState
     { spsVrf = sppVrf spp
     , spsPledge = sppPledge spp
@@ -232,6 +244,7 @@ mkStakePoolState deposit spp =
     , spsRelays = sppRelays spp
     , spsMetadata = sppMetadata spp
     , spsDeposit = deposit
+    , spsDelegators = delegators
     }
 
 -- | Convert 'StakePoolState' back to 'StakePoolParams' by providing the pool ID.

--- a/libs/cardano-ledger-core/test/Test/Cardano/Ledger/State/StakePoolSpec.hs
+++ b/libs/cardano-ledger-core/test/Test/Cardano/Ledger/State/StakePoolSpec.hs
@@ -7,16 +7,22 @@
 module Test.Cardano.Ledger.State.StakePoolSpec (spec) where
 
 import Cardano.Ledger.Coin
+import Cardano.Ledger.Core
+import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.State
+import Data.Set (Set)
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Arbitrary ()
 
 spec :: Spec
 spec = do
   describe "StakePoolState" $ do
-    prop "mkStakePoolState/stakePoolStateToStakePoolParams round-trip" $
-      \(stakePoolParams :: StakePoolParams, deposit :: CompactForm Coin) ->
-        let poolId = sppId stakePoolParams
-            stakePoolState = mkStakePoolState deposit stakePoolParams
-            stakePoolParams' = stakePoolStateToStakePoolParams poolId stakePoolState
-         in stakePoolParams === stakePoolParams'
+    prop "mkStakePoolState/stakePoolStateToPoolParams round-trip" $
+      \( stakePoolParams :: StakePoolParams
+         , deposit :: CompactForm Coin
+         , delegs :: Set (Credential 'Staking)
+         ) ->
+          let poolId = sppId stakePoolParams
+              stakePoolState = mkStakePoolState deposit delegs stakePoolParams
+              stakePoolParams' = stakePoolStateToStakePoolParams poolId stakePoolState
+           in stakePoolParams === stakePoolParams'

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -462,6 +462,7 @@ instance Arbitrary StakePoolState where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary
 
 instance Arbitrary PoolMetadata where
   arbitrary = PoolMetadata <$> arbitrary <*> arbitrary

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
@@ -379,7 +379,7 @@ pStateSpec univ currepoch = constrained $ \ [var|pState|] ->
     , witness univ (dom_ retiring)
     , assertExplain (pure "dom of retiring is a subset of dom of stakePoolParams") $
         dom_ retiring `subset_` dom_ stakePoolParams
-    , forAll' (rng_ stakePoolParams) $ \_ _ _ _ _ _ _ _ [var|d|] ->
+    , forAll' (rng_ stakePoolParams) $ \_ _ _ _ _ _ _ _ [var|d|] _ ->
         assertExplain (pure "all deposits are greater then (Coin 0)") $ d >=. lit 0
     , assertExplain (pure "dom of stakePoolParams is disjoint from futureStakePoolParams") $
         dom_ stakePoolParams `disjoint_` dom_ futureStakePoolParams

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Pool.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Pool.hs
@@ -52,7 +52,7 @@ pStateSpec univ = constrained $ \ps ->
     , witness univ (dom_ retiring)
     , assertExplain (pure "dom of retiring is a subset of dom of stakePoolParams") $
         dom_ retiring `subset_` dom_ stakePools
-    , forAll' (rng_ stakePools) $ \_ _ _ _ _ _ _ _ [var|d|] ->
+    , forAll' (rng_ stakePools) $ \_ _ _ _ _ _ _ _ [var|d|] _ ->
         assertExplain (pure "all deposits are greater then (Coin 0)") $ d >=. lit 0
     , assertExplain (pure "dom of stakePoolParams is disjoint from futureStakePoolParams") $
         dom_ stakePools `disjoint_` dom_ futureStakePools

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
@@ -670,7 +670,7 @@ initialLedgerState gstate = LedgerState utxostate dpstate
     pstate =
       PState
         Map.empty
-        (mkStakePoolState poolDeposit <$> pools)
+        (mkStakePoolState poolDeposit mempty <$> pools)
         Map.empty
         Map.empty
     -- In a wellformed LedgerState the deposited equals the obligation
@@ -1008,7 +1008,7 @@ initStableFields = do
     modifyGenStateInitialStakePoolParams (Map.insert kh stakePoolParams)
     modifyGenStateInitialPoolDistr (Map.insert kh ips)
     modifyModelStakePools
-      (Map.insert kh $ mkStakePoolState (pp ^. ppPoolDepositCompactL) stakePoolParams)
+      (Map.insert kh $ mkStakePoolState (pp ^. ppPoolDepositCompactL) mempty stakePoolParams)
     return kh
 
   -- This incantation gets a list of fresh (not previously generated) Credential
@@ -1082,7 +1082,7 @@ genRetirementHash = do
 
       -- add the Pool to the Model
       modifyModelStakePools
-        (Map.insert poolid $ mkStakePoolState (pp ^. ppPoolDepositCompactL) poolparams)
+        (Map.insert poolid $ mkStakePoolState (pp ^. ppPoolDepositCompactL) mempty poolparams)
       modifyModelPoolDistr (Map.insert poolid stake)
       pure poolid
 
@@ -1100,7 +1100,8 @@ genPool = frequencyT [(10, genNew), (90, pickExisting)]
       modifyGenStateInitialStakePoolParams (Map.insert kh spp)
       modifyGenStateInitialPoolDistr (Map.insert kh ips)
       -- update the model
-      modifyModelStakePools (Map.insert kh $ mkStakePoolState (pparams ^. ppPoolDepositCompactL) spp)
+      modifyModelStakePools
+        (Map.insert kh $ mkStakePoolState (pparams ^. ppPoolDepositCompactL) mempty spp)
       return (kh, spp)
     pickExisting = do
       psStakePools <- gets (mStakePools . gsModel)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Instances.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Instances.hs
@@ -118,7 +118,7 @@ applyShelleyCert model dcert = case dcert of
       { mStakePools =
           Map.insert
             hk
-            (mkStakePoolState (pp ^. ppPoolDepositCompactL) stakePoolParams)
+            (mkStakePoolState (pp ^. ppPoolDepositCompactL) mempty stakePoolParams)
             (mStakePools model)
       , mDeposited =
           if Map.member hk (mStakePools model)


### PR DESCRIPTION
# Description

Store, in each pool's StakePoolState, the stake credentials that have delegated to that pool. 
This set is updated in DELEG rule, for both shelley and conway: 

- on (re)delegation
- when the stake credential is unregistered 

The set is used to improve the performance of removing delegations when retiring the pool. 
Based on PR: https://github.com/IntersectMBO/cardano-ledger/pull/5330

Closes: https://github.com/IntersectMBO/cardano-ledger/issues/4990


<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
