### PR TITLE
Add optional previous epoch Nonce to BHeaderView

### DIFF
--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/BbodySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/BbodySpec.hs
@@ -281,6 +281,7 @@ spec = do
               , bhviewHSize = 0
               , bhviewBHash = hashBlockBody blockBody
               , bhviewSlot = slotNo
+              , bhviewPrevEpochNonce = Nothing
               }
       tryRunImpRule @"BBODY"
         (BbodyEnv pp (nes ^. chainAccountStateL))

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.2.0.0
 
+* Add `bhviewPrevEpochNonce` to `BHeaderView`
+* Change `makeHeaderView` to expect an additional `Maybe Nonce`
+* Add `dijkstraBbodyTransition` to the BBODY rule
 * Add `DijkstraBlockBody` type and pattern
 * Add `mkBasicBlockBodyDijkstra`
 * Add `DijkstraEraBlockBody` class and instance for `DijkstraEraBlockBody`

--- a/eras/shelley/test-suite/bench/BenchValidation.hs
+++ b/eras/shelley/test-suite/bench/BenchValidation.hs
@@ -93,7 +93,7 @@ benchValidate ::
   ValidateInput era ->
   IO (NewEpochState era)
 benchValidate (ValidateInput globals state (Block bh txs)) =
-  let block = Block (makeHeaderView bh) txs
+  let block = Block (makeHeaderView bh Nothing) txs
    in case API.applyBlockEitherNoEvents ValidateAll globals state block of
         Right x -> pure x
         Left x -> error (show x)
@@ -111,7 +111,7 @@ applyBlock ::
   Int ->
   Int
 applyBlock (ValidateInput globals state (Block bh txs)) n =
-  let block = Block (makeHeaderView bh) txs
+  let block = Block (makeHeaderView bh Nothing) txs
    in case API.applyBlockEitherNoEvents ValidateAll globals state block of
         Right x -> seq (rnf x) (n + 1)
         Left x -> error (show x)
@@ -121,7 +121,7 @@ benchreValidate ::
   ValidateInput era ->
   NewEpochState era
 benchreValidate (ValidateInput globals state (Block bh txs)) =
-  API.applyBlockNoValidaton globals state (Block (makeHeaderView bh) txs)
+  API.applyBlockNoValidaton globals state (Block (makeHeaderView bh Nothing) txs)
 
 -- ==============================================================
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Block.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Block.hs
@@ -173,7 +173,7 @@ genBlockWithTxGen
         -- e.g. the KES period in which this key starts to be valid.
         <*> pure (fromIntegral (m * fromIntegral maxKESIterations))
         <*> pure oCert
-    let hView = makeHeaderView (blockHeader theBlock)
+    let hView = makeHeaderView (blockHeader theBlock) Nothing
     unless (bhviewBSize hView <= pp ^. ppMaxBBSizeL) $
       tracedDiscard $
         "genBlockWithTxGen: bhviewBSize too large"

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
@@ -326,7 +326,7 @@ chainTransition =
 
         let pp = nes ^. nesEpochStateL . curPParamsEpochStateL
             chainChecksData = pparamsToChainChecksPParams pp
-            bhView = makeHeaderView bh
+            bhView = makeHeaderView bh Nothing
 
         -- We allow one protocol version higher than the current era's maximum, because
         -- that is the way we can get out of the current era into the next one. We test

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BHeaderView.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BHeaderView.hs
@@ -3,7 +3,7 @@
 
 module Cardano.Ledger.BHeaderView where
 
-import Cardano.Ledger.BaseTypes (BoundedRational (..), UnitInterval)
+import Cardano.Ledger.BaseTypes (BoundedRational (..), Nonce, UnitInterval)
 import Cardano.Ledger.Hashes (EraIndependentBlockBody, HASH, Hash, KeyHash, KeyRole (..))
 import Cardano.Ledger.Slot (SlotNo (..), (-*))
 import Data.Word (Word32)
@@ -29,6 +29,9 @@ data BHeaderView = BHeaderView
   -- ^ The purported hash of the block body.
   , bhviewSlot :: SlotNo
   -- ^ The slot for which this block was submitted to the chain.
+  , bhviewPrevEpochNonce :: Maybe Nonce
+  -- ^ The previous epoch nonce, needed to validate Peras certificates
+  -- contained in blocks.
   }
 
 -- | Determine if the given slot is reserved for the overlay schedule.

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoBBODY.hs
@@ -598,6 +598,7 @@ makeNaiveBlock txs = Block {blockHeader = bhView, blockBody}
         , bhviewHSize = 0
         , bhviewBHash = hashBlockBody blockBody
         , bhviewSlot = SlotNo 0
+        , bhviewPrevEpochNonce = Nothing
         }
     blockBody = mkBasicBlockBody & txSeqBlockBodyL .~ StrictSeq.fromList txs
 

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/BHeader.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/BHeader.hs
@@ -454,11 +454,12 @@ lastAppliedHash (At lab) = BlockHash $ labHash lab
 bnonce :: BHBody c -> Nonce
 bnonce = mkNonceFromOutputVRF . VRF.certifiedOutput . bheaderEta
 
-makeHeaderView :: Crypto c => BHeader c -> BHeaderView
-makeHeaderView bh@(BHeader bhb _) =
+makeHeaderView :: Crypto c => BHeader c -> Maybe Nonce -> BHeaderView
+makeHeaderView bh@(BHeader bhb _) nonce =
   BHeaderView
     (hashKey . bheaderVk $ bhb)
     (bsize bhb)
     (originalBytesSize bh)
     (bhash bhb)
     (bheaderSlotNo bhb)
+    nonce


### PR DESCRIPTION
# Description

This PR addresses #5437 by:

* Adding an optional Nonce to the `BHeaderView` record,
* Tweaking the signature of `makeHeaderView` so that this optional nonce can be passed from the consensus side (not super sure if this is the right place to tweak the Ledger <-> Consensus API),
* Requiring the Nonce to be present for Dijkstra via a new `dijkstraBbodyTransition` rule (not super sure about this either, see note below).

NOTE: I'm not sure if the second commit actually helps by enforcing that the nonce will be present later on, or if we instead want to defer this check until we actually want to use the nonce for certificate validation once these start popping up in blocks.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
