### PR TITLE
Replace `okeyL` method with `toOKey`

### DIFF
--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -83,7 +83,7 @@ library
     base64-bytestring,
     bytestring,
     cardano-crypto-class,
-    cardano-data ^>=1.2.1,
+    cardano-data ^>=1.3,
     cardano-ledger-allegra ^>=1.9,
     cardano-ledger-binary ^>=1.8,
     cardano-ledger-core:{cardano-ledger-core, internal} ^>=1.19,

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -95,7 +95,7 @@ library
     aeson >=2.2,
     base >=4.18 && <5,
     cardano-crypto-class,
-    cardano-data >=1.2.3,
+    cardano-data >=1.3,
     cardano-ledger-allegra ^>=1.9,
     cardano-ledger-alonzo ^>=1.15,
     cardano-ledger-babbage ^>=1.13,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
@@ -327,7 +327,7 @@ instance EraPParams era => EncCBOR (GovActionState era) where
         !> To gasExpiresAfter
 
 instance OMap.HasOKey GovActionId (GovActionState era) where
-  okeyL = lens gasId $ \gas gi -> gas {gasId = gi}
+  toOKey = gasId
 
 data Voter
   = CommitteeVoter !(Credential 'HotCommitteeRole)

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -83,7 +83,7 @@ library
     base >=4.14 && <5,
     bytestring,
     cardano-crypto-class,
-    cardano-data,
+    cardano-data ^>=1.3,
     cardano-ledger-allegra,
     cardano-ledger-alonzo ^>=1.15,
     cardano-ledger-babbage,

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -77,7 +77,7 @@ library
     base16-bytestring,
     bytestring,
     cardano-crypto-class,
-    cardano-data ^>=1.2,
+    cardano-data ^>=1.3,
     cardano-ledger-allegra ^>=1.9,
     cardano-ledger-binary >=1.4,
     cardano-ledger-core:{cardano-ledger-core, internal} >=1.19,

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -107,7 +107,7 @@ library
     bytestring,
     cardano-crypto-class,
     cardano-crypto-wrapper,
-    cardano-data ^>=1.2.2,
+    cardano-data ^>=1.3,
     cardano-ledger-binary ^>=1.8,
     cardano-ledger-byron,
     cardano-ledger-core:{cardano-ledger-core, internal} ^>=1.19,

--- a/libs/cardano-data/CHANGELOG.md
+++ b/libs/cardano-data/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-data`
 
-## 1.2.4.2
+## 1.3.0.0
 
-*
+* Replace `okeyL` with `toOKey`
 
 ## 1.2.4.1
 

--- a/libs/cardano-data/cardano-data.cabal
+++ b/libs/cardano-data/cardano-data.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-data
-version: 1.2.4.2
+version: 1.3.0.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/libs/cardano-data/cardano-data.cabal
+++ b/libs/cardano-data/cardano-data.cabal
@@ -44,7 +44,6 @@ library
     containers,
     data-default,
     deepseq,
-    microlens,
     mtl,
     nothunks,
     vector,
@@ -73,7 +72,6 @@ library testlib
     cardano-ledger-binary:testlib,
     containers,
     hspec,
-    microlens,
 
 test-suite cardano-data-tests
   type: exitcode-stdio-1.0
@@ -103,6 +101,5 @@ test-suite cardano-data-tests
     cardano-strict-containers,
     containers,
     hspec,
-    microlens,
     quickcheck-classes,
     testlib,

--- a/libs/cardano-data/src/Data/OMap/Strict.hs
+++ b/libs/cardano-data/src/Data/OMap/Strict.hs
@@ -304,13 +304,12 @@ extractKeys ks (OMap sseq kv) =
 --
 -- >>> :set -XFlexibleInstances -XMultiParamTypeClasses
 -- >>> import Data.OMap.Strict
--- >>> import Lens.Micro
--- >>> instance HasOKey Int (Int, Char) where okeyL = _1
+-- >>> instance HasOKey Int (Int, Char) where toOKey = fst
 -- >>> let m = fromFoldable $ zip [1,2] ['a','b'] :: OMap Int (Int, Char)
 -- >>> m
 -- StrictSeq {fromStrict = fromList [(1,(1,'a')),(2,(2,'b'))]}
 -- >>> let adjustingFn (k, v) = (k, succ v) -- Changes the value
--- >>> let overwritingAdjustingFn (k,v) = (succ k, v) -- Changes the `okeyL`.
+-- >>> let overwritingAdjustingFn (k,v) = (succ k, v) -- Modify the key.
 -- >>> adjust adjustingFn 1 m
 -- StrictSeq {fromStrict = fromList [(1,(1,'b')),(2,(2,'b'))]}
 -- >>> adjust overwritingAdjustingFn  1 m

--- a/libs/cardano-data/testlib/Test/Cardano/Data/Arbitrary.hs
+++ b/libs/cardano-data/testlib/Test/Cardano/Data/Arbitrary.hs
@@ -1,13 +1,12 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Data.Arbitrary (genOSet) where
 
-import Data.Map.Strict qualified as Map
 import Data.OMap.Strict qualified as OMap
 import Data.OSet.Strict qualified as OSet
-import Lens.Micro (set)
 import Test.Cardano.Ledger.Binary.Arbitrary ()
 import Test.QuickCheck
 
@@ -18,5 +17,4 @@ genOSet :: Ord a => Gen a -> Gen (OSet.OSet a)
 genOSet = fmap OSet.fromFoldable . listOf
 
 instance (Ord v, Arbitrary v, OMap.HasOKey k v, Arbitrary k) => Arbitrary (OMap.OMap k v) where
-  arbitrary =
-    fmap OMap.fromFoldable . shuffle . Map.elems . Map.mapWithKey (flip (set OMap.okeyL)) =<< arbitrary
+  arbitrary = OMap.fromFoldable @[] <$> arbitrary


### PR DESCRIPTION
# Description

This PR replaces the `okeyL` lens with the `toOKey` method, which projects a key out of the value. This will allow me to use `OMap TxId (Tx SubTx era)` as the type of the subtransactions field. With the lens approach I would have to implement a lens that modifies the hash of a transaction.

unblocks https://github.com/IntersectMBO/cardano-ledger/pull/5386

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
