### PR TITLE
Add Imp test to check that SPO votes are validated against tx witnesses

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
   subdir: hs
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `*-artifacts` BEFORE MERGE!
-  tag: 9291fe30190180631e79589c506a062e95123961
+  tag: 3da1ceec493ade9bc6347e342ca51054cc166e78
 
 source-repository-package
   type: git

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxowSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxowSpec.hs
@@ -35,19 +35,19 @@ import Cardano.Ledger.Conway.Core (
   txIdTx,
  )
 import Cardano.Ledger.Conway.Governance
-import Cardano.Ledger.Conway.TxBody
 import Cardano.Ledger.Conway.Rules (ConwayUtxowPredFailure (..))
+import Cardano.Ledger.Conway.TxBody
 import Cardano.Ledger.Credential (Credential (..), StakeReference)
+import Cardano.Ledger.Keys (asWitness, witVKeyHash)
 import Cardano.Ledger.Plutus (Language (..), SLanguage (..), hashPlutusScript)
 import Cardano.Ledger.TxIn (TxIn (..))
-import Lens.Micro ((&), (.~), (^.), (%~))
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Set.NonEmpty as NES
+import Lens.Micro ((%~), (&), (.~), (^.))
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Imp.Common
 import Test.Cardano.Ledger.Plutus.Examples (alwaysSucceedsWithDatum)
-import Cardano.Ledger.Keys (asWitness, witVKeyHash)
 
 spec ::
   forall era.
@@ -93,6 +93,35 @@ spec = do
       $ submitFailingTx
         tx
         [ injectFailure $ ScriptIntegrityHashMismatch mismatch (SJust $ originalBytes scriptIntegrity)
+        ]
+  it "Transaction containing SPO vote but no witness for it fails" $ do
+    spoKh <- freshKeyHash
+    registerPool spoKh
+    gaId <- mkProposal InfoAction >>= submitProposal
+    submitVote_ @era VoteYes (StakePoolVoter spoKh) gaId
+    let tx =
+          mkBasicTx mkBasicTxBody
+            & bodyTxL . votingProceduresTxBodyL
+              .~ VotingProcedures
+                ( Map.singleton
+                    (StakePoolVoter spoKh)
+                    ( Map.singleton
+                        gaId
+                        ( VotingProcedure
+                            { vProcVote = VoteYes
+                            , vProcAnchor = SNothing
+                            }
+                        )
+                    )
+                )
+    let isSPOWitness wit = witVKeyHash wit == asWitness spoKh
+    withPostFixup (pure . (witsTxL . addrTxWitsL %~ Set.filter (not . isSPOWitness))) $
+      submitFailingTx
+        tx
+        [ injectFailure $
+            MissingVKeyWitnessesUTXOW $
+              NES.singleton $
+                asWitness spoKh
         ]
 
 setupBadPPViewHashTx ::

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxowSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxowSpec.hs
@@ -34,21 +34,29 @@ import Cardano.Ledger.Conway.Core (
   ppCoinsPerUTxOByteL,
   txIdTx,
  )
+import Cardano.Ledger.Conway.Governance
+import Cardano.Ledger.Conway.TxBody
 import Cardano.Ledger.Conway.Rules (ConwayUtxowPredFailure (..))
 import Cardano.Ledger.Credential (Credential (..), StakeReference)
 import Cardano.Ledger.Plutus (Language (..), SLanguage (..), hashPlutusScript)
 import Cardano.Ledger.TxIn (TxIn (..))
-import Lens.Micro ((&), (.~), (^.))
+import Lens.Micro ((&), (.~), (^.), (%~))
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import qualified Data.Set.NonEmpty as NES
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Imp.Common
 import Test.Cardano.Ledger.Plutus.Examples (alwaysSucceedsWithDatum)
+import Cardano.Ledger.Keys (asWitness, witVKeyHash)
 
 spec ::
   forall era.
   ConwayEraImp era =>
   SpecWith (ImpInit (LedgerSpec era))
 spec = do
-  it "Fails with PPViewHashesDontMatch before PV 11" . whenMajorVersionAtMost @10 $ do
+  -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/1029
+  -- TODO: Re-enable after issue is resolved, by removing this override
+  disableInConformanceIt "Fails with PPViewHashesDontMatch before PV 11" . whenMajorVersionAtMost @10 $ do
     fixedTx <- fixupTx =<< setupBadPPViewHashTx
     badScriptIntegrityHash <- arbitrary
     tx <- substituteIntegrityHashAndFixWits badScriptIntegrityHash fixedTx

--- a/flake.lock
+++ b/flake.lock
@@ -204,11 +204,11 @@
     "formal-ledger-specifications": {
       "flake": false,
       "locked": {
-        "lastModified": 1765210866,
-        "narHash": "sha256-Trswzjmd+N8Y8QBY386fFQkMiXOr6i5e/3bjXisMw1s=",
+        "lastModified": 1768581272,
+        "narHash": "sha256-kc9DbGbbyigV4XYFXMAn2CLPpXT93+xqLU7j0i/L6H0=",
         "owner": "IntersectMBO",
         "repo": "formal-ledger-specifications",
-        "rev": "9291fe30190180631e79589c506a062e95123961",
+        "rev": "3da1ceec493ade9bc6347e342ca51054cc166e78",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Conway.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Conway.hs
@@ -19,6 +19,7 @@ import Test.Cardano.Ledger.Conway.Imp.LedgerSpec qualified as Ledger
 import Test.Cardano.Ledger.Conway.Imp.RatifySpec qualified as Ratify
 import Test.Cardano.Ledger.Conway.Imp.UtxoSpec qualified as Utxo
 import Test.Cardano.Ledger.Conway.Imp.UtxosSpec qualified as Utxos
+import Test.Cardano.Ledger.Conway.Imp.UtxowSpec qualified as Utxow
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Imp.Common hiding (Args)
 import UnliftIO (evaluateDeep)
@@ -46,6 +47,7 @@ spec = do
             describe "LEDGER" Ledger.spec
             describe "RATIFY" Ratify.spec
             describe "UTXO" Utxo.spec
+            describe "UTXOW" Utxow.spec
             xdescribe "UTXOS" Utxos.spec
   describe "Imp (only spec)" $ do
     RatifySpec.spec


### PR DESCRIPTION
# Description

In addition, this PR:
- Enables Utxow imp tests in conformance (disabling those that fail due to known reasons).
- Updates the formal specification

Blocked on https://github.com/IntersectMBO/formal-ledger-specifications/pull/1028

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
