### PR TITLE
Fix a bug in `queryPoolState`

### DIFF
--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -18,6 +18,10 @@
 
 * Remove the `State.Query` module and `getFilteredDelegationsAndRewardAccounts` function.
 
+## 1.12.1.0
+
+* Fix a bug in `queryPoolState`, where current Pool parameters where returned instead of the future ones.
+
 ## 1.12.0.0
 
 * Add `upgradeNativeScript` method to `EraApi`

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -469,7 +469,8 @@ mkQueryPoolStateResult ::
 mkQueryPoolStateResult f ps =
   QueryPoolStateResult
     { qpsrStakePoolParams = Map.mapWithKey stakePoolStateToStakePoolParams restrictedStakePools
-    , qpsrFutureStakePoolParams = Map.mapWithKey stakePoolStateToStakePoolParams restrictedStakePools
+    , qpsrFutureStakePoolParams =
+        Map.mapWithKey stakePoolStateToStakePoolParams (f $ psFutureStakePools ps)
     , qpsrRetiring = f $ psRetiring ps
     , qpsrDeposits = Map.map (fromCompact . spsDeposit) restrictedStakePools
     }


### PR DESCRIPTION
# Description

This bug manifested itself in current pool parameters being returned instead of the future ones.

This fix is needed for cardano-node-10.6 release, as such it is also backported in this #5366

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
