### PR TITLE
Remove default implementation for the DecCBOR class

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Genesis.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Genesis.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -90,16 +91,15 @@ newtype AlonzoExtraConfig = AlonzoExtraConfig
   deriving (Eq)
   deriving newtype (NFData, NoThunks, Show)
 
-instance DecCBOR AlonzoExtraConfig
+instance DecCBOR AlonzoExtraConfig where
+  decCBOR = decode (RecD AlonzoExtraConfig <! D (decodeNullMaybe decodeCostModelsLenient))
+  {-# INLINE decCBOR #-}
 
 instance EncCBOR AlonzoExtraConfig
 
 instance FromCBOR AlonzoExtraConfig where
-  fromCBOR =
-    eraDecoder @AlonzoEra $
-      decode $
-        RecD AlonzoExtraConfig
-          <! D (decodeNullMaybe decodeCostModelsLenient)
+  fromCBOR = fromEraCBOR @AlonzoEra
+  {-# INLINE fromCBOR #-}
 
 instance ToCBOR AlonzoExtraConfig where
   toCBOR x@(AlonzoExtraConfig _) =
@@ -184,24 +184,26 @@ instance EraGenesis AlonzoEra where
   type Genesis AlonzoEra = AlonzoGenesis
 
 -- | Genesis types are always encoded with the version of era they are defined in.
-instance DecCBOR AlonzoGenesis
+instance DecCBOR AlonzoGenesis where
+  decCBOR =
+    decode $
+      RecD AlonzoGenesis
+        <! From
+        <! D (decodeCostModel PlutusV1)
+        <! From
+        <! From
+        <! From
+        <! From
+        <! From
+        <! From
+        <! From
+  {-# INLINE decCBOR #-}
 
 instance EncCBOR AlonzoGenesis
 
 instance FromCBOR AlonzoGenesis where
-  fromCBOR =
-    eraDecoder @AlonzoEra $
-      decode $
-        RecD AlonzoGenesis
-          <! From
-          <! D (decodeCostModel PlutusV1)
-          <! From
-          <! From
-          <! From
-          <! From
-          <! From
-          <! From
-          <! From
+  fromCBOR = fromEraCBOR @AlonzoEra
+  {-# INLINE fromCBOR #-}
 
 instance ToCBOR AlonzoGenesis where
   toCBOR x@(AlonzoGenesis _ _ _ _ _ _ _ _ _) =

--- a/eras/byron/crypto/src/Cardano/Crypto/Signing/Redeem/SigningKey.hs
+++ b/eras/byron/crypto/src/Cardano/Crypto/Signing/Redeem/SigningKey.hs
@@ -14,7 +14,7 @@ import Cardano.Crypto.Signing.Redeem.VerificationKey (
   redeemVKB64F,
  )
 import Cardano.Ledger.Binary (
-  DecCBOR,
+  DecCBOR (..),
   EncCBOR,
   FromCBOR (..),
   ToCBOR (..),
@@ -34,7 +34,9 @@ newtype RedeemSigningKey
 
 instance EncCBOR RedeemSigningKey
 
-instance DecCBOR RedeemSigningKey
+instance DecCBOR RedeemSigningKey where
+  decCBOR = RedeemSigningKey <$> decCBOR
+  {-# INLINE decCBOR #-}
 
 -- Note that there is deliberately no Ord instance. The crypto libraries
 -- encourage using key /hashes/ not keys for things like sets, map etc.

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0.0
 
+* Remove `ToCBOR` and `FromCBOR` instances for `DefaultVote`
 * Add `validateTreasuryValue`, `validateWithdrawalsDelegated`
 * Update `resolveConwayInstantStake` to return `ActiveStake`
 * Remove `asBoundedIntegralHKD`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Genesis.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Genesis.hs
@@ -70,10 +70,8 @@ instance NFData ConwayGenesis
 
 -- | Genesis are always encoded with the version of era they are defined in.
 instance FromCBOR ConwayGenesis where
-  fromCBOR =
-    eraDecoder @ConwayEra $
-      decode $
-        RecD ConwayGenesis <! From <! From <! From <! From <! From
+  fromCBOR = fromEraCBOR @ConwayEra
+  {-# INLINE fromCBOR #-}
 
 instance ToCBOR ConwayGenesis where
   toCBOR x@(ConwayGenesis _ _ _ _ _) =
@@ -86,7 +84,9 @@ instance ToCBOR ConwayGenesis where
             !> To cgDelegs
             !> To cgInitialDReps
 
-instance DecCBOR ConwayGenesis
+instance DecCBOR ConwayGenesis where
+  decCBOR = decode (RecD ConwayGenesis <! From <! From <! From <! From <! From)
+  {-# INLINE decCBOR #-}
 
 instance EncCBOR ConwayGenesis
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -195,15 +195,13 @@ import Cardano.Ledger.Binary (
   ToCBOR (..),
   decNoShareCBOR,
   decodeRecordNamedT,
+  decodeWord8,
+  encodeWord8,
  )
 import Cardano.Ledger.Binary.Coders (
   Encode (..),
   encode,
   (!>),
- )
-import Cardano.Ledger.Binary.Plain (
-  decodeWord8,
-  encodeWord8,
  )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Compactible (CompactForm)
@@ -537,23 +535,21 @@ data DefaultVote
     DefaultNoConfidence
   deriving (Eq, Show)
 
-instance FromCBOR DefaultVote where
-  fromCBOR = do
+instance EncCBOR DefaultVote where
+  encCBOR DefaultNo = encodeWord8 0
+  encCBOR DefaultAbstain = encodeWord8 1
+  encCBOR DefaultNoConfidence = encodeWord8 2
+  {-# INLINE encCBOR #-}
+
+instance DecCBOR DefaultVote where
+  decCBOR = do
     tag <- decodeWord8
     case tag of
       0 -> pure DefaultNo
       1 -> pure DefaultAbstain
       2 -> pure DefaultNoConfidence
       _ -> fail $ "Invalid DefaultVote tag " ++ show tag
-
-instance ToCBOR DefaultVote where
-  toCBOR DefaultNo = encodeWord8 0
-  toCBOR DefaultAbstain = encodeWord8 1
-  toCBOR DefaultNoConfidence = encodeWord8 2
-
-instance EncCBOR DefaultVote
-
-instance DecCBOR DefaultVote
+  {-# INLINE decCBOR #-}
 
 defaultStakePoolVote ::
   ConwayEraAccounts era =>

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Genesis.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Genesis.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -37,11 +38,8 @@ instance EraGenesis DijkstraEra where
   type Genesis DijkstraEra = DijkstraGenesis
 
 instance FromCBOR DijkstraGenesis where
-  fromCBOR =
-    eraDecoder @DijkstraEra $
-      decode $
-        RecD DijkstraGenesis
-          <! From
+  fromCBOR = fromEraCBOR @DijkstraEra
+  {-# INLINE fromCBOR #-}
 
 instance ToCBOR DijkstraGenesis where
   toCBOR dg@(DijkstraGenesis _) =
@@ -50,6 +48,8 @@ instance ToCBOR DijkstraGenesis where
           Rec DijkstraGenesis
             !> To dgUpgradePParams
 
-instance DecCBOR DijkstraGenesis
+instance DecCBOR DijkstraGenesis where
+  decCBOR = decode (RecD DijkstraGenesis <! From)
+  {-# INLINE decCBOR #-}
 
 instance EncCBOR DijkstraGenesis

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Translation.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -20,11 +21,17 @@ import Cardano.Ledger.Binary (
   FromCBOR (..),
   ToCBOR (..),
   shelleyProtVer,
-  toPlainDecoder,
   toPlainEncoding,
  )
-import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
-import Cardano.Ledger.Core (PParams, TranslationContext, emptyPParams)
+import Cardano.Ledger.Binary.Coders (
+  Decode (..),
+  Encode (..),
+  decode,
+  encode,
+  (!>),
+  (<!),
+ )
+import Cardano.Ledger.Core (PParams, TranslationContext, emptyPParams, fromEraCBOR)
 import Cardano.Ledger.Keys
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.Genesis (ShelleyGenesis (..))
@@ -55,17 +62,14 @@ instance ToCBOR FromByronTranslationContext where
               !> To fbtcMaxLovelaceSupply
 
 instance FromCBOR FromByronTranslationContext where
-  fromCBOR =
-    toPlainDecoder Nothing shelleyProtVer $
-      decode $
-        RecD FromByronTranslationContext
-          <! From
-          <! From
-          <! From
+  fromCBOR = fromEraCBOR @ShelleyEra
+  {-# INLINE fromCBOR #-}
 
 instance EncCBOR FromByronTranslationContext
 
-instance DecCBOR FromByronTranslationContext
+instance DecCBOR FromByronTranslationContext where
+  decCBOR = decode (RecD FromByronTranslationContext <! From <! From <! From)
+  {-# INLINE decCBOR #-}
 
 instance FromJSON FromByronTranslationContext where
   parseJSON = withObject "FromByronTranslationContext" $ \o -> do

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.8.0.0
 
+* Remove default implementation for `DecCBOR` class
 * Add `Uniform`, `UniformRange` instances and fix `Random` instance
 * Change `Version` from `Word64` to `Word32`
   - Add `mkVersion32` and `getVersion32`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Remove `ToCBOR` and `FromCBOR` instances for `Nonce`
 * In `SnapShot`, subsume `ssDelegations` into `ssActiveStake`.
   - Add `ActiveStake`, `sumAllActiveStake`, `sumCredentialsCompactActiveStake`.
   - Add `StakeWithDelegation` for the range of `ActiveStake`.

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
@@ -63,6 +63,7 @@ import Cardano.Ledger.Binary (
   FromCBOR (..),
   ToCBOR,
   decodeWord64,
+  fromPlainDecoder,
  )
 import qualified Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Compactible
@@ -105,7 +106,9 @@ newtype Coin = Coin {unCoin :: Integer}
 instance FromCBOR Coin where
   fromCBOR = Coin . toInteger <$> Plain.decodeWord64
 
-instance DecCBOR Coin
+instance DecCBOR Coin where
+  decCBOR = fromPlainDecoder fromCBOR
+  {-# INLINE decCBOR #-}
 
 newtype DeltaCoin = DeltaCoin Integer
   deriving (Eq, Ord, Generic, Enum, NoThunks)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/Era.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/Era.hs
@@ -94,7 +94,9 @@ instance (KnownSymbol rule, Era era) => EncCBOR (VoidEraRule (rule :: Symbol) er
 instance (KnownSymbol rule, Era era) => FromCBOR (VoidEraRule (rule :: Symbol) era) where
   fromCBOR = cborError DecoderErrorVoid
 
-instance (KnownSymbol rule, Era era) => DecCBOR (VoidEraRule (rule :: Symbol) era)
+instance (KnownSymbol rule, Era era) => DecCBOR (VoidEraRule (rule :: Symbol) era) where
+  decCBOR = cborError DecoderErrorVoid
+  {-# INLINE decCBOR #-}
 
 absurdEraRule :: VoidEraRule rule era -> a
 absurdEraRule a = case a of {}

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Genesis.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Genesis.hs
@@ -48,7 +48,9 @@ instance Era era => FromCBOR (NoGenesis era) where
 
 instance Era era => EncCBOR (NoGenesis era)
 
-instance Era era => DecCBOR (NoGenesis era)
+instance Era era => DecCBOR (NoGenesis era) where
+  decCBOR = NoGenesis <$ decCBOR @()
+  {-# INLINE decCBOR #-}
 
 instance ToKeyValuePairs (NoGenesis era) where
   toKeyValuePairs _ = []

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/Bootstrap.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/Bootstrap.hs
@@ -28,11 +28,17 @@ import qualified Cardano.Crypto.DSIGN.Class as C
 import qualified Cardano.Crypto.Hash as Hash
 import qualified Cardano.Crypto.Signing as Byron
 import qualified Cardano.Crypto.Wallet as WC
-import Cardano.Ledger.Binary (Annotator, DecCBOR (..), EncCBOR (..))
+import Cardano.Ledger.Binary (
+  Annotator,
+  DecCBOR (..),
+  EncCBOR (..),
+  shelleyProtVer,
+  toPlainDecoder,
+ )
+import Cardano.Ledger.Binary.Coders (Decode (..), decode, (<!))
 import Cardano.Ledger.Binary.Plain (
   FromCBOR (..),
   ToCBOR (..),
-  decodeRecordNamed,
   encodeListLen,
   serialize',
  )
@@ -83,14 +89,16 @@ instance ToCBOR BootstrapWitness where
 instance EncCBOR BootstrapWitness
 
 instance FromCBOR BootstrapWitness where
-  fromCBOR =
-    decodeRecordNamed "BootstrapWitness" (const 4) $
-      BootstrapWitness <$> fromCBOR <*> C.decodeSignedDSIGN <*> fromCBOR <*> fromCBOR
+  fromCBOR = toPlainDecoder Nothing shelleyProtVer decCBOR
+  {-# INLINE fromCBOR #-}
 
-instance DecCBOR BootstrapWitness
+instance DecCBOR BootstrapWitness where
+  decCBOR = decode (RecD BootstrapWitness <! From <! From <! From <! From)
+  {-# INLINE decCBOR #-}
 
 instance DecCBOR (Annotator BootstrapWitness) where
   decCBOR = pure <$> decCBOR
+  {-# INLINE decCBOR #-}
 
 instance Ord BootstrapWitness where
   compare = comparing bootstrapWitKeyHash

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/WitVKey.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/WitVKey.hs
@@ -15,10 +15,16 @@ module Cardano.Ledger.Keys.WitVKey (
 
 import Cardano.Crypto.DSIGN.Class (
   SignedDSIGN,
-  decodeSignedDSIGN,
   encodeSignedDSIGN,
  )
-import Cardano.Ledger.Binary (Annotator, DecCBOR (..), EncCBOR (..))
+import Cardano.Ledger.Binary (
+  Annotator,
+  DecCBOR (..),
+  EncCBOR (..),
+  shelleyProtVer,
+  toPlainDecoder,
+ )
+import Cardano.Ledger.Binary.Coders (Decode (..), decode, (<!))
 import qualified Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Hashes (
   EraIndependentTxBody,
@@ -72,13 +78,14 @@ instance Typeable kr => Plain.ToCBOR (WitVKey kr) where
       <> encodeSignedDSIGN wvkSignature
 
 instance Typeable kr => Plain.FromCBOR (WitVKey kr) where
-  fromCBOR =
-    Plain.decodeRecordNamed "WitVKey" (const 2) $
-      WitVKey <$> Plain.fromCBOR <*> decodeSignedDSIGN
+  fromCBOR = toPlainDecoder Nothing shelleyProtVer decCBOR
+  {-# INLINE fromCBOR #-}
 
 instance Typeable kr => EncCBOR (WitVKey kr)
 
-instance Typeable kr => DecCBOR (WitVKey kr)
+instance Typeable kr => DecCBOR (WitVKey kr) where
+  decCBOR = decode (RecD WitVKey <! From <! From)
+  {-# INLINE decCBOR #-}
 
 instance Typeable kr => DecCBOR (Annotator (WitVKey kr)) where
   decCBOR = pure <$> decCBOR

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Language.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Language.hs
@@ -63,6 +63,7 @@ import Cardano.Ledger.Binary (
   FromCBOR (..),
   ToCBOR (..),
   Version,
+  decodeEnumBounded,
   decodeRecordNamed,
   decodeScriptContextFromData,
   encodeEnum,
@@ -286,7 +287,9 @@ instance FromCBOR Language where
 
 instance EncCBOR Language
 
-instance DecCBOR Language
+instance DecCBOR Language where
+  decCBOR = decodeEnumBounded
+  {-# INLINE decCBOR #-}
 
 nonNativeLanguages :: [Language]
 nonNativeLanguages = [minBound .. maxBound]
@@ -310,7 +313,9 @@ instance PlutusLanguage l => FromCBOR (SLanguage l) where
 
 instance PlutusLanguage l => EncCBOR (SLanguage l)
 
-instance PlutusLanguage l => DecCBOR (SLanguage l)
+instance PlutusLanguage l => DecCBOR (SLanguage l) where
+  decCBOR = toSLanguage =<< decCBOR @Language
+  {-# INLINE decCBOR #-}
 
 -- | Construct value level laguage version from the type level
 plutusLanguage :: forall l proxy. PlutusLanguage l => proxy l -> Language


### PR DESCRIPTION
# Description

First part of #5513: we remove the default implementation for `DecCBOR` through `FromCBOR`, so that types that contain Bytestrings are more easily routed to the version-aware decoding

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
