### PR TITLE
Set scriptIntegrityHash to 0 to match the behavior of Agda in conformance tests

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
   subdir: hs
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `*-artifacts` BEFORE MERGE!
-  tag: ce149016c8294b9b91a9ee91fdbc449d6bb91a97
+  tag: 5ed76f93a6c71ef7450d540d5a3ca836b67e5253
 
 source-repository-package
   type: git

--- a/flake.lock
+++ b/flake.lock
@@ -204,11 +204,11 @@
     "formal-ledger-specifications": {
       "flake": false,
       "locked": {
-        "lastModified": 1769576365,
+        "lastModified": 1771861769,
         "narHash": "sha256-OmxmlLlzaKVEYCjWe30AQqgBpBGVoO39rS79nh0vGiQ=",
         "owner": "IntersectMBO",
         "repo": "formal-ledger-specifications",
-        "rev": "ce149016c8294b9b91a9ee91fdbc449d6bb91a97",
+        "rev": "5ed76f93a6c71ef7450d540d5a3ca836b67e5253",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledger.hs
@@ -89,7 +89,14 @@ instance
       <*> toSpecRep (txb ^. currentTreasuryValueTxBodyL)
       <*> pure 0
       <*> toSpecRep (txb ^. reqSignerHashesTxBodyL)
-      <*> toSpecRep (txb ^. scriptIntegrityHashTxBodyL)
+      -- The script integrity hash is computed using @const 0@ on the Agda
+      -- side (@Hashable-ScriptIntegrity = record { hash = λ x → 0 }@).
+      -- Until a proper hash function is used in Agda, we emulate the same
+      -- behavior here.
+      --
+      -- The following PR documents the discrepancy on the Agda side:
+      -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/1086
+      <*> fmap (fmap (const 0)) (toSpecRep (txb ^. scriptIntegrityHashTxBodyL))
 
 instance SpecTranslate ctx (Tx TopTx ConwayEra) where
   type SpecRep (Tx TopTx ConwayEra) = Agda.Tx


### PR DESCRIPTION
The script integrity hash is computed using `const 0` on the Agda side (`Hashable-ScriptIntegrity = record { hash = λ x → 0 }`).

Until a proper hash function is used in Agda, we emulate the same behavior in the translation of TxBody to Agda.

The following PR documents the discrepancy on the Agda side: https://github.com/IntersectMBO/formal-ledger-specifications/issues/1086