### PR TITLE
Prevent sub-tx-ids to be spent in the same tx.

### DIFF
--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.0.0
 
+* Add `DijkstraSpendingOutputFromSameTx` to `DijkstraLedgerPredFailure`, to report when a sub-tx-id is being spent within the same transaction.
 * Add:
   - `DijkstraSUBCERT`
   - `DijkstraSUBCERTS`
@@ -103,6 +104,7 @@
 
 ### `testlib`
 
+* Add `Test.Cardano.Ledger.Dijkstra.Imp.LedgerSpec`
 * Add `Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec`
 * Remove `huddle-cddl` and the `CDDL` modules.
 * Re-export `Test.Cardano.Ledger.Conway.Binary.Golden`

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -132,6 +132,7 @@ library testlib
     Test.Cardano.Ledger.Dijkstra.Examples
     Test.Cardano.Ledger.Dijkstra.Imp
     Test.Cardano.Ledger.Dijkstra.Imp.CertSpec
+    Test.Cardano.Ledger.Dijkstra.Imp.LedgerSpec
     Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec
     Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec
     Test.Cardano.Ledger.Dijkstra.ImpTest

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
@@ -15,6 +15,7 @@ import Cardano.Ledger.Shelley.Rules
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Conway.Imp as ConwayImp
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.CertSpec as Cert
+import qualified Test.Cardano.Ledger.Dijkstra.Imp.LedgerSpec as Ledger
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec as Utxo
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec as Utxow
 import Test.Cardano.Ledger.Dijkstra.ImpTest
@@ -37,6 +38,7 @@ dijkstraEraGenericSpec ::
   DijkstraEraImp era =>
   SpecWith (ImpInit (LedgerSpec era))
 dijkstraEraGenericSpec = do
