### PR TITLE
Extras for working with maps

### DIFF
--- a/libs/cardano-data/CHANGELOG.md
+++ b/libs/cardano-data/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Add `Data.Map.NonEmpty`
 * Add `Data.Set.NonEmpty`
 * Add `lookupInternMap`
+* Add `Data.MapExtras.boundedEnumMap`
+* Add `Data.MapExtras.lookupMapFail`
 * Replace `okeyL` with `toOKey`
 
 ## 1.2.4.1

--- a/libs/cardano-data/src/Data/MapExtras.hs
+++ b/libs/cardano-data/src/Data/MapExtras.hs
@@ -24,6 +24,8 @@ module Data.MapExtras (
   intersectDomPLeft,
   intersectMapSetFold,
   disjointMapSetFold,
+  boundedEnumMap,
+  lookupMapFail,
   extractKeys,
   extractKeysSmallSet,
   fromKeys,
@@ -284,3 +286,13 @@ lookupInternMap k = go
         LT -> go l
         GT -> go r
         EQ -> Just (kx, v)
+
+boundedEnumMap :: (Ord k, Bounded a, Enum a) => (a -> k) -> Map k a
+boundedEnumMap toTxt = Map.fromList [(toTxt t, t) | t <- [minBound .. maxBound]]
+
+lookupMapFail ::
+  (Ord k, Show k, MonadFail m) => String -> Map k v -> k -> m v
+lookupMapFail name m key =
+  case Map.lookup key m of
+    Just t -> pure t
+    Nothing -> fail $ "Unrecognized " <> name <> ": " ++ show key

--- a/libs/cardano-data/test/Test/Cardano/Data/MapExtrasSpec.hs
+++ b/libs/cardano-data/test/Test/Cardano/Data/MapExtrasSpec.hs
@@ -6,6 +6,7 @@ import Control.Monad
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
 import Data.MapExtras
+import Data.Word (Word8)
 import Test.Cardano.Data
 import Test.Hspec
 import Test.Hspec.QuickCheck
@@ -39,3 +40,9 @@ mapExtrasSpec =
           ma = intersectDomPLeft f m1 m2
       expectValidMap ma
       ma `shouldBe` Map.mapMaybeWithKey (\k v -> v <$ (guard . f k =<< Map.lookup k m2)) m1
+    prop "boundedEnumMap" $ do
+      let convert = fromIntegral :: Word8 -> Int
+          m = boundedEnumMap convert :: Map Int Word8
+      expectValidMap m
+      forM_ [minBound .. maxBound] $ \t -> do
+        Map.lookup (convert t) m `shouldBe` Just t


### PR DESCRIPTION
Two extra helper functions that simplifies working with maps.

boundedEnumMap builds a functional index map for a bounded values. lookupMapFail provides conventient search with error reporting.

The code was proposed by @lehins in a separate PR.

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
