### PR TITLE
Fix compatibility with `mempack-0.2`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -27,8 +27,8 @@ source-repository-package
 -- NOTE: If you would like to update the above,
 -- see CONTRIBUTING.md#to-update-the-referenced-agda-ledger-spec
 index-state:
-  , hackage.haskell.org 2025-09-09T23:37:25Z
-  , cardano-haskell-packages 2025-06-11T08:32:56Z
+  , hackage.haskell.org 2025-09-30T00:00:00Z
+  , cardano-haskell-packages 2025-10-01T14:54:47Z
 
 packages:
   -- == Byron era ==

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1749631879,
-        "narHash": "sha256-H7dxW3fRA8/U4u4GaR+YVnu6aKkev4GPTPgY524V5uM=",
+        "lastModified": 1759339316,
+        "narHash": "sha256-SW/K9yfhNLNCDAl2ZC8ol0w8X+AwyLin0XOvnn50468=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "2d1517e42e1ed5b19deb29c1c4fc9e30d360b961",
+        "rev": "aa50d6dffede91c8fdfcef94c71641a00214522a",
         "type": "github"
       },
       "original": {
@@ -217,23 +217,6 @@
         "type": "github"
       }
     },
-    "ghc-8.6.5-iohk": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1600920045,
-        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
-        "owner": "input-output-hk",
-        "repo": "ghc",
-        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "release/8.6.5-iohk",
-        "repo": "ghc",
-        "type": "github"
-      }
-    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -258,11 +241,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1748478380,
-        "narHash": "sha256-tL9oo3kqsGggwyu+6SzqmwvxMgP9TW4kYr7wrcT4F9Y=",
+        "lastModified": 1759278512,
+        "narHash": "sha256-5v7+L3DZ45AdoQ+aq7cf1gfCJMBeehKZ4kQq9Vykk9Q=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "4c1cfe985a6d2f0e8c6d903d2b5297fece257382",
+        "rev": "b4098dcb9398efe39397e80fe7486e58abf0cb5b",
         "type": "github"
       },
       "original": {
@@ -272,14 +255,30 @@
         "type": "github"
       }
     },
+    "hackage-internal": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750307553,
+        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1757523633,
-        "narHash": "sha256-nLzEuichc4tfUbzlJhMvAVi6EisQVyXMNwv4CKwRd1A=",
+        "lastModified": 1759326691,
+        "narHash": "sha256-yBNa17m1UkpuHPIjdMvovGaEUNB+t6TWoVSoG/g7Cbo=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "1b9604d6c2f1d48e9e204e420103c0a5514a0be9",
+        "rev": "078e5fe35c40386f2ba4e74bf9475f9752ed878a",
         "type": "github"
       },
       "original": {
@@ -296,15 +295,16 @@
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat_2",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": [
           "hackageNix"
         ],
         "hackage-for-stackage": "hackage-for-stackage",
+        "hackage-internal": "hackage-internal",
         "hls": "hls",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
         "hls-2.10": "hls-2.10",
+        "hls-2.11": "hls-2.11",
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
         "hls-2.4": "hls-2.4",
@@ -323,16 +323,17 @@
         "nixpkgs-2311": "nixpkgs-2311",
         "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-2411": "nixpkgs-2411",
+        "nixpkgs-2505": "nixpkgs-2505",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1748516483,
-        "narHash": "sha256-nqtbSbs2G/Ldjkt7KLgePqyDjd+zZtj3YxAbRk1M8wo=",
+        "lastModified": 1759279947,
+        "narHash": "sha256-IP2lmTTckH3GJsvsRHcYTXeA+6HUwYiya6L0oH2TFjc=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "7707658389458461553071792fa744f80663ee30",
+        "rev": "753543a051921bbfa2fbdc61a56ea4dc15412551",
         "type": "github"
       },
       "original": {
@@ -404,6 +405,23 @@
       "original": {
         "owner": "haskell",
         "ref": "2.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.11": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747306193,
+        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.11.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -568,11 +586,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1745582862,
-        "narHash": "sha256-dMoJ6yHcRvUcB66nofzfAtmVxnDg8oPW3wiVtimXT/o=",
+        "lastModified": 1757407040,
+        "narHash": "sha256-rSHOQli+iffMmneSF/Ov8Uci6APaROWen+EfRb5mmiU=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "5c16fdfc45deda7a4ccf964b6dfa1c3cab72f1f7",
+        "rev": "a94259528eb6d37073512d1767f14fd8ea12a8f0",
         "type": "github"
       },
       "original": {
@@ -584,11 +602,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1747047742,
-        "narHash": "sha256-PCDULyZSIPdDdF8Lanbcy+Dl6AJ5z6H2ng3sRsv+gwc=",
+        "lastModified": 1755243078,
+        "narHash": "sha256-GLbl1YaohKdpzZVJFRdcI1O1oE3F3uBer4lFv3Yy0l8=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "dea34de4bde325aca22472c18d659bee7800b477",
+        "rev": "150605195cb7183a6fb7bed82f23fedf37c6f52a",
         "type": "github"
       },
       "original": {
@@ -600,16 +618,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684171562,
-        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
+        "lastModified": 1751071626,
+        "narHash": "sha256-/uHE/AD2qGq4QLigWAnBHiVvpVXB04XAfrOtw8JMv+Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
+        "rev": "a47938d89bdf8e279ad432bd6a473cf4c430f48c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "release-22.11",
+        "ref": "release-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -664,11 +682,11 @@
     },
     "nixpkgs-2411": {
       "locked": {
-        "lastModified": 1746566971,
-        "narHash": "sha256-I40weT0FZWth1IEjgR5a0zC9LLyrPwTC0DAQcejtTJE=",
+        "lastModified": 1748037224,
+        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "209c5b3b0f5cf5b5a7e12ddea59bf19699f97e75",
+        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
         "type": "github"
       },
       "original": {
@@ -678,13 +696,29 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
+    "nixpkgs-2505": {
       "locked": {
-        "lastModified": 1746576598,
-        "narHash": "sha256-FshoQvr6Aor5SnORVvh/ZdJ1Sa2U4ZrIMwKBX5k2wu0=",
+        "lastModified": 1754477006,
+        "narHash": "sha256-suIgZZHXdb4ca9nN4MIcmdjeN+ZWsTwCtYAG4HExqAo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3582c75c7f21ce0b429898980eddbbf05c68e55",
+        "rev": "4896699973299bffae27d0d9828226983544d9e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1754393734,
+        "narHash": "sha256-fbnmAwTQkuXHKBlcL5Nq1sMAzd3GFqCOQgEQw6Hy0Ak=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a683adc19ff5228af548c6539dbc3440509bfed3",
         "type": "github"
       },
       "original": {
@@ -801,11 +835,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1748477586,
-        "narHash": "sha256-XlNzJApYAlnV+rPcFIHgxaA304jbfY00JbbkDpsd6bs=",
+        "lastModified": 1759277672,
+        "narHash": "sha256-AlxRPhwYYXsDsWRUxjuQ1nLuAKNIi6glo4NpqZ1MoIA=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "c04f95ad0731ff773c027ed1390aca827d9ca902",
+        "rev": "ad6886644fd182566c12b9fe99bdad3c99b6ddd0",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -121,7 +121,7 @@ library
     groups,
     iproute,
     measures,
-    mempack,
+    mempack >=0.2,
     microlens,
     mtl,
     non-integral >=1.0,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes/Internal.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes/Internal.hs
@@ -139,7 +139,7 @@ unpackMemoBytesM ::
   , Typeable t
   , Buffer b
   ) =>
-  Version -> Unpack b (MemoBytes t)
+  Version -> Unpack s b (MemoBytes t)
 unpackMemoBytesM v = unpackM >>= decodeMemoBytes v
 
 decodeMemoBytes ::

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Plutus/Examples.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Plutus/Examples.hs
@@ -34,7 +34,7 @@ decodeHexPlutus = either error (Plutus . PlutusBinary . SBS.toShort) . Base16.de
 alwaysSucceedsNoDatum :: SLanguage l -> Plutus l
 alwaysSucceedsNoDatum =
   decodeHexPlutus . mconcat . \case
-    -- ScriptHash "e09e82766bfe6df2f6b6d4c1c347657e0bc1b6064d12a0b7c101426a"
+    -- ScriptHash "3f284e451d67e2c2ed1b255d253a58c1810cce58cde329ad04f3bc92"
     -- Preprocessed PlutusV1 Script:
     -- @@@
     -- alwaysSucceedsNoDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -47,9 +47,9 @@ alwaysSucceedsNoDatum =
     --                                                                                                                                                              _ -> GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV1 ->
-      [ "582701000022533333573466e1d200235573a6ea8d5d09aba235573c6ea80048800888004584480041"
+      [ "5821010000225333573466e1d200235573a6ea8d5d09aba235573c6ea8004584480041"
       ]
-    -- ScriptHash "132397a885b923fd890d41606a62c547b2892f9e7abee9a64a624d75"
+    -- ScriptHash "f610f0bf10e7d6607e34074a162db1b98965dd322c23e2754a7eec0c"
     -- Preprocessed PlutusV2 Script:
     -- @@@
     -- alwaysSucceedsNoDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -62,9 +62,9 @@ alwaysSucceedsNoDatum =
     --                                                                                                                                                              _ -> GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV2 ->
-      [ "582701000022533333573466e1d200235573a6ea8d5d09aba235573c6ea80048800888004584480041"
+      [ "5821010000225333573466e1d200235573a6ea8d5d09aba235573c6ea8004584480041"
       ]
-    -- ScriptHash "fe55d3cc74c450d6c71bd0fdb4fc1025899e9cb7b73b3e23c727582a"
+    -- ScriptHash "4e9db3dc0d211bd9b8c958b7fd3969c6224226c84d52a1e09f0ea25f"
     -- Preprocessed PlutusV3 Script:
     -- @@@
     -- alwaysSucceedsNoDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -78,12 +78,13 @@ alwaysSucceedsNoDatum =
     --                                                                         _ -> GHC.Types.True})
     -- @@@
     SPlutusV3 ->
-      [ "588f01010025329325333573466e1d200235573a0022b2646464a666ae68cdc3a4004004300215333573466e1d"
-      , "200000218009aba100109802a481035054310035573c0046aae74004dd51aba1357446aae78006430028c00030"
-      , "003755264650013574200535742003357426ae880046ae88004d55cf1baa002911000a29344c00524103505435"
-      , "00119319ab9c00180001"
+      [ "58bf0101002532333573464a666ae68cdc3a40046aae7400464c8cc88cc94ccd5cd19b88003480004c01924103"
+      , "5054360013300100380194004d5d0800b003280160001918008009114800cc0212410350543700912999ab9a33"
+      , "70e9000002080109991980300300099b81004480080040026aae74004d55cf0009baa357426ae88d55cf000c92"
+      , "852885289baa932328009aba10029aba10019aba135744002357440026aae78dd5001488800429309800a48103"
+      , "50543500232633573800300001"
       ]
-    -- ScriptHash "df51d14275d6a08131f62936d067cf54981d402bf1b4ce52d7574868"
+    -- ScriptHash "b9c620f0276889c6573e987c322342924d97c8ec4bee83593aef999d"
     -- Preprocessed PlutusV4 Script:
     -- @@@
     -- alwaysSucceedsNoDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -97,17 +98,18 @@ alwaysSucceedsNoDatum =
     --                                                                         _ -> GHC.Types.True})
     -- @@@
     SPlutusV4 ->
-      [ "588f01010025329325333573466e1d200235573a0022b2646464a666ae68cdc3a4004004300215333573466e1d"
-      , "200000218009aba100109802a481035054310035573c0046aae74004dd51aba1357446aae78006430028c00030"
-      , "003755264650013574200535742003357426ae880046ae88004d55cf1baa002911000a29344c00524103505435"
-      , "00119319ab9c00180001"
+      [ "58bf0101002532333573464a666ae68cdc3a40046aae7400464c8cc88cc94ccd5cd19b88003480004c01924103"
+      , "5054360013300100380194004d5d0800b003280160001918008009114800cc0212410350543700912999ab9a33"
+      , "70e9000002080109991980300300099b81004480080040026aae74004d55cf0009baa357426ae88d55cf000c92"
+      , "852885289baa932328009aba10029aba10019aba135744002357440026aae78dd5001488800429309800a48103"
+      , "50543500232633573800300001"
       ]
 
 -- | Script that always succeeds, unless arguments are malformed or context does not contain a datum
 alwaysSucceedsWithDatum :: SLanguage l -> Plutus l
 alwaysSucceedsWithDatum =
   decodeHexPlutus . mconcat . \case
-    -- ScriptHash "80794ea889fbdad2f9fd8be85e015186b74f9f16d673da0d8cd0a0cb"
+    -- ScriptHash "bf97f02604ffd780f1d72d535d60dbcd40e941577e8865f51c311478"
     -- Preprocessed PlutusV1 Script:
     -- @@@
     -- alwaysSucceedsWithDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -120,10 +122,9 @@ alwaysSucceedsWithDatum =
     --                                                                                                                                                                                           (PlutusLedgerApi.V1.Data.Contexts.Spending _) -> GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV1 ->
-      [ "582c010000222533333573466e1d200235573a6ea8d5d09aba235573c6ea800488008880044480044c8d400400"
-      , "59"
+      [ "58260100002225333573466e1d200235573a6ea8d5d09aba235573c6ea80044480044c8d40040059"
       ]
-    -- ScriptHash "6ebdd9edabd7377ce0adc5808f5b2a382f56db91af622274a3437242"
+    -- ScriptHash "32c1100dea60b653233e32adb33e20d9a30c8359f7072027ec3e00a0"
     -- Preprocessed PlutusV2 Script:
     -- @@@
     -- alwaysSucceedsWithDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -136,10 +137,9 @@ alwaysSucceedsWithDatum =
     --                                                                                                                                                                                           (PlutusLedgerApi.V1.Data.Contexts.Spending _) -> GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV2 ->
-      [ "582c010000222533333573466e1d200235573a6ea8d5d09aba235573c6ea800488008880044480044c8d400400"
-      , "59"
+      [ "58260100002225333573466e1d200235573a6ea8d5d09aba235573c6ea80044480044c8d40040059"
       ]
-    -- ScriptHash "050705265925bfed6d648141a2c90186196cac5d42d348fd71e3e8a4"
+    -- ScriptHash "5eac0376e2d041e1753d8a5a5f133d4fcdb69ac40c8030bad97bc3ad"
     -- Preprocessed PlutusV3 Script:
     -- @@@
     -- alwaysSucceedsWithDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -153,12 +153,13 @@ alwaysSucceedsWithDatum =
     --                                                                           _ -> GHC.Types.False})
     -- @@@
     SPlutusV3 ->
-      [ "588f01010025329325333573466e1d200235573a0022b2646464a666ae68cdc3a4004004300215333573466e1d"
-      , "200000218009aba100109802a481035054310035573c0046aae74004dd51aba1357446aae78006430008c00830"
-      , "023755264650013574200535742003357426ae880046ae88004d55cf1baa002911000a29344c00524103505435"
-      , "00119319ab9c00180001"
+      [ "58bf0101002532333573464a666ae68cdc3a40046aae7400464c8cc88cc94ccd5cd19b88003480004c01924103"
+      , "5054360013300100380194004d5d0800b003280160001918008009114800cc0212410350543700912999ab9a33"
+      , "70e9000002080109991980300300099b81004480080040026aae74004d55cf0009baa357426ae88d55cf000c92"
+      , "8d2805281baa932328009aba10029aba10019aba135744002357440026aae78dd5001488800429309800a48103"
+      , "50543500232633573800300001"
       ]
-    -- ScriptHash "345143a3c89001e035cdb186772a8a0ec06bae75008e83b47a208afd"
+    -- ScriptHash "dd4d8b97cfe1fef9d93cefb219d0d29689caa714a9acc9a432fa571e"
     -- Preprocessed PlutusV4 Script:
     -- @@@
     -- alwaysSucceedsWithDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -172,17 +173,18 @@ alwaysSucceedsWithDatum =
     --                                                                           _ -> GHC.Types.False})
     -- @@@
     SPlutusV4 ->
-      [ "588f01010025329325333573466e1d200235573a0022b2646464a666ae68cdc3a4004004300215333573466e1d"
-      , "200000218009aba100109802a481035054310035573c0046aae74004dd51aba1357446aae78006430008c00830"
-      , "023755264650013574200535742003357426ae880046ae88004d55cf1baa002911000a29344c00524103505435"
-      , "00119319ab9c00180001"
+      [ "58bf0101002532333573464a666ae68cdc3a40046aae7400464c8cc88cc94ccd5cd19b88003480004c01924103"
+      , "5054360013300100380194004d5d0800b003280160001918008009114800cc0212410350543700912999ab9a33"
+      , "70e9000002080109991980300300099b81004480080040026aae74004d55cf0009baa357426ae88d55cf000c92"
+      , "8d2805281baa932328009aba10029aba10019aba135744002357440026aae78dd5001488800429309800a48103"
+      , "50543500232633573800300001"
       ]
 
 -- | Script that always fails, unless arguments are malformed or context contains a datum
 alwaysFailsNoDatum :: SLanguage l -> Plutus l
 alwaysFailsNoDatum =
   decodeHexPlutus . mconcat . \case
-    -- ScriptHash "fb056216e4771d75bebe284f847973d339debcab1efa4aca41042904"
+    -- ScriptHash "b85a057b2c91b4c2984a77a5dd10afe15a404687825324ba58ad07f5"
     -- Preprocessed PlutusV1 Script:
     -- @@@
     -- alwaysFailsNoDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -197,9 +199,9 @@ alwaysFailsNoDatum =
     --                                                                                                                                                                        _) -> PlutusTx.Builtins.error GHC.Tuple.Prim.()}}
     -- @@@
     SPlutusV1 ->
-      [ "582701000022533333573466e1d200235573a6ea8d5d09aba235573c6ea80048800888004448004581"
+      [ "5821010000225333573466e1d200235573a6ea8d5d09aba235573c6ea8004448004581"
       ]
-    -- ScriptHash "5e6f02d2c239a842496fab233941779e1a79f78f3fb869e6882d249a"
+    -- ScriptHash "02f4fe174ec961b3cc942ab15baa193a266ea4560a28690dd78d975d"
     -- Preprocessed PlutusV2 Script:
     -- @@@
     -- alwaysFailsNoDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -214,9 +216,9 @@ alwaysFailsNoDatum =
     --                                                                                                                                                                        _) -> PlutusTx.Builtins.error GHC.Tuple.Prim.()}}
     -- @@@
     SPlutusV2 ->
-      [ "582701000022533333573466e1d200235573a6ea8d5d09aba235573c6ea80048800888004448004581"
+      [ "5821010000225333573466e1d200235573a6ea8d5d09aba235573c6ea8004448004581"
       ]
-    -- ScriptHash "397eaf37d93a75d41e796ff480110f69bdbdcb5c06ed77817430c757"
+    -- ScriptHash "d17097dcd2e7298f8050fa045e9ea045c443d3af574099fd2c3813f4"
     -- Preprocessed PlutusV3 Script:
     -- @@@
     -- alwaysFailsNoDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -231,11 +233,12 @@ alwaysFailsNoDatum =
     --                                                                  GHC.Maybe.Nothing -> GHC.Types.True})
     -- @@@
     SPlutusV3 ->
