### PR TITLE
Fail PlutusV4 `TxInfo` translation when `Ptr` is present in the `TxOut`s

### DIFF
--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.0.0
 
+* Add `DijkstraContextError`
 * Add `dtbSubTransactions` to `TxBody`
 * Add `subTransactionsTxBodyL` method to `DijkstraEraTxBody` class
 * Add `DijkstraTx` type with `DijkstraTx` and `DijkstraSubTx` constructors

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -121,6 +121,7 @@ library testlib
     Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec
     Test.Cardano.Ledger.Dijkstra.ImpTest
     Test.Cardano.Ledger.Dijkstra.TreeDiff
+    Test.Cardano.Ledger.Dijkstra.TxInfoSpec
 
   other-modules: Paths_cardano_ledger_dijkstra
   default-language: Haskell2010

--- a/eras/dijkstra/impl/test/Main.hs
+++ b/eras/dijkstra/impl/test/Main.hs
@@ -16,6 +16,7 @@ import Test.Cardano.Ledger.Dijkstra.Binary.RoundTrip ()
 import qualified Test.Cardano.Ledger.Dijkstra.GoldenSpec as GoldenSpec
 import qualified Test.Cardano.Ledger.Dijkstra.Imp as Imp
 import Test.Cardano.Ledger.Dijkstra.ImpTest ()
+import qualified Test.Cardano.Ledger.Dijkstra.TxInfoSpec as DijkstraTxInfoSpec
 import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
 
 main :: IO ()
@@ -33,5 +34,6 @@ main =
         BabbageTxInfo.spec @DijkstraEra
         txInfoSpec @DijkstraEra SPlutusV3
         txInfoSpec @DijkstraEra SPlutusV4
+        DijkstraTxInfoSpec.spec @DijkstraEra
       describe "Golden" $ do
         Golden.spec @DijkstraEra

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -29,6 +29,7 @@ import Cardano.Ledger.Dijkstra.Transition (TransitionConfig (..))
 import Cardano.Ledger.Dijkstra.Tx (DijkstraTx (..), Tx (..))
 import Cardano.Ledger.Dijkstra.TxBody (TxBody (..))
 import Cardano.Ledger.Dijkstra.TxCert
+import Cardano.Ledger.Dijkstra.TxInfo (DijkstraContextError)
 import Cardano.Ledger.Shelley.Scripts (
   pattern RequireSignature,
  )
@@ -137,3 +138,16 @@ instance Era era => Arbitrary (DijkstraTxCert era) where
 
 instance Arbitrary DijkstraDelegCert where
   arbitrary = DijkstraRegDelegCert <$> arbitrary <*> arbitrary <*> arbitrary
