### PR TITLE
Add a subtransactions field to `DijkstraTxBodyRaw`

### DIFF
--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.2.0.0
 
+* Add `dtbSubTransactions` to `TxBody`
+* Add `subTransactionsTxBodyL` method to `DijkstraEraTxBody` class
 * Add `DijkstraTx` type with `DijkstraTx` and `DijkstraSubTx` constructors
 * Add `DijkstraSubTxBody` constructor to `DijkstraTxBodyRaw`
 * Add `TxLevel` argument to `Tx` and `TxBody`

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
@@ -279,7 +279,8 @@ instance Typeable l => DecCBOR (Annotator (Tx l DijkstraEra)) where
   decCBOR = fmap MkDijkstraTx <$> decCBOR
 
 validateDijkstraNativeScript ::
-  ( DijkstraEraTxBody era
+  ( EraTx era
+  , DijkstraEraTxBody era
   , DijkstraEraScript era
   , NativeScript era ~ DijkstraNativeScript era
   ) =>

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
@@ -279,8 +279,7 @@ instance Typeable l => DecCBOR (Annotator (Tx l DijkstraEra)) where
   decCBOR = fmap MkDijkstraTx <$> decCBOR
 
 validateDijkstraNativeScript ::
-  ( EraTx era
-  , DijkstraEraTxBody era
+  ( DijkstraEraTxBody era
   , DijkstraEraScript era
   , NativeScript era ~ DijkstraNativeScript era
   ) =>

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxBody.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxBody.hs
@@ -193,19 +193,14 @@ data DijkstraTxBodyRaw l era where
 
 deriving instance EraTx era => Eq (DijkstraTxBodyRaw l era)
 
-instance
-  EraTx DijkstraEra =>
-  EqRaw (TxBody l DijkstraEra)
+instance EraTx DijkstraEra => EqRaw (TxBody l DijkstraEra)
 
 deriving via
   InspectHeap (DijkstraTxBodyRaw l era)
   instance
     (Typeable l, EraTxBody era) => NoThunks (DijkstraTxBodyRaw l era)
 
-instance
-  EraTx era =>
-  NFData (DijkstraTxBodyRaw l era)
-  where
+instance EraTx era => NFData (DijkstraTxBodyRaw l era) where
   rnf txBodyRaw@(DijkstraTxBodyRaw _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) =
     let DijkstraTxBodyRaw {..} = txBodyRaw
      in dtbrSpendInputs `deepseq`
@@ -248,9 +243,7 @@ instance
 
 deriving instance EraTx era => Show (DijkstraTxBodyRaw l era)
 
-basicDijkstraTxBodyRaw ::
-  DijkstraEraTxBody era =>
-  STxBothLevels l era -> DijkstraTxBodyRaw l era
+basicDijkstraTxBodyRaw :: DijkstraEraTxBody era => STxBothLevels l era -> DijkstraTxBodyRaw l era
 basicDijkstraTxBodyRaw STopTx =
   DijkstraTxBodyRaw
     mempty
@@ -384,9 +377,8 @@ instance
         "TxBody: '" <> fieldName <> "' must be " <> requirement <> " when supplied"
 
 encodeTxBodyRaw ::
-  (DijkstraEraTxBody era, EraTx era) =>
-  DijkstraTxBodyRaw l era ->
-  Encode ('Closed 'Sparse) (DijkstraTxBodyRaw l era)
+  EraTx era =>
+  DijkstraTxBodyRaw l era -> Encode ('Closed 'Sparse) (DijkstraTxBodyRaw l era)
 encodeTxBodyRaw DijkstraTxBodyRaw {..} =
   let ValidityInterval bot top = dtbrVldt
    in Keyed
@@ -437,29 +429,16 @@ encodeTxBodyRaw DijkstraSubTxBodyRaw {..} =
         !> encodeKeyedStrictMaybe 21 dstbrCurrentTreasuryValue
         !> Omit (== mempty) (Key 22 $ To dstbrTreasuryDonation)
 
-instance
-  (DijkstraEraTxBody era, EraTx era) =>
-  EncCBOR (DijkstraTxBodyRaw l era)
-  where
+instance EraTx era => EncCBOR (DijkstraTxBodyRaw l era) where
   encCBOR = encode . encodeTxBodyRaw
 
-deriving instance
-  ( Typeable l
-  , EraTx DijkstraEra
-  ) =>
-  NoThunks (TxBody l DijkstraEra)
+deriving instance (Typeable l, EraTx DijkstraEra) => NoThunks (TxBody l DijkstraEra)
 
-deriving instance
-  EraTx DijkstraEra =>
-  Eq (TxBody l DijkstraEra)
+deriving instance EraTx DijkstraEra => Eq (TxBody l DijkstraEra)
 
-deriving newtype instance
-  EraTx DijkstraEra =>
-  NFData (TxBody l DijkstraEra)
+deriving newtype instance EraTx DijkstraEra => NFData (TxBody l DijkstraEra)
 
-deriving instance
-  EraTx DijkstraEra =>
-  Show (TxBody l DijkstraEra)
+deriving instance EraTx DijkstraEra => Show (TxBody l DijkstraEra)
 
 pattern DijkstraTxBody ::
   EraTx DijkstraEra =>
@@ -687,10 +666,7 @@ instance
 deriving via
   Mem (DijkstraTxBodyRaw l DijkstraEra)
   instance
-    ( Typeable l
-    , EraTx DijkstraEra
-    ) =>
-    DecCBOR (Annotator (TxBody l DijkstraEra))
+    (Typeable l, EraTx DijkstraEra) => DecCBOR (Annotator (TxBody l DijkstraEra))
 
 instance HasEraTxLevel DijkstraTxBodyRaw DijkstraEra where
   toSTxLevel DijkstraTxBodyRaw {} = STopTx
@@ -765,10 +741,7 @@ withdrawalsDijkstraTxBodyRawL =
         x@DijkstraSubTxBodyRaw {} -> \y -> x {dstbrWithdrawals = y}
     )
 
-instance
-  EraTx DijkstraEra =>
-  EraTxBody DijkstraEra
-  where
+instance EraTx DijkstraEra => EraTxBody DijkstraEra where
   newtype TxBody l DijkstraEra = MkDijkstraTxBody (MemoBytes (DijkstraTxBodyRaw l DijkstraEra))
     deriving (Generic, SafeToHash, ToCBOR)
 
@@ -906,10 +879,7 @@ vldtDijkstraTxBodyRawL =
         x@DijkstraSubTxBodyRaw {} -> \y -> x {dstbrVldt = y}
     )
 