-      [ "587d01010025329325333573466e1d200235573a0022b2646464a666ae68cdc3a4004004300215333573466e1d"
-      , "200000218009aba100109802a481035054310035573c0046aae74004dd51aba1357446aae78006430008c00830"
-      , "0237546ae84d5d11aba235573c6ea800a29344c00524010350543500119319ab9c00180001"
+      [ "58aa0101002532333573464a666ae68cdc3a40046aae7400464c8c8cc94ccd5cd19b88002480004c0152410350"
+      , "54360013300100280194004d5d0800b003280160001918008009114800cc01d2410350543700912999ab9a3370"
+      , "e9000002080109991980300300099b81004480080046aae78008d55ce8009baa357426ae88d55cf000c928d280"
+      , "5281baa357426ae88d5d11aab9e375400429309800a4810350543500232633573800300001"
       ]
-    -- ScriptHash "b2b06c827945aed108a3067c14db0401a70cccd8bd76e9193ca30171"
+    -- ScriptHash "9c34883e72eb93d6ec4f6fc325a15270538f4c798694d20fc899fe8b"
     -- Preprocessed PlutusV4 Script:
     -- @@@
     -- alwaysFailsNoDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -250,16 +253,17 @@ alwaysFailsNoDatum =
     --                                                                  GHC.Maybe.Nothing -> GHC.Types.True})
     -- @@@
     SPlutusV4 ->
-      [ "587d01010025329325333573466e1d200235573a0022b2646464a666ae68cdc3a4004004300215333573466e1d"
-      , "200000218009aba100109802a481035054310035573c0046aae74004dd51aba1357446aae78006430008c00830"
-      , "0237546ae84d5d11aba235573c6ea800a29344c00524010350543500119319ab9c00180001"
+      [ "58aa0101002532333573464a666ae68cdc3a40046aae7400464c8c8cc94ccd5cd19b88002480004c0152410350"
+      , "54360013300100280194004d5d0800b003280160001918008009114800cc01d2410350543700912999ab9a3370"
+      , "e9000002080109991980300300099b81004480080046aae78008d55ce8009baa357426ae88d55cf000c928d280"
+      , "5281baa357426ae88d5d11aab9e375400429309800a4810350543500232633573800300001"
       ]
 
 -- | Script that always fails, unless arguments are malformed or context does not contain a datum
 alwaysFailsWithDatum :: SLanguage l -> Plutus l
 alwaysFailsWithDatum =
   decodeHexPlutus . mconcat . \case
-    -- ScriptHash "a8074e5eb2d6fd0405c18c3b8c271661dfe253eecb2d1e606b168522"
+    -- ScriptHash "4d21fdf22b322b92f116190ded13f1a2f5e8eae550af556a2c3898fc"
     -- Preprocessed PlutusV1 Script:
     -- @@@
     -- alwaysFailsWithDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -277,9 +281,9 @@ alwaysFailsWithDatum =
     --                                                                                                                                                                                                                                          _) -> GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV1 ->
-      [ "5827010000222533333573466e1d200235573a6ea8d5d09aba235573c6ea8004880088800458448005"
+      [ "58210100002225333573466e1d200235573a6ea8d5d09aba235573c6ea800458448005"
       ]
-    -- ScriptHash "093940a15bd9f34c94117d7e46fe646c0234128675f11f623f3a25a0"
+    -- ScriptHash "aade2c5c9e32ea7a8f9c284d3e958fbabe9f4838ef6bdd665b43d9d6"
     -- Preprocessed PlutusV2 Script:
     -- @@@
     -- alwaysFailsWithDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -297,9 +301,9 @@ alwaysFailsWithDatum =
     --                                                                                                                                                                                                                                          _) -> GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV2 ->
-      [ "5827010000222533333573466e1d200235573a6ea8d5d09aba235573c6ea8004880088800458448005"
+      [ "58210100002225333573466e1d200235573a6ea8d5d09aba235573c6ea800458448005"
       ]
-    -- ScriptHash "0e654a380f53ed4b74f3564a290cf5d10c17ed3740ec5c4c96403cce"
+    -- ScriptHash "fe06a34d1d485bd8a21b83a980ba663e9ceba5ff3f782e7b43e9c757"
     -- Preprocessed PlutusV3 Script:
     -- @@@
     -- alwaysFailsWithDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -314,11 +318,12 @@ alwaysFailsWithDatum =
     --                                                                    GHC.Maybe.Nothing -> GHC.Types.True})
     -- @@@
     SPlutusV3 ->
-      [ "587d01010025329325333573466e1d200235573a0022b2646464a666ae68cdc3a4004004300215333573466e1d"
-      , "200000218009aba100109802a481035054310035573c0046aae74004dd51aba1357446aae78006430028c00030"
-      , "0037546ae84d5d11aba235573c6ea800a29344c00524010350543500119319ab9c00180001"
+      [ "58aa0101002532333573464a666ae68cdc3a40046aae7400464c8c8cc94ccd5cd19b88002480004c0152410350"
+      , "54360013300100280194004d5d0800b003280160001918008009114800cc01d2410350543700912999ab9a3370"
+      , "e9000002080109991980300300099b81004480080046aae78008d55ce8009baa357426ae88d55cf000c9285288"
+      , "5289baa357426ae88d5d11aab9e375400429309800a4810350543500232633573800300001"
       ]
-    -- ScriptHash "79e6b15fb0a76f065ed37ac22abdc424c8564d196aa1db0f74eec726"
+    -- ScriptHash "134610f2ab49e9f57bed9797a5605236b323d5bf61d533fbbf94d9a9"
     -- Preprocessed PlutusV4 Script:
     -- @@@
     -- alwaysFailsWithDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -333,9 +338,10 @@ alwaysFailsWithDatum =
     --                                                                    GHC.Maybe.Nothing -> GHC.Types.True})
     -- @@@
     SPlutusV4 ->
-      [ "587d01010025329325333573466e1d200235573a0022b2646464a666ae68cdc3a4004004300215333573466e1d"
-      , "200000218009aba100109802a481035054310035573c0046aae74004dd51aba1357446aae78006430028c00030"
-      , "0037546ae84d5d11aba235573c6ea800a29344c00524010350543500119319ab9c00180001"
+      [ "58aa0101002532333573464a666ae68cdc3a40046aae7400464c8c8cc94ccd5cd19b88002480004c0152410350"
+      , "54360013300100280194004d5d0800b003280160001918008009114800cc01d2410350543700912999ab9a3370"
+      , "e9000002080109991980300300099b81004480080046aae78008d55ce8009baa357426ae88d55cf000c9285288"
+      , "5289baa357426ae88d5d11aab9e375400429309800a4810350543500232633573800300001"
       ]
 
 -- | Script that succeeds whenever redeemer equals to the datum
@@ -343,7 +349,7 @@ alwaysFailsWithDatum =
 redeemerSameAsDatum :: SLanguage l -> Plutus l
 redeemerSameAsDatum =
   decodeHexPlutus . mconcat . \case
-    -- ScriptHash "efcfdd640c3dda3c352704e4b09152b6e2aa08f8cece773e50d038d8"
+    -- ScriptHash "8434e5ac35b5faf73a6f48cfaeb75d946149d15ebcac279993761fe5"
     -- Preprocessed PlutusV1 Script:
     -- @@@
     -- redeemerSameAsDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -357,10 +363,10 @@ redeemerSameAsDatum =
     --                                                                                                                                                                                                                                         | GHC.Base.otherwise -> PlutusTx.Builtins.error GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV1 ->
-      [ "584201000022253332235333573466e1d200235573a6ea8d5d09aba235573c6ea800c00800454cd4ccd5cd19ba"
-      , "f004005002001112001161220021220011323500100161"
+      [ "58310100002225333573466e1d200235573a6ea8d5d09aba235573c6ea800454ccd5cd19baf002003112001161"
+      , "323500100161"
       ]
-    -- ScriptHash "0a08efae260718fdef595e33e1c7bc23134c477f592e25069e3ba0fe"
+    -- ScriptHash "b2cde39d731e1a641e3efab1fe83d09e77dde65ee50848d18107f039"
     -- Preprocessed PlutusV2 Script:
     -- @@@
     -- redeemerSameAsDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -374,10 +380,10 @@ redeemerSameAsDatum =
     --                                                                                                                                                                                                                                         | GHC.Base.otherwise -> PlutusTx.Builtins.error GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV2 ->
-      [ "584201000022253332235333573466e1d200235573a6ea8d5d09aba235573c6ea800c00800454cd4ccd5cd19ba"
-      , "f004005002001112001161220021220011323500100161"
+      [ "58310100002225333573466e1d200235573a6ea8d5d09aba235573c6ea800454ccd5cd19baf002003112001161"
+      , "323500100161"
       ]
-    -- ScriptHash "e253270385499049e2a2bdc82e885bef9ef7ea720e31d1f6771e89e4"
+    -- ScriptHash "709ed1e9554b38acc0ad0eb8fbc14847d6fe3b8e710a2a11d1a0b39c"
     -- Preprocessed PlutusV3 Script:
     -- @@@
     -- redeemerSameAsDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -390,12 +396,13 @@ redeemerSameAsDatum =
     --                                                                   _ -> GHC.Types.False})
     -- @@@
     SPlutusV3 ->
-      [ "588c0101002532932325333573466e1d200235573a0022b2646464a666ae68cdc3a4004004300215333573466e"
-      , "1d200000218009aba1001098032481035054310035573c0046aae74004dd51aba1357446aae7800642666ae68c"
-      , "dd78009aba1003800400a30020c008dd51aba1357440026ae88d55cf1baa0028a4d13001490103505435001193"
-      , "19ab9c00180001"
+      [ "58b3010100253233357346464a666ae68cdc3a40046aae7400464c8c8cc94ccd5cd19b88002480004c01924103"
+      , "5054360013300100280194004d5d0800b003280160001918008009114800cc0212410350543700912999ab9a33"
+      , "70e9000002080109991980300300099b81004480080046aae78008d55ce8009baa357426ae88d55cf000c8cdd7"
+      , "8009aba1003a500a5037546ae84d5d10009aba235573c6ea800852613001490103505435002326335738003000"
+      , "01"
       ]
-    -- ScriptHash "add5e5653671c36925384d801e143220a2b86383fd13be43068350b0"
+    -- ScriptHash "2af82f67d14401419594b15791a9b6cd71927359bd83cd9f322d2673"
     -- Preprocessed PlutusV4 Script:
     -- @@@
     -- redeemerSameAsDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -408,10 +415,11 @@ redeemerSameAsDatum =
     --                                                                   _ -> GHC.Types.False})
     -- @@@
     SPlutusV4 ->
-      [ "588c0101002532932325333573466e1d200235573a0022b2646464a666ae68cdc3a4004004300215333573466e"
-      , "1d200000218009aba1001098032481035054310035573c0046aae74004dd51aba1357446aae7800642666ae68c"
-      , "dd78009aba1003800400a30020c008dd51aba1357440026ae88d55cf1baa0028a4d13001490103505435001193"
-      , "19ab9c00180001"
+      [ "58b3010100253233357346464a666ae68cdc3a40046aae7400464c8c8cc94ccd5cd19b88002480004c01924103"
+      , "5054360013300100280194004d5d0800b003280160001918008009114800cc0212410350543700912999ab9a33"
+      , "70e9000002080109991980300300099b81004480080046aae78008d55ce8009baa357426ae88d55cf000c8cdd7"
+      , "8009aba1003a500a5037546ae84d5d10009aba235573c6ea800852613001490103505435002326335738003000"
+      , "01"
       ]
 
 -- | Script that succeeds whenever Integer datum is supplied and it's value is even.
@@ -419,7 +427,7 @@ redeemerSameAsDatum =
 evenDatum :: SLanguage l -> Plutus l
 evenDatum =
   decodeHexPlutus . mconcat . \case
-    -- ScriptHash "1c80082f0c1eb0dfd87825ea96d0d513b0cf197799da830b7e0ef276"
+    -- ScriptHash "48b29a063768bc21d0e6eeed6e3e4f23a174164f8e8252c8845daceb"
     -- Preprocessed PlutusV1 Script:
     -- @@@
     -- evenDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -433,10 +441,10 @@ evenDatum =
     --                                                                                                                                                                                                                             | GHC.Base.otherwise -> PlutusTx.Builtins.error GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV1 ->
-      [ "584901000022253332235333573466e1d200235573a6ea8d5d09aba235573c6ea800c00800454cd4ccd5cd19b8"
-      , "748000cdc31bad00548010008004448004584880084880044c8d40040059"
+      [ "58380100002225333573466e1d200235573a6ea8d5d09aba235573c6ea800454ccd5cd19b8748000cdc31bad00"
+      , "348010448004584c8d40040059"
       ]
-    -- ScriptHash "6569ce6d13f3f4933fb6b9a98bcca83be34b2d4e57b3dbc9323136c7"
+    -- ScriptHash "a1741f496dd45f8ce84db15246ee75a663914bce6807a14ee9a543bc"
     -- Preprocessed PlutusV2 Script:
     -- @@@
     -- evenDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -450,10 +458,10 @@ evenDatum =
     --                                                                                                                                                                                                                             | GHC.Base.otherwise -> PlutusTx.Builtins.error GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV2 ->
-      [ "584901000022253332235333573466e1d200235573a6ea8d5d09aba235573c6ea800c00800454cd4ccd5cd19b8"
-      , "748000cdc31bad00548010008004448004584880084880044c8d40040059"
+      [ "58380100002225333573466e1d200235573a6ea8d5d09aba235573c6ea800454ccd5cd19b8748000cdc31bad00"
+      , "348010448004584c8d40040059"
       ]
-    -- ScriptHash "3683d601f751922c67fca7c15d7101e4ae5ff1c499b8da0462a77f06"
+    -- ScriptHash "acd6e72aa28151b8a9527c742475bb96601ca44711c1d8cb01a6601c"
     -- Preprocessed PlutusV3 Script:
     -- @@@
     -- evenDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -465,12 +473,13 @@ evenDatum =
     --                                                                                                                                                         (GHC.Maybe.Just (PlutusLedgerApi.V1.Scripts.Datum datum_4))) -> PlutusTx.Prelude.modulo (PlutusTx.Builtins.unsafeDataAsI datum_4) 2 PlutusTx.Eq.== 0})
     -- @@@
     SPlutusV3 ->
-      [ "589501010025329325333573466e1d200235573a0022b2646464a666ae68cdc3a4004004300215333573466e1d"
-      , "200000218009aba100109802a481035054310035573c0046aae74004dd51aba1357446aae7800642666ae68cdc"
-      , "3a400066e18dd6800a400900080144ca400600260994800c004c6ea8d5d09aba2357446aae78dd500145268980"
-      , "0a490350543500119319ab9c00180001"
+      [ "58bd0101002532333573464a666ae68cdc3a40046aae7400464c8c8cc94ccd5cd19b88002480004c0152410350"
+      , "54360013300100280194004d5d0800b003280160001918008009114800cc01d2410350543700912999ab9a3370"
+      , "e9000002080109991980300300099b81004480080046aae78008d55ce8009baa357426ae88d55cf000c8cdc3a4"
+      , "00066e18dd6800a400932900180098265200300131baa357426ae88d5d11aab9e375400429309800a481035054"
+      , "3500232633573800300001"
       ]
-    -- ScriptHash "6049e4258efcaeb1184cce4aad22dad0faab2982bd90b9118b7ac7b3"
+    -- ScriptHash "82d6046ef0fce690415684c09513a5e3cb6ec22f86845fff4ca9d430"
     -- Preprocessed PlutusV4 Script:
     -- @@@
     -- evenDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -482,10 +491,11 @@ evenDatum =
     --                                                                                                                                                         (GHC.Maybe.Just (PlutusLedgerApi.V1.Scripts.Datum datum_4))) -> PlutusTx.Prelude.modulo (PlutusTx.Builtins.unsafeDataAsI datum_4) 2 PlutusTx.Eq.== 0})
     -- @@@
     SPlutusV4 ->
-      [ "589501010025329325333573466e1d200235573a0022b2646464a666ae68cdc3a4004004300215333573466e1d"
-      , "200000218009aba100109802a481035054310035573c0046aae74004dd51aba1357446aae7800642666ae68cdc"
-      , "3a400066e18dd6800a400900080144ca400600260994800c004c6ea8d5d09aba2357446aae78dd500145268980"
-      , "0a490350543500119319ab9c00180001"
+      [ "58bd0101002532333573464a666ae68cdc3a40046aae7400464c8c8cc94ccd5cd19b88002480004c0152410350"
+      , "54360013300100280194004d5d0800b003280160001918008009114800cc01d2410350543700912999ab9a3370"
+      , "e9000002080109991980300300099b81004480080046aae78008d55ce8009baa357426ae88d55cf000c8cdc3a4"
+      , "00066e18dd6800a400932900180098265200300131baa357426ae88d5d11aab9e375400429309800a481035054"
+      , "3500232633573800300001"
       ]
 
 -- | Script that succeeds whenever Integer redeemer is supplied and it's value is even
@@ -493,7 +503,7 @@ evenDatum =
 evenRedeemerNoDatum :: SLanguage l -> Plutus l
 evenRedeemerNoDatum =
   decodeHexPlutus . mconcat . \case
-    -- ScriptHash "ce69f88ce1fff3d8d2ee0bc573597fbac5f48097618b471bfa852010"
+    -- ScriptHash "ff651f4b89881b72407d020292291809ed49e4f1757a9745e35498c1"
     -- Preprocessed PlutusV1 Script:
     -- @@@
     -- evenRedeemerNoDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -508,10 +518,10 @@ evenRedeemerNoDatum =
     --                                                                                                                                                                    else PlutusTx.Builtins.error GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV1 ->
-      [ "58440100002253322335333573466e1d200235573a6ea8d5d09aba235573c6ea800c0080045854cd4ccd5cd19b"
-      , "8748000cdc31bad00448010008004448004584880084880041"
+      [ "5833010000225333573466e1d200235573a6ea8d5d09aba235573c6ea80045854ccd5cd19b8748000cdc31bad0"
+      , "0248010448004581"
       ]
-    -- ScriptHash "d6b4c62713e16b076c69abd2cc0291aace4a2214707be6d445d80127"
+    -- ScriptHash "5dae481efaf96e0c4203cf261dc16bda7e91171afc69c655ff623a66"
     -- Preprocessed PlutusV2 Script:
     -- @@@
     -- evenRedeemerNoDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -526,10 +536,10 @@ evenRedeemerNoDatum =
     --                                                                                                                                                                    else PlutusTx.Builtins.error GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV2 ->
-      [ "58440100002253322335333573466e1d200235573a6ea8d5d09aba235573c6ea800c0080045854cd4ccd5cd19b"
-      , "8748000cdc31bad00448010008004448004584880084880041"
+      [ "5833010000225333573466e1d200235573a6ea8d5d09aba235573c6ea80045854ccd5cd19b8748000cdc31bad0"
+      , "0248010448004581"
       ]
-    -- ScriptHash "995999ddbb8a454f312c81b8abef4d0da01e4c10497189228fba0cc6"
+    -- ScriptHash "2f7dc5ea3191b1a56836f1547ed58d2af1f1917b784333e8332938c9"
     -- Preprocessed PlutusV3 Script:
     -- @@@
     -- evenRedeemerNoDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -543,12 +553,13 @@ evenRedeemerNoDatum =
     --                                                                                                                                   _ -> PlutusTx.Prelude.modulo (PlutusTx.Builtins.unsafeDataAsI redeemer_3) 2 PlutusTx.Eq.== 0}})
     -- @@@
     SPlutusV3 ->