+
+instance
+  ( EraPParams era
+  , Arbitrary (PlutusPurpose AsItem era)
+  , Arbitrary (PlutusPurpose AsIx era)
+  , Arbitrary (PParamsHKD Identity era)
+  , Arbitrary (PParamsHKD StrictMaybe era)
+  , Arbitrary (TxCert era)
+  , Arbitrary (TxOut era)
+  ) =>
+  Arbitrary (DijkstraContextError era)
+  where
+  arbitrary = genericArbitraryU

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -16,7 +17,18 @@ module Test.Cardano.Ledger.Dijkstra.TreeDiff (
 
 import Cardano.Ledger.BaseTypes (StrictMaybe)
 import Cardano.Ledger.Dijkstra (DijkstraEra)
-import Cardano.Ledger.Dijkstra.Core (EraTx (..), EraTxBody (..), PlutusScript)
+import Cardano.Ledger.Dijkstra.Core (
+  AlonzoEraScript (..),
+  AsItem,
+  AsIx,
+  Era,
+  EraPParams (..),
+  EraTx (..),
+  EraTxBody (..),
+  EraTxCert (..),
+  EraTxOut (..),
+  PlutusScript,
+ )
 import Cardano.Ledger.Dijkstra.PParams (DijkstraPParams)
 import Cardano.Ledger.Dijkstra.Scripts (
   DijkstraNativeScript,
@@ -26,6 +38,7 @@ import Cardano.Ledger.Dijkstra.Scripts (
 import Cardano.Ledger.Dijkstra.Tx (DijkstraTx (..), Tx (..))
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraTxBodyRaw (..))
 import Cardano.Ledger.Dijkstra.TxCert
+import Cardano.Ledger.Dijkstra.TxInfo (DijkstraContextError)
 import Data.Functor.Identity (Identity)
 import qualified Data.TreeDiff.OMap as OMap
 import Test.Cardano.Ledger.Conway.TreeDiff (Expr (..), ToExpr)
@@ -120,3 +133,13 @@ deriving newtype instance ToExpr (Tx l DijkstraEra)
 instance ToExpr DijkstraDelegCert
 
 instance ToExpr (DijkstraTxCert era)
+
+instance
+  ( Era era
+  , ToExpr (PParamsHKD StrictMaybe era)
+  , ToExpr (PlutusPurpose AsIx era)
+  , ToExpr (PlutusPurpose AsItem era)
+  , ToExpr (TxCert era)
+  , ToExpr (TxOut era)
+  ) =>
+  ToExpr (DijkstraContextError era)

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TxInfoSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TxInfoSpec.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Dijkstra.TxInfoSpec (spec) where
+
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Alonzo.Plutus.Context (
+  EraPlutusContext (..),
+  EraPlutusTxInfo (..),
+  LedgerTxInfo (..),
+ )
+import Cardano.Ledger.BaseTypes (Globals (..), Inject (..), Network (..), ProtVer (..))
+import Cardano.Ledger.Credential (StakeReference (..))
+import Cardano.Ledger.Dijkstra.Core (
+  ConwayEraTxBody,
+  EraTx (..),
+  EraTxBody (..),
+  EraTxOut (..),
+  Value,
+  eraProtVerLow,
+ )
+import Cardano.Ledger.Dijkstra.State (UTxO (..))
+import Cardano.Ledger.Dijkstra.TxInfo (DijkstraContextError (..))
+import Cardano.Ledger.Plutus (Language (..), SLanguage (..))
+import Lens.Micro ((&), (.~))
+import Test.Cardano.Ledger.Common (Arbitrary (..), Spec, describe, prop, shouldBeLeft)
+import Test.Cardano.Ledger.Core.Utils (testGlobals)
+import Test.Cardano.Ledger.Dijkstra.Arbitrary ()
+
+spec ::
+  forall era.
+  ( EraPlutusTxInfo PlutusV4 era
+  , Inject (DijkstraContextError era) (ContextError era)
+  , ConwayEraTxBody era
+  , EraTx era
+  , Arbitrary (Value era)
+  ) =>
+  Spec
+spec = describe "TxInfo" $ do
+  describe "PlutusV4" $ do
+    prop "Fails translation when Ptr present in outputs" $
+      do
+        paymentCred <- arbitrary
+        ptr <- arbitrary
+        val <- arbitrary
+        let
+          txOut = mkBasicTxOut (Addr Testnet paymentCred (StakeRefPtr ptr)) val
+        txIn <- arbitrary
+        paymentCred2 <- arbitrary
+        stakeRef <- arbitrary
+        let
+          utxo =
+            UTxO
+              [ (txIn, mkBasicTxOut (Addr Testnet paymentCred2 stakeRef) val)
+              ]
+          tx =
+            mkBasicTx @era $
+              mkBasicTxBody
+                & outputsTxBodyL .~ [txOut]
+                & inputsTxBodyL .~ [txIn]
+          ledgerTxInfo =
+            LedgerTxInfo @era
+              (ProtVer (eraProtVerLow @era) 0)
+              (epochInfo testGlobals)
+              (systemStart testGlobals)
+              utxo
+              tx
+        pure $
+          toPlutusTxInfo SPlutusV4 ledgerTxInfo `shouldBeLeft` inject (PointerPresentInOutput @era [txOut])


### PR DESCRIPTION
# Description

This PR makes the PlutusV4 TxInfo translation fail if there is a `Ptr` present in any of the outputs.

close https://github.com/IntersectMBO/cardano-ledger/issues/4832

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