-instance
-  EraTx DijkstraEra =>
-  AllegraEraTxBody DijkstraEra
-  where
+instance EraTx DijkstraEra => AllegraEraTxBody DijkstraEra where
   vldtTxBodyL = memoRawTypeL @DijkstraEra . vldtDijkstraTxBodyRawL
   {-# INLINE vldtTxBodyL #-}
 
@@ -925,10 +895,7 @@ mintDijkstraTxBodyRawL =
         x@DijkstraSubTxBodyRaw {} -> \y -> x {dstbrMint = y}
     )
 
-instance
-  EraTx DijkstraEra =>
-  MaryEraTxBody DijkstraEra
-  where
+instance EraTx DijkstraEra => MaryEraTxBody DijkstraEra where
   mintTxBodyL = memoRawTypeL @DijkstraEra . mintDijkstraTxBodyRawL
   {-# INLINE mintTxBodyL #-}
 
@@ -961,10 +928,7 @@ networkIdDijkstraTxBodyRawL =
         x@DijkstraSubTxBodyRaw {} -> \y -> x {dstbrNetworkId = y}
     )
 
-instance
-  EraTx DijkstraEra =>
-  AlonzoEraTxBody DijkstraEra
-  where
+instance EraTx DijkstraEra => AlonzoEraTxBody DijkstraEra where
   collateralInputsTxBodyL = memoRawTypeL @DijkstraEra . collateralInputsDijkstraTxBodyRawL
   {-# INLINE collateralInputsTxBodyL #-}
 
@@ -1012,10 +976,7 @@ referenceInputsDijkstraTxBodyRawL =
         x@DijkstraSubTxBodyRaw {} -> \y -> x {dstbrReferenceInputs = y}
     )
 
-instance
-  EraTx DijkstraEra =>
-  BabbageEraTxBody DijkstraEra
-  where
+instance EraTx DijkstraEra => BabbageEraTxBody DijkstraEra where
   sizedOutputsTxBodyL =
     lensMemoRawType @DijkstraEra
       ( \case
@@ -1095,10 +1056,7 @@ currentTreasuryValueDijkstraTxBodyRawL =
         x@DijkstraSubTxBodyRaw {} -> \y -> x {dstbrCurrentTreasuryValue = y}
     )
 