-      [ "5899010100253293232532333573466e1d200235573a0042b2646464a666ae68cdc3a400400430021533357346"
-      , "6e1d200000218009aba100109803a481035054310035573c0046aae74004dd51aba1357446aae7800a43002898"
-      , "00a4c130014988ccd5cd19b8748000cdc31bad35742006900240020046ea8d5d09aba2001357446aae78dd5001"
-      , "452689800a490350543500119319ab9c00180001"
+      [ "58c1010100253233357346464a64666ae68cdc3a40046aae7400864c8c8cc94ccd5cd19b88002480004c01d241"
+      , "035054360013300100280194004d5d0800b003280160001918008009114800cc0252410350543700912999ab9a"
+      , "3370e9000002080109991980300300099b81004480080046aae78008d55ce8009baa357426ae88d55cf0014928"
+      , "4c0052609800a4c466e1d20003370c6eb4d5d0801a40086ea8d5d09aba2001357446aae78dd50010a4c2600292"
+      , "010350543500232633573800300001"
       ]
-    -- ScriptHash "cfaed7d88b97e925766ca17e00c875238660a763dda6ecbf072c7938"
+    -- ScriptHash "9f83efc6981b7c761bd519ec7f9c30ca90d99aa4c3d4ff70f9d5e8a2"
     -- Preprocessed PlutusV4 Script:
     -- @@@
     -- evenRedeemerNoDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -562,10 +573,11 @@ evenRedeemerNoDatum =
     --                                                                                                                                   _ -> PlutusTx.Prelude.modulo (PlutusTx.Builtins.unsafeDataAsI redeemer_3) 2 PlutusTx.Eq.== 0}})
     -- @@@
     SPlutusV4 ->
-      [ "5899010100253293232532333573466e1d200235573a0042b2646464a666ae68cdc3a400400430021533357346"
-      , "6e1d200000218009aba100109803a481035054310035573c0046aae74004dd51aba1357446aae7800a43002898"
-      , "00a4c130014988ccd5cd19b8748000cdc31bad35742006900240020046ea8d5d09aba2001357446aae78dd5001"
-      , "452689800a490350543500119319ab9c00180001"
+      [ "58c1010100253233357346464a64666ae68cdc3a40046aae7400864c8c8cc94ccd5cd19b88002480004c01d241"
+      , "035054360013300100280194004d5d0800b003280160001918008009114800cc0252410350543700912999ab9a"
+      , "3370e9000002080109991980300300099b81004480080046aae78008d55ce8009baa357426ae88d55cf0014928"
+      , "4c0052609800a4c466e1d20003370c6eb4d5d0801a40086ea8d5d09aba2001357446aae78dd50010a4c2600292"
+      , "010350543500232633573800300001"
       ]
 
 -- | Script that succeeds whenever Integer redeemer is supplied and it's value is even
@@ -573,7 +585,7 @@ evenRedeemerNoDatum =
 evenRedeemerWithDatum :: SLanguage l -> Plutus l
 evenRedeemerWithDatum =
   decodeHexPlutus . mconcat . \case
-    -- ScriptHash "5eda794e03460a4c89bd2fb5e529a69e7fef309adab03978e98fb5e1"
+    -- ScriptHash "ce2c6a09fd9706d2fa13bad68d83b9bee1e59423a9e8b4eb291c089c"
     -- Preprocessed PlutusV1 Script:
     -- @@@
     -- evenRedeemerWithDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -587,10 +599,10 @@ evenRedeemerWithDatum =
     --                                                                                                                                                                                                                                         | GHC.Base.otherwise -> PlutusTx.Builtins.error GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV1 ->
-      [ "584901000022253332235333573466e1d200235573a6ea8d5d09aba235573c6ea800c00800454cd4ccd5cd19b8"
-      , "748000cdc31bad00448010008004448004584880084880044c8d40040059"
+      [ "58380100002225333573466e1d200235573a6ea8d5d09aba235573c6ea800454ccd5cd19b8748000cdc31bad00"
+      , "248010448004584c8d40040059"
       ]
-    -- ScriptHash "e521695ec6eb4c320952779cc18773d661aa5708d437d903ffbcf41f"
+    -- ScriptHash "9c542eaf9fbd625c5ff40fe4eedbd1b415fa5edf73c679fc9d5aca32"
     -- Preprocessed PlutusV2 Script:
     -- @@@
     -- evenRedeemerWithDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -604,10 +616,10 @@ evenRedeemerWithDatum =
     --                                                                                                                                                                                                                                         | GHC.Base.otherwise -> PlutusTx.Builtins.error GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV2 ->
-      [ "584901000022253332235333573466e1d200235573a6ea8d5d09aba235573c6ea800c00800454cd4ccd5cd19b8"
-      , "748000cdc31bad00448010008004448004584880084880044c8d40040059"
+      [ "58380100002225333573466e1d200235573a6ea8d5d09aba235573c6ea800454ccd5cd19b8748000cdc31bad00"
+      , "248010448004584c8d40040059"
       ]
-    -- ScriptHash "9e4b54d2383790da632531780a87181e0d75ce74d8ce3d1c86f2ab1e"
+    -- ScriptHash "9e2cea9225060fd0338cd1727e556f64ea1cb34ef53aaaa1632723fd"
     -- Preprocessed PlutusV3 Script:
     -- @@@
     -- evenRedeemerWithDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -620,12 +632,13 @@ evenRedeemerWithDatum =
     --                                                                     _ -> GHC.Types.False})
     -- @@@
     SPlutusV3 ->
-      [ "58930101002532932325333573466e1d200235573a0022b2646464a666ae68cdc3a4004004300215333573466e"
-      , "1d200000218009aba1001098032481035054310035573c0046aae74004dd51aba1357446aae7800642666ae68c"
-      , "dc3a400066e18dd69aba1003480120010028c008300237546ae84d5d10009aba235573c6ea800a29344c005241"
-      , "0350543500119319ab9c00180001"
+      [ "58ba010100253233357346464a666ae68cdc3a40046aae7400464c8c8cc94ccd5cd19b88002480004c01924103"
+      , "5054360013300100280194004d5d0800b003280160001918008009114800cc0212410350543700912999ab9a33"
+      , "70e9000002080109991980300300099b81004480080046aae78008d55ce8009baa357426ae88d55cf000c8cdc3"
+      , "a400066e18dd69aba1003480129402940dd51aba1357440026ae88d55cf1baa00214984c005241035054350023"
+      , "2633573800300001"
       ]
-    -- ScriptHash "c4c12ed7d4d5478318974f60a46a5cbbf4a2eea2960a5296e3f2a69d"
+    -- ScriptHash "348c5f8a2b1a1ea2797e37f1eb109ee639c900736fb1f6176430a01f"
     -- Preprocessed PlutusV4 Script:
     -- @@@
     -- evenRedeemerWithDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -638,10 +651,11 @@ evenRedeemerWithDatum =
     --                                                                     _ -> GHC.Types.False})
     -- @@@
     SPlutusV4 ->
-      [ "58930101002532932325333573466e1d200235573a0022b2646464a666ae68cdc3a4004004300215333573466e"
-      , "1d200000218009aba1001098032481035054310035573c0046aae74004dd51aba1357446aae7800642666ae68c"
-      , "dc3a400066e18dd69aba1003480120010028c008300237546ae84d5d10009aba235573c6ea800a29344c005241"
-      , "0350543500119319ab9c00180001"
+      [ "58ba010100253233357346464a666ae68cdc3a40046aae7400464c8c8cc94ccd5cd19b88002480004c01924103"
+      , "5054360013300100280194004d5d0800b003280160001918008009114800cc0212410350543700912999ab9a33"
+      , "70e9000002080109991980300300099b81004480080046aae78008d55ce8009baa357426ae88d55cf000c8cdc3"
+      , "a400066e18dd69aba1003480129402940dd51aba1357440026ae88d55cf1baa00214984c005241035054350023"
+      , "2633573800300001"
       ]
 
 -- | Script that succeeds when datum is not expected and purpose arguments are validated against txInfo
@@ -649,7 +663,7 @@ evenRedeemerWithDatum =
 purposeIsWellformedNoDatum :: SLanguage l -> Plutus l
 purposeIsWellformedNoDatum =
   decodeHexPlutus . mconcat . \case
-    -- ScriptHash "1117d0f8a27607587f35f62a717798de99ce1b7a7361fcfcc69028a6"
+    -- ScriptHash "80cecc689f438b344917845205137d6e102dcae622420aeaa1d73011"
     -- Preprocessed PlutusV1 Script:
     -- @@@
     -- purposeIsWellformedNoDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -670,40 +684,38 @@ purposeIsWellformedNoDatum =
     --                                                                                                                                                                                                                              else GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV1 ->
-      [ "59058f01000022323232532323322323232335333573466e1d2000001005004153353323001001233003005253"
-      , "35333573466ebcdd49bae357426aae78028d55ce80080380309004091980180180099980180491111111110039"
-      , "308038b0a99a999ab9a3370e90010008028020b0a99191919a999ab9a3370e90020020040038a99a9801999980"
-      , "11191919299a999ab9a3370e90000010060058999109198008018011aba1001375a6ae84d5d100089806a48103"
-      , "5054310035573c0046aae74004dd500091a8009119ba548000cd5d000119aba0375000297ae0233002357426aa"
-      , "e78030d400488008ccc01803088888888880149858402854cd4ccd5cd19b874801801002001c54cd4c00ccccc0"
-      , "08800480048c8c94c8cd4ccd5cd19b8748000d55ce801006005899299a999ab9a3370e90001aab9d00100d00c1"
-      , "33006357426aae7800cd5d09aab9e00113002498dd500209800a4c4a6466a666ae68cdc3a40046aae7400c0340"
-      , "304c94cd4ccd5cd19b8748008d55ce8008070068998039aba135573c0086ae84d55cf0008980124c6ea80144c0"
-      , "052623232332330010072233300300a2253353300d004002133007003001101323005498888c94cd4ccd5cd19b"
-      , "8748010d55ce800809809099198021aba1001375c6ae84d5d10009aab9e00113002498dd50019180124c464664"
-      , "660020104466600601644a66a666ae68cdc780200100a80a099804001800880a11802a4c44464a66a666ae68cd"
-      , "c3a400c6aae7400405004c4c8cc010dd71aba1001375c6ae84d5d10009aab9e00113002498dd50019180124c46"
-      , "4664660020124466600601844a66a666ae68cdc780200100b00a8999ab9a3370e00600202c02a202a4600a9311"
-      , "119299a999ab9a3370e90041aab9d00101501413233004375c6ae84004dd69aba1357440026aae780044c00926"
-      , "37540064600493129919a999ab9a3370e90051aab9d00801201115335333573466e1d200a35573a6ea80280480"
-      , "4440484c005261300149894cd4ccd5cd19b8748030d55ce8040090088999ab9a3370e90061aab9d37540140240"
-      , "22202244666ae68cdc78010008078071baa001357426aae78030ccc0180308888888888018985840284c8d4004"
-      , "005888c94c8cd4ccd5cd19b8748000d55ce801005805099299a999ab9a3370e90001aab9d00100c00b13232532"
-      , "335333573466e1d200035573a00401e01c264a66a666ae68cdc3a40006aae7400404003c4ccd5cd19b8f375c6a"
-      , "e84d55cf0019bae357426aae7800404003c4c00926375400626002931299a999ab9a3370e90011aab9d00200f0"
-      , "0e1325335333573466e1d200235573a00202001e2666ae68cdc79bae357426aae7800cdd71aba135573c002020"
-      , "01e201e6ea800c4038dd51aba135573c0086ae84d55cf0008980124c6ea800c4c0052623323300100522233300"
-      , "40072225335333573466e1c01800c04804454cd4ccd5cd19b870050020120111333573466e1c01000404804440"
-      , "444044803c888c94cd4ccd5cd19b8748008d55ce800807807099191998029bad357420046eb4d5d08009bad357"
-      , "426ae88004d5d10009aab9e00113002498dd500190059baa0022223223002001323001001223330084bd701119"
-      , "299a980300089919aba03008002001330050050021330050050023007002001233357346ae8c004018014d55ce"
-      , "8039112999aab9f0011003133002357420026ae88004888c8c8c8c8c8c8c8c8c8cccccccccc02cdd61aba10093"
-      , "7586ae84020dd59aba100737566ae84018dd61aba100537586ae84010d5d08019bac357420046eb0d5d0800991"
-      , "919299a999ab9a3370e900000100880809bae35742002260249201035054310035573c0046aae74004dd51aba1"
-      , "357440026ae88004d5d10009aba2001357440026ae88004d5d10009aba2001357440026aae78dd500189100109"
-      , "1000919319ab9c0010021200137546ae84d5d10011aba100135573c6ea8005"
+      [ "59051c0100003232323232323232332222323232532323232333573466e1d20000011533357346646002002466"
+      , "0249408ccd5cd19baf37526eb8d5d09aab9e00735573a00249448cc00c00c004ccc008018888888888801c9840"
+      , "4c5854ccd5cd19b87480080045854ccd5cd19b874801000454ccd5cd1aba33333010233005375400244666a00c"
+      , "66a01a4664424660020060046ae84004dd69aba13574400201c00400246a0024466e95200033574000466ae80d"
+      , "d4000a5eb808cc040d5d09aab9e006350012200233300200622222222220052616101315333573466e1d200600"
+      , "11533357346ae8ccccc040800480048c8c94c8ccd5cd19b8748000d55ce8010992999ab9a3370e90001aab9d00"
+      , "1133014357426aae7800cd5d09aab9e00113002498dd500209800a4c4a64666ae68cdc3a40046aae7400c4c94c"
+      , "cd5cd19b8748008d55ce80089980a9aba135573c0086ae84d55cf0008980124c6ea80144c00526232333012005"
+      , "22333014008225333573466032008004266e3c00c0045281180224c460049311919980a0031119980b00491299"
+      , "9ab9a3371e008004266e3c00c0045281180224c460049311919980b0039119980c005112999ab9a3371e008004"
+      , "266e1c00c0045281180224c46004931299199ab9a3370e90051aab9d00715333573466e1d200a35573a6ea8024"
+      , "52889800a4c260029312999ab9a3370e90061aab9d00713370e90061aab9d37540122940dd50009aba135573c0"
+      , "0c66600400c444444444400c4c2c20262646a002002c6aae74010888c8c8c8c8c8c8c8c8c8cccccccccc02cdd6"
+      , "1aba100937586ae84020dd59aba100737566ae84018dd61aba100537586ae84010d5d08019bac357420046eb0d"
+      , "5d0800998071baa357426ae8800488ccd403ccd40588dd71aba1001017002001357440026ae88004d5d10009ab"
+      , "a2001357440026ae88004d5d10009aba200135573c6ea800c4c8894ccd5cd19b88001480004c04924103505436"
+      , "00133003001002323001001222533500113012490103505437002215333573466e1d2000004100213323300600"
+      , "600133702008900100091198009aab9d00235573c0046ea8d5d09aba2002357420026aae78dd50008910010910"
+      , "9119800802001911192999ab9a3370e90021aab9d00113233004357420026eb8d5d09aba200135573c00226004"
+      , "931baa003222325333573466e1d200635573a002264660086eb8d5d08009bae357426ae88004d55cf000898012"
+      , "4c6ea800c888c94ccd5cd19b8748020d55ce800899198021bae357420026eb4d5d09aba200135573c002260049"
+      , "31baa0032232532333573466e1d200035573a004264a666ae68cdc3a40006aae740044c8c94c8ccd5cd19b8748"
+      , "000d55ce8010992999ab9a3370e90001aab9d00113371e6eb8d5d09aab9e003375c6ae84d55cf0008980124c6e"
+      , "a800c4c0052625333573466e1d200235573a004264a666ae68cdc3a40046aae740044cdc79bae357426aae7800"
+      , "cdd71aba135573c0022940dd50018a5037546ae84d55cf0021aba135573c00226004931baa003130014988cc8c"
+      , "c004014888ccc01001c8894ccd5cd19b8700600315333573466e1c0140084cdc38020008a5014a04940888c94c"
+      , "cd5cd19b8748008d55ce800899191998029bad357420046eb4d5d08009bad357426ae88004d5d10009aab9e001"
+      , "13002498dd50019250375400444464460040026460020024466600c97ae0223253335734600c00226466ae80c0"
+      , "20008004cc0140140084cc014014008c01c0080048894ccd55cf80088018998011aba100135744002464c66ae7"
+      , "000400848005"
       ]
-    -- ScriptHash "e2d0a2424ccffe2404cece6c4be01383c33abbedf23465d42cea41fa"
+    -- ScriptHash "84166eecfa9f1a575868b2586c71f5e3137d763894c88f37c61b9d84"
     -- Preprocessed PlutusV2 Script:
     -- @@@
     -- purposeIsWellformedNoDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -724,38 +736,36 @@ purposeIsWellformedNoDatum =
     --                                                                                                                                                                                                                              else GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV2 ->
-      [ "59053501000022323232532332232323232335333573466e1d2000001006005153353330027526eb8d5d09aab9"
-      , "e0083330040092222222222220082610071615335333573466e1d20020010060051615335333573466e1d20040"
-      , "01006005153353330022001357426aae78020ccc01002488888888888801898401c584c8c8c8c8c8c94cd4ccd5"
-      , "cd19b874801801c03002c54cd4ccd5cd1aba3300133300a00f2222222222220072600c00b16100d13235001001"
-      , "63230010012233300a4bd7011299a991929919a999ab9a3370e90001aab9d0020120111325335333573466e1d2"
-      , "00035573a0020260242660126ae84d55cf0019aba135573c00226004931baa0051300149894c8cd4ccd5cd19b8"
-      , "748008d55ce801809809099299a999ab9a3370e90011aab9d00101401313300a357426aae78010d5d09aab9e00"
-      , "113002498dd500309800a4c46466601600a4466601a01244a66a6601c008004266024006002202e46008931180"
-      , "124c46466601a00c4466601e01444a66a666ae68cdc780200100c80c099809801800880c1180224c4600493119"
-      , "1998078039119980880591299a999ab9a3371e0080040340322666ae68cdc380180080d00c880c9180224c4600"
-      , "493129919a999ab9a3370e90051aab9d00701701615335333573466e1d200a35573a6ea802805c058405c4c005"
-      , "261300149894cd4ccd5cd19b8748030d55ce80380b80b0999ab9a3370e90061aab9d375401402e02c202c6ea80"
-      , "04d5d09aab9e0111335740004660080080022660080080020024464a6466a666ae68cdc3a40006aae740080380"
-      , "344c94cd4ccd5cd19b8748000d55ce8008078070991929919a999ab9a3370e90001aab9d002012011132533533"
-      , "3573466e1d200035573a0020260242666ae68cdc79bae357426aae7800cdd71aba135573c00202602426004931"
-      , "baa0031300149894cd4ccd5cd19b8748008d55ce801009008899299a999ab9a3370e90011aab9d001013012133"
-      , "3573466e3cdd71aba135573c0066eb8d5d09aab9e0010130121012375400620226ea8d5d09aab9e004357426aa"
-      , "e780044c0092637540062600293119919800802911199802003911299a999ab9a3370e00c00602a0282a66a666"
-      , "ae68cdc380280100a80a0999ab9a3370e00800202a02820282028402444464a66a666ae68cdc3a40046aae7400"
-      , "40480444c8c8ccc014dd69aba1002375a6ae84004dd69aba1357440026ae88004d55cf0008980124c6ea800c80"
-      , "38dd500111119299a999ab9a3370e90021aab9d00100d00c13233004357420026eb8d5d09aba200135573c0022"
-      , "6004931baa003222325335333573466e1d200635573a002018016264660086eb8d5d08009bae357426ae88004d"
-      , "55cf0008980124c6ea800c888c94cd4ccd5cd19b8748020d55ce800805805099198021bae357420026eb4d5d09"
-      , "aba200135573c00226004931baa00322333573466e3c00800402001cd55ce80391119918008009198028039299"
-      , "a999ab9a3375e600a0086aae740040240204802848cc00c00c0040048894ccd55cf80088018998011aba100135"
-      , "744002444646464646464646464646466666666666601a6eb0d5d08059bac357420146eb0d5d08049bab357420"
-      , "106eacd5d08039bac3574200c6eacd5d08029aba100437586ae8400cdd59aba100237566ae84004c8c8c94cd4c"
-      , "cd5cd19b874800000804c0484dd71aba100113263357389201035054310001435573c0046aae74004dd51aba13"
-      , "57440026ae88004d5d10009aba2001357440026ae88004d5d10009aba2001357440026ae88004d5d10009aab9e"
-      , "3754006244004244002240026ea8d5d09aba2002357420026aae78dd500081"
+      [ "5904c601000032323232323232322232323253232333573466e1d2000001153335734666018ea4dd71aba13557"
+      , "3c0066660040084444444444440104c201e2c2a666ae68cdc3a40040022c2a666ae68cdc3a40080022a666ae68"
+      , "ccc0308004d5d09aab9e00333300200422222222222200626100f161325333573466e1d20060021533357346ae"
+      , "8cc004ccc00c01488888888888801c985840404c8d40040058c8c00400488ccc03d2f5c044a666ae68c8c94c8c"
+      , "cd5cd19b8748000d55ce8010992999ab9a3370e90001aab9d001133010357426aae7800cd5d09aab9e00113002"
+      , "498dd500289800a4c4a64666ae68cdc3a40046aae7400c4c94ccd5cd19b8748008d55ce8008998089aba135573"
+      , "c0086ae84d55cf0008980124c6ea80184c005262323330120052233301400922533357346602a008004266e3c0"
+      , "0c0045281180224c460049311919980a0031119980b005112999ab9a3371e008004266e3c00c0045281180224c"
+      , "460049311919980b0039119980c005912999ab9a3371e008004266e1c00c0045281180224c46004931299199ab"
+      , "9a3370e90051aab9d00715333573466e1d200a35573a6ea802852889800a4c260029312999ab9a3370e90061aa"
+      , "b9d00713370e90061aab9d37540142940dd50009aba135573c00e266ae80008cc0100100044cc010010004004d"
+      , "55ce80111119191919191919191919191999999999998069bac357420166eb0d5d08051bac357420126eacd5d0"
+      , "8041bab3574200e6eb0d5d08031bab3574200a6ae84010dd61aba100337566ae84008dd59aba10013232332533"
+      , "3573466e2000920001301d49010350543600133001002122330012375c6ae84004488008c8c0040048894cd400"
+      , "44c07d240103505437002215333573466e1d200000410021332330060060013370200890010009aab9e0023557"
+      , "3a0026ea8d5d09aba2001357440026ae88004d5d10009aba2001357440026ae88004d5d10009aba20013574400"
+      , "26ae88004d55cf1baa00337546ae84d5d10011aba100135573c6ea800488c94c8ccd5cd19b8748000d55ce8010"
+      , "992999ab9a3370e90001aab9d00113232532333573466e1d200035573a004264a666ae68cdc3a40006aae74004"
+      , "4cdc79bae357426aae7800cdd71aba135573c00226004931baa0031300149894ccd5cd19b8748008d55ce80109"
+      , "92999ab9a3370e90011aab9d00113371e6eb8d5d09aab9e003375c6ae84d55cf0008a5037540062940dd51aba1"
+      , "35573c0086ae84d55cf0008980124c6ea800c4c005262332330010052223330040072225333573466e1c01800c"
+      , "54ccd5cd19b8700500213370e00800229405281250222325333573466e1d200235573a0022646466600a6eb4d5"
+      , "d08011bad357420026eb4d5d09aba2001357440026aae780044c0092637540064940dd5001111192999ab9a337"
+      , "0e90021aab9d00113233004357420026eb8d5d09aba200135573c00226004931baa003222325333573466e1d20"
+      , "0635573a002264660086eb8d5d08009bae357426ae88004d55cf0008980124c6ea800c888c94ccd5cd19b87480"
+      , "20d55ce800899198021bae357420026eb4d5d09aba200135573c00226004931baa00322233230010012330054a"
+      , "04666ae68cdd798028021aab9d00124a2466006006002002444a666aae7c004400c4cc008d5d08009aba200123"
+      , "26335738002004240021"
       ]
-    -- ScriptHash "831aa04ba5972260091c6ecb072beeb941ee806df3f7b086c1449c10"
+    -- ScriptHash "41521dba681990883acbb09504a036ce45966a0131d840e1e8533d66"
     -- Preprocessed PlutusV3 Script:
     -- @@@
     -- purposeIsWellformedNoDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -781,55 +791,50 @@ purposeIsWellformedNoDatum =
     --                                                                                                                                                                                           _propProc_17 -> GHC.Types.True}})
     -- @@@
     SPlutusV3 ->
