### PR TITLE
Make ticking a bit more realistic in Imp tests

### DIFF
--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxosSpec.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxosSpec.hs
@@ -65,7 +65,7 @@ spec = describe "UTXOS" $ do
     $ do
       ei <- use $ impGlobalsL . to epochInfo
       ss@(SystemStart sysStart) <- use $ impGlobalsL . to systemStart
-      SlotNo currentSlot <- use impLastTickG
+      SlotNo currentSlot <- use impCurSlotNoG
       protVer <- getProtVer
       utxo <- getUTxO
       let txValidity = 7200

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Valid.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Valid.hs
@@ -156,7 +156,7 @@ alonzoEraSpecificSpec = do
         --  Process a transaction with a succeeding script in every place possible,
         --  and also with succeeding timelock scripts.
         it "Validating scripts everywhere" $ do
-          slotNo <- use impLastTickG
+          slotNo <- use impCurSlotNoG
           let
             timelockScriptHash i = do
               addr <- freshKeyHash

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/BbodySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/BbodySpec.hs
@@ -269,7 +269,7 @@ spec = do
       let ls = nes ^. nesEsL . esLStateL
           pp = nes ^. nesEsL . curPParamsEpochStateL @era
       kh <- freshKeyHash
-      slotNo <- use impLastTickG
+      slotNo <- use impCurSlotNoG
       let bhView =
             BHeaderView
               { bhviewID = kh

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
@@ -215,7 +215,7 @@ spec = do
       submitFailingMempoolTx cause tx expectedFailures = do
         globals <- use impGlobalsL
         nes <- use impNESL
-        slotNo <- use impLastTickG
+        slotNo <- use impCurSlotNoG
         let
           mempoolEnv = mkMempoolEnv nes slotNo
           ls = nes ^. nesEsL . esLStateL

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### `testlib`
 
+* Renamed `impLastTick` to `impCurSlotNo` and `impLastTickG` to `impCurSlotNoG`
 * Add CDDL certificate definitions: `account_registration_cert`, `account_unregistration_cert`, `delegation_to_stake_pool_cert`
 * Add CDDL pool certificate definitions via `mkPoolRules`: `pool_registration_cert`, `pool_retirement_cert`
 * Add CDDL legacy certificate definitions: `genesis_delegation_cert`, `genesis_hash`, `genesis_delegate_hash`, `move_instantaneous_rewards_cert`, `move_instantaneous_reward`, `delta_coin`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Add `positiveUnitIntervalRelaxToUnitInterval`, `positiveUnitIntervalRelaxToPositiveInterval` and  `positiveIntervalRelaxToNonNegativeInterval`
 * Changed the type of the following functions by adding `Network` argument:
   - `stakePoolStateToStakePoolParams`
   - `snapShotFromInstantStake`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -37,6 +37,9 @@ module Cardano.Ledger.BaseTypes (
   PositiveUnitInterval,
   PositiveInterval,
   NonNegativeInterval,
+  positiveUnitIntervalRelaxToUnitInterval,
+  positiveUnitIntervalRelaxToPositiveInterval,
+  positiveIntervalRelaxToNonNegativeInterval,
   BoundedRational (..),
   fpPrecision,
   integralToBounded,
@@ -484,6 +487,15 @@ newtype PositiveUnitInterval
 instance Bounded (BoundedRatio PositiveUnitInterval Word64) where
   minBound = positiveIntervalEpsilon
   maxBound = BoundedRatio (1 % 1)
+
+positiveUnitIntervalRelaxToUnitInterval :: PositiveUnitInterval -> UnitInterval
+positiveUnitIntervalRelaxToUnitInterval = coerce
+
+positiveUnitIntervalRelaxToPositiveInterval :: PositiveUnitInterval -> PositiveInterval
+positiveUnitIntervalRelaxToPositiveInterval = coerce
+
+positiveIntervalRelaxToNonNegativeInterval :: PositiveInterval -> NonNegativeInterval
+positiveIntervalRelaxToNonNegativeInterval = coerce
 
 -- | Type to represent a value in the unit interval [0; 1]
 newtype UnitInterval


### PR DESCRIPTION
# Description

Current implementation of ticking in ImpSpec is a bit naive, since it calls `TICK` rule for every slot. This is not only slow, but it also does not match the reality. On an actual running node TICK is called on every block, which happens on average every `1/activeSlotCoefficient` number of slots. On mainnet this is about every 20 slots or every 20 seconds.

Switching to this approach makes imp tests significantly faster, namely about 80% faster on the example of Conway imp tests (Running Conway imp tests on my laptop went from 6.5 minutes to 1.5 minute)

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
