### PR TITLE
Added non-zero check for `nOpts` in `ppuWellFormed` from PV 11

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -108,7 +108,7 @@ import Cardano.Ledger.BaseTypes (
   NonNegativeInterval,
   NonZero,
   PositiveInterval,
-  ProtVer (ProtVer),
+  ProtVer (..),
   ToKeyValuePairs (..),
   UnitInterval,
   integralToBounded,
@@ -119,6 +119,7 @@ import Cardano.Ledger.Binary (
   DecCBOR (..),
   EncCBOR (..),
   encodeListLen,
+  natVersion,
  )
 import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.Coin (Coin (Coin), CompactForm (..), compactCoinOrError, partialCompactCoinL)
@@ -932,6 +933,8 @@ instance ConwayEraPParams ConwayEra where
       , hardforkConwayBootstrapPhase pv
           || isValid ((/= zero) . unCoinPerByte) ppuCoinsPerUTxOByteL
       , ppu /= emptyPParamsUpdate
+      , pvMajor pv < natVersion @11
+          || isValid (/= 0) ppuNOptL
       ]
     where
       isValid ::

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/PParams.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/PParams.hs
@@ -541,6 +541,7 @@ instance ConwayEraPParams DijkstraEra where
       , isValid (/= zero) ppuDRepDepositL
       , isValid ((/= zero) . unCoinPerByte) ppuCoinsPerUTxOByteL
       , ppu /= emptyPParamsUpdate
+      , isValid (/= 0) ppuNOptL
       ]
     where
       isValid ::


### PR DESCRIPTION
# Description

This PR adds a check that `nOpts` is not zero to `ppuWellFormed`.

resolves https://github.com/IntersectMBO/cardano-ledger/issues/5314

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
