### PR TITLE
Ensure `EraBlockBody` instances are not orphans.

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.15.0.0
 
+* Re-export `AlonzoBlockBody` from `Cardano.Ledger.Alonzo.Core`
 * Add `cddl` sub-library, and `generate-cddl` executable.
 * Renamed `uappCostModels` to `uappPlutusV1CostModel`
   and changed its type from `CostModels` to `CostModel`

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -17,6 +17,7 @@ module Cardano.Ledger.Alonzo (
   Tx (..),
 ) where
 
+import Cardano.Ledger.Alonzo.BlockBody ()
 import Cardano.Ledger.Alonzo.Era
 import Cardano.Ledger.Alonzo.PParams ()
 import Cardano.Ledger.Alonzo.Plutus.TxInfo ()

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Core.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Core.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 
 module Cardano.Ledger.Alonzo.Core (
+  AlonzoBlockBody (..),
   AlonzoEraTx (..),
   IsValid (..),
   AlonzoEraTxOut (..),
@@ -37,6 +38,7 @@ module Cardano.Ledger.Alonzo.Core (
   module Cardano.Ledger.Mary.Core,
 ) where
 
+import Cardano.Ledger.Alonzo.BlockBody (AlonzoBlockBody (..))
 import Cardano.Ledger.Alonzo.PParams (
   AlonzoEraPParams,
   CoinPerWord (..),

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
@@ -22,22 +22,19 @@ module Cardano.Ledger.Alonzo.Rules.Bbody (
 ) where
 
 import Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure)
-import Cardano.Ledger.Alonzo.BlockBody (AlonzoBlockBody)
+import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Era (AlonzoBBODY, AlonzoEra)
-import Cardano.Ledger.Alonzo.PParams (AlonzoEraPParams, ppMaxBlockExUnitsL)
 import Cardano.Ledger.Alonzo.Rules.Ledgers ()
 import Cardano.Ledger.Alonzo.Rules.Utxo (AlonzoUtxoPredFailure)
 import Cardano.Ledger.Alonzo.Rules.Utxos (AlonzoUtxosPredFailure)
 import Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoUtxowPredFailure)
 import Cardano.Ledger.Alonzo.Scripts (ExUnits (..), pointWiseExUnits)
 import Cardano.Ledger.Alonzo.Tx (totExUnits)
-import Cardano.Ledger.Alonzo.TxWits (AlonzoEraTxWits (..))
 import Cardano.Ledger.BHeaderView (BHeaderView (..), isOverlaySlot)
 import Cardano.Ledger.BaseTypes (Mismatch (..), Relation (..), ShelleyBase, epochInfoPure)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.Block (Block (..))
-import Cardano.Ledger.Core
 import Cardano.Ledger.Keys (coerceKeyRole)
 import Cardano.Ledger.Shelley.BlockBody (incrBlocks)
 import Cardano.Ledger.Shelley.LedgerState (LedgerState)
@@ -179,7 +176,6 @@ alonzoBbodyTransition ::
   , Signal (EraRule "LEDGERS" era) ~ Seq (Tx TopTx era)
   , EraBlockBody era
   , AlonzoEraTxWits era
-  , BlockBody era ~ AlonzoBlockBody era
   , AlonzoEraPParams era
   ) =>
   TransitionRule (EraRule "BBODY" era)
@@ -262,19 +258,14 @@ instance
   , State (EraRule "LEDGERS" era) ~ LedgerState era
   , Signal (EraRule "LEDGERS" era) ~ Seq (Tx TopTx era)
   , AlonzoEraTxWits era
-  , BlockBody era ~ AlonzoBlockBody era
   , EraBlockBody era
   , AlonzoEraPParams era
   ) =>
   STS (AlonzoBBODY era)
   where
-  type
-    State (AlonzoBBODY era) =
-      ShelleyBbodyState era
+  type State (AlonzoBBODY era) = ShelleyBbodyState era
 
-  type
-    Signal (AlonzoBBODY era) =
-      (Block BHeaderView era)
+  type Signal (AlonzoBBODY era) = Block BHeaderView era
 
   type Environment (AlonzoBBODY era) = BbodyEnv era
 

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
@@ -33,7 +33,6 @@ module Test.Cardano.Ledger.Alonzo.Arbitrary (
 ) where
 
 import Cardano.Ledger.Alonzo (AlonzoEra, Tx (..))