-      [ "590830010100323232323232322532932323232323253232333573466e1d200000113330027526eb8d5d09aab9"
-      , "e00333300c75246e98004c02cccc041d711bab00137566ae8401854c8c8c8c8ccd5cd19b87480080144c964cc0"
-      , "0800cd5d09aba200190c00a2600a6666008006400246464a666ae68c8cdc79800801180080191bae357426aae7"
-      , "8dd50008999ab9a323370e6002004600200646eb4d5d09aba235573c6ea800600100218011aba1003357426aae"
-      , "78dd50009bac3574201835573c00e2a666ae68cdc3a400800a266600c40026ae84d55cf0039bab357420102a66"
-      , "6ae68cdc3a400c00a264600a666600800640024646464664660020084466600600e44b26600e00800515900390"
-      , "ac801484ccd5cd19b87002001800400a30024564006430028c0008c0084600a93111192999ab9a3370e90001aa"
-      , "b9d001132330043574200266016eb4d5d09aba200135573c00226004931baa003230024988c8cc8cc00401488c"
-      , "cc00c0208964cc02001000a2b2007215900290999ab9a3370e004003000801460048ac800c8600518001180108"
-      , "c01526222325333573466e1d200235573a002264660086ae84004cc031d69aba1357440026aae780044c009263"
-      , "7540064600493119191991980080391199801805112c9980500200144cc01c00c006300211802a4c44464a666a"
-      , "e68cdc3a40086aae740044c8cc010d5d08009aba1357440026aae780044c009263754006460049311919919800"
-      , "8041111998020061112c99806803001c564cc02801400a2666ae68cdc3802000c0020051801230021180324c44"
-      , "464a666ae68cdc3a400c6aae740044c8c8ccc014d5d08011aba1001375a6ae84d5d10009aba200135573c00226"
-      , "004931baa003230024988c8cc8cc00402488ccc00c0308964cc03001000a2666ae68cdc3801800c00200518010"
-      , "8c01526222325333573466e1d200835573a002264660086ae84004dd69aba1357440026aae780044c009263754"
-      , "0064600493119299199ab9a3370e90051aab9d0021325333573466e1d200a35573a0022660146ae84d55cf0019"
-      , "aba135573c00226004931baa00b130014988c8cc8cc00403088ccc00c03c8964cc03c01000a2666ae68cdc3801"
-      , "800c002005180108c01526222325333573466e1d200c35573a002264660086ae84004dd69aba1357440026aae7"
-      , "80044c00926375400646004931191991980080691199801808112c9980800200144cc04000c006300211802a4c"
-      , "44464a666ae68cdc3a40246aae740044c8cc010d5d08009aba1357440026aae780044c00926375400646004931"
-      , "2999ab9a3370e900a1aab9d0041325333573466e1d201435573a0022660186ae84d55cf0029aba135573c00230"
-      , "02375401a300237540104464a64666ae68cdc3a40006aae740084c94ccd5cd19b8748000d55ce8008999ab9a33"
-      , "71e6eb8d5d09aab9e003375c6ae84d55cf000c00200426004931baa0031300149894c8c8ccd5cd19b8748008d5"
-      , "5ce8020992999ab9a3370e90011aab9d001133003357426aae78014d5d09aab9e00113002498dd500289800a4c"
-      , "46646600200e4466600601044a666ae68cdc78020010998038018008c008a00444464a666ae68cdc3a40086aae"
-      , "740044c8cc010dd71aba1001357426ae88004d55cf0008980124c6ea800ca0044464a64666ae68cdc3a40006aa"
-      , "e740084c94ccd5cd19b8748000d55ce8008998061aba135573c0066ae84d55cf0008980124c6ea800c4c005262"
-      , "532333573466e1d200235573a0062a666ae68cdc3a40046aae74dd50020c0004c005261300149894ccd5cd19b8"
-      , "748010d55ce8018999ab9a3370e90021aab9d37540090008010c008dd50011baa0022232532333573466e1d200"
-      , "035573a004264a666ae68cdc3a40006aae740044ccd5cd19b8f375c6ae84d55cf0019bae357426aae780060010"
-      , "0213002498dd500189800a4c4a666ae68cdc3a40046aae740084c94ccd5cd19b8748008d55ce8008999ab9a337"
-      , "1e6eb8d5d09aab9e003375c6ae84d55cf000c00200430023754006300237540046ae84d5d10011bac357420146"
-      , "aae7801c54ccd5cd19b87480200144ccc0188004d5d09aab9e00737566ae84d5d11aba2357446ae88d5d11aba2"
-      , "00815333573466e1d200a0051328001aab9e00713290018009888c8c8c94ccd5cd19b874800800860042a666ae"
-      , "68cdc3a4000004300130053574200213011491035054310035573c0046aae74004dd5000900091119118010009"
-      , "918008009119980ba5eb8088c964c01800626466ae80c020008004cc01401400a26600a00a0043007002001233"
-      , "357346ae8c00600100235573a00444466460020024660270022333573466ebcc014010d55ce800940008cc00c0"
-      , "0c004004dd51aba1357446ae88014d5d10009aba2001357446ae88d5d11aba200135573c6ea8d5d08009aab9e3"
-      , "754005149a260029210350543500119319ab9c001800191800800912c800c6001221900291192c9980594800c8"
-      , "c88c008c038004c8c00400489640063000910c00e00200b0024cc010010004000c4cc01c01c012443003800802"
-      , "cccc029d491ba80013300d29001919118011808000991800800912c800c6001221801c00401600499802002000"
-      , "80034cc02402401833300b75ceb4004223223005300200132300100122590018c0024430039002914004c02000"
-      , "a600e0024cc010010004323001001229001a5eb7bdb1824466ae82400a4466ec00080046600800800225333573"
-      , "466e24005200018000c00c00700011911801000991800800912c800c600122132332300100122590018801c886"
-      , "006005330040040010c01800ccc010010004444664600200246600b00022801c004c018d55ce8014c014d55cf0"
-      , "0126600600600200122253335573e00220062660046ae84004d5d10009"
+      [ "5907460101003232323225323335734646464646464a646464666ae68cdc3a40000022666004ea4dd71aba1355"
+      , "73c00866466600246eac0048dd30009192999ab9a35746002300218008008cccc009d691ba8001253335734666"
+      , "ae68cdc4800a4000941288c00400430020012223230010012330074bd6f7b63014980198029aab9e0019119aba"
+      , "0337606aae7400cc018008cc01001000646600600600237566ae8401c54c8c8c8ccd5cd19b87480080104ca4cc"
+      , "00800cd5d09aba200192509aba33333004003200123232533357346466e3cc004008c00400c8dd71aba135573c"
+      , "6ea80044c8cdc39800801180080191bad357426ae88d55cf1baa00114a06ae8400cd5d09aab9e37540026eb0d5"
+      , "d08060d55cf0038a999ab9a3370e9002002099980290009aba135573c00e6eacd5d08040a999ab9a3370e90030"
+      , "020991aba3333300400320012323233233001003223330030062253335734660320080043200729002919b8700"
+      , "2001a5064006494294414a04600a93111192999ab9a3370e90001aab9d001132330043574200266014eb4d5d09"
+      , "aba200135573c00226004931baa003230024988c8cc8cc00401088ccc00c01c894ccd5cd1980d0020010c801ca"
+      , "400a466e1c00800694190019250a51052811802a4c44464a666ae68cdc3a40046aae740044c8cc010d5d080099"
+      , "805bad357426ae88004d55cf0008980124c6ea800c8c00926232532333573466e1d200435573a00426464a666a"
+      , "e68cdc3a40086aae740044c94ccd5cd1980d1aba1003357420022660326ae84d5d10019aba1357440022940d55"
+      , "cf00089801a4c6ea801cd55cf00109800a4c46466603400c44466603a014444a666ae68cc07801800c54ccd5cd"
+      , "1980e802801099b8700400114a029408c01526230024988c8ccc06801c88ccc070028894ccd5cd1980e8020010"
+      , "99b8700300114a046008931180124c4a64666ae68cdc3a40146aae740144c94ccd5cd19b8748028d55ce800899"
+      , "80d9aba135573c00c6ae84d55cf0008980124c6ea80244c005262323323300100a2233300300d2253335734660"
+      , "40008004266e1c00c00452811802a4c44464a666ae68cdc3a40186aae740044c8cc010d5d08009bad357426ae8"
+      , "8004d55cf0008980124c6ea800c8c009262532333573466e1d201235573a00e26464a666ae68cdc3a40246aae7"
+      , "40044c94ccd5cd1980f9aba10033574200226603e6ae84d5d10019aba1357440022940d55cf00089801a4c6ea8"
+      , "030d55cf00389800a4c4a666ae68cdc3a40286aae7401c4c94ccd5cd19b8748050d55ce80089980e9aba135573"
+      , "c0106ae84d55cf0008a5037540162940dd50019aba1357440046eb0d5d08051aab9e00715333573466e1d20080"
+      , "0413330052001357426aae7801cdd59aba1357446ae88d5d11aba2357446ae8802054ccd5cd19b87480280104c"
+      , "9289aab9e00713290018009888c8c8cc94ccd5cd19b88002480004c0452401035054360013300100280194004c"
+      , "018d5d0800b003280160001918008009114800cc04d2410350543700912999ab9a3370e9000002080109991980"
+      , "300300099b81004480080046aae78008d55ce8009baa00120012223223002001323001001223330084bd701119"
+      , "2999ab9a300600113233574060100040026600a00a00426600a00a004600e0040026aae7400c888cc8c0040048"
+      , "cc015281199ab9a3375e600a0086aae740049289198018018008009112999aab9f0011003133002357420026ae"
+      , "88004dd51aba1357446ae88014d5d10009aba2001357446ae88d5d11aba200135573c6ea8d5d08009aab9e3754"
+      , "00429309800a49035054350023263357380030002232532333573466e1d200035573a004264a666ae68cdc3a40"
+      , "006aae740044cdc79bae357426aae7800cdd71aba135573c00226004931baa0031300149894c8c8ccd5cd19b87"
+      , "48008d55ce8020992999ab9a3370e90011aab9d001133003357426aae78014d5d09aab9e00113002498dd50028"
+      , "9800a4c46646600200e4466600601044a666ae68cdc78020010998038018008a5024a044464a666ae68cdc3a40"
+      , "086aae740044c8cc010dd71aba1001357426ae88004d55cf0008980124c6ea800c9281119299199ab9a3370e90"
+      , "001aab9d0021325333573466e1d200035573a0022660146ae84d55cf0019aba135573c00226004931baa003130"
+      , "0149894c8ccd5cd19b8748008d55ce8018a999ab9a3370e90011aab9d375400829444c005261300149894ccd5c"
+      , "d19b8748010d55ce801899b8748010d55ce9baa00414a06ea8008dd50011119299199ab9a3370e90001aab9d00"
+      , "21325333573466e1d200035573a002266e3cdd71aba135573c0066eb8d5d09aab9e00113002498dd500189800a"
+      , "4c4a666ae68cdc3a40046aae740084c94ccd5cd19b8748008d55ce800899b8f375c6ae84d55cf0019bae357426"
+      , "aae780045281baa00314a06ea8008888c94ccd5cd19b8748020d55ce800899198021aba1001375a6ae84d5d100"
+      , "09aab9e00113002498dd5001911192999ab9a3370e90031aab9d00113232333005357420046ae84004dd69aba1"
+      , "357440026ae88004d55cf0008980124c6ea800c1"
       ]
-    -- ScriptHash "21cea071538f4a2be40222a9b6dabaa064eeba991b8c8bca5da4258b"
+    -- ScriptHash "ac43e18917d7f23f26e073170f164fac84b9e421282926c260e919d0"
     -- Preprocessed PlutusV4 Script:
     -- @@@
     -- purposeIsWellformedNoDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -855,53 +860,48 @@ purposeIsWellformedNoDatum =
     --                                                                                                                                                                                           _propProc_17 -> GHC.Types.True}})
     -- @@@
     SPlutusV4 ->
