### PR TITLE
Canonical Ledger State: introduce blocks/v0 namespace

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -203,6 +203,7 @@ jobs:
         - cardano-ledger-babbage
         - cardano-ledger-binary
         - cardano-ledger-byron
+        - cardano-ledger-canonical-state
         - cardano-ledger-conformance
         - cardano-ledger-conway
         - cardano-ledger-core

--- a/cabal.project
+++ b/cabal.project
@@ -102,3 +102,5 @@ source-repository-package
   location: https://github.com/tweag/cardano-cls.git
   subdir: merkle-tree-incremental mempack-scls scls-cbor scls-cardano scls-format scls-core
   tag: 55d9af32aab35909a4f083797876d3e802835225
+
+--sha256: 1sprdlsgj0b4s9fw0hybl19yfnqdahkskkmw9mq5ng23f80qwbvs

--- a/cabal.project
+++ b/cabal.project
@@ -48,8 +48,9 @@ packages:
   eras/shelley/test-suite
   eras/shelley-ma/test-suite
   libs/cardano-ledger-api
-  libs/cardano-ledger-core
   libs/cardano-ledger-binary
+  libs/cardano-ledger-canonical-state
+  libs/cardano-ledger-core
   libs/cardano-protocol-tpraos
   libs/non-integral
   libs/small-steps
@@ -95,3 +96,9 @@ if impl(ghc >=9.12)
   allow-newer:
     -- Unique: https://github.com/kapralVV/Unique/issues/11
     , Unique:hashable
+
+source-repository-package
+  type: git
+  location: https://github.com/tweag/cardano-cls.git
+  subdir: merkle-tree-incremental mempack-scls scls-cbor scls-cardano scls-format scls-core
+  tag: 55d9af32aab35909a4f083797876d3e802835225

--- a/hie.yaml
+++ b/hie.yaml
@@ -237,6 +237,18 @@ cradle:
     - path: "libs/cardano-ledger-binary/bench/Bench.hs"
       component: "cardano-ledger-binary:bench:bench"
 
+    - path: "libs/cardano-ledger-canonical-state/./"
+      component: "cardano-ledger-canonical-state:lib:for"
+
+    - path: "libs/cardano-ledger-canonical-state/src"
+      component: "lib:cardano-ledger-canonical-state"
+
+    - path: "libs/cardano-ledger-canonical-state/testlib"
+      component: "cardano-ledger-canonical-state:lib:testlib"
+
+    - path: "libs/cardano-ledger-canonical-state/test"
+      component: "cardano-ledger-canonical-state:test:tests"
+
     - path: "libs/cardano-ledger-conformance/src"
       component: "lib:cardano-ledger-conformance"
 

--- a/libs/cardano-ledger-canonical-state/CHANGELOG.md
+++ b/libs/cardano-ledger-canonical-state/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for cardano-ledger-canonical-state
+
+## 9.9.9.9
+
+* First version. Released on an unsuspecting world.

--- a/libs/cardano-ledger-canonical-state/LICENSE
+++ b/libs/cardano-ledger-canonical-state/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/libs/cardano-ledger-canonical-state/cardano-ledger-canonical-state.cabal
+++ b/libs/cardano-ledger-canonical-state/cardano-ledger-canonical-state.cabal
@@ -1,0 +1,92 @@
+cabal-version: 3.0
+name: cardano-ledger-canonical-state
+version: 9.9.9.9
+synopsis:
+  Instaces for working with canonical ledger state representation
+
+description:
+  Library for definition of the canonical state. The library defines canonical types and conversion
+  functions for the non era-specific parts of the Cardano ledger state.
+
+license: Apache-2.0
+license-file: LICENSE
+author: Tweag
+maintainer: operations@iohk.io
+category: Cardano
+build-type: Simple
+extra-doc-files: CHANGELOG.md
+
+common warnings
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wpartial-fields
+    -Wunused-packages
+
+source-repository head
+  type: git
+  location: https://github.com/intersectmbo/cardano-ledger.git
+  subdir: libs/cardano-canonical
+
+library
+  import: warnings
+  default-language: Haskell2010
+  exposed-modules:
+    Cardano.Ledger.CanonicalState.Namespace.Blocks.V0
+
+  hs-source-dirs: src
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wpartial-fields
+    -Wredundant-constraints
+    -Wunused-packages
+    -Werror
+
+  build-depends:
+    base,
+    cardano-ledger-core,
+    mempack-scls,
+    scls-cardano,
+    scls-cbor,
+    scls-core,
+
+library testlib
+  import: warnings
+  exposed-modules:
+    Test.Cardano.Ledger.CanonicalState.Arbitrary
+
+  visibility: public
+  hs-source-dirs: testlib
+  default-language: Haskell2010
+  build-depends:
+    QuickCheck,
+    base,
+    cardano-ledger-canonical-state,
+
+test-suite tests
+  import: warnings
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs: test
+  other-modules:
+    Paths_cardano_ledger_canonical_state
+    Test.Cardano.Ledger.CanonicalState.Spec
+
+  default-language: Haskell2010
+  ghc-options:
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N
+
+  build-depends:
+    base,
+    cardano-ledger-canonical-state:{cardano-ledger-canonical-state, testlib},
+    cardano-ledger-core:testlib,
+    scls-cardano:testlib,
+    scls-cbor,