+  describe "LEDGER" Ledger.spec
   describe "CERTS" Cert.spec
   describe "UTXOW" Utxow.spec
   describe "UTXO" Utxo.spec

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/CertSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/CertSpec.hs
@@ -1,9 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE NumericUnderscores #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Test.Cardano.Ledger.Dijkstra.Imp.CertSpec (spec) where
 

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/LedgerSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/LedgerSpec.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Cardano.Ledger.Dijkstra.Imp.LedgerSpec (spec) where
+
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Dijkstra.Core
+import Cardano.Ledger.Dijkstra.Rules (
+  DijkstraLedgerPredFailure (..),
+  DijkstraUtxoPredFailure (BadInputsUTxO),
+ )
+import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody (..))
+import Cardano.Ledger.TxIn (mkTxInPartial)
+import qualified Data.Map.NonEmpty as NEM
+import qualified Data.OMap.Strict as OMap
+import qualified Data.Set as Set
+import qualified Data.Set.NonEmpty as NES
+import Lens.Micro ((&), (.~))
+import Test.Cardano.Ledger.Dijkstra.ImpTest
+import Test.Cardano.Ledger.Imp.Common
+
+spec :: forall era. DijkstraEraImp era => SpecWith (ImpInit (LedgerSpec era))
+spec = do
+  describe "Spending sub-transaction outputs" $ do
+    it "Fails when top-level transaction spends output from its own sub-transaction" $ do
+      (_, addr) <- freshKeyAddr
+      txIn <- sendCoinTo addr (Coin 10_000_000)
+
+      let subTx :: Tx SubTx era
+          subTx = mkBasicTx mkBasicTxBody
+          subTxId = txIdTx subTx
+
+          badInput = mkTxInPartial subTxId 0
+          tx =
+            mkBasicTx mkBasicTxBody
+              & bodyTxL . inputsTxBodyL .~ Set.fromList [txIn, badInput]
+              & bodyTxL . subTransactionsTxBodyL .~ OMap.singleton subTx
+
+      submitFailingTxM tx $ \txFixed ->
+        pure
+          [ injectFailure $ BadInputsUTxO $ NES.singleton badInput
+          , injectFailure $
+              DijkstraSpendingOutputFromSameTx $
+                NEM.singleton (txIdTx txFixed) $
+                  NES.singleton badInput
+          ]
+
+    it "Fails when sub-transaction spends output from another sub-transaction" $ do
+      (_, addr1) <- freshKeyAddr
+      txIn1 <- sendCoinTo addr1 (Coin 10_000_000)
+      (_, addr2) <- freshKeyAddr
+      txIn2 <- sendCoinTo addr2 (Coin 10_000_000)
+
+      let subTx1 :: Tx SubTx era
+          subTx1 =
+            mkBasicTx mkBasicTxBody
+              & bodyTxL . inputsTxBodyL .~ Set.singleton txIn1
+          subTx1Id = txIdTx subTx1
+
+          badInput = mkTxInPartial subTx1Id 0
+          subTx2 :: Tx SubTx era
+          subTx2 =
+            mkBasicTx mkBasicTxBody
+              & bodyTxL . inputsTxBodyL .~ Set.fromList [txIn2, badInput]
+          subTx2Id = txIdTx subTx2
+
+          tx =
+            mkBasicTx mkBasicTxBody
+              & bodyTxL . subTransactionsTxBodyL .~ OMap.fromFoldable ([subTx1, subTx2] :: [Tx SubTx era])
+
+      submitFailingTx
+        tx
+        [injectFailure $ DijkstraSpendingOutputFromSameTx $ NEM.singleton subTx2Id $ NES.singleton badInput]
+
+    it "Succeeds when inputs don't reference sub-transaction outputs" $ do
+      (_, addr1) <- freshKeyAddr
+      txIn1 <- sendCoinTo addr1 (Coin 10_000_000)
+      (_, addr2) <- freshKeyAddr
+      txIn2 <- sendCoinTo addr2 (Coin 10_000_000)
+
+      let subTx :: Tx SubTx era
+          subTx =
+            mkBasicTx mkBasicTxBody
+              & bodyTxL . inputsTxBodyL .~ Set.singleton txIn1
+
+          tx =
+            mkBasicTx mkBasicTxBody
+              & bodyTxL . inputsTxBodyL .~ Set.singleton txIn2
+              & bodyTxL . subTransactionsTxBodyL .~ OMap.singleton subTx
+
+      submitTx_ tx

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
@@ -104,6 +104,7 @@ instance ConwayEraImp DijkstraEra
 class
   ( ConwayEraImp era
   , DijkstraEraTest era
+  , InjectRuleFailure "LEDGER" DijkstraLedgerPredFailure era
   , InjectRuleFailure "LEDGER" DijkstraUtxoPredFailure era
   , InjectRuleFailure "MEMPOOL" DijkstraMempoolPredFailure era
   , InjectRuleFailure "MEMPOOL" DijkstraUtxoPredFailure era

--- a/libs/cardano-data/src/Data/Map/NonEmpty.hs
+++ b/libs/cardano-data/src/Data/Map/NonEmpty.hs
@@ -37,7 +37,7 @@ singleton k v = NonEmptyMap $ Map.singleton k v
 
 -- | \(O(1)\).
 fromMap :: forall k v. Map k v -> Maybe (NonEmptyMap k v)
-fromMap set = if Map.null set then Nothing else Just (NonEmptyMap set)
+fromMap x = if Map.null x then Nothing else Just (NonEmptyMap x)
 
 -- | \(O(1)\).
 toMap :: forall k v. NonEmptyMap k v -> Map k v
@@ -49,4 +49,4 @@ fromFoldable = fromMap . Foldable.foldl' (flip (uncurry Map.insert)) Map.empty
 
 -- | \(O(n)\).
 toList :: forall k v. NonEmptyMap k v -> [(k, v)]
-toList (NonEmptyMap set) = Map.toList set
+toList (NonEmptyMap x) = Map.toList x


### PR DESCRIPTION
# Description

Add `DijkstraSpendingSubTxOutput` to `DijkstraLedgerPredFailure` to report when a sub-tx-id is being spent within the same transaction.

Add `Dijkstra.Imp.LedgerSpec` with tests.

Closes #5489 

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