-      [ "590830010100323232323232322532932323232323253232333573466e1d200000113330027526eb8d5d09aab9"
-      , "e00333300c75246e98004c02cccc041d711bab00137566ae8401854c8c8c8c8ccd5cd19b87480080144c964cc0"
-      , "0800cd5d09aba200190c00a2600a6666008006400246464a666ae68c8cdc79800801180080191bae357426aae7"
-      , "8dd50008999ab9a323370e6002004600200646eb4d5d09aba235573c6ea800600100218011aba1003357426aae"
-      , "78dd50009bac3574201835573c00e2a666ae68cdc3a400800a266600c40026ae84d55cf0039bab357420102a66"
-      , "6ae68cdc3a400c00a264600a666600800640024646464664660020084466600600e44b26600e00800515900390"
-      , "ac801484ccd5cd19b87002001800400a30024564006430028c0008c0084600a93111192999ab9a3370e90001aa"
-      , "b9d001132330043574200266016eb4d5d09aba200135573c00226004931baa003230024988c8cc8cc00401488c"
-      , "cc00c0208964cc02001000a2b2007215900290999ab9a3370e004003000801460048ac800c8600518001180108"
-      , "c01526222325333573466e1d200235573a002264660086ae84004cc031d69aba1357440026aae780044c009263"
-      , "7540064600493119191991980080391199801805112c9980500200144cc01c00c006300211802a4c44464a666a"
-      , "e68cdc3a40086aae740044c8cc010d5d08009aba1357440026aae780044c009263754006460049311919919800"
-      , "8041111998020061112c99806803001c564cc02801400a2666ae68cdc3802000c0020051801230021180324c44"
-      , "464a666ae68cdc3a400c6aae740044c8c8ccc014d5d08011aba1001375a6ae84d5d10009aba200135573c00226"
-      , "004931baa003230024988c8cc8cc00402488ccc00c0308964cc03001000a2666ae68cdc3801800c00200518010"
-      , "8c01526222325333573466e1d200835573a002264660086ae84004dd69aba1357440026aae780044c009263754"
-      , "0064600493119299199ab9a3370e90051aab9d0021325333573466e1d200a35573a0022660146ae84d55cf0019"
-      , "aba135573c00226004931baa00b130014988c8cc8cc00403088ccc00c03c8964cc03c01000a2666ae68cdc3801"
-      , "800c002005180108c01526222325333573466e1d200c35573a002264660086ae84004dd69aba1357440026aae7"
-      , "80044c00926375400646004931191991980080691199801808112c9980800200144cc04000c006300211802a4c"
-      , "44464a666ae68cdc3a40246aae740044c8cc010d5d08009aba1357440026aae780044c00926375400646004931"
-      , "2999ab9a3370e900a1aab9d0041325333573466e1d201435573a0022660186ae84d55cf0029aba135573c00230"
-      , "02375401a300237540104464a64666ae68cdc3a40006aae740084c94ccd5cd19b8748000d55ce8008999ab9a33"
-      , "71e6eb8d5d09aab9e003375c6ae84d55cf000c00200426004931baa0031300149894c8c8ccd5cd19b8748008d5"
-      , "5ce8020992999ab9a3370e90011aab9d001133003357426aae78014d5d09aab9e00113002498dd500289800a4c"
-      , "46646600200e4466600601044a666ae68cdc78020010998038018008c008a00444464a666ae68cdc3a40086aae"
-      , "740044c8cc010dd71aba1001357426ae88004d55cf0008980124c6ea800ca0044464a64666ae68cdc3a40006aa"
-      , "e740084c94ccd5cd19b8748000d55ce8008998061aba135573c0066ae84d55cf0008980124c6ea800c4c005262"
-      , "532333573466e1d200235573a0062a666ae68cdc3a40046aae74dd50020c0004c005261300149894ccd5cd19b8"
-      , "748010d55ce8018999ab9a3370e90021aab9d37540090008010c008dd50011baa0022232532333573466e1d200"
-      , "035573a004264a666ae68cdc3a40006aae740044ccd5cd19b8f375c6ae84d55cf0019bae357426aae780060010"
-      , "0213002498dd500189800a4c4a666ae68cdc3a40046aae740084c94ccd5cd19b8748008d55ce8008999ab9a337"
-      , "1e6eb8d5d09aab9e003375c6ae84d55cf000c00200430023754006300237540046ae84d5d10011bac357420146"
-      , "aae7801c54ccd5cd19b87480200144ccc0188004d5d09aab9e00737566ae84d5d11aba2357446ae88d5d11aba2"
-      , "00815333573466e1d200a0051328001aab9e00713290018009888c8c8c94ccd5cd19b874800800860042a666ae"
-      , "68cdc3a4000004300130053574200213011491035054310035573c0046aae74004dd5000900091119118010009"
-      , "918008009119980ba5eb8088c964c01800626466ae80c020008004cc01401400a26600a00a0043007002001233"
-      , "357346ae8c00600100235573a00444466460020024660270022333573466ebcc014010d55ce800940008cc00c0"
-      , "0c004004dd51aba1357446ae88014d5d10009aba2001357446ae88d5d11aba200135573c6ea8d5d08009aab9e3"
-      , "754005149a260029210350543500119319ab9c001800191800800912c800c6001221900291192c9980594800c8"
-      , "c88c008c038004c8c00400489640063000910c00e00200b0024cc010010004000c4cc01c01c012443003800802"
-      , "cccc029d491ba80013300d29001919118011808000991800800912c800c6001221801c00401600499802002000"
-      , "80034cc02402401833300b75ceb4004223223005300200132300100122590018c0024430039002914004c02000"
-      , "a600e0024cc010010004323001001229001a5eb7bdb1824466ae82400a4466ec00080046600800800225333573"
-      , "466e24005200018000c00c00700011911801000991800800912c800c600122132332300100122590018801c886"
-      , "006005330040040010c01800ccc010010004444664600200246600b00022801c004c018d55ce8014c014d55cf0"
-      , "0126600600600200122253335573e00220062660046ae84004d5d10009"
+      [ "5907460101003232323225323335734646464646464a646464666ae68cdc3a40000022666004ea4dd71aba1355"
+      , "73c00866466600246eac0048dd30009192999ab9a35746002300218008008cccc009d691ba8001253335734666"
+      , "ae68cdc4800a4000941288c00400430020012223230010012330074bd6f7b63014980198029aab9e0019119aba"
+      , "0337606aae7400cc018008cc01001000646600600600237566ae8401c54c8c8c8ccd5cd19b87480080104ca4cc"
+      , "00800cd5d09aba200192509aba33333004003200123232533357346466e3cc004008c00400c8dd71aba135573c"
+      , "6ea80044c8cdc39800801180080191bad357426ae88d55cf1baa00114a06ae8400cd5d09aab9e37540026eb0d5"
+      , "d08060d55cf0038a999ab9a3370e9002002099980290009aba135573c00e6eacd5d08040a999ab9a3370e90030"
+      , "020991aba3333300400320012323233233001003223330030062253335734660320080043200729002919b8700"
+      , "2001a5064006494294414a04600a93111192999ab9a3370e90001aab9d001132330043574200266014eb4d5d09"
+      , "aba200135573c00226004931baa003230024988c8cc8cc00401088ccc00c01c894ccd5cd1980d0020010c801ca"
+      , "400a466e1c00800694190019250a51052811802a4c44464a666ae68cdc3a40046aae740044c8cc010d5d080099"
+      , "805bad357426ae88004d55cf0008980124c6ea800c8c00926232532333573466e1d200435573a00426464a666a"
+      , "e68cdc3a40086aae740044c94ccd5cd1980d1aba1003357420022660326ae84d5d10019aba1357440022940d55"
+      , "cf00089801a4c6ea801cd55cf00109800a4c46466603400c44466603a014444a666ae68cc07801800c54ccd5cd"
+      , "1980e802801099b8700400114a029408c01526230024988c8ccc06801c88ccc070028894ccd5cd1980e8020010"
+      , "99b8700300114a046008931180124c4a64666ae68cdc3a40146aae740144c94ccd5cd19b8748028d55ce800899"
+      , "80d9aba135573c00c6ae84d55cf0008980124c6ea80244c005262323323300100a2233300300d2253335734660"
+      , "40008004266e1c00c00452811802a4c44464a666ae68cdc3a40186aae740044c8cc010d5d08009bad357426ae8"
+      , "8004d55cf0008980124c6ea800c8c009262532333573466e1d201235573a00e26464a666ae68cdc3a40246aae7"
+      , "40044c94ccd5cd1980f9aba10033574200226603e6ae84d5d10019aba1357440022940d55cf00089801a4c6ea8"
+      , "030d55cf00389800a4c4a666ae68cdc3a40286aae7401c4c94ccd5cd19b8748050d55ce80089980e9aba135573"
+      , "c0106ae84d55cf0008a5037540162940dd50019aba1357440046eb0d5d08051aab9e00715333573466e1d20080"
+      , "0413330052001357426aae7801cdd59aba1357446ae88d5d11aba2357446ae8802054ccd5cd19b87480280104c"
+      , "9289aab9e00713290018009888c8c8cc94ccd5cd19b88002480004c0452401035054360013300100280194004c"
+      , "018d5d0800b003280160001918008009114800cc04d2410350543700912999ab9a3370e9000002080109991980"
+      , "300300099b81004480080046aae78008d55ce8009baa00120012223223002001323001001223330084bd701119"
+      , "2999ab9a300600113233574060100040026600a00a00426600a00a004600e0040026aae7400c888cc8c0040048"
+      , "cc015281199ab9a3375e600a0086aae740049289198018018008009112999aab9f0011003133002357420026ae"
+      , "88004dd51aba1357446ae88014d5d10009aba2001357446ae88d5d11aba200135573c6ea8d5d08009aab9e3754"
+      , "00429309800a49035054350023263357380030002232532333573466e1d200035573a004264a666ae68cdc3a40"
+      , "006aae740044cdc79bae357426aae7800cdd71aba135573c00226004931baa0031300149894c8c8ccd5cd19b87"
+      , "48008d55ce8020992999ab9a3370e90011aab9d001133003357426aae78014d5d09aab9e00113002498dd50028"
+      , "9800a4c46646600200e4466600601044a666ae68cdc78020010998038018008a5024a044464a666ae68cdc3a40"
+      , "086aae740044c8cc010dd71aba1001357426ae88004d55cf0008980124c6ea800c9281119299199ab9a3370e90"
+      , "001aab9d0021325333573466e1d200035573a0022660146ae84d55cf0019aba135573c00226004931baa003130"
+      , "0149894c8ccd5cd19b8748008d55ce8018a999ab9a3370e90011aab9d375400829444c005261300149894ccd5c"
+      , "d19b8748010d55ce801899b8748010d55ce9baa00414a06ea8008dd50011119299199ab9a3370e90001aab9d00"
+      , "21325333573466e1d200035573a002266e3cdd71aba135573c0066eb8d5d09aab9e00113002498dd500189800a"
+      , "4c4a666ae68cdc3a40046aae740084c94ccd5cd19b8748008d55ce800899b8f375c6ae84d55cf0019bae357426"
+      , "aae780045281baa00314a06ea8008888c94ccd5cd19b8748020d55ce800899198021aba1001375a6ae84d5d100"
+      , "09aab9e00113002498dd5001911192999ab9a3370e90031aab9d00113232333005357420046ae84004dd69aba1"
+      , "357440026ae88004d55cf0008980124c6ea800c1"
       ]
 
 -- | Script that succeeds when datum is expected and purpose arguments are validated against txInfo
@@ -909,7 +909,7 @@ purposeIsWellformedNoDatum =
 purposeIsWellformedWithDatum :: SLanguage l -> Plutus l
 purposeIsWellformedWithDatum =
   decodeHexPlutus . mconcat . \case
-    -- ScriptHash "275c6d0f64ff36d226c106f4f812da4029f23cea6cc2d44a911e8cc4"
+    -- ScriptHash "8749798deb0743c573fad7a8e4a692f9aa25f6fc947bdf97f4a19fd4"
     -- Preprocessed PlutusV1 Script:
     -- @@@
     -- purposeIsWellformedWithDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -925,14 +925,15 @@ purposeIsWellformedWithDatum =
     --                                                                                                                                                    _ -> PlutusTx.Builtins.error GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV1 ->
-      [ "58fa01000022232323232332232325335333573466e1d200235573a00e0080062a66a666ae68d5d198009bac35"
-      , "7426aae78dd51aba1008004003161005163230010012253335573e002297ae013322533532325335333573466e"
-      , "3cc01c004c01c0080240204ccd5cd19b87300b001300b0020090081008357426aae7802cd5d09aab9e37540042"
-      , "66ae80008cc0100100044cc010010004d5d08009aba200123232325335333573466e1d20000020060051375c6a"
-      , "e840044c98cd5ce249035054310000735573c0046aae74004dd51aba135573c6ea8004488008488004480048dd"
-      , "69aba1357446aae78dd50009baa357426ae88004d55cf1baa00101"
+      [ "59011d010000323222232323232325333573466e1d200235573a0082a666ae68d5d198009bac357426aae78dd5"
+      , "1aba100516100a163230010012253335573e002297ae013322533357346464a666ae68cdc79803800980380109"
+      , "9b873008001300800214a06ae84d55cf0041aba135573c6ea80084cd5d0001198020020008998020020009aba1"
+      , "0013574400246464664a666ae68cdc4001240002601692010350543600133001002122330012375c6ae8400448"
+      , "8008c8c0040048894cd40044c035240103505437002215333573466e1d20000041002133233006006001337020"
+      , "0890010009aab9e00235573a0026ea8d5d09aab9e375400246eb4d5d09aba235573c6ea8004dd51aba13574400"
+      , "26aae78dd5000919319ab9c0010021200101"
       ]
-    -- ScriptHash "8acef8524732331a0173ab62dbabb32853c16be4d2d50fbdfcaaaf08"
+    -- ScriptHash "10eb5bbb3496cf638cd65e03874653bfafc954808c0224655ba7193d"
     -- Preprocessed PlutusV2 Script:
     -- @@@
     -- purposeIsWellformedWithDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -948,14 +949,15 @@ purposeIsWellformedWithDatum =
     --                                                                                                                                                    _ -> PlutusTx.Builtins.error GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV2 ->
-      [ "58fa01000022232323232332232325335333573466e1d200235573a00e0080062a66a666ae68d5d198009bac35"
-      , "7426aae78dd51aba1008004003161005163230010012253335573e002297ae013322533532325335333573466e"
-      , "3cc01c004c01c0080240204ccd5cd19b87300b001300b0020090081008357426aae7802cd5d09aab9e37540042"
-      , "66ae80008cc0100100044cc010010004d5d08009aba200123232325335333573466e1d20000020060051375c6a"
-      , "e840044c98cd5ce249035054310000735573c0046aae74004dd51aba135573c6ea8004488008488004480048dd"
-      , "69aba1357446aae78dd50009baa357426ae88004d55cf1baa00101"
+      [ "59011d010000323222232323232325333573466e1d200235573a0082a666ae68d5d198009bac357426aae78dd5"
+      , "1aba100516100a163230010012253335573e002297ae013322533357346464a666ae68cdc79803800980380109"
+      , "9b873008001300800214a06ae84d55cf0041aba135573c6ea80084cd5d0001198020020008998020020009aba1"
+      , "0013574400246464664a666ae68cdc4001240002601692010350543600133001002122330012375c6ae8400448"
+      , "8008c8c0040048894cd40044c035240103505437002215333573466e1d20000041002133233006006001337020"
+      , "0890010009aab9e00235573a0026ea8d5d09aab9e375400246eb4d5d09aba235573c6ea8004dd51aba13574400"
+      , "26aae78dd5000919319ab9c0010021200101"
       ]
-    -- ScriptHash "bf43b0e77d200b46b7fc95181f7228b17c4a748dc1abf7e400549e3d"
+    -- ScriptHash "22bc5f6b3c721260818a5bbbbf5be7c0c430c30b1cb6e1fb48898186"
     -- Preprocessed PlutusV3 Script:
     -- @@@
     -- purposeIsWellformedWithDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -968,15 +970,15 @@ purposeIsWellformedWithDatum =
     --                                                                            _ -> GHC.Types.False})
     -- @@@
     SPlutusV3 ->
-      [ "59010c0101002532932325333573466e1d200235573a002264646464b2646464a666ae68cdc3a4004004300215"
-      , "333573466e1d200000218009aba1001098052481035054310035573c0046aae74004dd51aba135744009213335"
-      , "7346ae8cc008dd61aba135573c6ea8d5d0803c00a00118010c8c004004894ccd55cf8008a5eb804cc8964c8c94"
-      , "ccd5cd19b8f300700130070021333573466e1cc020004c02000a00100218011aba1008357426aae78dd500144c"
-      , "d5d000119802002000c4cc0100100046ae84004d5d100091bae357426aae78dd500091bad357426ae88d55cf1b"
-      , "aa00135573c002300237546ae84d5d11aba200135573c6ea800a29344c0052410350543500119319ab9c001800"
-      , "01"
+      [ "590135010100322533357346464a666ae68cdc3a40046aae740044c8c8c8ca4c8c8cc94ccd5cd19b8800248000"
+      , "4c02d241035054360013300100280194004d5d0800b003280160001918008009114800cc035241035054370091"
+      , "2999ab9a3370e9000002080109991980300300099b81004480080046aae78008d55ce8009baa357426ae880124"
+      , "666ae68d5d198011bac357426aae78dd51aba10074a094694064600200244a666aae7c00452f5c026644a666ae"
+      , "68c8c94ccd5cd19b8f3007001300700213370e601000260100042940d5d08041aba135573c6ea80084cd5d0001"
+      , "198020020008998020020009aba10013574400246eb8d5d09aab9e375400246eb4d5d09aba235573c6ea8004d5"
+      , "5cf0008a5037546ae84d5d11aba200135573c6ea80045261300249010350543500232633573800300001"
       ]
-    -- ScriptHash "ce5224aa462865d543250f9be2e404880a545f0325c38beca19a2322"
+    -- ScriptHash "94b9ec6dcebbf0f56edee997ccde9b3475dc0b9bb7fbf455c38448ec"
     -- Preprocessed PlutusV4 Script:
     -- @@@
     -- purposeIsWellformedWithDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -989,13 +991,13 @@ purposeIsWellformedWithDatum =
     --                                                                            _ -> GHC.Types.False})
     -- @@@
     SPlutusV4 ->