-instance
-  EraTx DijkstraEra =>
-  ConwayEraTxBody DijkstraEra
-  where
+instance EraTx DijkstraEra => ConwayEraTxBody DijkstraEra where
   votingProceduresTxBodyL = memoRawTypeL @DijkstraEra . votingProceduresDijkstraTxBodyRawL
   {-# INLINE votingProceduresTxBodyL #-}
   proposalProceduresTxBodyL = memoRawTypeL @DijkstraEra . proposalProceduresDijkstraTxBodyRawL
@@ -1136,10 +1094,7 @@ subTransactionsDijkstraTxBodyL = lens dtbrSubTransactions (\x y -> x {dtbrSubTra
 instance EraTx DijkstraEra => HasOKey TxId (Tx SubTx DijkstraEra) where
   toOKey = txIdTx
 
-instance
-  EraTx DijkstraEra =>
-  DijkstraEraTxBody DijkstraEra
-  where
+instance EraTx DijkstraEra => DijkstraEraTxBody DijkstraEra where
   {-# INLINE guardsTxBodyL #-}
   guardsTxBodyL = memoRawTypeL @DijkstraEra . guardsDijkstraTxBodyRawL
 

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -46,6 +46,25 @@ instance Arbitrary (DijkstraPParams Identity DijkstraEra) where
 instance Arbitrary (DijkstraPParams StrictMaybe DijkstraEra) where
   arbitrary = genericArbitraryU
 
+instance Arbitrary (TxBody SubTx DijkstraEra) where
+  arbitrary =
+    DijkstraSubTxBody
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> scale (`div` 15) arbitrary
+      <*> arbitrary
+      <*> scale (`div` 15) arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+
 instance Arbitrary (TxBody TopTx DijkstraEra) where
   arbitrary =
     DijkstraTxBody
@@ -61,6 +80,7 @@ instance Arbitrary (TxBody TopTx DijkstraEra) where
       <*> scale (`div` 15) arbitrary
       <*> arbitrary
       <*> scale (`div` 15) arbitrary
+      <*> arbitrary
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Examples.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Examples.hs
@@ -114,6 +114,7 @@ exampleTxBodyDijkstra =
     mempty
     (SJust $ Coin 867530900000) -- current treasury value
     mempty
+    mempty
   where
     MaryValue _ exampleMultiAsset = exampleMultiAssetValue 3
 

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
@@ -47,7 +47,7 @@ instance ToExpr (DijkstraPParams StrictMaybe DijkstraEra)
 
 instance ToExpr (DijkstraTxBodyRaw l DijkstraEra) where
   toExpr = \case
-    txBody@(DijkstraTxBodyRaw _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) ->
+    txBody@(DijkstraTxBodyRaw _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) ->
       let DijkstraTxBodyRaw {..} = txBody
        in Rec "DijkstraTxBodyRaw" $
             OMap.fromList
@@ -70,6 +70,7 @@ instance ToExpr (DijkstraTxBodyRaw l DijkstraEra) where
               , ("dtbrProposalProcedures", toExpr dtbrProposalProcedures)
               , ("dtbrCurrentTreasuryValue", toExpr dtbrCurrentTreasuryValue)
               , ("dtbrTreasuryDonation", toExpr dtbrTreasuryDonation)
+              , ("dtbrSubTransactions", toExpr dtbrSubTransactions)
               ]
     txBody@(DijkstraSubTxBodyRaw _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) ->
       let DijkstraSubTxBodyRaw {..} = txBody

--- a/libs/cardano-data/testlib/Test/Cardano/Data/Arbitrary.hs
+++ b/libs/cardano-data/testlib/Test/Cardano/Data/Arbitrary.hs
@@ -16,5 +16,5 @@ instance (Arbitrary a, Ord a) => Arbitrary (OSet.OSet a) where
 genOSet :: Ord a => Gen a -> Gen (OSet.OSet a)
 genOSet = fmap OSet.fromFoldable . listOf
 
-instance (Ord v, Arbitrary v, OMap.HasOKey k v, Arbitrary k) => Arbitrary (OMap.OMap k v) where
+instance (Arbitrary v, OMap.HasOKey k v, Arbitrary k) => Arbitrary (OMap.OMap k v) where
   arbitrary = OMap.fromFoldable @[] <$> arbitrary

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Era.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Era.hs
@@ -639,6 +639,7 @@ instance EraApi DijkstraEra where
             , dtbProposalProcedures = OSet.mapL upgradeProposals ctbrProposalProcedures
             , dtbVotingProcedures = coerce ctbrVotingProcedures
             , dtbTreasuryDonation = ctbrTreasuryDonation
+            , dtbSubTransactions = mempty
             }
 
   upgradeTxWits atw =

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Add `HasOKey` instance for `TxId (Tx l era)`
 * Remove `Generic` instance from `BoundedRatio` type
 * Remove deprecated function `addrPtrNormalize`
 * Remove deprecated functions `mkTxIx`, `mkCertIx`, `hashAnchorData`

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -110,6 +110,7 @@ library
     cardano-crypto,
     cardano-crypto-class ^>=2.2,
     cardano-crypto-wrapper,
+    cardano-data >=1.3,
     cardano-ledger-binary ^>=1.8,
     cardano-ledger-byron,
     cardano-ledger-core:internal,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -130,6 +130,7 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust)
 import Data.Maybe.Strict (StrictMaybe, maybeToStrictMaybe, strictMaybe, strictMaybeToMaybe)
 import Data.MemPack
+import Data.OMap.Strict (HasOKey (..))
 import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -679,3 +680,6 @@ toStrictMaybeL = lens maybeToStrictMaybe (const strictMaybeToMaybe)
 
 fromStrictMaybeL :: Lens' (StrictMaybe a) (Maybe a)
 fromStrictMaybeL = lens strictMaybeToMaybe (const maybeToStrictMaybe)
+
+instance EraTx era => HasOKey TxId (Tx l era) where
+  toOKey = txIdTx


### PR DESCRIPTION
# Description

This PR adds a subtransactions field to `DijkstraTxBodyRaw`. There are some fully saturated superclass constraints on some of the instances, those are there to avoid a dependency cycle between `Cardano.Ledger.Dijkstra.Tx` and `Cardano.Ledger.Dijkstra.TxBody`.

close #5355

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
