### PR TITLE
Fix nightly nothunks tests for snapshot

### DIFF
--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/SnapShots.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/SnapShots.hs
@@ -422,7 +422,9 @@ snapShotFromInstantStake instantStake dState PState {psStakePools} =
     keepAndCountDelegations cred accountState acc@(!curDelegs, !curCount) =
       case accountState ^. stakePoolDelegationAccountStateL of
         Nothing -> acc
-        Just deleg -> ((cred, deleg) : curDelegs, curCount + 1)
+        Just deleg ->
+          let !d = (cred, deleg)
+           in (d : curDelegs, curCount + 1)
     (delegsAscList, delegsCount) =
       Map.foldrWithKey keepAndCountDelegations ([], 0) $ accounts ^. accountsMapL
 {-# INLINE snapShotFromInstantStake #-}

--- a/libs/vector-map/src/Data/VMap.hs
+++ b/libs/vector-map/src/Data/VMap.hs
@@ -236,10 +236,14 @@ map ::
   (a -> b) ->
   VMap kv vv k a ->
   VMap kv vv k b
-map f (VMap vec) = VMap (VG.map (\(k, v) -> (k, f v)) vec)
+map f (VMap vec) = VMap (VG.map (\(k, v) -> let v' = f v in v' `seq` (k, v')) vec)
 -- TODO: benchmark and switch to this implementation when we switch to Data.Vector.Strict
 -- VMap (KV.mapValsKVVector f vec)
-{-# INLINE map #-}
+--
+-- This is marked as NOINLINE because there is some strange issue in `vector`, likely due to stream
+-- fusion, that prevents elements from being forced. This needs further investigation, but for now
+-- we can get away with NOINLINE. FTR. `Data.Vector.Strict` is also susceptible to this problem.
+{-# NOINLINE map #-}
 
 mapMaybe ::
   (VG.Vector kv k, VG.Vector vv a, VG.Vector vv b) =>


### PR DESCRIPTION
# Description

There is likely an issue in `vector` that needs investigation. For now we can work around it with `NOINLINE`

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