-      [ "59010c0101002532932325333573466e1d200235573a002264646464b2646464a666ae68cdc3a4004004300215"
-      , "333573466e1d200000218009aba1001098052481035054310035573c0046aae74004dd51aba135744009213335"
-      , "7346ae8cc008dd61aba135573c6ea8d5d0803c00a00118010c8c004004894ccd55cf8008a5eb804cc8964c8c94"
-      , "ccd5cd19b8f300700130070021333573466e1cc020004c02000a00100218011aba1008357426aae78dd500144c"
-      , "d5d000119802002000c4cc0100100046ae84004d5d100091bae357426aae78dd500091bad357426ae88d55cf1b"
-      , "aa00135573c002300237546ae84d5d11aba200135573c6ea800a29344c0052410350543500119319ab9c001800"
-      , "01"
+      [ "590135010100322533357346464a666ae68cdc3a40046aae740044c8c8c8ca4c8c8cc94ccd5cd19b8800248000"
+      , "4c02d241035054360013300100280194004d5d0800b003280160001918008009114800cc035241035054370091"
+      , "2999ab9a3370e9000002080109991980300300099b81004480080046aae78008d55ce8009baa357426ae880124"
+      , "666ae68d5d198011bac357426aae78dd51aba10074a094694064600200244a666aae7c00452f5c026644a666ae"
+      , "68c8c94ccd5cd19b8f3007001300700213370e601000260100042940d5d08041aba135573c6ea80084cd5d0001"
+      , "198020020008998020020009aba10013574400246eb8d5d09aab9e375400246eb4d5d09aba235573c6ea8004d5"
+      , "5cf0008a5037546ae84d5d11aba200135573c6ea80045261300249010350543500232633573800300001"
       ]
 
 -- | Script that succeeds when datum is expected and datum is validated against txInfo
@@ -1003,7 +1005,7 @@ purposeIsWellformedWithDatum =
 datumIsWellformed :: SLanguage l -> Plutus l
 datumIsWellformed =
   decodeHexPlutus . mconcat . \case
-    -- ScriptHash "b5b66c1df938ad157d807c61c0f7adcc61e2f71f989ea3cbb97dcbf7"
+    -- ScriptHash "37b9340a2e6f1450032bb02f755b1f1cb4f36bc89cf2bd2715ff4168"
     -- Preprocessed PlutusV1 Script:
     -- @@@
     -- datumIsWellformed_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -1019,14 +1021,15 @@ datumIsWellformed =
     --                                                                                                                                                    _ -> PlutusTx.Builtins.error GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV1 ->
-      [ "58ee010000222325323332235333573466e1d200235573a6ea8d5d09aba20040020011533533357346ae8ccc8c"
-      , "004004894ccd55cf8008a5eb804c8c94cd4ccd5cd19baf00b30012200100600513233574060044466e95200033"
-      , "57406ea4008cd5d0000a5eb80004cc0100100084cc0100100094c8c8c94cd4ccd5cd19b874800000802001c4cc"
-      , "8848cc00400c008dd71aba1001357426ae880044c98cd5ce2481035054310000935573c0046aae74004dd51aba"
-      , "1002357440026eb0d5d09aba2357446ae88d5d11aba2357446ae88d5d11aab9e37546ae8401000800458400c48"
-      , "80084880045848004d55cf1baa0011"
+      [ "5901140100003232222325333573466e1d200235573a6ea8d5d09aba20011533357346ae8ccc8c004004894ccd"
+      , "55cf8008a5eb804c8c94ccd5cd19baf00830012200113233574060044466e9520003357406ea4008cd5d0000a5"
+      , "eb80004cc0100100084cc0100100094c8c8cc94ccd5cd19b88002480004c02d241035054360013300100212233"
+      , "001233221233001003002375c6ae84004d5d09aba200112200232300100122253350011300d491035054370022"
+      , "15333573466e1d200000410021332330060060013370200890010009aab9e00235573a0026ea8d5d08011aba20"
+      , "0137586ae84d5d11aba2357446ae88d5d11aba2357446ae88d55cf1baa357420022c200c2c6aae78dd50009193"
+      , "19ab9c001002120011"
       ]
-    -- ScriptHash "67932e69c2aa347e10bf9f5b90bb05791fac4dc3a50a9c316ccb7cff"
+    -- ScriptHash "6d0768fb0a8bb127d6857e064645e2968a3b3266fc82e5233880a02e"
     -- Preprocessed PlutusV2 Script:
     -- @@@
     -- datumIsWellformed_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -1042,13 +1045,12 @@ datumIsWellformed =
     --                                                                                                                                                    _ -> PlutusTx.Builtins.error GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV2 ->
-      [ "58bd01000023322323222325335333573466e1d200235573a6ea8d5d09aba20010070061533533357346ae8cc0"
-      , "10cc8c0040048cc0192f5c04466ae80d55cf001198018018009bab357426ae88d5d11aba2357446ae88d5d11ab"
-      , "a2357446ae88d5d11aab9e37546ae8400401c0185844800458d55cf1baa001323001001223330034bd7011299a"
-      , "999ab9a3375e01000400e00c266ae80008cc0100100044cc0100100040048894ccd55cf80088018998011aba10"
-      , "0135744002244004244003"
+      [ "58a80100003223222325333573466e1d200235573a6ea8d5d09aba20011533357346ae8cc010cc8c0040048cc0"
+      , "1d2f5c04466ae80d55cf001198018018009bab357426ae88d5d11aba2357446ae88d5d11aba2357446ae88d5d1"
+      , "1aab9e37546ae840045844800458d55cf1baa001323001001223330044bd70112999ab9a3375e00a004266ae80"
+      , "008cc0100100044cc0100100040048894ccd55cf80088018998011aba1001357440021"
       ]
-    -- ScriptHash "d5c3cd3fc9bef17abd9a148f0a2f993df0a99a3766a5c604cc61891d"
+    -- ScriptHash "581d94dbafe7b1d6315b15f4f8232e0217726b7c56af062e7a929aaa"
     -- Preprocessed PlutusV3 Script:
     -- @@@
     -- datumIsWellformed_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -1061,14 +1063,15 @@ datumIsWellformed =
     --                                                                 _ -> GHC.Types.False})
     -- @@@
     SPlutusV3 ->
-      [ "5901030101002532932325333573466e1d200235573a0022b2646464a666ae68cdc3a400400430021533357346"
-      , "6e1d200000218009aba1001098032481035054310035573c0046aae74004dd51aba1357446aae7800646464266"
-      , "6ae68d5d198009991800800919801a5eb8088cd5d01aab9e0023300300300137566ae84d5d11aba2357446ae88"
-      , "d5d11aba2357446ae88d5d11aba235573c6ea8d5d0802c00a0006460020024466600697ae0225333573466ebc0"
-      , "180084cd5d0001198020020008998020020008009112999aab9f0011003133002357420026ae8800630020c008"
-      , "dd51aba1357446ae88004d55cf1baa0028a4d1300149010350543500119319ab9c00180001"
+      [ "59013201010032322533357346464a666ae68cdc3a40046aae74004564c8c8cc94ccd5cd19b88002480004c021"
+      , "2401035054360013300100280194004d5d0800b003280160001918008009114800cc0292410350543700912999"
+      , "ab9a3370e9000002080109991980300300099b81004480080046aae78008d55ce8009baa357426ae88d55cf000"
+      , "c8c84ccd5cd1aba3300133230010012330074bd701119aba035573c004660060060026eacd5d09aba2357446ae"
+      , "88d5d11aba2357446ae88d5d11aba2357446aae78dd51aba10044a0944c8c00400488ccc01d2f5c044a666ae68"
+      , "cdd7802801099aba0002330040040011330040040010018a500a5037546ae84d5d11aba200135573c6ea800452"
+      , "6130034901035054350022253335573e00220062660046ae84004d5d1000919319ab9c00180001"
       ]
-    -- ScriptHash "efdd466bdb73ef3fa6aef4d9ea72f8b83bcabab97ed924422145f593"
+    -- ScriptHash "b8a8e91163013a8b637f7477421bf4546eeefde7290b112fcccd5c0a"
     -- Preprocessed PlutusV4 Script:
     -- @@@
     -- datumIsWellformed_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -1081,12 +1084,13 @@ datumIsWellformed =
     --                                                                 _ -> GHC.Types.False})
     -- @@@
     SPlutusV4 ->
-      [ "5901030101002532932325333573466e1d200235573a0022b2646464a666ae68cdc3a400400430021533357346"
-      , "6e1d200000218009aba1001098032481035054310035573c0046aae74004dd51aba1357446aae7800646464266"
-      , "6ae68d5d198009991800800919801a5eb8088cd5d01aab9e0023300300300137566ae84d5d11aba2357446ae88"
-      , "d5d11aba2357446ae88d5d11aba235573c6ea8d5d0802c00a0006460020024466600697ae0225333573466ebc0"
-      , "180084cd5d0001198020020008998020020008009112999aab9f0011003133002357420026ae8800630020c008"
-      , "dd51aba1357446ae88004d55cf1baa0028a4d1300149010350543500119319ab9c00180001"
+      [ "59013201010032322533357346464a666ae68cdc3a40046aae74004564c8c8cc94ccd5cd19b88002480004c021"
+      , "2401035054360013300100280194004d5d0800b003280160001918008009114800cc0292410350543700912999"
+      , "ab9a3370e9000002080109991980300300099b81004480080046aae78008d55ce8009baa357426ae88d55cf000"
+      , "c8c84ccd5cd1aba3300133230010012330074bd701119aba035573c004660060060026eacd5d09aba2357446ae"
+      , "88d5d11aba2357446ae88d5d11aba2357446aae78dd51aba10044a0944c8c00400488ccc01d2f5c044a666ae68"
+      , "cdd7802801099aba0002330040040011330040040010018a500a5037546ae84d5d11aba200135573c6ea800452"
+      , "6130034901035054350022253335573e00220062660046ae84004d5d1000919319ab9c00180001"
       ]
 
 -- | Script that succeeds when inputs and outputs are not empty validated against txInfo
@@ -1094,7 +1098,7 @@ datumIsWellformed =
 inputsOutputsAreNotEmptyNoDatum :: SLanguage l -> Plutus l
 inputsOutputsAreNotEmptyNoDatum =
   decodeHexPlutus . mconcat . \case
-    -- ScriptHash "294117b5a364e699807796de314f64e1e2c00e203259f57d770863c3"
+    -- ScriptHash "b4730007df6e096ae54cdfb9e446b502921e198129b47f597780ea03"
     -- Preprocessed PlutusV1 Script:
     -- @@@
     -- inputsOutputsAreNotEmptyNoDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -1107,14 +1111,15 @@ inputsOutputsAreNotEmptyNoDatum =
     --                                                                                                                                                                            else GHC.Tuple.Prim.()}}
     -- @@@
     SPlutusV1 ->
-      [ "58e301000022532335332253232335300233001222222222200a26100413002330012222222222009262232323"
-      , "2323232323232333333333300b37586ae84024dd61aba100837566ae8401cdd59aba100637586ae84014dd61ab"
-      , "a1004357420066eb0d5d08011bac35742002646464a66a666ae68cdc3a400000402202026eb8d5d0800899319a"
-      , "b9c491035054310001235573c0046aae74004dd51aba1357440026ae88004d5d10009aba2001357440026ae880"
-      , "04d5d10009aba2001357440026aae78dd51aba135573c6ea801c8ccd5cd1aba300100300212200212200116100"
-      , "11200101"
+      [ "59011001000032322253335734a64666ae68d5d1998009111111111005130a511357466600244444444440124c"
+      , "4464646464646464646466666666660166eb0d5d08049bac357420106eacd5d08039bab3574200c6eb0d5d0802"
+      , "9bac357420086ae8400cdd61aba100237586ae84004c8c8cc94ccd5cd19b88002480004c045241035054360013"
+      , "3001002122330012375c6ae84004488008c8c0040048894cd40044c04d240103505437002215333573466e1d20"
+      , "0000410021332330060060013370200890010009aab9e00235573a0026ea8d5d09aba2001357440026ae88004d"
+      , "5d10009aba2001357440026ae88004d5d10009aba200135573c6ea8d5d09aab9e37540062c2008464c66ae7000"
+      , "4008480041"
       ]
-    -- ScriptHash "02bcd203776ea49739cbcacfad85d08ec88d1caeb86ef16b6bf3a848"
+    -- ScriptHash "9348ca03cad04b0046a04c212ec6fdf473272ce3926bee4359a4adde"
     -- Preprocessed PlutusV2 Script:
     -- @@@
     -- inputsOutputsAreNotEmptyNoDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -1127,14 +1132,15 @@ inputsOutputsAreNotEmptyNoDatum =
     --                                                                                                                                                                            else GHC.Tuple.Prim.()}}
     -- @@@
     SPlutusV2 ->
-      [ "58fb0100002253233533225323233530023300122222222222200c261004130023300122222222222200a26223"
-      , "23232323232323232323233333333333300d37586ae8402cdd61aba100a37586ae84024dd59aba100837566ae8"
-      , "401cdd61aba100637566ae84014d5d08021bac357420066eacd5d08011bab35742002646464a66a666ae68cdc3"
-      , "a400000402602426eb8d5d0800899319ab9c4901035054310001435573c0046aae74004dd51aba1357440026ae"
-      , "88004d5d10009aba2001357440026ae88004d5d10009aba2001357440026ae88004d5d10009aab9e37546ae84d"
-      , "55cf1baa007233357346ae8c00400c00848800848800458400448005"
+      [ "59012901000032322253335734a64666ae68d5d199800911111111111006130a51135746660024444444444440"
+      , "144c44646464646464646464646466666666666601a6eb0d5d08059bac357420146eb0d5d08049bab357420106"
+      , "eacd5d08039bac3574200c6eacd5d08029aba100437586ae8400cdd59aba100237566ae84004c8c8cc94ccd5cd"
+      , "19b88002480004c04d24010350543600133001002122330012375c6ae84004488008c8c0040048894cd40044c0"
+      , "55240103505437002215333573466e1d200000410021332330060060013370200890010009aab9e00235573a00"
+      , "26ea8d5d09aba2001357440026ae88004d5d10009aba2001357440026ae88004d5d10009aba2001357440026ae"
+      , "88004d55cf1baa357426aae78dd50018b0802119319ab9c0010021200101"
       ]
-    -- ScriptHash "3a3417519d32dba24dbc79cd428369f75e60d17964317c9eb695fe90"
+    -- ScriptHash "3e3c64e208b3c8c1b6fd2c74da9c72a23db29376a85a8653749bbee9"
     -- Preprocessed PlutusV3 Script:
     -- @@@
     -- inputsOutputsAreNotEmptyNoDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -1149,13 +1155,18 @@ inputsOutputsAreNotEmptyNoDatum =
     --                                                                                                                              _scriptPurpose_7 -> GHC.Classes.not GHC.Base.$ (PlutusTx.Data.List.null (PlutusLedgerApi.V3.Data.Contexts.txInfoInputs txInfo_5) GHC.Classes.|| PlutusTx.Data.List.null (PlutusLedgerApi.V3.Data.Contexts.txInfoOutputs txInfo_5))})
     -- @@@
     SPlutusV3 ->
-      [ "58d601010025329323253232333573466e1d200235573a006264b26600640026ae84d5d1000c86005130024986"
-      , "aae7800c4c0052625953293001323237586ae84008c011d69aab9e37546ae8401630008980099191bac3574200"
-      , "46008eb4d5d11aba235573c6ea8d5d080288ccd5cd1aba3001800400a30028c00044646464a666ae68cdc3a400"
-      , "4004300215333573466e1d2000002180098029aba1001098042481035054310035573c0046aae74004dd50009b"
-      , "aa357426ae88d5d10009aab9e3754005149a260029210350543500119319ab9c00180001"
+      [ "5901a4010100322533357346464a6464666ae68cdc3a40046aae7400c4ca4cc00c8004d5d09aba200192509801"
+      , "24c35573c00626002931199ab9a53233357346ae8ccc00488888888888888880409852889aba33300122222222"
+      , "2222222200e262232323232323232323232323232323232333333333333333301237586ae84040dd61aba100f3"
+      , "7586ae84038dd69aba100d37566ae84030dd61aba100b37566ae84028d5d08049bac357420106eacd5d08039ba"
+      , "b3574200c6eb8d5d08029bab357420086eb0d5d080198009aba10023001357426ae88008c04dd69aba20013574"
+      , "40026ae88004d5d10009aba2001357440026ae88004d5d10009aba2001357440026ae88004d5d10009aba20013"
+      , "57440026aae78dd51aba10064a094488c8c8cc94ccd5cd19b88002480004c02524010350543600133001002801"
+      , "94004c018d5d0800b003280160001918008009114800cc02d2410350543700912999ab9a3370e9000002080109"
+      , "991980300300099b81004480080046aae78008d55ce8009baa00137546ae84d5d11aba200135573c6ea8004526"
+      , "130024910350543500232633573800300001"
       ]
-    -- ScriptHash "8d3acabe234d8db8378fd213577f450fd57c450fc20b1d940c0b30e0"
+    -- ScriptHash "04a0a4e1c62183843862ad0b9104a03d6928c0cab9f5d624f9c88692"
     -- Preprocessed PlutusV4 Script:
     -- @@@
     -- inputsOutputsAreNotEmptyNoDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -1170,11 +1181,16 @@ inputsOutputsAreNotEmptyNoDatum =
     --                                                                                                                              _scriptPurpose_7 -> GHC.Classes.not GHC.Base.$ (PlutusTx.Data.List.null (PlutusLedgerApi.V3.Data.Contexts.txInfoInputs txInfo_5) GHC.Classes.|| PlutusTx.Data.List.null (PlutusLedgerApi.V3.Data.Contexts.txInfoOutputs txInfo_5))})
     -- @@@
     SPlutusV4 ->