--- a/libs/cardano-ledger-canonical-state/cardano-ledger-canonical-state.cabal
+++ b/libs/cardano-ledger-canonical-state/cardano-ledger-canonical-state.cabal
@@ -29,7 +29,7 @@ common warnings
 source-repository head
   type: git
   location: https://github.com/intersectmbo/cardano-ledger.git
-  subdir: libs/cardano-canonical
+  subdir: libs/cardano-ledger-canonical-state
 
 library
   import: warnings

--- a/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/Blocks/V0.hs
+++ b/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/Blocks/V0.hs
@@ -36,8 +36,8 @@ instance KnownNamespace "blocks/v0" where
   type NamespaceEntry "blocks/v0" = BlockOut
 
 data BlockIn = BlockIn
-  { blockInHash :: !(KeyHash StakePool)
-  , blockInEpoch :: !EpochNo
+  { blockInStakePoolId :: !(KeyHash StakePool)
+  , blockInEpochNo :: !EpochNo
   }
   deriving (Eq, Ord, Show)
 

--- a/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/Blocks/V0.hs
+++ b/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/Blocks/V0.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -28,6 +29,7 @@ import Cardano.SCLS.NamespaceCodec (
 import Data.MemPack (MemPack (..))
 import Data.MemPack.ByteOrdered (packWord64beM, unpackBigEndianM)
 import Data.Proxy (Proxy (..))
+import GHC.Generics (Generic)
 import GHC.Num.Natural (Natural)
 
 -- | Definition of the namespace.
@@ -39,7 +41,7 @@ data BlockIn = BlockIn
   { blockInStakePoolId :: !(KeyHash StakePool)
   , blockInEpochNo :: !EpochNo
   }
-  deriving (Eq, Ord, Show)
+  deriving stock (Eq, Ord, Show, Generic)
 
 instance IsKey BlockIn where
   keySize = namespaceKeySize @"blocks/v0"
@@ -60,5 +62,5 @@ instance CanonicalCBOREntryDecoder "blocks/v0" BlockOut where
   decodeEntry = fromCanonicalCBOR
 
 newtype BlockOut = BlockOut Natural
-  deriving stock (Eq, Ord, Show)
+  deriving stock (Eq, Ord, Show, Generic)
   deriving newtype (ToCanonicalCBOR v, FromCanonicalCBOR v)

--- a/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/Blocks/V0.hs
+++ b/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/Blocks/V0.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.CanonicalState.Namespace.Blocks.V0 (
+  BlockIn (..),
+  BlockOut (..),
+) where
+
+import Cardano.Ledger.BaseTypes (EpochNo (..))
+import Cardano.Ledger.Keys (KeyHash, StakePool)
+import Cardano.SCLS.CBOR.Canonical.Decoder as D
+import Cardano.SCLS.CBOR.Canonical.Encoder (ToCanonicalCBOR (..))
+import Cardano.SCLS.CDDL ()
+import Cardano.SCLS.Entry.IsKey (IsKey (..))
+import Cardano.SCLS.NamespaceCodec (
+  CanonicalCBOREntryDecoder (..),
+  CanonicalCBOREntryEncoder (..),
+  KnownNamespace (..),
+  namespaceKeySize,
+ )
+import Data.MemPack (MemPack (..))
+import Data.MemPack.ByteOrdered (packWord64beM, unpackBigEndianM)
+import Data.Proxy (Proxy (..))
+import GHC.Num.Natural (Natural)
+
+-- | Definition of the namespace.
+instance KnownNamespace "blocks/v0" where
+  type NamespaceKey "blocks/v0" = BlockIn
+  type NamespaceEntry "blocks/v0" = BlockOut
+
+data BlockIn = BlockIn
+  { blockInHash :: !(KeyHash StakePool)
+  , blockInEpoch :: !EpochNo
+  }
+  deriving (Eq, Ord, Show)
+
+instance IsKey BlockIn where
+  keySize = namespaceKeySize @"blocks/v0"
+  packKeyM (BlockIn kh (EpochNo epochNo)) = do
+    packM kh
+    packWord64beM epochNo
+  unpackKeyM = do
+    a <- unpackM
+    epochNo <- unpackBigEndianM
+    return $ BlockIn a (EpochNo epochNo)
+
+-- Top level encoding/decoding
+
+instance CanonicalCBOREntryEncoder "blocks/v0" BlockOut where
+  encodeEntry (BlockOut n) = toCanonicalCBOR (Proxy @"blocks/v0") (BlockOut n)
+
+instance CanonicalCBOREntryDecoder "blocks/v0" BlockOut where
+  decodeEntry = fromCanonicalCBOR
+
+newtype BlockOut = BlockOut Natural
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (ToCanonicalCBOR v, FromCanonicalCBOR v)

--- a/libs/cardano-ledger-canonical-state/test/Main.hs
+++ b/libs/cardano-ledger-canonical-state/test/Main.hs
@@ -1,0 +1,10 @@
+module Main (
+  main,
+) where
+
+import qualified Test.Cardano.Ledger.CanonicalState.Spec
+import Test.Cardano.Ledger.Common
+
+main :: IO ()
+main = ledgerTestMain $ do
+  Test.Cardano.Ledger.CanonicalState.Spec.spec

--- a/libs/cardano-ledger-canonical-state/test/Test/Cardano/Ledger/CanonicalState/Spec.hs
+++ b/libs/cardano-ledger-canonical-state/test/Test/Cardano/Ledger/CanonicalState/Spec.hs
@@ -15,7 +15,7 @@ import GHC.TypeLits
 import Test.Cardano.Ledger.CanonicalState.Arbitrary ()
 import Test.Cardano.Ledger.Common
 
-spec :: SpecWith ()
+spec :: Spec
 spec = do
   describe "types" $ do
     describe "blocks/v0" $ do
@@ -26,7 +26,6 @@ spec = do
 
 isCanonical ::
   forall ns a. (KnownSymbol ns, ToCanonicalCBOR ns a, Typeable a, Arbitrary a, Show a) => Spec
-isCanonical = go
+isCanonical = prop propName $ propTypeIsCanonical @ns @a
   where
-    typ = showsTypeRep (typeRep (Proxy @a))
-    go = prop (typ " is canonical") $ propTypeIsCanonical @ns @a
+    propName = showsTypeRep (typeRep (Proxy @a)) " is canonical"

--- a/libs/cardano-ledger-canonical-state/test/Test/Cardano/Ledger/CanonicalState/Spec.hs
+++ b/libs/cardano-ledger-canonical-state/test/Test/Cardano/Ledger/CanonicalState/Spec.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.CanonicalState.Spec (spec) where
+
+import qualified Cardano.Ledger.CanonicalState.Namespace.Blocks.V0 as Blocks.V0
+import Cardano.SCLS.CBOR.Canonical.Encoder (ToCanonicalCBOR (..))
+import Cardano.SCLS.Testlib
+import Data.Typeable
+import GHC.TypeLits
+import Test.Cardano.Ledger.CanonicalState.Arbitrary ()
+import Test.Cardano.Ledger.Common
+
+spec :: SpecWith ()
+spec = do
+  describe "types" $ do
+    describe "blocks/v0" $ do
+      isCanonical @"blocks/v0" @Blocks.V0.BlockOut
+      validateType @"blocks/v0" @Blocks.V0.BlockOut "record_entry"
+  describe "namespaces" $ do
+    testNS @"blocks/v0"
+
+isCanonical ::
+  forall ns a. (KnownSymbol ns, ToCanonicalCBOR ns a, Typeable a, Arbitrary a, Show a) => Spec
+isCanonical = go
+  where
+    typ = showsTypeRep (typeRep (Proxy @a))
+    go = prop (typ " is canonical") $ propTypeIsCanonical @ns @a

--- a/libs/cardano-ledger-canonical-state/testlib/Test/Cardano/Ledger/CanonicalState/Arbitrary.hs
+++ b/libs/cardano-ledger-canonical-state/testlib/Test/Cardano/Ledger/CanonicalState/Arbitrary.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Ledger.CanonicalState.Arbitrary () where
+
+import qualified Cardano.Ledger.CanonicalState.Namespace.Blocks.V0 as Blocks.V0
+import Test.QuickCheck (Arbitrary (..), Positive (..))
+
+instance Arbitrary Blocks.V0.BlockOut where
+  arbitrary = Blocks.V0.BlockOut . fromIntegral . getPositive @Integer <$> arbitrary

--- a/libs/cardano-ledger-canonical-state/testlib/Test/Cardano/Ledger/CanonicalState/Arbitrary.hs
+++ b/libs/cardano-ledger-canonical-state/testlib/Test/Cardano/Ledger/CanonicalState/Arbitrary.hs
@@ -8,4 +8,6 @@ import qualified Cardano.Ledger.CanonicalState.Namespace.Blocks.V0 as Blocks.V0
 import Test.QuickCheck (Arbitrary (..), Positive (..))
 
 instance Arbitrary Blocks.V0.BlockOut where
+  -- starting form the QuickCheck-2.17 there is an arbirary instance for
+  -- Natural, so it's possible to use genericArbitraryU directly.
   arbitrary = Blocks.V0.BlockOut . fromIntegral . getPositive @Integer <$> arbitrary


### PR DESCRIPTION
Introduced instances for the simplest of the blocks.

This commit defines a new library where the main definitions persist. In the library there will be definitions for the era angostic types.

As blocks/v0 is common for all eras, it doesn't cripple into the era libraries.

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
