### PR TITLE
Add direct-deposits field to transaction body

### DIFF
--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.2.0.0
 
+* Add `DirectDeposits` to transaction bodies at both (top and sub) levels.
+  - Add `directDepositsTxBodyL` lens to the `DijkstraEraTxBody` typeclass.
 * Add `DijkstraSpendingOutputFromSameTx` to `DijkstraLedgerPredFailure`, to report when a sub-tx-id is being spent within the same transaction.
 * Add:
   - `DijkstraSUBCERT`
@@ -98,6 +100,7 @@
 
 ### `cddl`
 
+* Add `directDepositsRule` to the transaction body.
 * Constrain `protocol_version` minor field to `uint .size 4`.
 * Renamed `policy_hash` to `guardrails_script_hash` in governance actions to avoid confusion with multi-asset policy IDs
 * Move `cddl-files` to `cddl/data`.

--- a/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+++ b/eras/dijkstra/impl/cddl/data/dijkstra.cddl
@@ -123,6 +123,7 @@ transaction_body =
   , ? 21 : coin                             ; current treasury value
   , ? 22 : positive_coin                    ; donation
   , ? 23 : sub_transactions                 ; sub-transactions (NEW)
+  , ? 25 : direct_deposits                  ; direct deposits
   }
 
 
@@ -729,10 +730,13 @@ sub_transaction_body =
   , ? 21 : coin                            
   , ? 22 : positive_coin                   
   , ? 24 : required_top_level_guards       
+  , ? 25 : direct_deposits                 
   }
 
 
 required_top_level_guards = {+ credential => plutus_data/ nil}
+
+direct_deposits = {+ reward_account => coin}
 
 transaction_witness_set = 
   { ? 0 : nonempty_set<vkeywitness>      

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -69,6 +69,7 @@ instance Arbitrary (TxBody SubTx DijkstraEra) where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary
 
 instance Arbitrary (TxBody TopTx DijkstraEra) where
   arbitrary =
@@ -93,6 +94,7 @@ instance Arbitrary (TxBody TopTx DijkstraEra) where
       <*> arbitrary
       <*> arbitrary
       <*> (choose (0, 4) >>= \n -> OMap.fromFoldable <$> vectorOf n arbitrary)
+      <*> arbitrary
 
 instance Arbitrary (UpgradeDijkstraPParams Identity DijkstraEra) where
   arbitrary = genericArbitraryU

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
@@ -15,7 +15,7 @@ module Test.Cardano.Ledger.Dijkstra.Binary.Annotator (
 
 ) where
 
-import Cardano.Ledger.Address (Withdrawals (..))
+import Cardano.Ledger.Address (DirectDeposits (..), Withdrawals (..))
 import Cardano.Ledger.Allegra.Scripts (invalidBeforeL, invalidHereAfterL)
 import Cardano.Ledger.Alonzo.Tx (IsValid (..))
 import Cardano.Ledger.BaseTypes
@@ -132,6 +132,12 @@ instance Typeable l => DecCBOR (DijkstraTxBodyRaw l DijkstraEra) where
                 Map.null
                 (requiredTopLevelGuardsDijkstraTxBodyRawL .~)
                 (D (decodeMap decCBOR (decodeNullStrictMaybe decCBOR)))
+        25 ->
+          fieldGuarded
+            (emptyFailure "DirectDeposits" "non-empty")
+            (null . unDirectDeposits)
+            (directDepositsDijkstraTxBodyRawL .~)
+            From
         n -> invalidField n
       requiredFields :: STxBothLevels l DijkstraEra -> [(Word, String)]
       requiredFields sTxLevel

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Examples.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Examples.hs
@@ -4,12 +4,12 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators #-}
 
 module Test.Cardano.Ledger.Dijkstra.Examples (
   ledgerExamples,
 ) where
 
+import Cardano.Ledger.Address (DirectDeposits (..))
 import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (mkSized)
@@ -117,8 +117,9 @@ exampleTxBodyDijkstra =
     (VotingProcedures mempty)
     mempty
     (SJust $ Coin 867530900000) -- current treasury value
-    mempty
-    mempty
+    mempty -- treasury donation
+    mempty -- sub-transactions
+    (DirectDeposits mempty)
   where
     MaryValue _ exampleMultiAsset = exampleMultiAssetValue 3
 

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
@@ -67,7 +67,7 @@ instance ToExpr (DijkstraPParams StrictMaybe DijkstraEra)
 
 instance ToExpr (DijkstraTxBodyRaw l DijkstraEra) where
   toExpr = \case
-    txBody@(DijkstraTxBodyRaw _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) ->
+    txBody@(DijkstraTxBodyRaw _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) ->
       let DijkstraTxBodyRaw {..} = txBody
        in Rec "DijkstraTxBodyRaw" $
             OMap.fromList
@@ -91,8 +91,9 @@ instance ToExpr (DijkstraTxBodyRaw l DijkstraEra) where
               , ("dtbrCurrentTreasuryValue", toExpr dtbrCurrentTreasuryValue)
               , ("dtbrTreasuryDonation", toExpr dtbrTreasuryDonation)
               , ("dtbrSubTransactions", toExpr dtbrSubTransactions)
+              , ("dtbrDirectDeposits", toExpr dtbrDirectDeposits)
               ]
-    txBody@(DijkstraSubTxBodyRaw _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) ->
+    txBody@(DijkstraSubTxBodyRaw _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) ->
       let DijkstraSubTxBodyRaw {..} = txBody
        in Rec "DijkstraSubTxBodyRaw" $
             OMap.fromList