-      [ "58d601010025329323253232333573466e1d200235573a006264b26600640026ae84d5d1000c86005130024986"
-      , "aae7800c4c0052625953293001323237586ae84008c011d69aab9e37546ae8401630008980099191bac3574200"
-      , "46008eb4d5d11aba235573c6ea8d5d080288ccd5cd1aba3001800400a30028c00044646464a666ae68cdc3a400"
-      , "4004300215333573466e1d2000002180098029aba1001098042481035054310035573c0046aae74004dd50009b"
-      , "aa357426ae88d5d10009aab9e3754005149a260029210350543500119319ab9c00180001"
+      [ "5901a4010100322533357346464a6464666ae68cdc3a40046aae7400c4ca4cc00c8004d5d09aba200192509801"
+      , "24c35573c00626002931199ab9a53233357346ae8ccc00488888888888888880409852889aba33300122222222"
+      , "2222222200e262232323232323232323232323232323232333333333333333301237586ae84040dd61aba100f3"
+      , "7586ae84038dd69aba100d37566ae84030dd61aba100b37566ae84028d5d08049bac357420106eacd5d08039ba"
+      , "b3574200c6eb8d5d08029bab357420086eb0d5d080198009aba10023001357426ae88008c04dd69aba20013574"
+      , "40026ae88004d5d10009aba2001357440026ae88004d5d10009aba2001357440026ae88004d5d10009aba20013"
+      , "57440026aae78dd51aba10064a094488c8c8cc94ccd5cd19b88002480004c02524010350543600133001002801"
+      , "94004c018d5d0800b003280160001918008009114800cc02d2410350543700912999ab9a3370e9000002080109"
+      , "991980300300099b81004480080046aae78008d55ce8009baa00137546ae84d5d11aba200135573c6ea8004526"
+      , "130024910350543500232633573800300001"
       ]
 
 -- | Script that succeeds when inputs and outputs are not empty validated against txInfo
@@ -1182,7 +1198,7 @@ inputsOutputsAreNotEmptyNoDatum =
 inputsOutputsAreNotEmptyWithDatum :: SLanguage l -> Plutus l
 inputsOutputsAreNotEmptyWithDatum =
   decodeHexPlutus . mconcat . \case
-    -- ScriptHash "e6d86a1aed1966b121f489c3c032a1c72139ecbb2ecdc88c3cb99517"
+    -- ScriptHash "02bf4789f87d26358cb94384a628c64d4544e8e536f661df181c9fd0"
     -- Preprocessed PlutusV1 Script:
     -- @@@
     -- inputsOutputsAreNotEmptyWithDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -1197,14 +1213,15 @@ inputsOutputsAreNotEmptyWithDatum =
     --                                                                                                                                                                                                                             else GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV1 ->
-      [ "58e4010000222532335332253232335300233001222222222200a2610041300233001222222222200926223232"
-      , "32323232323232333333333300b37586ae84024dd61aba100837566ae8401cdd59aba100637586ae84014dd61a"
-      , "ba1004357420066eb0d5d08011bac35742002646464a66a666ae68cdc3a400000402202026eb8d5d0800899319"
-      , "ab9c4901035054310001235573c0046aae74004dd51aba1357440026ae88004d5d10009aba2001357440026ae8"
-      , "8004d5d10009aba2001357440026aae78dd51aba135573c6ea801c8ccd5cd1aba3001003002122002122001161"
-      , "0011200101"
+      [ "590111010000323222253335734a64666ae68d5d1998009111111111005130a511357466600244444444440124"
+      , "c4464646464646464646466666666660166eb0d5d08049bac357420106eacd5d08039bab3574200c6eb0d5d080"
+      , "29bac357420086ae8400cdd61aba100237586ae84004c8c8cc94ccd5cd19b88002480004c04924010350543600"
+      , "133001002122330012375c6ae84004488008c8c0040048894cd40044c051240103505437002215333573466e1d"
+      , "200000410021332330060060013370200890010009aab9e00235573a0026ea8d5d09aba2001357440026ae8800"
+      , "4d5d10009aba2001357440026ae88004d5d10009aba200135573c6ea8d5d09aab9e37540062c200a464c66ae70"
+      , "004008480041"
       ]
-    -- ScriptHash "8e6aa62d4514da1018898798c40b4ecb442b54dce1d38fee8e115314"
+    -- ScriptHash "d858e669a1da1f64e8fbf1031734d3486a6f50f6fe8c6db0d53d0a93"
     -- Preprocessed PlutusV2 Script:
     -- @@@
     -- inputsOutputsAreNotEmptyWithDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -1219,14 +1236,15 @@ inputsOutputsAreNotEmptyWithDatum =
     --                                                                                                                                                                                                                             else GHC.Tuple.Prim.()}}}
     -- @@@
     SPlutusV2 ->
-      [ "58fb01000022253233533225323233530023300122222222222200c261004130023300122222222222200a2622"
-      , "323232323232323232323233333333333300d37586ae8402cdd61aba100a37586ae84024dd59aba100837566ae"
-      , "8401cdd61aba100637566ae84014d5d08021bac357420066eacd5d08011bab35742002646464a66a666ae68cdc"
-      , "3a400000402602426eb8d5d0800899319ab9c491035054310001435573c0046aae74004dd51aba1357440026ae"
-      , "88004d5d10009aba2001357440026ae88004d5d10009aba2001357440026ae88004d5d10009aab9e37546ae84d"
-      , "55cf1baa007233357346ae8c00400c00848800848800458400448005"
+      [ "590129010000323222253335734a64666ae68d5d199800911111111111006130a5113574666002444444444444"
+      , "0144c44646464646464646464646466666666666601a6eb0d5d08059bac357420146eb0d5d08049bab35742010"
+      , "6eacd5d08039bac3574200c6eacd5d08029aba100437586ae8400cdd59aba100237566ae84004c8c8cc94ccd5c"
+      , "d19b88002480004c0512410350543600133001002122330012375c6ae84004488008c8c0040048894cd40044c0"
+      , "59240103505437002215333573466e1d200000410021332330060060013370200890010009aab9e00235573a00"
+      , "26ea8d5d09aba2001357440026ae88004d5d10009aba2001357440026ae88004d5d10009aba2001357440026ae"
+      , "88004d55cf1baa357426aae78dd50018b0802919319ab9c0010021200101"
       ]
-    -- ScriptHash "89434e86b5c711ec050162be750b5be2ab0d2213f1016b208972866d"
+    -- ScriptHash "e979372cafd2822b678194dd1ccff2ca152ff4d5a6d9e73a32f163ff"
     -- Preprocessed PlutusV3 Script:
     -- @@@
     -- inputsOutputsAreNotEmptyWithDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -1241,13 +1259,18 @@ inputsOutputsAreNotEmptyWithDatum =
     --                                                                                                                                _scriptPurpose_7 -> GHC.Classes.not GHC.Base.$ (PlutusTx.Data.List.null (PlutusLedgerApi.V3.Data.Contexts.txInfoInputs txInfo_5) GHC.Classes.|| PlutusTx.Data.List.null (PlutusLedgerApi.V3.Data.Contexts.txInfoOutputs txInfo_5))})
     -- @@@
     SPlutusV3 ->
-      [ "58d601010025329323253232333573466e1d200235573a006264b26600640026ae84d5d1000c84c00d268c0086"
-      , "aae7800c4c0052625953293001323237586ae84008c011d69aab9e37546ae8401630008980099191bac3574200"
-      , "46008eb4d5d11aba235573c6ea8d5d080288ccd5cd1aba3001800400a30028c00044646464a666ae68cdc3a400"
-      , "4004300215333573466e1d2000002180098029aba1001098042481035054310035573c0046aae74004dd50009b"
-      , "aa357426ae88d5d10009aab9e3754005149a260029210350543500119319ab9c00180001"
+      [ "5901a4010100322533357346464a6464666ae68cdc3a40046aae7400c4ca4cc00c8004d5d09aba200191801a4d"
+      , "4a035573c00626002931199ab9a53233357346ae8ccc00488888888888888880409852889aba33300122222222"
+      , "2222222200e262232323232323232323232323232323232333333333333333301237586ae84040dd61aba100f3"
+      , "7586ae84038dd69aba100d37566ae84030dd61aba100b37566ae84028d5d08049bac357420106eacd5d08039ba"
+      , "b3574200c6eb8d5d08029bab357420086eb0d5d080198009aba10023001357426ae88008c04dd69aba20013574"
+      , "40026ae88004d5d10009aba2001357440026ae88004d5d10009aba2001357440026ae88004d5d10009aba20013"
+      , "57440026aae78dd51aba10064a094488c8c8cc94ccd5cd19b88002480004c02524010350543600133001002801"
+      , "94004c018d5d0800b003280160001918008009114800cc02d2410350543700912999ab9a3370e9000002080109"
+      , "991980300300099b81004480080046aae78008d55ce8009baa00137546ae84d5d11aba200135573c6ea8004526"
+      , "130024910350543500232633573800300001"
       ]
-    -- ScriptHash "4c51d0e81fbca99e719a99dfee5c8c45648901e2057166be90d5ff67"
+    -- ScriptHash "9bdd5669aab46266cc856a414d8a7e01d1bb24b1bce2c1c0d88072d0"
     -- Preprocessed PlutusV4 Script:
     -- @@@
     -- inputsOutputsAreNotEmptyWithDatum_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -1262,11 +1285,16 @@ inputsOutputsAreNotEmptyWithDatum =
     --                                                                                                                                _scriptPurpose_7 -> GHC.Classes.not GHC.Base.$ (PlutusTx.Data.List.null (PlutusLedgerApi.V3.Data.Contexts.txInfoInputs txInfo_5) GHC.Classes.|| PlutusTx.Data.List.null (PlutusLedgerApi.V3.Data.Contexts.txInfoOutputs txInfo_5))})
     -- @@@
     SPlutusV4 ->
-      [ "58d601010025329323253232333573466e1d200235573a006264b26600640026ae84d5d1000c84c00d268c0086"
-      , "aae7800c4c0052625953293001323237586ae84008c011d69aab9e37546ae8401630008980099191bac3574200"
-      , "46008eb4d5d11aba235573c6ea8d5d080288ccd5cd1aba3001800400a30028c00044646464a666ae68cdc3a400"
-      , "4004300215333573466e1d2000002180098029aba1001098042481035054310035573c0046aae74004dd50009b"
-      , "aa357426ae88d5d10009aab9e3754005149a260029210350543500119319ab9c00180001"
+      [ "5901a4010100322533357346464a6464666ae68cdc3a40046aae7400c4ca4cc00c8004d5d09aba200191801a4d"
+      , "4a035573c00626002931199ab9a53233357346ae8ccc00488888888888888880409852889aba33300122222222"
+      , "2222222200e262232323232323232323232323232323232333333333333333301237586ae84040dd61aba100f3"
+      , "7586ae84038dd69aba100d37566ae84030dd61aba100b37566ae84028d5d08049bac357420106eacd5d08039ba"
+      , "b3574200c6eb8d5d08029bab357420086eb0d5d080198009aba10023001357426ae88008c04dd69aba20013574"
+      , "40026ae88004d5d10009aba2001357440026ae88004d5d10009aba2001357440026ae88004d5d10009aba20013"
+      , "57440026aae78dd51aba10064a094488c8c8cc94ccd5cd19b88002480004c02524010350543600133001002801"
+      , "94004c018d5d0800b003280160001918008009114800cc02d2410350543700912999ab9a3370e9000002080109"
+      , "991980300300099b81004480080046aae78008d55ce8009baa00137546ae84d5d11aba200135573c6ea8004526"
+      , "130024910350543500232633573800300001"
       ]
 
 -- | Script that succeeds only if any the inputs also appears in the reference inputs
@@ -1274,7 +1302,7 @@ inputsOverlapsWithRefInputs :: SLanguage l -> Plutus l
 inputsOverlapsWithRefInputs =
   decodeHexPlutus . mconcat . \case
     SPlutusV1 -> error "Script not available in PlutusV1"
-    -- ScriptHash "8611660671ed0cec38d850fe6f1be6d5db75360ed67be1cea18ba678"
+    -- ScriptHash "bc562d8aba01a7534d18775cbb8a3b15c388805ada374bd46c8a506d"
     -- Preprocessed PlutusV2 Script:
     -- @@@
     -- inputsOverlapsWithRefInputs_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -1287,45 +1315,43 @@ inputsOverlapsWithRefInputs =
     --                                                                                                                                     else PlutusTx.Builtins.error GHC.Tuple.Prim.()}
     -- @@@
     SPlutusV2 ->
-      [ "590666010000323232323322323232323232323222232325335332300100122333015010232253355335300233"
-      , "00622222222222200b262101510131014133005005001323001001223330180102253353232533532325335333"
-      , "573466e3cc05c008c05c0040680644ccd5cd19b87301d002301d00101a0191019357420046ae840084ccc048d5"
-      , "d09aba20022222333016357426ae8801488894cd4c8c94cd4cc068d5d08011aba100113253353001357426ae88"
-      , "00c854cd4c008d5d09aba20032132532335333573466e1d200035573a00404e04c264a66a666ae68cdc3a40006"
-      , "aae740040a009c4cc080d5d09aab9e003357426aae780044c00926375400626002931199810002111199811803"
-      , "111299a999ab9a3370e00c00605a0582a66a666ae68cdc38028010168160999ab9a3370e00800205a058205820"
-      , "584054404e6ea8008408c54cd4c004d5d09aba2002210231023301d2001102135573c6ea8014d55cf1baa00815"
-      , "33533330132332300100123302602225335333573466e1d2000375a6aae7800408c08848cc00c00c0044808cdd"
-      , "580091199980a9199ab9a3370e90001bad00102302222333573466e1cdd68011bad00102402337560046eac004"
-      , "01c00c54cd54c8cd4ccd5cd19b8748000d55ce9baa00702102015335333573466e1d200035573a6ea800c08408"
-      , "040844c00526130014988c94c8cd4ccd5cd19b8748008d55ce801011811099299a999ab9a3370e90011aab9d00"
-      , "10240231333573466e3cdd71aba135573c0066eb8d5d09aab9e00102402313002498dd500289800a4c4a66a666"
-      , "ae68cdc3a40086aae7400808c0884c94cd4ccd5cd19b8748010d55ce8008120118999ab9a3375e6ae84d55cf00"
-      , "19aba135573c00204804620466ea80144088dd50038a99a80290a99a80110999ab9a3371e00400204404220402"
-      , "a66a002420402040203e203e203e4646a002002c4646a002002c202e6aae78dd50031aab9e3754004224460040"
-      , "08266008008002002002660024444444444440184c20222c44646464646464646464646466666666666601a6eb"
-      , "0d5d08059bac357420146eb0d5d08049bab357420106eacd5d08039bac3574200c6eacd5d08029aba100437586"
-      , "ae8400cdd59aba100237566ae84004c064d5d09aba2001357440026ae88004d5d10009aba2001357440026ae88"
-      , "004d5d10009aba2001357440026ae88004d55cf1baa357426aae78dd5002111911198018010009918008009111"
-      , "99980b1199980b900a111199180080091980d80b9299a98059aab9e00112330030030011201800500201522233"
-      , "330192332300100123301b01725335300b35573c00224660060060022403000c4446464a66a666ae68cdd78011"
-      , "aab9d00501a019153353300c35573c0106aae780144ccc02c02c01c010406454cd4c034d55cf00409998058058"
-      , "03804899800a99a98069aab9e00514bd6f7b630099aba00054bd6f7b6300021918008009111999810100e11119"
-      , "299a980980089998038038030018a99a999ab9a3375e6aae7401002008007c54cd4cc048d55cf0070008999808"
-      , "80880699a80b803001880f89991980400400099aba000400600335573c00600203c6aae7401801005c008050cc"
-      , "8c00400488488cccc0448008888cd4cc01c01c48004008cd5d000180200100789000911929919a999ab9a3370e"
-      , "90001aab9d00200c00b1325335333573466e1d200035573a00201a0182666ae68cdc79bae357426aae7800cdd7"
-      , "1aba135573c00201a01826004931baa0031300149894cd4ccd5cd19b8748008d55ce801006005899299a999ab9"
-      , "a3370e90011aab9d00100d00c1333573466e3cdd71aba135573c0066eb8d5d09aab9e00100d00c100c37540062"
-      , "0166ea8008888c94cd4ccd5cd19b8748008d55ce800805805099191998029bad357420046eb4d5d08009bad357"
-      , "426ae88004d5d10009aab9e00113002498dd500191119191919998029aba100337566ae84008d5d080099803ba"
-      , "e357426ae88004d5d10009aba200135573c6ea800c88c8c8c94cd4ccd5cd19b8748008008028024401854cd4cc"
-      , "d5cd19b87480000080280244c8488c00800cc014d5d080089805a481035054310035573c0046aae74004dd5000"
-      , "891000918011aba135573c6ea80048c8c8c94cd4ccd5cd19b87480000080180144dd71aba10011300749010350"
-      , "54310035573c0046aae74004dd5000891001091000919319ab9c001002120012375a6ae84d5d11aab9e3754002"
-      , "444a666aae7c004400c4cc008d5d08009aba200101"
+      [ "59060d010000323232323233223232323232323232322223232533357346646002002446660209408c894ccd5c"
+      , "d19a9801198031111111111110059312514a029444cc014014004c8c00400488ccc04c060894ccd5cd19192999"
+      , "ab9a32325333573466e3cc050008c0500044cdc3980c001180c0008a50357420046ae840084ccc040d5d09aba2"
+      , "0022222333014357426ae8801488894ccd5cd19192999ab9a33024357420046ae840044c94cd4c004d5d09aba2"
+      , "003213353002357426ae8800c8c94c8ccd5cd19b8748000d55ce8010992999ab9a3370e90001aab9d00113302a"
+      , "357426aae7800cd5d09aab9e00113002498dd500189800a4c466605400844466605a00c444a666ae68cdc38030"
+      , "018a999ab9a3370e00a004266e1c0100045280a5024a04940dd500125013353001357426ae88008928251301b2"
+      , "00114a06aae78dd50029aab9e37540102a666ae68cccc04c8cc8c0040048cc085289199ab9a3370e90001bad35"
+      , "573c0024660060060024940dd580091199980a919b8748000dd68009119b87375a0046eb4004dd58011bab0010"
+      , "07003153335734a64666ae68cdc3a40006aae74dd50038a999ab9a3370e90001aab9d375400629444c00526130"
+      , "014988c94c8ccd5cd19b8748008d55ce8010992999ab9a3370e90011aab9d00113371e6eb8d5d09aab9e003375"
+      , "c6ae84d55cf0008980124c6ea80144c0052625333573466e1d200435573a004264a666ae68cdc3a40086aae740"
+      , "044cdd79aba135573c0066ae84d55cf0008a50375400a2940dd50038a99a8029099a801119b8f0020014a0266a"
+      , "0024941288a5014a029408c8d400400588c8d400400585281aab9e375400c6aae78dd500108911801002099802"
+      , "0020008008009980091111111111100613080a8b1119191919191919191919191999999999998069bac3574201"
+      , "66eb0d5d08051bac357420126eacd5d08041bab3574200e6eb0d5d08031bab3574200a6ae84010dd61aba10033"
+      , "7566ae84008dd59aba10013016357426ae88004d5d10009aba2001357440026ae88004d5d10009aba200135744"
+      , "0026ae88004d5d10009aba200135573c6ea8d5d09aab9e37540084464446600600400264600200244466660224"
+      , "66660244944888cc8c0040048cc059289199ab9a300b35573c0024660060060024940014008064888cccc0508c"
+      , "c8c0040048cc059289199ab9a300b35573c0024660060060024940018888c8c94ccd5cd19baf00235573a00a2a"
+      , "666ae68cc030d55cf0041aab9e005133300b00b00700414a02a666ae68c034d55cf00409998058058038048998"
+      , "00a999ab9a300d35573c00a297adef6c60133574000a97adef6c60004323001001222333301b24a044464a666a"
+      , "e68c04c0044ccc01c01c01800c54ccd5cd19baf35573a0080102a666ae68cc048d55cf00700089998088088069"
+      , "9a80b8030018a5013323300800800133574000800c0066aae7800c004088d55ce80300200d80100c1991800800"
+      , "910911999806100111119a998038038900080119aba0003004002013120012223232323333005357420066eacd"
+      , "5d08011aba10013300775c6ae84d5d10009aba2001357440026aae78dd500191198031baa00122323335008330"
+      , "01232122300200330063574200266002402201a006004a016460046ae84d55cf1baa001233003375400244666a"
+      , "00866a01046eb8d5d0800804801000899112999ab9a33710002900009806248103505436001330030010023230"
+      , "0100122253350011300c490103505437002215333573466e1d2000004100213323300600600133702008900100"
+      , "091198009aab9d00235573c00446eb4d5d09aba235573c6ea80048894ccd55cf80088018998011aba100135744"
+      , "002244004244244660020080064464a64666ae68cdc3a40006aae740084c94ccd5cd19b8748000d55ce800899b"
+      , "8f375c6ae84d55cf0019bae357426aae780044c009263754006260029312999ab9a3370e90011aab9d00213253"
+      , "33573466e1d200235573a002266e3cdd71aba135573c0066eb8d5d09aab9e00114a06ea800c5281baa00222232"
+      , "5333573466e1d200235573a0022646466600a6eb4d5d08011bad357420026eb4d5d09aba2001357440026aae78"
+      , "0044c009263754006244002464c66ae7000400848005"
       ]
-    -- ScriptHash "c22c7cddbf374dc5478e04c297e0e9d838a70060e6a672ff80ef2332"
+    -- ScriptHash "8b97fb204b3c00be3b9df89288257b0bc816b41833d70effbdecfac7"
     -- Preprocessed PlutusV3 Script:
     -- @@@
     -- inputsOverlapsWithRefInputs_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -1337,42 +1363,43 @@ inputsOverlapsWithRefInputs =
     --                                                                               _ -> GHC.Types.False})
     -- @@@
     SPlutusV3 ->