-import Cardano.Ledger.Alonzo.BlockBody (AlonzoBlockBody (AlonzoBlockBody))
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Genesis (AlonzoExtraConfig (..), AlonzoGenesis (..))
 import Cardano.Ledger.Alonzo.PParams (

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
@@ -26,7 +26,6 @@ module Cardano.Ledger.Conway.Rules.Bbody (
 ) where
 
 import Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure)
-import Cardano.Ledger.Alonzo.BlockBody (AlonzoBlockBody)
 import Cardano.Ledger.Alonzo.PParams (AlonzoEraPParams)
 import Cardano.Ledger.Alonzo.Rules (
   AlonzoBbodyEvent (..),
@@ -246,7 +245,6 @@ instance
   , State (EraRule "LEDGERS" era) ~ LedgerState era
   , Signal (EraRule "LEDGERS" era) ~ Seq (Tx TopTx era)
   , AlonzoEraTxWits era
-  , BlockBody era ~ AlonzoBlockBody era
   , EraBlockBody era
   , AlonzoEraPParams era
   , InjectRuleFailure "BBODY" AlonzoBbodyPredFailure era
@@ -279,7 +277,6 @@ conwayBbodyTransition ::
   , State (EraRule "BBODY" era) ~ ShelleyBbodyState era
   , Environment (EraRule "BBODY" era) ~ BbodyEnv era
   , State (EraRule "LEDGERS" era) ~ LedgerState era
-  , BlockBody era ~ AlonzoBlockBody era
   , InjectRuleFailure "BBODY" AlonzoBbodyPredFailure era
   , InjectRuleFailure "BBODY" ConwayBbodyPredFailure era
   , AlonzoEraTx era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Bbody.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Bbody.hs
@@ -24,7 +24,6 @@ module Cardano.Ledger.Dijkstra.Rules.Bbody (
 ) where
 
 import Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure)
-import Cardano.Ledger.Alonzo.BlockBody (AlonzoBlockBody)
 import Cardano.Ledger.Alonzo.PParams (AlonzoEraPParams)
 import Cardano.Ledger.Alonzo.Rules (
   AlonzoBbodyEvent (ShelleyInAlonzoEvent),
@@ -294,7 +293,6 @@ instance
   , State (EraRule "LEDGERS" era) ~ LedgerState era
   , Signal (EraRule "LEDGERS" era) ~ Seq (Tx TopTx era)
   , AlonzoEraTxWits era
-  , BlockBody era ~ AlonzoBlockBody era
   , EraBlockBody era
   , AlonzoEraPParams era
   , InjectRuleFailure "BBODY" AlonzoBbodyPredFailure era

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.18.0.0
 
+* Re-export `ShelleyBlockBody` from `Cardano.Ledger.Shelley.Core`
 * Add `cddl` sub-library, and `generate-cddl` executable.
 * Change the field type of `ShelleyIncompleteWithdrawals` to `Map RewardAccount (Mismatch RelEQ Coin)`
 * Replace `StakePoolState` values in `psFutureStakePoolParams` with `StakePoolParams`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley.hs
@@ -12,6 +12,7 @@ module Cardano.Ledger.Shelley (
   hardforkBabbageForgoRewardPrefilter,
 ) where
 
+import Cardano.Ledger.Shelley.BlockBody ()
 import Cardano.Ledger.Shelley.Era (
   ShelleyEra,
   hardforkAllegraAggregatedRewards,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Core.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Core.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 
 module Cardano.Ledger.Shelley.Core (
+  ShelleyBlockBody (..),
   ShelleyEraTxBody (..),
   Withdrawals (..),
   ShelleyEraTxCert (..),
@@ -29,6 +30,7 @@ import Cardano.Ledger.Core (
   ),
  )
 import Cardano.Ledger.Core hiding (EraPParams (..))
+import Cardano.Ledger.Shelley.BlockBody (ShelleyBlockBody (..))
 import Cardano.Ledger.Shelley.Governance
 import Cardano.Ledger.Shelley.Tx ()
 import Cardano.Ledger.Shelley.TxBody (ShelleyEraTxBody (..))

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
@@ -71,7 +71,6 @@ import Cardano.Ledger.Keys (
  )
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.API (MultiSig)
-import Cardano.Ledger.Shelley.BlockBody (ShelleyBlockBody (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.PParams (
   ProposedPPUpdates (..),


### PR DESCRIPTION
# Description

Unorphan, by re-exporting orphan `EraBlockBody` instances from `Cardano.Ledger.Alonzo` and `Cardano.Ledger.Shelley`
Also remove redundant `BlockBody ~ AlonzoBlockBody` constraints

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
