### PR TITLE
Run Imp DELEG tests across eras

### DIFF
--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Imp.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Imp.hs
@@ -20,4 +20,5 @@ spec = do
   describe "AllegraImpSpec" . withEachEraVersion @era $
     UtxowSpec.spec
 
-instance EraSpecificSpec AllegraEra
+instance EraSpecificSpec AllegraEra where
+  eraSpecificSpec = ShelleyImp.shelleyEraSpecificSpec

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/ImpTest.hs
@@ -43,6 +43,7 @@ instance ShelleyEraImp AllegraEra where
   modifyImpInitProtVer = shelleyModifyImpInitProtVer
   genRegTxCert = shelleyGenRegTxCert
   genUnRegTxCert = shelleyGenUnRegTxCert
+  delegStakeTxCert = shelleyDelegStakeTxCert
 
 impAllegraSatisfyNativeScript ::
   ( ShelleyEraImp era

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp.hs
@@ -16,6 +16,7 @@ import qualified Test.Cardano.Ledger.Alonzo.Imp.UtxowSpec as Utxow
 import Test.Cardano.Ledger.Alonzo.ImpTest
 import Test.Cardano.Ledger.Imp.Common
 import qualified Test.Cardano.Ledger.Mary.Imp as MaryImp
+import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 
 spec ::
   forall era.
@@ -40,4 +41,5 @@ alonzoEraSpecificSpec = do
       Utxow.alonzoEraSpecificSpec
 
 instance EraSpecificSpec AlonzoEra where
-  eraSpecificSpec = alonzoEraSpecificSpec
+  eraSpecificSpec =
+    ShelleyImp.shelleyEraSpecificSpec >> alonzoEraSpecificSpec

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -439,6 +439,7 @@ instance ShelleyEraImp AlonzoEra where
   modifyImpInitProtVer = shelleyModifyImpInitProtVer
   genRegTxCert = shelleyGenRegTxCert
   genUnRegTxCert = shelleyGenUnRegTxCert
+  delegStakeTxCert = shelleyDelegStakeTxCert
 
 instance MaryEraImp AlonzoEra
 

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
@@ -16,6 +16,7 @@ import qualified Test.Cardano.Ledger.Babbage.Imp.UtxosSpec as Utxos
 import qualified Test.Cardano.Ledger.Babbage.Imp.UtxowSpec as Utxow
 import Test.Cardano.Ledger.Babbage.ImpTest (BabbageEraImp)
 import Test.Cardano.Ledger.Imp.Common
+import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 
 spec :: forall era. (BabbageEraImp era, EraSpecificSpec era) => Spec
 spec = do
@@ -28,4 +29,4 @@ spec = do
 
 instance EraSpecificSpec BabbageEra where
   eraSpecificSpec =
-    AlonzoImp.alonzoEraSpecificSpec
+    ShelleyImp.shelleyEraSpecificSpec >> AlonzoImp.alonzoEraSpecificSpec

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
@@ -62,6 +62,7 @@ instance ShelleyEraImp BabbageEra where
   modifyImpInitProtVer = shelleyModifyImpInitProtVer
   genRegTxCert = shelleyGenRegTxCert
   genUnRegTxCert = shelleyGenUnRegTxCert
+  delegStakeTxCert = shelleyDelegStakeTxCert
 
 babbageFixupTx ::
   ( HasCallStack

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -73,10 +73,9 @@ conwayEraGenericSpec = do
 
 conwayEraSpecificSpec :: SpecWith (ImpInit (LedgerSpec ConwayEra))
 conwayEraSpecificSpec = do
-  describe "Conway era specific Imp spec" $
-    describe "Certificates without deposits" $ do
-      describe "DELEG" Deleg.conwayEraSpecificSpec
-      describe "UTXO" Utxo.conwayEraSpecificSpec
+  describe "Conway era specific Imp spec" $ do
+    describe "DELEG" Deleg.conwayEraSpecificSpec
+    describe "UTXO" Utxo.conwayEraSpecificSpec
 
 instance EraSpecificSpec ConwayEra where
   eraSpecificSpec =

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -133,6 +133,7 @@ module Test.Cardano.Ledger.Conway.ImpTest (
   FailBoth (..),
   delegateSPORewardAddressToDRep_,
   getCommittee,
+  conwayDelegStakeTxCert,
 ) where
 
 import Cardano.Ledger.Address (RewardAccount (..))
@@ -313,6 +314,7 @@ instance ShelleyEraImp ConwayEra where
   modifyImpInitProtVer = conwayModifyImpInitProtVer
   genRegTxCert = conwayGenRegTxCert
   genUnRegTxCert = conwayGenUnRegTxCert
+  delegStakeTxCert = conwayDelegStakeTxCert
 
 conwayModifyImpInitProtVer ::
   forall era.
@@ -417,7 +419,6 @@ unRegisterDRep drep = do
         .~ SSeq.singleton (UnRegDRepTxCert drep refund)
 
 conwayGenUnRegTxCert ::
-  forall era.
   ( ShelleyEraImp era
   , ConwayEraTxCert era
   , ShelleyEraTxCert era
@@ -435,7 +436,6 @@ conwayGenUnRegTxCert stakingCredential = do
         ]
 
 conwayGenRegTxCert ::
-  forall era.
   ( ShelleyEraImp era
   , ConwayEraTxCert era
   , ShelleyEraTxCert era
@@ -448,6 +448,13 @@ conwayGenRegTxCert stakingCredential =
     , RegDepositTxCert stakingCredential
         <$> getsNES (nesEsL . curPParamsEpochStateL . ppKeyDepositL)
     ]
+
+conwayDelegStakeTxCert ::
+  ConwayEraTxCert era =>
+  Credential 'Staking ->
+  KeyHash 'StakePool ->
+  TxCert era
+conwayDelegStakeTxCert cred pool = DelegTxCert cred (DelegStake pool)
 
 -- | Submit a transaction that updates a given DRep
 updateDRep ::

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
@@ -80,6 +80,7 @@ instance ShelleyEraImp DijkstraEra where
   modifyImpInitProtVer = conwayModifyImpInitProtVer
   genRegTxCert = dijkstraGenRegTxCert
   genUnRegTxCert = dijkstraGenUnRegTxCert
+  delegStakeTxCert = conwayDelegStakeTxCert
 
 instance MaryEraImp DijkstraEra
 

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Imp.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Imp.hs
@@ -13,6 +13,7 @@ import qualified Test.Cardano.Ledger.Allegra.Imp as AllegraImp
 import Test.Cardano.Ledger.Imp.Common
 import qualified Test.Cardano.Ledger.Mary.Imp.UtxoSpec as Utxo
 import Test.Cardano.Ledger.Mary.ImpTest
+import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 
 spec :: forall era. (MaryEraImp era, EraSpecificSpec era) => Spec
 spec = do
@@ -21,4 +22,5 @@ spec = do
     withEachEraVersion @era $
       Utxo.spec
 
-instance EraSpecificSpec MaryEra
+instance EraSpecificSpec MaryEra where
+  eraSpecificSpec = ShelleyImp.shelleyEraSpecificSpec

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/ImpTest.hs
@@ -29,6 +29,7 @@ instance ShelleyEraImp MaryEra where
   modifyImpInitProtVer = shelleyModifyImpInitProtVer
   genRegTxCert = shelleyGenRegTxCert
   genUnRegTxCert = shelleyGenUnRegTxCert
+  delegStakeTxCert = shelleyDelegStakeTxCert
 
 class
   ( ShelleyEraImp era

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Added `shelleyGenRegTxCert`
 * Added `genRegTxCert` to `ShelleyEraImp`
 * Added `delegStakeTxCert` to `ShelleyEraImp`
+* Added `expectStakeCredRegistered`, `expectStakeCredNotRegistered`, `expectDelegatedToPool`, `expectNotDelegatedToPool` to `ImpTest`
 
 ## 1.17.0.0
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Added `genUnRegTxCert` to `ShelleyEraImp`
 * Added `shelleyGenRegTxCert`
 * Added `genRegTxCert` to `ShelleyEraImp`
+* Added `delegStakeTxCert` to `ShelleyEraImp`
 
 ## 1.17.0.0
 

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -146,6 +146,7 @@ library testlib
     Test.Cardano.Ledger.Shelley.Era
     Test.Cardano.Ledger.Shelley.Examples
     Test.Cardano.Ledger.Shelley.Imp
+    Test.Cardano.Ledger.Shelley.Imp.DelegSpec
     Test.Cardano.Ledger.Shelley.Imp.EpochSpec
     Test.Cardano.Ledger.Shelley.Imp.LedgerSpec
     Test.Cardano.Ledger.Shelley.Imp.PoolSpec

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
@@ -9,6 +9,7 @@ module Test.Cardano.Ledger.Shelley.Imp (spec) where
 
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Test.Cardano.Ledger.Imp.Common
+import qualified Test.Cardano.Ledger.Shelley.Imp.DelegSpec as Deleg
 import qualified Test.Cardano.Ledger.Shelley.Imp.EpochSpec as Epoch
 import qualified Test.Cardano.Ledger.Shelley.Imp.LedgerSpec as Ledger
 import qualified Test.Cardano.Ledger.Shelley.Imp.PoolSpec as Pool
@@ -26,6 +27,7 @@ spec ::
 spec = do
   describe "Era specific tests" . withEachEraVersion @era $ eraSpecificSpec
   describe "ShelleyImpSpec" $ withEachEraVersion @era $ do
+    describe "DELEG" Deleg.spec
     Epoch.spec
     Ledger.spec
     Pool.spec

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
@@ -5,9 +5,11 @@
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Cardano.Ledger.Shelley.Imp (spec) where
+module Test.Cardano.Ledger.Shelley.Imp (spec, shelleyEraSpecificSpec) where
 
 import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Ledger.Shelley.Core
+import Cardano.Ledger.Shelley.Rules
 import Test.Cardano.Ledger.Imp.Common
 import qualified Test.Cardano.Ledger.Shelley.Imp.DelegSpec as Deleg
 import qualified Test.Cardano.Ledger.Shelley.Imp.EpochSpec as Epoch
@@ -36,4 +38,17 @@ spec = do
   describe "ShelleyPureTests" $ do
     Instant.spec @era
 
-instance EraSpecificSpec ShelleyEra
+shelleyEraSpecificSpec ::
+  forall era.
+  ( ShelleyEraImp era
+  , InjectRuleFailure "LEDGER" ShelleyDelegsPredFailure era
+  ) =>
+  SpecWith (ImpInit (LedgerSpec era))
+shelleyEraSpecificSpec = do
+  describe "Shelley era specific Imp spec" $
+    describe "DELEG" $
+      Deleg.shelleyEraSpecificSpec
+
+instance EraSpecificSpec ShelleyEra where
+  eraSpecificSpec =
+    describe "DELEG" Deleg.shelleyEraSpecificSpec

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/DelegSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/DelegSpec.hs
@@ -1,0 +1,200 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Test.Cardano.Ledger.Shelley.Imp.DelegSpec (
+  spec,
+) where
+
+import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Ledger.Shelley.Core
+import Cardano.Ledger.Shelley.Rules
+import Cardano.Ledger.Shelley.Scripts
+import Lens.Micro
+import Test.Cardano.Ledger.Imp.Common
+import Test.Cardano.Ledger.Shelley.Arbitrary ()
+import Test.Cardano.Ledger.Shelley.ImpTest
+
+spec ::
+  ShelleyEraImp era =>
+  SpecWith (ImpInit (LedgerSpec era))
+spec = do
+  describe "Register stake credential" $ do
+    it "With correct deposit or without any deposit" $ do
+      cred <- KeyHashObj <$> freshKeyHash
+      -- NOTE: This will always generate certs with deposits post-Conway
+      regTxCert <- genRegTxCert cred
+      submitTx_ $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . certsTxBodyL .~ [regTxCert]
+      expectStakeCredRegistered cred
+
+    it "When already already registered" $ do
+      cred <- ScriptHashObj <$> impAddNativeScript (RequireAllOf [])
+      regTxCert <- genRegTxCert cred
+      let tx =
+            mkBasicTx mkBasicTxBody
+              & bodyTxL . certsTxBodyL
+                .~ [regTxCert]
+      submitTx_ tx
+      submitFailingTx
+        tx
+        [ injectFailure $ StakeKeyAlreadyRegisteredDELEG cred
+        ]
+      expectStakeCredRegistered cred
+
+  describe "Unregister stake credentials" $ do
+    it "When registered" $ do
+      cred <- ScriptHashObj <$> impAddNativeScript (RequireAllOf [])
+      regTxCert <- genRegTxCert cred
+      submitTx_ $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . certsTxBodyL .~ [regTxCert]
+      expectStakeCredRegistered cred
+
+      unRegTxCert <- genUnRegTxCert cred
+      submitTx_ $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . certsTxBodyL
+            .~ [unRegTxCert]
+      expectStakeCredNotRegistered cred
+
+    it "When not registered" $ do
+      freshKeyHash >>= \kh -> do
+        unRegTxCert <- genUnRegTxCert (KeyHashObj kh)
+        submitFailingTx
+          ( mkBasicTx mkBasicTxBody
+              & bodyTxL . certsTxBodyL
+                .~ [unRegTxCert]
+          )
+          [injectFailure $ StakeKeyNotRegisteredDELEG (KeyHashObj kh)]
+
+    -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/917
+    -- impacts `registerAndRetirePoolToMakeReward`
+    -- TODO: Re-enable after issue is resolved, by removing this override
+    disableInConformanceIt "With non-zero reward balance" $ do
+      cred <- KeyHashObj <$> freshKeyHash
+      regTxCert <- genRegTxCert cred
+
+      submitTx_ $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . certsTxBodyL .~ [regTxCert]
+
+      registerAndRetirePoolToMakeReward cred
+
+      balance <- getBalance cred
+      unRegTxCert <- genUnRegTxCert cred
+      submitFailingTx
+        ( mkBasicTx mkBasicTxBody
+            & bodyTxL . certsTxBodyL .~ [unRegTxCert]
+        )
+        [injectFailure $ StakeKeyNonZeroAccountBalanceDELEG balance]
+      expectStakeCredRegistered cred
+
+    it "Register and unregister in the same transaction" $ do
+      freshKeyHash >>= \kh -> do
+        regTxCert <- genRegTxCert (KeyHashObj kh)
+        unRegTxCert <- genUnRegTxCert (KeyHashObj kh)
+        submitTx_ $
+          mkBasicTx mkBasicTxBody
+            & bodyTxL . certsTxBodyL .~ [regTxCert, unRegTxCert]
+        expectStakeCredNotRegistered (KeyHashObj kh)
+
+  describe "Delegate stake" $ do
+    it "Delegate registered stake credentials to registered pool" $ do
+      cred <- KeyHashObj <$> freshKeyHash
+      regTxCert <- genRegTxCert cred
+      submitTx_ $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . certsTxBodyL .~ [regTxCert]
+
+      poolKh <- freshKeyHash
+      registerPool poolKh
+
+      submitTx_ $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . certsTxBodyL .~ [delegStakeTxCert cred poolKh]
+      expectDelegatedToPool cred poolKh
+
+    it "Register and delegate in the same transaction" $ do
+      poolKh <- freshKeyHash
+      registerPool poolKh
+      freshKeyHash >>= \kh -> do
+        regTxCert <- genRegTxCert (KeyHashObj kh)
+        submitTx_ $
+          mkBasicTx mkBasicTxBody
+            & bodyTxL . certsTxBodyL
+              .~ [regTxCert, delegStakeTxCert (KeyHashObj kh) poolKh]
+        expectDelegatedToPool (KeyHashObj kh) poolKh
+
+    it "Delegate unregistered stake credentials" $ do
+      cred <- KeyHashObj <$> freshKeyHash
+      poolKh <- freshKeyHash
+      registerPool poolKh
+      pv <- getProtVer
+      submitFailingTx
+        ( mkBasicTx mkBasicTxBody
+            & bodyTxL . certsTxBodyL
+              .~ [delegStakeTxCert cred poolKh]
+        )
+        [ injectFailure $
+            if pvMajor pv < natVersion @9
+              then StakeDelegationImpossibleDELEG cred
+              else StakeKeyNotRegisteredDELEG cred
+        ]
+      expectStakeCredNotRegistered cred
+
+    it "Delegate already delegated credentials" $ do
+      cred <- KeyHashObj <$> freshKeyHash
+      poolKh <- freshKeyHash
+      registerPool poolKh
+      regTxCert <- genRegTxCert cred
+      let delegTxCert = delegStakeTxCert cred poolKh
+      submitTx_ $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . certsTxBodyL .~ [regTxCert, delegTxCert]
+      expectDelegatedToPool cred poolKh
+      submitTx_ $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . certsTxBodyL .~ [delegTxCert]
+      expectDelegatedToPool cred poolKh
+
+      poolKh1 <- freshKeyHash
+      registerPool poolKh1
+      submitTx_ $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . certsTxBodyL
+            .~ [delegStakeTxCert cred poolKh1]
+      expectDelegatedToPool cred poolKh1
+
+      poolKh2 <- freshKeyHash
+      registerPool poolKh2
+      poolKh3 <- freshKeyHash
+      registerPool poolKh3
+
+      submitTx_ $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . certsTxBodyL
+            .~ [ delegStakeTxCert cred poolKh2
+               , delegStakeTxCert cred poolKh3
+               ]
+
+      expectDelegatedToPool cred poolKh3
+
+    it "Delegate and unregister" $ do
+      cred <- KeyHashObj <$> freshKeyHash
+      poolKh <- freshKeyHash
+      registerPool poolKh
+      regTxCert <- genRegTxCert cred
+      unRegTxCert <- genUnRegTxCert cred
+      submitTx_ $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . certsTxBodyL
+            .~ [regTxCert, delegStakeTxCert cred poolKh, unRegTxCert]
+      expectStakeCredNotRegistered cred


### PR DESCRIPTION
# Description

Currently, Deleg Imp specs are only written and ran from Conway onwards, even though some functionality is applicable for pre-Conway.

This PR: 
      * extracts the Deleg tests that are valid for all eras  - from conway  DelegSpec to a new shelley DelegSpec
      * adds some tests that are shelley-specific

To see the changes that made Conway tests compatible to previous eras,  see the second commit.
    
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
