### PR TITLE
Support Plutus V4 CBOR tag in AlonzoScript decoder

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -624,6 +624,7 @@ instance AlonzoEraScript era => DecCBOR (Annotator (AlonzoScript era)) where
         1 -> decodeAnnPlutus SPlutusV1
         2 -> decodeAnnPlutus SPlutusV2
         3 -> decodeAnnPlutus SPlutusV3
+        4 -> decodeAnnPlutus SPlutusV4
         n -> Invalid n
       {-# INLINE decodeScript #-}
   {-# INLINE decCBOR #-}


### PR DESCRIPTION
Motivation
The encoder for AlonzoScript uses tag 4 for Plutus V4, but the decoder did not handle tag 4, which can cause valid Plutus V4 scripts to be rejected when decoding.
Description
Add 4 -> decodeAnnPlutus SPlutusV4 to the decodeScript function in eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs so decoding matches the encoder's tags.
Testing
No automated tests were run for this trivial decoder fix.