### PR TITLE
Upgrade from ghc 9.12.1 to 9.12.2 nix builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -211,7 +211,7 @@
           cabalProject.flake (
             lib.optionalAttrs (system == "x86_64-linux") {
               # on linux, build/test other supported compilers
-              variants = lib.genAttrs ["ghc967" "ghc9121"] (compiler-nix-name: {
+              variants = lib.genAttrs ["ghc967" "ghc9122"] (compiler-nix-name: {
                 inherit compiler-nix-name;
               });
             }
@@ -292,7 +292,7 @@
             };
           in
             mkDevShells cabalProject
-            # Additional shells for every GHC version supported by haskell.nix, eg. `nix develop .#ghc9121`
+            # Additional shells for every GHC version supported by haskell.nix, eg. `nix develop .#ghc9122`
             // lib.mapAttrs (compiler-nix-name: _: let
               p = cabalProject.appendModule {inherit compiler-nix-name;};
             in


### PR DESCRIPTION
# Description

There's a bug in ghc `9.12.1` that makes it unbuildable with nix, which in turn causes our Hydra CI to fail. The problem is fixed in `9.12.2`.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