@@ -111,7 +112,8 @@ instance ToExpr (DijkstraTxBodyRaw l DijkstraEra) where
               , ("dstbrProposalProcedures", toExpr dstbrProposalProcedures)
               , ("dstbrCurrentTreasuryValue", toExpr dstbrCurrentTreasuryValue)
               , ("dstbrTreasuryDonation", toExpr dstbrTreasuryDonation)
-              , ("dstbrRequiredTopLevelGuards", toExpr dstbrTreasuryDonation)
+              , ("dstbrRequiredTopLevelGuards", toExpr dstbrRequiredTopLevelGuards)
+              , ("dstbrDirectDeposits", toExpr dstbrDirectDeposits)
               ]
 
 instance ToExpr (TxBody l DijkstraEra)

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.0.0
 
+* Re-export `DirectDeposits` and `directDepositsTxBodyL` from `Cardano.Ledger.Api.Tx.Body`.
 * Re-export `constitutionGuardrailsScriptHashL` from `Cardano.Ledger.Api.Governance`.
 * Changed the type of the following functions by adding `Network` argument:
   - `queryPoolParameters`

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Era.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Era.hs
@@ -69,6 +69,7 @@ module Cardano.Ledger.Api.Era (
   atMostEra,
 ) where
 
+import Cardano.Ledger.Address (DirectDeposits (..))
 import Cardano.Ledger.Allegra (AllegraEra)
 import Cardano.Ledger.Allegra.Scripts (translateTimelock, upgradeMultiSig)
 import Cardano.Ledger.Allegra.TxAuxData (AllegraTxAuxData (..))
@@ -640,6 +641,7 @@ instance EraApi DijkstraEra where
             , dtbVotingProcedures = coerce ctbrVotingProcedures
             , dtbTreasuryDonation = ctbrTreasuryDonation
             , dtbSubTransactions = mempty
+            , dtbDirectDeposits = DirectDeposits mempty
             }
 
   upgradeTxWits atw =

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Body.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Body.hs
@@ -79,13 +79,15 @@ module Cardano.Ledger.Api.Tx.Body (
   -- * Dijstra Era
   DijkstraEraTxBody,
   guardsTxBodyL,
+  directDepositsTxBodyL,
+  DirectDeposits (..),
 
   -- * Upgrade
   binaryUpgradeTxBody,
   upgradeTxBody,
 ) where
 
-import Cardano.Ledger.Address (Withdrawals (..))
+import Cardano.Ledger.Address (DirectDeposits (..), Withdrawals (..))
 import Cardano.Ledger.Allegra.Core (AllegraEraTxBody (..))
 import Cardano.Ledger.Allegra.Scripts (invalidBeforeL, invalidHereAfterL)
 import Cardano.Ledger.Alonzo.TxBody (AlonzoEraTxBody (..), ScriptIntegrityHash)

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Add `DirectDeposits` newtype.
 * Change `PoolMetadata.pmHash` from `ByteString` to `Data.Array.Byte.ByteArray` to reduce memory fragmentation.
 * Added:
   - `ppTxFeeFixedCompactL`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
@@ -54,6 +54,7 @@ module Cardano.Ledger.Address (
   decodeRewardAccount,
   fromCborRewardAccount,
   Withdrawals (..),
+  DirectDeposits (..),
 ) where
 
 import qualified Cardano.Chain.Common as Byron
@@ -902,5 +903,10 @@ fromBoostrapCompactAddress = UnsafeCompactAddr . Byron.unsafeGetCompactAddress
 
 -- | This is called @wdrl@ in the spec.
 newtype Withdrawals = Withdrawals {unWithdrawals :: Map RewardAccount Coin}
+  deriving (Show, Eq, Generic)
+  deriving newtype (NoThunks, NFData, EncCBOR, DecCBOR)
+
+-- | Direct deposits to reward accounts.
+newtype DirectDeposits = DirectDeposits {unDirectDeposits :: Map RewardAccount Coin}
   deriving (Show, Eq, Generic)
   deriving newtype (NoThunks, NFData, EncCBOR, DecCBOR)

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -405,6 +405,10 @@ instance Arbitrary Withdrawals where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
+instance Arbitrary DirectDeposits where
+  arbitrary = genericArbitraryU
+  shrink = genericShrink
+
 ------------------------------------------------------------------------------------------
 -- Cardano.Ledger.Reward -----------------------------------------------------------------
 ------------------------------------------------------------------------------------------

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
@@ -199,6 +199,8 @@ instance ToExpr BootstrapAddress where
 
 instance ToExpr Withdrawals
 
+instance ToExpr DirectDeposits
+
 instance ToExpr CompactAddr
 
 -- PoolParams


### PR DESCRIPTION
# Description

Add direct-deposits field at index 25 for the transaction bodies at both levels.

Add
* `DirectDeposits` newtype wrapping `Map RewardAccount Coin`.
* `directDepositsTxBodyL` lens to the `DijkstraEraTxBody` typeclass.
* `directDepositsRule` to `dijkstra` CDDL.
* Re-export the necessary functionality in `cardano-ledger-api`.

Fix
* `ToExpr` instance for `DijkstraSubTxBodyRaw` using the wrong field for `dstbrRequiredTopLevelGuards`.

Closes #5502 

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] ~~Tests added or updated when needed.~~
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] ~~Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).~~
- [ ] ~~Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).~~
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