-      [ "5905f7010100323232323232323232259323233230010012232330012322595930023300722222222222222220"
-      , "0f2690c0023002460011330060060011918008009119802112c99192c99192999ab9a3371e602c004602c00226"
-      , "66ae68cdc3980b801180b800c0020043002357420046ae8400a26660226ae84d5d1001111119980a9aba135744"
-      , "00a4444b26464b2660326ae84008d5d0800c4c964c004d5d09aba200390ac98011aba135744007213253233357"
-      , "3466e1d200035573a004264a666ae68cdc3a40006aae740044cc07cd5d09aab9e003357426aae780044c009263"
-      , "7540062600293119980f8021111998110031112999ab9a3370e00c0062a666ae68cdc38028010999ab9a3370e0"
-      , "080030008010c0086004500228011baa0028c0091593001357426ae8800a430028c000301c20018c0086aae78d"
-      , "d50029aab9e37540111593333014233230010012330208001199ab9a3370e90001bad35573c002466006006002"
-      , "5002375600244666602c4666ae68cdc3a40006eb400600100222333573466e1cdd68011bad0018004008dd5801"
-      , "1bab0010070038aca99199ab9a3370e90001aab9d375400e2a666ae68cdc3a40006aae74dd50018c0004c00526"
-      , "130014988c94c8ccd5cd19b8748008d55ce8010992999ab9a3370e90011aab9d0011333573466e3cdd71aba135"
-      , "573c0066eb8d5d09aab9e00180040084c00926375400a260029312999ab9a3370e90021aab9d00213253335734"
-      , "66e1d200435573a0022666ae68cdd79aba135573c0066ae84d55cf000c0020043002375400a3002375400f1590"
-      , "0590ac801484ccd5cd19b8f002001800400a30024564006430028c0008c0091801230021194800c004c4652003"
-      , "00134600435573c6ea8018d55cf1baa0028c00400913300400400100080118074008cc00488888888888888880"
-      , "409888c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8cccccccccccccccc048dd61aba101037586ae8403cdd61aba100"
-      , "e375a6ae84034dd59aba100c37586ae8402cdd59aba100a357420126eb0d5d08041bab3574200e6eacd5d08031"
-      , "bae3574200a6eacd5d08021bac3574200660026ae84008c004d5d09aba2002301875a6ae88004d5d10009aba20"
-      , "01357440026ae88004d5d10009aba2001357440026ae88004d5d10009aba2001357440026ae88004d5d10009aa"
-      , "b9e37546ae84d55cf1baa00422322233003002001323001001222333300f233330102800111199180080091980"
-      , "a4000964c02cd55cf000c48cc00c00c006250020028014000888cccc0488cc8c0040048cc0520004b260166aae"
-      , "780062466006006003128010018888c8c94ccd5cd19baf00235573a00a2b2660186aae78020d55cf002c4ccc02"
-      , "c02c01c01230020ac98069aab9e0088999805805803804c4cc00564c034d55cf002c52f5bded8c1133574000a9"
-      , "7adef6c600020c8c004004888cccc064a00444464b2602600313330070070060038a999ab9a3375e6aae740100"
-      , "20564cc048d55cf007000c4ccc044044034cd405401800e300209991980400400099aba00040060031aab9e003"
-      , "0018001aab9d006004800001400229344c01d24103505435001991800800910911999806100111119a99803803"
-      , "8900080119aba0003004002800090009119299199ab9a3370e90001aab9d0021325333573466e1d200035573a0"
-      , "022666ae68cdc79bae357426aae7800cdd71aba135573c0030008010980124c6ea800c4c0052625333573466e1"
-      , "d200235573a004264a666ae68cdc3a40046aae740044ccd5cd19b8f375c6ae84d55cf0019bae357426aae78006"
-      , "00100218011baa00318011baa002222325333573466e1d200235573a0022646466600a6eb4d5d08011bad35742"
-      , "0026eb4d5d09aba2001357440026aae780044c009263754006444646464666600a6ae8400cdd59aba100235742"
-      , "0026600eeb8d5d09aba2001357440026ae88004d55cf1baa003223232325333573466e1d200200218010a999ab"
-      , "9a3370e90000010c004c014d5d080084c0192401035054310035573c0046aae74004dd5000919319ab9c001800"
-      , "11bae357426aae78dd500091bad357426ae88d55cf1baa00122253335573e00220062660046ae84004d5d10009"
+      [ "5905fa01010032323232323232323225333573464646646002002446660169408c894ccd5cd498011980311111"
+      , "11111111111007934928d280528899802802800991800800911998074008894ccd5cd19192999ab9a323253335"
+      , "73466e3cc048008c0480044cdc3980980118098008a50357420046ae840084ccc038d5d09aba20022222333012"
+      , "357426ae8801488894ccd5cd19192999ab9a3301d357420046ae8400464cc0648004d5d09aba2002949980d100"
+      , "09aba135744005232532333573466e1d200035573a004264a666ae68cdc3a40006aae740044cc088d5d09aab9e"
+      , "003357426aae780044c009263754006260029311998110021111998128031112999ab9a3370e00c0062a666ae6"
+      , "8cdc3802801099b8700400114a02940928125037540054a0c9980c90009aba13574400324a14a20a5035573c6e"
+      , "a8014d55cf1baa0081533357346666026466460020024660389448ccd5cd19b8748000dd69aab9e00123300300"
+      , "300124a06eac00488cccc0548cdc3a40006eb400488cdc39bad002375a0026eac008dd58008038018a999ab9a5"
+      , "32333573466e1d200035573a6ea801c54ccd5cd19b8748000d55ce9baa00314a2260029309800a4c464a64666a"
+      , "e68cdc3a40046aae740084c94ccd5cd19b8748008d55ce800899b8f375c6ae84d55cf0019bae357426aae78004"
+      , "4c00926375400a260029312999ab9a3370e90021aab9d0021325333573466e1d200435573a002266ebcd5d09aa"
+      , "b9e003357426aae780045281baa00514a06ea801c640165200523371e0040034a0c800c928528829405280a502"
+      , "329001800988ca4006002614a06aae78dd50031aab9e3754004300100209980200200080080099800911111111"
+      , "111111100813111919191919191919191919191919191919999999999999998091bac357420206eb0d5d08079b"
+      , "ac3574201c6eb4d5d08069bab357420186eb0d5d08059bab357420146ae84024dd61aba100837566ae8401cdd5"
+      , "9aba1006375c6ae84014dd59aba100437586ae8400cc004d5d080118009aba135744004602ceb4d5d10009aba2"
+      , "001357440026ae88004d5d10009aba2001357440026ae88004d5d10009aba2001357440026ae88004d5d10009a"
+      , "ba200135573c6ea8d5d09aab9e37540084464446600600400264600200244466660184666601a4944888cc8c00"
+      , "40048cc045289199ab9a300b35573c002466006006002494001400a000444666601e466460020024660229448c"
+      , "cd5cd18059aab9e00123300300300124a000c4446464a666ae68cdd78011aab9d005153335734660186aae7802"
+      , "0d55cf00289998058058038020a50153335734601a6aae780204ccc02c02c01c0244cc0054ccd5cd18069aab9e"
+      , "00514bd6f7b630099aba00054bd6f7b630002191800800911199980b125022232533357346026002266600e00e"
+      , "00c0062a666ae68cdd79aab9d004008153335734660246aae780380044ccc044044034cd405401800c52809991"
+      , "980400400099aba000400600335573c00600300035573a00c0090000028000a4c2601492010350543500332300"
+      , "100122122333300920022223353300700712001002335740006008005000120012223232323333005357420066"
+      , "eacd5d08011aba10013300775c6ae84d5d10009aba2001357440026aae78dd50019119191992999ab9a3371000"
+      , "4900009805a481035054360013300100280194004c018d5d0800b003280160001918008009114800cc03524103"
+      , "50543700912999ab9a3370e9000002080109991980300300099b81004480080046aae78008d55ce8009baa0012"
+      , "375c6ae84d55cf1baa0012375a6ae84d5d11aab9e3754002444a666aae7c004400c4cc008d5d08009aba200122"
+      , "32532333573466e1d200035573a004264a666ae68cdc3a40006aae740044cdc79bae357426aae7800cdd71aba1"
+      , "35573c00226004931baa0031300149894ccd5cd19b8748008d55ce8010992999ab9a3370e90011aab9d0011337"
+      , "1e6eb8d5d09aab9e003375c6ae84d55cf0008a5037540062940dd5001111192999ab9a3370e90011aab9d00113"
+      , "232333005375a6ae84008dd69aba1001375a6ae84d5d10009aba200135573c00226004931baa00323263357380"
+      , "030001"
       ]
-    -- ScriptHash "f8f7b0e11325b468c5bd034ac8c094f1d37303b40b53cf349942f1a9"
+    -- ScriptHash "e049bc84462c6e11f2b965d5aaba0d59b745fc2e8522bc57aa803ce3"
     -- Preprocessed PlutusV4 Script:
     -- @@@
     -- inputsOverlapsWithRefInputs_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
@@ -1384,38 +1411,39 @@ inputsOverlapsWithRefInputs =
     --                                                                               _ -> GHC.Types.False})
     -- @@@
     SPlutusV4 ->
-      [ "5905f7010100323232323232323232259323233230010012232330012322595930023300722222222222222220"
-      , "0f2690c0023002460011330060060011918008009119802112c99192c99192999ab9a3371e602c004602c00226"
-      , "66ae68cdc3980b801180b800c0020043002357420046ae8400a26660226ae84d5d1001111119980a9aba135744"
-      , "00a4444b26464b2660326ae84008d5d0800c4c964c004d5d09aba200390ac98011aba135744007213253233357"
-      , "3466e1d200035573a004264a666ae68cdc3a40006aae740044cc07cd5d09aab9e003357426aae780044c009263"
-      , "7540062600293119980f8021111998110031112999ab9a3370e00c0062a666ae68cdc38028010999ab9a3370e0"
-      , "080030008010c0086004500228011baa0028c0091593001357426ae8800a430028c000301c20018c0086aae78d"
-      , "d50029aab9e37540111593333014233230010012330208001199ab9a3370e90001bad35573c002466006006002"
-      , "5002375600244666602c4666ae68cdc3a40006eb400600100222333573466e1cdd68011bad0018004008dd5801"
-      , "1bab0010070038aca99199ab9a3370e90001aab9d375400e2a666ae68cdc3a40006aae74dd50018c0004c00526"
-      , "130014988c94c8ccd5cd19b8748008d55ce8010992999ab9a3370e90011aab9d0011333573466e3cdd71aba135"
-      , "573c0066eb8d5d09aab9e00180040084c00926375400a260029312999ab9a3370e90021aab9d00213253335734"
-      , "66e1d200435573a0022666ae68cdd79aba135573c0066ae84d55cf000c0020043002375400a3002375400f1590"
-      , "0590ac801484ccd5cd19b8f002001800400a30024564006430028c0008c0091801230021194800c004c4652003"
-      , "00134600435573c6ea8018d55cf1baa0028c00400913300400400100080118074008cc00488888888888888880"
-      , "409888c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8cccccccccccccccc048dd61aba101037586ae8403cdd61aba100"
-      , "e375a6ae84034dd59aba100c37586ae8402cdd59aba100a357420126eb0d5d08041bab3574200e6eacd5d08031"
-      , "bae3574200a6eacd5d08021bac3574200660026ae84008c004d5d09aba2002301875a6ae88004d5d10009aba20"
-      , "01357440026ae88004d5d10009aba2001357440026ae88004d5d10009aba2001357440026ae88004d5d10009aa"
-      , "b9e37546ae84d55cf1baa00422322233003002001323001001222333300f233330102800111199180080091980"
-      , "a4000964c02cd55cf000c48cc00c00c006250020028014000888cccc0488cc8c0040048cc0520004b260166aae"
-      , "780062466006006003128010018888c8c94ccd5cd19baf00235573a00a2b2660186aae78020d55cf002c4ccc02"
-      , "c02c01c01230020ac98069aab9e0088999805805803804c4cc00564c034d55cf002c52f5bded8c1133574000a9"
-      , "7adef6c600020c8c004004888cccc064a00444464b2602600313330070070060038a999ab9a3375e6aae740100"
-      , "20564cc048d55cf007000c4ccc044044034cd405401800e300209991980400400099aba00040060031aab9e003"
-      , "0018001aab9d006004800001400229344c01d24103505435001991800800910911999806100111119a99803803"
-      , "8900080119aba0003004002800090009119299199ab9a3370e90001aab9d0021325333573466e1d200035573a0"
-      , "022666ae68cdc79bae357426aae7800cdd71aba135573c0030008010980124c6ea800c4c0052625333573466e1"
-      , "d200235573a004264a666ae68cdc3a40046aae740044ccd5cd19b8f375c6ae84d55cf0019bae357426aae78006"
-      , "00100218011baa00318011baa002222325333573466e1d200235573a0022646466600a6eb4d5d08011bad35742"
-      , "0026eb4d5d09aba2001357440026aae780044c009263754006444646464666600a6ae8400cdd59aba100235742"
-      , "0026600eeb8d5d09aba2001357440026ae88004d55cf1baa003223232325333573466e1d200200218010a999ab"
-      , "9a3370e90000010c004c014d5d080084c0192401035054310035573c0046aae74004dd5000919319ab9c001800"
-      , "11bae357426aae78dd500091bad357426ae88d55cf1baa00122253335573e00220062660046ae84004d5d10009"
+      [ "5905fa01010032323232323232323225333573464646646002002446660169408c894ccd5cd498011980311111"
+      , "11111111111007934928d280528899802802800991800800911998074008894ccd5cd19192999ab9a323253335"
+      , "73466e3cc048008c0480044cdc3980980118098008a50357420046ae840084ccc038d5d09aba20022222333012"
+      , "357426ae8801488894ccd5cd19192999ab9a3301d357420046ae8400464cc0648004d5d09aba2002949980d100"
+      , "09aba135744005232532333573466e1d200035573a004264a666ae68cdc3a40006aae740044cc088d5d09aab9e"
+      , "003357426aae780044c009263754006260029311998110021111998128031112999ab9a3370e00c0062a666ae6"
+      , "8cdc3802801099b8700400114a02940928125037540054a0c9980c90009aba13574400324a14a20a5035573c6e"
+      , "a8014d55cf1baa0081533357346666026466460020024660389448ccd5cd19b8748000dd69aab9e00123300300"
+      , "300124a06eac00488cccc0548cdc3a40006eb400488cdc39bad002375a0026eac008dd58008038018a999ab9a5"
+      , "32333573466e1d200035573a6ea801c54ccd5cd19b8748000d55ce9baa00314a2260029309800a4c464a64666a"
+      , "e68cdc3a40046aae740084c94ccd5cd19b8748008d55ce800899b8f375c6ae84d55cf0019bae357426aae78004"
+      , "4c00926375400a260029312999ab9a3370e90021aab9d0021325333573466e1d200435573a002266ebcd5d09aa"
+      , "b9e003357426aae780045281baa00514a06ea801c640165200523371e0040034a0c800c928528829405280a502"
+      , "329001800988ca4006002614a06aae78dd50031aab9e3754004300100209980200200080080099800911111111"
+      , "111111100813111919191919191919191919191919191919999999999999998091bac357420206eb0d5d08079b"
+      , "ac3574201c6eb4d5d08069bab357420186eb0d5d08059bab357420146ae84024dd61aba100837566ae8401cdd5"
+      , "9aba1006375c6ae84014dd59aba100437586ae8400cc004d5d080118009aba135744004602ceb4d5d10009aba2"
+      , "001357440026ae88004d5d10009aba2001357440026ae88004d5d10009aba2001357440026ae88004d5d10009a"
+      , "ba200135573c6ea8d5d09aab9e37540084464446600600400264600200244466660184666601a4944888cc8c00"
+      , "40048cc045289199ab9a300b35573c002466006006002494001400a000444666601e466460020024660229448c"
+      , "cd5cd18059aab9e00123300300300124a000c4446464a666ae68cdd78011aab9d005153335734660186aae7802"
+      , "0d55cf00289998058058038020a50153335734601a6aae780204ccc02c02c01c0244cc0054ccd5cd18069aab9e"
+      , "00514bd6f7b630099aba00054bd6f7b630002191800800911199980b125022232533357346026002266600e00e"
+      , "00c0062a666ae68cdd79aab9d004008153335734660246aae780380044ccc044044034cd405401800c52809991"
+      , "980400400099aba000400600335573c00600300035573a00c0090000028000a4c2601492010350543500332300"
+      , "100122122333300920022223353300700712001002335740006008005000120012223232323333005357420066"
+      , "eacd5d08011aba10013300775c6ae84d5d10009aba2001357440026aae78dd50019119191992999ab9a3371000"
+      , "4900009805a481035054360013300100280194004c018d5d0800b003280160001918008009114800cc03524103"
+      , "50543700912999ab9a3370e9000002080109991980300300099b81004480080046aae78008d55ce8009baa0012"
+      , "375c6ae84d55cf1baa0012375a6ae84d5d11aab9e3754002444a666aae7c004400c4cc008d5d08009aba200122"
+      , "32532333573466e1d200035573a004264a666ae68cdc3a40006aae740044cdc79bae357426aae7800cdd71aba1"
+      , "35573c00226004931baa0031300149894ccd5cd19b8748008d55ce8010992999ab9a3370e90011aab9d0011337"
+      , "1e6eb8d5d09aab9e003375c6ae84d55cf0008a5037540062940dd5001111192999ab9a3370e90011aab9d00113"
+      , "232333005375a6ae84008dd69aba1001375a6ae84d5d10009aba200135573c00226004931baa00323263357380"
+      , "030001"
       ]


### PR DESCRIPTION
# Description

This PR updates CHaP and Hackage in order to bring mempack-0.2 and cardano-crypto-class-2.2.3.1 that is also compatible with it.
It also applies a minor patch to make this mempack-0.2 compatibility in `cardano-ledger-core`

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
