### PR TITLE
Store future pools in `PState` as `StakePoolParams`

### DIFF
--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.18.0.0
 
+* Replace `StakePoolState` values in `psFutureStakePoolParams` with `StakePoolParams`
+* Remove `psFutureStakePoolsL`
+* Add `psFutureStakePoolParamsL`
 * Remove deprecated function `getPoolParameters`
 * Remove deprecated function `toShelleyGenesisPairs`
 * Remove deprecated type `RewardAccounts`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -104,7 +104,7 @@ module Cardano.Ledger.Shelley.LedgerState (
   dsIRewardsL,
   dsFutureGenDelegsL,
   psStakePoolsL,
-  psFutureStakePoolsL,
+  psFutureStakePoolParamsL,
   psRetiringL,
   psVRFKeyHashesL,
 

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/PoolSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/PoolSpec.hs
@@ -384,8 +384,8 @@ spec = describe "POOL" $ do
       pps <- psStakePools <$> getPState
       spsVrf <$> Map.lookup poolKh pps `shouldBe` mbVrf
     expectFuturePool poolKh mbVrf = do
-      fps <- psFutureStakePools <$> getPState
-      spsVrf <$> Map.lookup poolKh fps `shouldBe` mbVrf
+      fps <- psFutureStakePoolParams <$> getPState
+      sppVrf <$> Map.lookup poolKh fps `shouldBe` mbVrf
     expectPoolDelegs poolKh delegs = do
       pps <- psStakePools <$> getPState
       spsDelegators <$> Map.lookup poolKh pps `shouldBe` delegs

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -24,7 +24,6 @@ import Cardano.Protocol.TPraos.BHeader (bhbody, bheaderSlotNo)
 import Control.SetAlgebra (dom, eval, (∈), (∉))
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-import Lens.Micro
 import Lens.Micro.Extras (view)
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (MockCrypto)
 import Test.Cardano.Ledger.Shelley.Constants (defaultConstants)
@@ -126,15 +125,15 @@ poolRegistrationProp
     } =
     let hk = sppId stakePoolParams
      in case Map.lookup hk $ psStakePools sourceSt of
-          Just sps ->
+          Just _ ->
             conjoin
               [ counterexample
                   "Pre-existing StakePoolParams must still be registered in pParams"
                   (eval (hk ∈ dom (psStakePools targetSt)) :: Bool)
               , counterexample
                   "New StakePoolParams are registered in future Params map"
-                  ( Map.lookup hk (psFutureStakePools targetSt)
-                      === Just (mkStakePoolState (sps ^. spsDepositL) mempty stakePoolParams)
+                  ( Map.lookup hk (psFutureStakePoolParams targetSt)
+                      === Just stakePoolParams
                   )
               , counterexample
                   "StakePoolParams are removed in 'retiring'"
@@ -150,7 +149,7 @@ poolRegistrationProp
                   )
               , counterexample
                   "StakePoolParams are not present in 'future pool params'"
-                  (eval (hk ∉ dom (psFutureStakePools targetSt)) :: Bool)
+                  (eval (hk ∉ dom (psFutureStakePoolParams targetSt)) :: Bool)
               , counterexample
                   "StakePoolParams are removed in 'retiring'"
                   (eval (hk ∉ dom (psRetiring targetSt)) :: Bool)

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -461,8 +461,7 @@ mkQueryPoolStateResult ::
 mkQueryPoolStateResult f ps =
   QueryPoolStateResult
     { qpsrStakePoolParams = Map.mapWithKey stakePoolStateToStakePoolParams restrictedStakePools
-    , qpsrFutureStakePoolParams =
-        Map.mapWithKey stakePoolStateToStakePoolParams (f $ psFutureStakePools ps)
+    , qpsrFutureStakePoolParams = f $ psFutureStakePoolParams ps
     , qpsrRetiring = f $ psRetiring ps
     , qpsrDeposits = Map.map (fromCompact . spsDeposit) restrictedStakePools
     }

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
@@ -33,7 +33,7 @@ instance SpecTranslate ctx (PState era) where
   toSpecRep PState {..} =
     Agda.MkPState
       <$> toSpecRep (Map.mapWithKey stakePoolStateToStakePoolParams psStakePools)
-      <*> toSpecRep (Map.mapWithKey stakePoolStateToStakePoolParams psFutureStakePools)
+      <*> toSpecRep psFutureStakePoolParams
       <*> toSpecRep psRetiring
 
 instance SpecTranslate ctx PoolCert where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ModelState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ModelState.hs
@@ -109,7 +109,7 @@ data ModelNewEpochState era = ModelNewEpochState
   , mCount :: !Int
   , mIndex :: !(Map Int TxId)
   , -- below here NO EFFECT until we model EpochBoundary
-    mFStakePools :: !(Map (KeyHash 'StakePool) StakePoolState)
+    mFStakePools :: !(Map (KeyHash 'StakePool) StakePoolParams)
   , mRetiring :: !(Map (KeyHash 'StakePool) EpochNo)
   , mSnapshots :: !SnapShots
   , mEL :: !EpochNo -- The current epoch,
@@ -161,7 +161,7 @@ pStateZero =
   PState
     { psVRFKeyHashes = Map.empty
     , psStakePools = Map.empty
-    , psFutureStakePools = Map.empty
+    , psFutureStakePoolParams = Map.empty
     , psRetiring = Map.empty
     }
 
@@ -340,7 +340,7 @@ abstract x =
     , mIndex = Map.empty
     , -- below here NO EFFECT until we model EpochBoundary
       mFStakePools =
-        ( psFutureStakePools
+        ( psFutureStakePoolParams
             . certPState
             . lsCertState
             . esLState

--- a/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
@@ -486,11 +486,11 @@ countPStateStats PState {..} =
   PStateStats
     { pssKeyHashStakePool =
         statMapKeys psStakePools
-          <> statMapKeys psFutureStakePools
+          <> statMapKeys psFutureStakePoolParams
           <> statMapKeys psRetiring
     , pssPoolParamsStats =
         foldMap countPoolParamsStats (Map.mapWithKey stakePoolStateToStakePoolParams psStakePools)
-          <> foldMap countPoolParamsStats (Map.mapWithKey stakePoolStateToStakePoolParams psFutureStakePools)
+          <> foldMap countPoolParamsStats psFutureStakePoolParams
     }
 
 data LedgerStateStats = LedgerStateStats


### PR DESCRIPTION
instead of `StakePoolState`

Closes https://github.com/IntersectMBO/cardano-ledger/issues/5343

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
