### PR TITLE
SUBUTXOW implementation

### DIFF
--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-babbage`
 
-## 1.13.0.1
+## 1.13.1.0
 
-*
+* Add `validateScriptsWellFormedTxOuts`
 
 ## 1.13.0.0
 

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-babbage
-version: 1.13.0.0
+version: 1.13.1.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -229,7 +229,7 @@ babbageMissingScripts _ sNeeded sRefs sReceived =
 {-  ∀ s ∈ (txscripts txw utxo ∩ Scriptnative), validateScript s tx   -}
 validateFailedBabbageScripts ::
   EraTx era =>
-  Tx TopTx era ->
+  Tx l era ->
   ScriptsProvided era ->
   Set ScriptHash ->
   Test (ShelleyUtxowPredFailure era)

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -20,6 +20,7 @@ module Cardano.Ledger.Babbage.Rules.Utxow (
   babbageMissingScripts,
   validateFailedBabbageScripts,
   validateScriptsWellFormed,
+  validateScriptsWellFormedTxOuts,
   babbageUtxowTransition,
 ) where
 
@@ -82,6 +83,7 @@ import Data.Foldable (sequenceA_, toList)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (mapMaybe)
 import Data.Maybe.Strict (StrictMaybe (..))
+import qualified Data.Sequence.Strict as StrictSeq (singleton)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Set.NonEmpty (NonEmptySet)
@@ -259,21 +261,31 @@ validateScriptsWellFormed ::
   Tx TopTx era ->
   Test (BabbageUtxowPredFailure era)
 validateScriptsWellFormed pp tx =
+  validateScriptsWellFormedTxOuts
+    pp
+    (tx ^. witsTxL . scriptTxWitsL)
+    (normalOuts <> foldMap StrictSeq.singleton returnOut)
+  where
+    normalOuts = tx ^. bodyTxL . outputsTxBodyL
+    returnOut = tx ^. bodyTxL . collateralReturnTxBodyL
+
+validateScriptsWellFormedTxOuts ::
+  forall era f.
+  ( BabbageEraTxOut era
+  , Foldable f
+  ) =>
+  PParams era ->
+  Map.Map ScriptHash (Script era) ->
+  f (TxOut era) ->
+  Test (BabbageUtxowPredFailure era)
+validateScriptsWellFormedTxOuts pp scriptWits txOuts =
   sequenceA_
     [ failureOnNonEmptySet (Map.keysSet invalidScriptWits) MalformedScriptWitnesses
     , failureOnNonEmptySet invalidRefScriptHashes MalformedReferenceScripts
     ]
   where
-    scriptWits = tx ^. witsTxL . scriptTxWitsL
     invalidScriptWits = Map.filter (not . validScript (pp ^. ppProtocolVersionL)) scriptWits
-
-    txBody = tx ^. bodyTxL
-    normalOuts = toList $ txBody ^. outputsTxBodyL
-    returnOut = txBody ^. collateralReturnTxBodyL
-    outs = case returnOut of
-      SNothing -> normalOuts
-      SJust rOut -> rOut : normalOuts
-    rScripts = mapMaybe (strictMaybeToMaybe . view referenceScriptTxOutL) outs
+    rScripts = mapMaybe (strictMaybeToMaybe . view referenceScriptTxOutL) (toList txOuts)
     invalidRefScripts = filter (not . validScript (pp ^. ppProtocolVersionL)) rScripts
     invalidRefScriptHashes = Set.fromList $ map (hashScript @era) invalidRefScripts
 

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Revision history for cardano-ledger-dijkstra
 
-## 0.2.0.1
+## 0.2.1.0
 
-*
+* Add `SubLedgerEnv` and `SubUtxowEnv`
 
 ## 0.2.0.0
 

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-dijkstra
-version: 0.2.0.1
+version: 0.2.1.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -104,6 +104,8 @@ import Cardano.Ledger.Dijkstra.TxCert
 import Cardano.Ledger.Shelley.LedgerState (
   LedgerState (..),
   UTxOState (..),
+  lsUTxOStateL,
+  utxosUtxo,
  )
 import Cardano.Ledger.Shelley.Rules (
   LedgerEnv (..),
@@ -335,6 +337,7 @@ instance
   , ConwayEraTxBody era
   , ConwayEraGov era
   , DijkstraEraTxBody era
+  , EraUTxO era
   , GovState era ~ ConwayGovState era
   , Embed (EraRule "UTXOW" era) (DijkstraLEDGER era)
   , Embed (EraRule "GOV" era) (DijkstraLEDGER era)
@@ -393,6 +396,7 @@ dijkstraLedgerTransition ::
   , ConwayEraCertState era
   , ConwayEraGov era
   , DijkstraEraTxBody era
+  , EraUTxO era
   , GovState era ~ ConwayGovState era
   , Embed (EraRule "UTXOW" era) (DijkstraLEDGER era)
   , Embed (EraRule "GOV" era) (DijkstraLEDGER era)
@@ -415,13 +419,26 @@ dijkstraLedgerTransition ::
   ) =>
   TransitionRule (DijkstraLEDGER era)
 dijkstraLedgerTransition = do
-  TRC (env, ledgerState, tx) <- judgmentContext
+  TRC (env@(LedgerEnv slot mbCurEpochNo txIx pp chainAccountState), ledgerState, tx) <-
+    judgmentContext
 
   failOnNonEmptyMap (spentSubTxOutputs tx) DijkstraSpendingOutputFromSameTx
 
+  let utxo = utxosUtxo (ledgerState ^. lsUTxOStateL)
+      subTxs = tx ^. bodyTxL . subTransactionsTxBodyL
+      scriptsProvided =
+        ScriptsProvided $
+          Map.unions $
+            unScriptsProvided (getScriptsProvided utxo tx)
+              : map (unScriptsProvided . getScriptsProvided utxo) (OMap.elems subTxs)
+
   ledgerStateAfterSubledgers <-
     trans @(EraRule "SUBLEDGERS" era) $
-      TRC (env, ledgerState, tx ^. bodyTxL . subTransactionsTxBodyL)
+      TRC
+        ( SubLedgerEnv slot mbCurEpochNo txIx pp chainAccountState scriptsProvided
+        , ledgerState
+        , subTxs
+        )
   conwayLedgerTransitionTRC (TRC (env, ledgerStateAfterSubledgers, tx))
 
 instance

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -496,6 +496,7 @@ instance
   , InjectRuleFailure "SUBUTXOW" DijkstraSubUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
+  , InjectRuleFailure "SUBUTXOW" BabbageUtxowPredFailure era
   , TxCert era ~ DijkstraTxCert era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>
@@ -611,6 +612,7 @@ instance
   , InjectRuleFailure "SUBUTXOW" DijkstraSubUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
+  , InjectRuleFailure "SUBUTXOW" BabbageUtxowPredFailure era
   , TxCert era ~ DijkstraTxCert era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -497,6 +497,7 @@ instance
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
   , TxCert era ~ DijkstraTxCert era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>
   Embed (DijkstraLEDGER era) (ShelleyLEDGERS era)
   where
@@ -611,6 +612,7 @@ instance
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
   , TxCert era ~ DijkstraTxCert era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>
   Embed (DijkstraSUBLEDGERS era) (DijkstraLEDGER era)
   where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -495,6 +495,7 @@ instance
   , InjectRuleFailure "SUBLEDGER" ConwayLedgerPredFailure era
   , InjectRuleFailure "SUBUTXOW" DijkstraSubUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
+  , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraLEDGER era) (ShelleyLEDGERS era)
@@ -608,6 +609,7 @@ instance
   , InjectRuleFailure "SUBLEDGER" ConwayLedgerPredFailure era
   , InjectRuleFailure "SUBUTXOW" DijkstraSubUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
+  , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraSUBLEDGERS era) (DijkstraLEDGER era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -31,7 +31,7 @@ import Cardano.Ledger.Alonzo.Rules (
   AlonzoUtxowEvent,
   AlonzoUtxowPredFailure,
  )
-import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded)
+import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
 import Cardano.Ledger.Babbage (BabbageTxOut)
 import Cardano.Ledger.Babbage.Rules (
   BabbageUtxoPredFailure,
@@ -96,6 +96,7 @@ import Cardano.Ledger.Dijkstra.Rules.SubGovCert (DijkstraSubGovCertPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubLedger
 import Cardano.Ledger.Dijkstra.Rules.SubLedgers
 import Cardano.Ledger.Dijkstra.Rules.SubPool
+import Cardano.Ledger.Dijkstra.Rules.SubUtxow (DijkstraSubUtxowPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.Utxo (DijkstraUtxoPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.Utxow (DijkstraUtxowPredFailure)
 import Cardano.Ledger.Dijkstra.TxBody
@@ -448,9 +449,9 @@ instance
   ( Embed (EraRule "UTXOW" era) (DijkstraLEDGER era)
   , Embed (EraRule "CERTS" era) (DijkstraLEDGER era)
   , Embed (EraRule "GOV" era) (DijkstraLEDGER era)
-  , Embed (EraRule "SUBLEDGERS" era) (DijkstraSUBLEDGERS era)
   , ConwayEraGov era
   , AlonzoEraTx era
+  , AlonzoEraUTxO era
   , ConwayEraPParams era
   , DijkstraEraTxBody era
   , EraPlutusContext era
@@ -492,6 +493,8 @@ instance
   , InjectRuleFailure "SUBGOV" DijkstraSubGovPredFailure era
   , InjectRuleFailure "SUBGOV" ConwayGovPredFailure era
   , InjectRuleFailure "SUBLEDGER" ConwayLedgerPredFailure era
+  , InjectRuleFailure "SUBUTXOW" DijkstraSubUtxowPredFailure era
+  , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraLEDGER era) (ShelleyLEDGERS era)
@@ -570,7 +573,8 @@ instance
   wrapEvent = CertsEvent . CertEvent . DelegEvent
 
 instance
-  ( EraTx era
+  ( AlonzoEraTx era
+  , AlonzoEraUTxO era
   , ConwayEraTxBody era
   , ConwayEraGov era
   , ConwayEraCertState era
@@ -602,6 +606,8 @@ instance
   , InjectRuleFailure "SUBGOV" DijkstraSubGovPredFailure era
   , InjectRuleFailure "SUBGOV" ConwayGovPredFailure era
   , InjectRuleFailure "SUBLEDGER" ConwayLedgerPredFailure era
+  , InjectRuleFailure "SUBUTXOW" DijkstraSubUtxowPredFailure era
+  , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraSUBLEDGERS era) (DijkstraLEDGER era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
@@ -24,6 +24,7 @@ module Cardano.Ledger.Dijkstra.Rules.Mempool (
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
 import Cardano.Ledger.Alonzo.Rules (AlonzoUtxowPredFailure)
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
+import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure)
 import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders (
@@ -287,6 +288,7 @@ instance
   , InjectRuleFailure "SUBUTXOW" DijkstraSubUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
+  , InjectRuleFailure "SUBUTXOW" BabbageUtxowPredFailure era
   , TxCert era ~ DijkstraTxCert era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
@@ -22,6 +22,8 @@ module Cardano.Ledger.Dijkstra.Rules.Mempool (
 ) where
 
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
+import Cardano.Ledger.Alonzo.Rules (AlonzoUtxowPredFailure)
+import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO)
 import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders (
@@ -72,6 +74,7 @@ import Cardano.Ledger.Dijkstra.Rules.SubGov (DijkstraSubGovEvent, DijkstraSubGov
 import Cardano.Ledger.Dijkstra.Rules.SubGovCert (DijkstraSubGovCertPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubLedgers (DijkstraSubLedgersPredFailure (..))
 import Cardano.Ledger.Dijkstra.Rules.SubPool (DijkstraSubPoolEvent, DijkstraSubPoolPredFailure)
+import Cardano.Ledger.Dijkstra.Rules.SubUtxow (DijkstraSubUtxowPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.Utxo (DijkstraUtxoPredFailure)
 import Cardano.Ledger.Dijkstra.State
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody)
@@ -234,6 +237,7 @@ mempoolTransition = do
 
 instance
   ( AlonzoEraTx era
+  , AlonzoEraUTxO era
   , ConwayEraCertState era
   , DijkstraEraTxBody era
   , ConwayEraGov era
@@ -279,6 +283,8 @@ instance
   , InjectRuleFailure "SUBGOV" DijkstraSubGovPredFailure era
   , InjectRuleFailure "SUBGOV" ConwayGovPredFailure era
   , InjectRuleFailure "SUBLEDGER" ConwayLedgerPredFailure era
+  , InjectRuleFailure "SUBUTXOW" DijkstraSubUtxowPredFailure era
+  , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraLEDGER era) (DijkstraMEMPOOL era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
@@ -23,7 +23,7 @@ module Cardano.Ledger.Dijkstra.Rules.Mempool (
 
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
 import Cardano.Ledger.Alonzo.Rules (AlonzoUtxowPredFailure)
-import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO)
+import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
 import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders (
@@ -288,6 +288,7 @@ instance
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
   , TxCert era ~ DijkstraTxCert era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>
   Embed (DijkstraLEDGER era) (DijkstraMEMPOOL era)
   where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
@@ -85,6 +85,7 @@ import Cardano.Ledger.Shelley.Rules (
   PoolEvent,
   ShelleyLedgerPredFailure,
   ShelleyPoolPredFailure,
+  ShelleyUtxowPredFailure,
   UtxoEnv,
  )
 import Control.DeepSeq (NFData)
@@ -285,6 +286,7 @@ instance
   , InjectRuleFailure "SUBLEDGER" ConwayLedgerPredFailure era
   , InjectRuleFailure "SUBUTXOW" DijkstraSubUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
+  , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraLEDGER era) (DijkstraMEMPOOL era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
@@ -76,6 +76,7 @@ import Cardano.Ledger.Shelley.Rules (
   LedgerEnv (..),
   PoolEvent,
   ShelleyPoolPredFailure,
+  ShelleyUtxowPredFailure,
   UtxoEnv (..),
   epochFromSlot,
  )
@@ -334,6 +335,7 @@ instance
   , EraRule "SUBUTXO" era ~ DijkstraSUBUTXO era
   , EraRule "SUBUTXOW" era ~ DijkstraSUBUTXOW era
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
+  , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
   ) =>
   Embed (DijkstraSUBUTXOW era) (DijkstraSUBLEDGER era)
   where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
@@ -24,6 +24,7 @@ module Cardano.Ledger.Dijkstra.Rules.SubLedger (
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
 import Cardano.Ledger.Alonzo.Rules (AlonzoUtxowPredFailure)
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
+import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure)
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (
   DecCBOR (..),
@@ -336,6 +337,7 @@ instance
   , EraRule "SUBUTXOW" era ~ DijkstraSUBUTXOW era
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
+  , InjectRuleFailure "SUBUTXOW" BabbageUtxowPredFailure era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>
   Embed (DijkstraSUBUTXOW era) (DijkstraSUBLEDGER era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
@@ -23,7 +23,7 @@ module Cardano.Ledger.Dijkstra.Rules.SubLedger (
 
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
 import Cardano.Ledger.Alonzo.Rules (AlonzoUtxowPredFailure)
-import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO)
+import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (
   DecCBOR (..),
@@ -336,6 +336,7 @@ instance
   , EraRule "SUBUTXOW" era ~ DijkstraSUBUTXOW era
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>
   Embed (DijkstraSUBUTXOW era) (DijkstraSUBLEDGER era)
   where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
@@ -19,6 +19,7 @@ module Cardano.Ledger.Dijkstra.Rules.SubLedger (
   DijkstraSUBLEDGER,
   DijkstraSubLedgerPredFailure (..),
   DijkstraSubLedgerEvent (..),
+  SubLedgerEnv (..),
 ) where
 
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
@@ -68,17 +69,15 @@ import Cardano.Ledger.Dijkstra.Rules.SubDeleg (DijkstraSubDelegPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubGov (DijkstraSubGovEvent, DijkstraSubGovPredFailure (..))
 import Cardano.Ledger.Dijkstra.Rules.SubGovCert (DijkstraSubGovCertPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubPool (DijkstraSubPoolEvent, DijkstraSubPoolPredFailure)
-import Cardano.Ledger.Dijkstra.Rules.SubUtxow (DijkstraSubUtxowPredFailure (..))
+import Cardano.Ledger.Dijkstra.Rules.SubUtxow (DijkstraSubUtxowPredFailure (..), SubUtxowEnv (..))
 import Cardano.Ledger.Dijkstra.Rules.Utxow (DijkstraUtxowPredFailure (..))
 import Cardano.Ledger.Dijkstra.TxCert
 import Cardano.Ledger.Rules.ValidationMode (runTest)
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.Rules (
-  LedgerEnv (..),
   PoolEvent,
   ShelleyPoolPredFailure,
   ShelleyUtxowPredFailure,
-  UtxoEnv (..),
   epochFromSlot,
  )
 import Control.DeepSeq (NFData)
@@ -103,6 +102,15 @@ import qualified Data.Sequence.Strict as StrictSeq
 import GHC.Generics (Generic)
 import Lens.Micro
 import NoThunks.Class (NoThunks (..))
+
+data SubLedgerEnv era = SubLedgerEnv
+  { sleSlotNo :: SlotNo
+  , sleEpochNo :: Maybe EpochNo
+  , sleTxIx :: TxIx
+  , slePParams :: PParams era
+  , sleAccount :: ChainAccountState
+  , sleScriptsProvided :: ScriptsProvided era
+  }
 
 data DijkstraSubLedgerPredFailure era
   = SubUtxowFailure (PredicateFailure (EraRule "SUBUTXOW" era))
@@ -213,7 +221,7 @@ instance
   where
   type State (DijkstraSUBLEDGER era) = LedgerState era
   type Signal (DijkstraSUBLEDGER era) = Tx SubTx era
-  type Environment (DijkstraSUBLEDGER era) = LedgerEnv era
+  type Environment (DijkstraSUBLEDGER era) = SubLedgerEnv era
   type BaseM (DijkstraSUBLEDGER era) = ShelleyBase
   type PredicateFailure (DijkstraSUBLEDGER era) = DijkstraSubLedgerPredFailure era
   type Event (DijkstraSUBLEDGER era) = DijkstraSubLedgerEvent era
@@ -251,7 +259,7 @@ dijkstraSubLedgersTransition ::
   TransitionRule (EraRule "SUBLEDGER" era)
 dijkstraSubLedgersTransition = do
   TRC
-    ( LedgerEnv slot mbCurEpochNo _ pp chainAccountState
+    ( SubLedgerEnv slot mbCurEpochNo _ pp chainAccountState scriptsProvided
       , ledgerState@(LedgerState utxoState certState)
       , tx
       ) <-
@@ -300,7 +308,7 @@ dijkstraSubLedgersTransition = do
   utxoStateAfterSubUtxow <-
     trans @(EraRule "SUBUTXOW" era) $
       TRC
-        ( UtxoEnv @era slot pp certState
+        ( SubUtxowEnv slot pp certState scriptsProvided
         , utxoState
         , tx
         )

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
@@ -22,6 +22,8 @@ module Cardano.Ledger.Dijkstra.Rules.SubLedger (
 ) where
 
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
+import Cardano.Ledger.Alonzo.Rules (AlonzoUtxowPredFailure)
+import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO)
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (
   DecCBOR (..),
@@ -202,6 +204,7 @@ instance
   , InjectRuleFailure "SUBDELEG" ConwayDelegPredFailure era
   , InjectRuleFailure "SUBDELEG" DijkstraSubDelegPredFailure era
   , InjectRuleFailure "SUBLEDGER" ConwayLedgerPredFailure era
+  , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   STS (DijkstraSUBLEDGER era)
@@ -322,12 +325,15 @@ instance
   wrapEvent = SubGovEvent
 
 instance
-  ( ConwayEraGov era
+  ( AlonzoEraTx era
+  , AlonzoEraUTxO era
+  , ConwayEraGov era
   , ConwayEraCertState era
   , ConwayEraTxBody era
   , EraPlutusContext era
   , EraRule "SUBUTXO" era ~ DijkstraSUBUTXO era
   , EraRule "SUBUTXOW" era ~ DijkstraSUBUTXOW era
+  , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   ) =>
   Embed (DijkstraSUBUTXOW era) (DijkstraSUBLEDGER era)
   where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
@@ -59,7 +59,12 @@ import Cardano.Ledger.Dijkstra.Rules.SubLedger (DijkstraSubLedgerPredFailure (..
 import Cardano.Ledger.Dijkstra.Rules.SubPool (DijkstraSubPoolEvent, DijkstraSubPoolPredFailure (..))
 import Cardano.Ledger.Dijkstra.TxCert
 import Cardano.Ledger.Shelley.LedgerState
-import Cardano.Ledger.Shelley.Rules (LedgerEnv, PoolEvent, ShelleyPoolPredFailure)
+import Cardano.Ledger.Shelley.Rules (
+  LedgerEnv,
+  PoolEvent,
+  ShelleyPoolPredFailure,
+  ShelleyUtxowPredFailure,
+ )
 import Cardano.Ledger.TxIn (TxId)
 import Control.DeepSeq (NFData)
 import Control.Monad (foldM)
@@ -190,6 +195,7 @@ instance
   , InjectRuleFailure "SUBGOV" ConwayGovPredFailure era
   , InjectRuleFailure "SUBLEDGER" ConwayLedgerPredFailure era
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
+  , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraSUBLEDGER era) (DijkstraSUBLEDGERS era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
@@ -22,6 +22,7 @@ module Cardano.Ledger.Dijkstra.Rules.SubLedgers (
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
 import Cardano.Ledger.Alonzo.Rules (AlonzoUtxowPredFailure)
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
+import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure)
 import Cardano.Ledger.BaseTypes (
   ShelleyBase,
  )
@@ -196,6 +197,7 @@ instance
   , InjectRuleFailure "SUBLEDGER" ConwayLedgerPredFailure era
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
+  , InjectRuleFailure "SUBUTXOW" BabbageUtxowPredFailure era
   , TxCert era ~ DijkstraTxCert era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
@@ -56,12 +56,14 @@ import Cardano.Ledger.Dijkstra.Era (
 import Cardano.Ledger.Dijkstra.Rules.SubDeleg (DijkstraSubDelegPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubGov (DijkstraSubGovEvent, DijkstraSubGovPredFailure (..))
 import Cardano.Ledger.Dijkstra.Rules.SubGovCert (DijkstraSubGovCertPredFailure)
-import Cardano.Ledger.Dijkstra.Rules.SubLedger (DijkstraSubLedgerPredFailure (..))
+import Cardano.Ledger.Dijkstra.Rules.SubLedger (
+  DijkstraSubLedgerPredFailure (..),
+  SubLedgerEnv (..),
+ )
 import Cardano.Ledger.Dijkstra.Rules.SubPool (DijkstraSubPoolEvent, DijkstraSubPoolPredFailure (..))
 import Cardano.Ledger.Dijkstra.TxCert
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.Rules (
-  LedgerEnv,
   PoolEvent,
   ShelleyPoolPredFailure,
   ShelleyUtxowPredFailure,
@@ -141,7 +143,7 @@ instance
   where
   type State (DijkstraSUBLEDGERS era) = LedgerState era
   type Signal (DijkstraSUBLEDGERS era) = OMap TxId (Tx SubTx era)
-  type Environment (DijkstraSUBLEDGERS era) = LedgerEnv era
+  type Environment (DijkstraSUBLEDGERS era) = SubLedgerEnv era
   type BaseM (DijkstraSUBLEDGERS era) = ShelleyBase
   type PredicateFailure (DijkstraSUBLEDGERS era) = DijkstraSubLedgersPredFailure era
   type Event (DijkstraSUBLEDGERS era) = DijkstraSubLedgersEvent era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
@@ -21,7 +21,7 @@ module Cardano.Ledger.Dijkstra.Rules.SubLedgers (
 
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
 import Cardano.Ledger.Alonzo.Rules (AlonzoUtxowPredFailure)
-import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO)
+import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
 import Cardano.Ledger.BaseTypes (
   ShelleyBase,
  )
@@ -197,6 +197,7 @@ instance
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
   , TxCert era ~ DijkstraTxCert era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>
   Embed (DijkstraSUBLEDGER era) (DijkstraSUBLEDGERS era)
   where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
@@ -20,6 +20,8 @@ module Cardano.Ledger.Dijkstra.Rules.SubLedgers (
 ) where
 
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
+import Cardano.Ledger.Alonzo.Rules (AlonzoUtxowPredFailure)
+import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO)
 import Cardano.Ledger.BaseTypes (
   ShelleyBase,
  )
@@ -157,7 +159,8 @@ dijkstraSubLedgersTransition = do
     subTxs
 
 instance
-  ( EraTx era
+  ( AlonzoEraTx era
+  , AlonzoEraUTxO era
   , ConwayEraTxBody era
   , ConwayEraGov era
   , ConwayEraCertState era
@@ -186,6 +189,7 @@ instance
   , InjectRuleFailure "SUBGOV" DijkstraSubGovPredFailure era
   , InjectRuleFailure "SUBGOV" ConwayGovPredFailure era
   , InjectRuleFailure "SUBLEDGER" ConwayLedgerPredFailure era
+  , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraSUBLEDGER era) (DijkstraSUBLEDGERS era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -19,6 +19,7 @@ module Cardano.Ledger.Dijkstra.Rules.SubUtxow (
   DijkstraSUBUTXOW,
   DijkstraSubUtxowPredFailure (..),
   DijkstraSubUtxowEvent (..),
+  SubUtxowEnv (..),
 ) where
 
 import Cardano.Crypto.Hash (ByteString)
@@ -70,7 +71,7 @@ import qualified Cardano.Ledger.Shelley.Rules as Shelley (
   validateNeededWitnesses,
   validateVerifiedWits,
  )
-import Cardano.Ledger.State (EraUTxO (..))
+import Cardano.Ledger.State (CertState, EraUTxO (..), ScriptsProvided (..))
 import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended
@@ -83,6 +84,13 @@ import NoThunks.Class (
   InspectHeapNamed (..),
   NoThunks (..),
  )
+
+data SubUtxowEnv era = SubUtxowEnv
+  { sueSlot :: SlotNo
+  , suePParams :: PParams era
+  , sueCertState :: CertState era
+  , sueScriptsProvided :: ScriptsProvided era
+  }
 
 data DijkstraSubUtxowPredFailure era
   = SubUtxoFailure (PredicateFailure (EraRule "SUBUTXO" era))
@@ -213,7 +221,7 @@ instance
   where
   type State (DijkstraSUBUTXOW era) = UTxOState era
   type Signal (DijkstraSUBUTXOW era) = Tx SubTx era
-  type Environment (DijkstraSUBUTXOW era) = UtxoEnv era
+  type Environment (DijkstraSUBUTXOW era) = SubUtxowEnv era
   type BaseM (DijkstraSUBUTXOW era) = ShelleyBase
   type PredicateFailure (DijkstraSUBUTXOW era) = DijkstraSubUtxowPredFailure era
   type Event (DijkstraSUBUTXOW era) = DijkstraSubUtxowEvent era
@@ -235,7 +243,7 @@ dijkstraSubUtxowTransition ::
   ) =>
   TransitionRule (EraRule "SUBUTXOW" era)
 dijkstraSubUtxowTransition = do
-  TRC (env@(UtxoEnv _ pp certState), utxoState, tx) <- judgmentContext
+  TRC (SubUtxowEnv slot pp certState scriptsProvided, utxoState, tx) <- judgmentContext
   let utxo = utxosUtxo utxoState
       txBody = tx ^. bodyTxL
       witsKeyHashes = keyHashWitnessesTxWits (tx ^. witsTxL)
@@ -244,7 +252,6 @@ dijkstraSubUtxowTransition = do
   runTestOnSignal $ Shelley.validateVerifiedWits tx
 
   let scriptsNeeded = getScriptsNeeded utxo txBody
-      scriptsProvided = getScriptsProvided utxo tx
       scriptHashesNeeded = getScriptsHashesNeeded scriptsNeeded
 
   {- ∀[ s ∈ p1ScriptsNeeded ] validP1Script vKeyHashesProvided txVldt s -}
@@ -270,7 +277,7 @@ dijkstraSubUtxowTransition = do
       (tx ^. witsTxL . scriptTxWitsL)
       (tx ^. bodyTxL . outputsTxBodyL)
 
-  trans @(EraRule "SUBUTXO" era) $ TRC (env, utxoState, tx)
+  trans @(EraRule "SUBUTXO" era) $ TRC (UtxoEnv slot pp certState, utxoState, tx)
 
 instance
   ( ConwayEraGov era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -24,9 +24,15 @@ module Cardano.Ledger.Dijkstra.Rules.SubUtxow (
 import Cardano.Crypto.Hash (ByteString)
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
 import Cardano.Ledger.Alonzo.Rules (AlonzoUtxowPredFailure)
-import qualified Cardano.Ledger.Alonzo.Rules as Alonzo (missingRequiredDatums)
+import qualified Cardano.Ledger.Alonzo.Rules as Alonzo (
+  checkScriptIntegrityHash,
+  missingRequiredDatums,
+ )
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO (..))
-import qualified Cardano.Ledger.Babbage.Rules as Babbage (validateFailedBabbageScripts)
+import qualified Cardano.Ledger.Babbage.Rules as Babbage (
+  validateFailedBabbageScripts,
+ )
+import Cardano.Ledger.Babbage.Tx (mkScriptIntegrity)
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (
   DecCBOR (..),
@@ -240,6 +246,9 @@ dijkstraSubUtxowTransition = do
 
   {- txADhash ≡ map hash txAuxData -}
   runTestOnSignal $ Shelley.validateMetadata pp tx
+
+  let scriptIntegrity = mkScriptIntegrity pp tx scriptsProvided scriptHashesNeeded
+  runTest $ Alonzo.checkScriptIntegrityHash tx pp scriptIntegrity
 
   trans @(EraRule "SUBUTXO" era) $ TRC (env, utxoState, tx)
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -26,9 +26,10 @@ import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
 import Cardano.Ledger.Alonzo.Rules (AlonzoUtxowPredFailure)
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo (
   checkScriptIntegrityHash,
+  hasExactSetOfRedeemers,
   missingRequiredDatums,
  )
-import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO (..))
+import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO (..), AlonzoScriptsNeeded)
 import qualified Cardano.Ledger.Babbage.Rules as Babbage (
   validateFailedBabbageScripts,
  )
@@ -199,6 +200,7 @@ instance
   , Embed (EraRule "SUBUTXO" era) (DijkstraSUBUTXOW era)
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>
   STS (DijkstraSUBUTXOW era)
   where
@@ -220,6 +222,7 @@ dijkstraSubUtxowTransition ::
   , Embed (EraRule "SUBUTXO" era) (DijkstraSUBUTXOW era)
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>
   TransitionRule (EraRule "SUBUTXOW" era)
 dijkstraSubUtxowTransition = do
@@ -249,6 +252,8 @@ dijkstraSubUtxowTransition = do
 
   let scriptIntegrity = mkScriptIntegrity pp tx scriptsProvided scriptHashesNeeded
   runTest $ Alonzo.checkScriptIntegrityHash tx pp scriptIntegrity
+
+  runTest $ Alonzo.hasExactSetOfRedeemers tx scriptsProvided scriptsNeeded
 
   trans @(EraRule "SUBUTXO" era) $ TRC (env, utxoState, tx)
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -30,8 +30,10 @@ import qualified Cardano.Ledger.Alonzo.Rules as Alonzo (
   missingRequiredDatums,
  )
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO (..), AlonzoScriptsNeeded)
+import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure)
 import qualified Cardano.Ledger.Babbage.Rules as Babbage (
   validateFailedBabbageScripts,
+  validateScriptsWellFormedTxOuts,
  )
 import Cardano.Ledger.Babbage.Tx (mkScriptIntegrity)
 import Cardano.Ledger.BaseTypes
@@ -46,6 +48,7 @@ import Cardano.Ledger.Conway.Rules (
   ConwayUtxowPredFailure,
   UtxoEnv (..),
   alonzoToConwayUtxowPredFailure,
+  babbageToConwayUtxowPredFailure,
   shelleyToConwayUtxowPredFailure,
  )
 import Cardano.Ledger.Dijkstra.Era (
@@ -168,6 +171,12 @@ instance InjectRuleFailure "SUBUTXOW" DijkstraUtxowPredFailure DijkstraEra where
 instance InjectRuleFailure "SUBUTXOW" ConwayUtxowPredFailure DijkstraEra where
   injectFailure = dijkstraUtxowToDijkstraSubUtxowPredFailure . conwayToDijkstraUtxowPredFailure
 
+instance InjectRuleFailure "SUBUTXOW" BabbageUtxowPredFailure DijkstraEra where
+  injectFailure =
+    dijkstraUtxowToDijkstraSubUtxowPredFailure
+      . conwayToDijkstraUtxowPredFailure
+      . babbageToConwayUtxowPredFailure
+
 instance InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure DijkstraEra where
   injectFailure =
     dijkstraUtxowToDijkstraSubUtxowPredFailure
@@ -192,6 +201,7 @@ instance NFData (Event (EraRule "SUBUTXO" era)) => NFData (DijkstraSubUtxowEvent
 instance
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
+  , BabbageEraTxOut era
   , ConwayEraGov era
   , ConwayEraTxBody era
   , EraPlutusContext era
@@ -200,6 +210,7 @@ instance
   , Embed (EraRule "SUBUTXO" era) (DijkstraSUBUTXOW era)
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
+  , InjectRuleFailure "SUBUTXOW" BabbageUtxowPredFailure era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>
   STS (DijkstraSUBUTXOW era)
@@ -217,11 +228,13 @@ dijkstraSubUtxowTransition ::
   forall era.
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
+  , BabbageEraTxOut era
   , EraRule "SUBUTXO" era ~ DijkstraSUBUTXO era
   , EraRule "SUBUTXOW" era ~ DijkstraSUBUTXOW era
   , Embed (EraRule "SUBUTXO" era) (DijkstraSUBUTXOW era)
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
+  , InjectRuleFailure "SUBUTXOW" BabbageUtxowPredFailure era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>
   TransitionRule (EraRule "SUBUTXOW" era)
@@ -254,6 +267,12 @@ dijkstraSubUtxowTransition = do
   runTest $ Alonzo.checkScriptIntegrityHash tx pp scriptIntegrity
 
   runTest $ Alonzo.hasExactSetOfRedeemers tx scriptsProvided scriptsNeeded
+
+  runTest $
+    Babbage.validateScriptsWellFormedTxOuts
+      pp
+      (tx ^. witsTxL . scriptTxWitsL)
+      (tx ^. bodyTxL . outputsTxBodyL)
 
   trans @(EraRule "SUBUTXO" era) $ TRC (env, utxoState, tx)
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -23,6 +23,9 @@ module Cardano.Ledger.Dijkstra.Rules.SubUtxow (
 
 import Cardano.Crypto.Hash (ByteString)
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
+import Cardano.Ledger.Alonzo.Rules (AlonzoUtxowPredFailure)
+import qualified Cardano.Ledger.Alonzo.Rules as Alonzo (missingRequiredDatums)
+import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO)
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (
   DecCBOR (..),
@@ -31,7 +34,11 @@ import Cardano.Ledger.Binary (
 import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
-import Cardano.Ledger.Conway.Rules (ConwayUtxowPredFailure, UtxoEnv)
+import Cardano.Ledger.Conway.Rules (
+  ConwayUtxowPredFailure,
+  UtxoEnv,
+  alonzoToConwayUtxowPredFailure,
+ )
 import Cardano.Ledger.Dijkstra.Era (
   DijkstraEra,
   DijkstraSUBUTXOW,
@@ -43,7 +50,8 @@ import Cardano.Ledger.Dijkstra.Rules.Utxow (
   conwayToDijkstraUtxowPredFailure,
  )
 import Cardano.Ledger.Keys (VKey)
-import Cardano.Ledger.Shelley.LedgerState (UTxOState)
+import Cardano.Ledger.Rules.ValidationMode
+import Cardano.Ledger.Shelley.LedgerState (UTxOState, utxosUtxo)
 import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended
@@ -143,6 +151,12 @@ instance InjectRuleFailure "SUBUTXOW" DijkstraUtxowPredFailure DijkstraEra where
 instance InjectRuleFailure "SUBUTXOW" ConwayUtxowPredFailure DijkstraEra where
   injectFailure = dijkstraUtxowToDijkstraSubUtxowPredFailure . conwayToDijkstraUtxowPredFailure
 
+instance InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure DijkstraEra where
+  injectFailure =
+    dijkstraUtxowToDijkstraSubUtxowPredFailure
+      . conwayToDijkstraUtxowPredFailure
+      . alonzoToConwayUtxowPredFailure
+
 instance InjectRuleEvent "SUBUTXOW" DijkstraSubUtxowEvent DijkstraEra
 
 newtype DijkstraSubUtxowEvent era = SubUtxo (Event (EraRule "SUBUTXO" era))
@@ -153,12 +167,15 @@ deriving instance Eq (Event (EraRule "SUBUTXO" era)) => Eq (DijkstraSubUtxowEven
 instance NFData (Event (EraRule "SUBUTXO" era)) => NFData (DijkstraSubUtxowEvent era)
 
 instance
-  ( ConwayEraGov era
+  ( AlonzoEraTx era
+  , AlonzoEraUTxO era
+  , ConwayEraGov era
   , ConwayEraTxBody era
   , EraPlutusContext era
   , EraRule "SUBUTXO" era ~ DijkstraSUBUTXO era
   , EraRule "SUBUTXOW" era ~ DijkstraSUBUTXOW era
   , Embed (EraRule "SUBUTXO" era) (DijkstraSUBUTXOW era)
+  , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   ) =>
   STS (DijkstraSUBUTXOW era)
   where
@@ -173,14 +190,22 @@ instance
 
 dijkstraSubUtxowTransition ::
   forall era.
-  ( EraRule "SUBUTXO" era ~ DijkstraSUBUTXO era
+  ( AlonzoEraTx era
+  , AlonzoEraUTxO era
+  , EraRule "SUBUTXO" era ~ DijkstraSUBUTXO era
   , EraRule "SUBUTXOW" era ~ DijkstraSUBUTXOW era
   , Embed (EraRule "SUBUTXO" era) (DijkstraSUBUTXOW era)
+  , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
   ) =>
   TransitionRule (EraRule "SUBUTXOW" era)
 dijkstraSubUtxowTransition = do
-  TRC (env, state, signal) <- judgmentContext
-  trans @(EraRule "SUBUTXO" era) $ TRC (env, state, signal)
+  TRC (env, utxoState, tx) <- judgmentContext
+  let utxo = utxosUtxo utxoState
+
+  {- dataHashesNeeded ⊆ mapˢ hash dataProvided -}
+  runTest $ Alonzo.missingRequiredDatums utxo tx
+
+  trans @(EraRule "SUBUTXO" era) $ TRC (env, utxoState, tx)
 
 instance
   ( ConwayEraGov era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -37,7 +37,7 @@ import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Conway.Rules (
   ConwayUtxowPredFailure,
-  UtxoEnv,
+  UtxoEnv (..),
   alonzoToConwayUtxowPredFailure,
   shelleyToConwayUtxowPredFailure,
  )
@@ -55,7 +55,10 @@ import Cardano.Ledger.Keys (VKey)
 import Cardano.Ledger.Rules.ValidationMode
 import Cardano.Ledger.Shelley.LedgerState (UTxOState, utxosUtxo)
 import Cardano.Ledger.Shelley.Rules (ShelleyUtxowPredFailure)
-import qualified Cardano.Ledger.Shelley.Rules as Shelley (validateVerifiedWits)
+import qualified Cardano.Ledger.Shelley.Rules as Shelley (
+  validateNeededWitnesses,
+  validateVerifiedWits,
+ )
 import Cardano.Ledger.State (EraUTxO (..))
 import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData)
@@ -213,9 +216,10 @@ dijkstraSubUtxowTransition ::
   ) =>
   TransitionRule (EraRule "SUBUTXOW" era)
 dijkstraSubUtxowTransition = do
-  TRC (env, utxoState, tx) <- judgmentContext
+  TRC (env@(UtxoEnv _ _ certState), utxoState, tx) <- judgmentContext
   let utxo = utxosUtxo utxoState
       txBody = tx ^. bodyTxL
+      witsKeyHashes = keyHashWitnessesTxWits (tx ^. witsTxL)
 
   {- ∀[ (vk , σ) ∈ vKeySigs ] isSigned vk (txidBytes txId) σ -}
   runTestOnSignal $ Shelley.validateVerifiedWits tx
@@ -226,6 +230,9 @@ dijkstraSubUtxowTransition = do
 
   {- ∀[ s ∈ p1ScriptsNeeded ] validP1Script vKeyHashesProvided txVldt s -}
   runTest $ Babbage.validateFailedBabbageScripts tx scriptsProvided scriptHashesNeeded
+
+  {- vKeyHashesNeeded ⊆ vKeyHashesProvided -}
+  runTest $ Shelley.validateNeededWitnesses witsKeyHashes certState utxo txBody
 
   {- dataHashesNeeded ⊆ mapˢ hash dataProvided -}
   runTest $ Alonzo.missingRequiredDatums utxo tx

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -25,7 +25,8 @@ import Cardano.Crypto.Hash (ByteString)
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
 import Cardano.Ledger.Alonzo.Rules (AlonzoUtxowPredFailure)
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo (missingRequiredDatums)
-import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO)
+import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO (..))
+import qualified Cardano.Ledger.Babbage.Rules as Babbage (validateFailedBabbageScripts)
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (
   DecCBOR (..),
@@ -55,6 +56,7 @@ import Cardano.Ledger.Rules.ValidationMode
 import Cardano.Ledger.Shelley.LedgerState (UTxOState, utxosUtxo)
 import Cardano.Ledger.Shelley.Rules (ShelleyUtxowPredFailure)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley (validateVerifiedWits)
+import Cardano.Ledger.State (EraUTxO (..))
 import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended
@@ -62,6 +64,7 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.Set (Set)
 import Data.Set.NonEmpty (NonEmptySet)
 import GHC.Generics (Generic)
+import Lens.Micro
 import NoThunks.Class (
   InspectHeapNamed (..),
   NoThunks (..),
@@ -212,9 +215,17 @@ dijkstraSubUtxowTransition ::
 dijkstraSubUtxowTransition = do
   TRC (env, utxoState, tx) <- judgmentContext
   let utxo = utxosUtxo utxoState
+      txBody = tx ^. bodyTxL
 
   {- ∀[ (vk , σ) ∈ vKeySigs ] isSigned vk (txidBytes txId) σ -}
   runTestOnSignal $ Shelley.validateVerifiedWits tx
+
+  let scriptsNeeded = getScriptsNeeded utxo txBody
+      scriptsProvided = getScriptsProvided utxo tx
+      scriptHashesNeeded = getScriptsHashesNeeded scriptsNeeded
+
+  {- ∀[ s ∈ p1ScriptsNeeded ] validP1Script vKeyHashesProvided txVldt s -}
+  runTest $ Babbage.validateFailedBabbageScripts tx scriptsProvided scriptHashesNeeded
 
   {- dataHashesNeeded ⊆ mapˢ hash dataProvided -}
   runTest $ Alonzo.missingRequiredDatums utxo tx

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -38,6 +38,7 @@ import Cardano.Ledger.Conway.Rules (
   ConwayUtxowPredFailure,
   UtxoEnv,
   alonzoToConwayUtxowPredFailure,
+  shelleyToConwayUtxowPredFailure,
  )
 import Cardano.Ledger.Dijkstra.Era (
   DijkstraEra,
@@ -52,6 +53,8 @@ import Cardano.Ledger.Dijkstra.Rules.Utxow (
 import Cardano.Ledger.Keys (VKey)
 import Cardano.Ledger.Rules.ValidationMode
 import Cardano.Ledger.Shelley.LedgerState (UTxOState, utxosUtxo)
+import Cardano.Ledger.Shelley.Rules (ShelleyUtxowPredFailure)
+import qualified Cardano.Ledger.Shelley.Rules as Shelley (validateVerifiedWits)
 import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended
@@ -157,6 +160,12 @@ instance InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure DijkstraEra where
       . conwayToDijkstraUtxowPredFailure
       . alonzoToConwayUtxowPredFailure
 
+instance InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure DijkstraEra where
+  injectFailure =
+    dijkstraUtxowToDijkstraSubUtxowPredFailure
+      . conwayToDijkstraUtxowPredFailure
+      . shelleyToConwayUtxowPredFailure
+
 instance InjectRuleEvent "SUBUTXOW" DijkstraSubUtxowEvent DijkstraEra
 
 newtype DijkstraSubUtxowEvent era = SubUtxo (Event (EraRule "SUBUTXO" era))
@@ -176,6 +185,7 @@ instance
   , EraRule "SUBUTXOW" era ~ DijkstraSUBUTXOW era
   , Embed (EraRule "SUBUTXO" era) (DijkstraSUBUTXOW era)
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
+  , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
   ) =>
   STS (DijkstraSUBUTXOW era)
   where
@@ -196,11 +206,15 @@ dijkstraSubUtxowTransition ::
   , EraRule "SUBUTXOW" era ~ DijkstraSUBUTXOW era
   , Embed (EraRule "SUBUTXO" era) (DijkstraSUBUTXOW era)
   , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
+  , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
   ) =>
   TransitionRule (EraRule "SUBUTXOW" era)
 dijkstraSubUtxowTransition = do
   TRC (env, utxoState, tx) <- judgmentContext
   let utxo = utxosUtxo utxoState
+
+  {- ∀[ (vk , σ) ∈ vKeySigs ] isSigned vk (txidBytes txId) σ -}
+  runTestOnSignal $ Shelley.validateVerifiedWits tx
 
   {- dataHashesNeeded ⊆ mapˢ hash dataProvided -}
   runTest $ Alonzo.missingRequiredDatums utxo tx

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -56,6 +56,7 @@ import Cardano.Ledger.Rules.ValidationMode
 import Cardano.Ledger.Shelley.LedgerState (UTxOState, utxosUtxo)
 import Cardano.Ledger.Shelley.Rules (ShelleyUtxowPredFailure)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley (
+  validateMetadata,
   validateNeededWitnesses,
   validateVerifiedWits,
  )
@@ -216,7 +217,7 @@ dijkstraSubUtxowTransition ::
   ) =>
   TransitionRule (EraRule "SUBUTXOW" era)
 dijkstraSubUtxowTransition = do
-  TRC (env@(UtxoEnv _ _ certState), utxoState, tx) <- judgmentContext
+  TRC (env@(UtxoEnv _ pp certState), utxoState, tx) <- judgmentContext
   let utxo = utxosUtxo utxoState
       txBody = tx ^. bodyTxL
       witsKeyHashes = keyHashWitnessesTxWits (tx ^. witsTxL)
@@ -236,6 +237,9 @@ dijkstraSubUtxowTransition = do
 
   {- dataHashesNeeded ⊆ mapˢ hash dataProvided -}
   runTest $ Alonzo.missingRequiredDatums utxo tx
+
+  {- txADhash ≡ map hash txAuxData -}
+  runTestOnSignal $ Shelley.validateMetadata pp tx
 
   trans @(EraRule "SUBUTXO" era) $ TRC (env, utxoState, tx)
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -91,8 +91,6 @@ data DijkstraSubUtxowPredFailure era
     SubMissingVKeyWitnessesUTXOW
       -- | witnesses which were needed and not supplied
       (NonEmptySet (KeyHash Witness))
-  | -- | missing scripts
-    SubMissingScriptWitnessesUTXOW (NonEmptySet ScriptHash)
   | -- | failed scripts
     SubScriptWitnessNotValidatingUTXOW (NonEmptySet ScriptHash)
   | -- | hash of the full metadata
@@ -102,8 +100,6 @@ data DijkstraSubUtxowPredFailure era
   | SubConflictingMetadataHash (Mismatch RelEQ TxAuxDataHash)
   | -- | Contains out of range values (string`s too long)
     SubInvalidMetadata
-  | -- | extraneous scripts
-    SubExtraneousScriptWitnessesUTXOW (NonEmptySet ScriptHash)
   | SubMissingRedeemers (NonEmpty (PlutusPurpose AsItem era, ScriptHash))
   | SubMissingRequiredDatums
       -- | Set of missing data hashes
@@ -299,22 +295,20 @@ instance
       SubUtxoFailure x -> Sum SubUtxoFailure 0 !> To x
       SubInvalidWitnessesUTXOW xs -> Sum SubInvalidWitnessesUTXOW 1 !> To xs
       SubMissingVKeyWitnessesUTXOW xs -> Sum SubMissingVKeyWitnessesUTXOW 2 !> To xs
-      SubMissingScriptWitnessesUTXOW xs -> Sum SubMissingScriptWitnessesUTXOW 3 !> To xs
-      SubScriptWitnessNotValidatingUTXOW xs -> Sum SubScriptWitnessNotValidatingUTXOW 4 !> To xs
-      SubMissingTxBodyMetadataHash xs -> Sum SubMissingTxBodyMetadataHash 5 !> To xs
-      SubMissingTxMetadata xs -> Sum SubMissingTxMetadata 6 !> To xs
-      SubConflictingMetadataHash mm -> Sum SubConflictingMetadataHash 7 !> To mm
-      SubInvalidMetadata -> Sum SubInvalidMetadata 8
-      SubExtraneousScriptWitnessesUTXOW xs -> Sum SubExtraneousScriptWitnessesUTXOW 9 !> To xs
-      SubMissingRedeemers x -> Sum SubMissingRedeemers 10 !> To x
-      SubMissingRequiredDatums x y -> Sum SubMissingRequiredDatums 11 !> To x !> To y
-      SubNotAllowedSupplementalDatums x y -> Sum SubNotAllowedSupplementalDatums 12 !> To x !> To y
-      SubPPViewHashesDontMatch mm -> Sum SubPPViewHashesDontMatch 13 !> To mm
-      SubUnspendableUTxONoDatumHash x -> Sum SubUnspendableUTxONoDatumHash 14 !> To x
-      SubExtraRedeemers x -> Sum SubExtraRedeemers 15 !> To x
-      SubMalformedScriptWitnesses x -> Sum SubMalformedScriptWitnesses 16 !> To x
-      SubMalformedReferenceScripts x -> Sum SubMalformedReferenceScripts 17 !> To x
-      SubScriptIntegrityHashMismatch x y -> Sum SubScriptIntegrityHashMismatch 18 !> To x !> To y
+      SubScriptWitnessNotValidatingUTXOW xs -> Sum SubScriptWitnessNotValidatingUTXOW 3 !> To xs
+      SubMissingTxBodyMetadataHash xs -> Sum SubMissingTxBodyMetadataHash 4 !> To xs
+      SubMissingTxMetadata xs -> Sum SubMissingTxMetadata 5 !> To xs
+      SubConflictingMetadataHash mm -> Sum SubConflictingMetadataHash 6 !> To mm
+      SubInvalidMetadata -> Sum SubInvalidMetadata 7
+      SubMissingRedeemers x -> Sum SubMissingRedeemers 8 !> To x
+      SubMissingRequiredDatums x y -> Sum SubMissingRequiredDatums 9 !> To x !> To y
+      SubNotAllowedSupplementalDatums x y -> Sum SubNotAllowedSupplementalDatums 10 !> To x !> To y
+      SubPPViewHashesDontMatch mm -> Sum SubPPViewHashesDontMatch 11 !> To mm
+      SubUnspendableUTxONoDatumHash x -> Sum SubUnspendableUTxONoDatumHash 12 !> To x
+      SubExtraRedeemers x -> Sum SubExtraRedeemers 13 !> To x
+      SubMalformedScriptWitnesses x -> Sum SubMalformedScriptWitnesses 14 !> To x
+      SubMalformedReferenceScripts x -> Sum SubMalformedReferenceScripts 15 !> To x
+      SubScriptIntegrityHashMismatch x y -> Sum SubScriptIntegrityHashMismatch 16 !> To x !> To y
 
 instance
   ( ConwayEraScript era
@@ -326,22 +320,20 @@ instance
     0 -> SumD SubUtxoFailure <! From
     1 -> SumD SubInvalidWitnessesUTXOW <! From
     2 -> SumD SubMissingVKeyWitnessesUTXOW <! From
-    3 -> SumD SubMissingScriptWitnessesUTXOW <! From
-    4 -> SumD SubScriptWitnessNotValidatingUTXOW <! From
-    5 -> SumD SubMissingTxBodyMetadataHash <! From
-    6 -> SumD SubMissingTxMetadata <! From
-    7 -> SumD SubConflictingMetadataHash <! From
-    8 -> SumD SubInvalidMetadata
-    9 -> SumD SubExtraneousScriptWitnessesUTXOW <! From
-    10 -> SumD SubMissingRedeemers <! From
-    11 -> SumD SubMissingRequiredDatums <! From <! From
-    12 -> SumD SubNotAllowedSupplementalDatums <! From <! From
-    13 -> SumD SubPPViewHashesDontMatch <! From
-    14 -> SumD SubUnspendableUTxONoDatumHash <! From
-    15 -> SumD SubExtraRedeemers <! From
-    16 -> SumD SubMalformedScriptWitnesses <! From
-    17 -> SumD SubMalformedReferenceScripts <! From
-    18 -> SumD SubScriptIntegrityHashMismatch <! From <! From
+    3 -> SumD SubScriptWitnessNotValidatingUTXOW <! From
+    4 -> SumD SubMissingTxBodyMetadataHash <! From
+    5 -> SumD SubMissingTxMetadata <! From
+    6 -> SumD SubConflictingMetadataHash <! From
+    7 -> SumD SubInvalidMetadata
+    8 -> SumD SubMissingRedeemers <! From
+    9 -> SumD SubMissingRequiredDatums <! From <! From
+    10 -> SumD SubNotAllowedSupplementalDatums <! From <! From
+    11 -> SumD SubPPViewHashesDontMatch <! From
+    12 -> SumD SubUnspendableUTxONoDatumHash <! From
+    13 -> SumD SubExtraRedeemers <! From
+    14 -> SumD SubMalformedScriptWitnesses <! From
+    15 -> SumD SubMalformedReferenceScripts <! From
+    16 -> SumD SubScriptIntegrityHashMismatch <! From <! From
     n -> Invalid n
 
 dijkstraUtxowToDijkstraSubUtxowPredFailure ::
@@ -354,13 +346,13 @@ dijkstraUtxowToDijkstraSubUtxowPredFailure = \case
   UtxoFailure f -> SubUtxoFailure (injectFailure @"SUBUTXO" f)
   InvalidWitnessesUTXOW ks -> SubInvalidWitnessesUTXOW ks
   MissingVKeyWitnessesUTXOW ks -> SubMissingVKeyWitnessesUTXOW ks
-  MissingScriptWitnessesUTXOW hs -> SubMissingScriptWitnessesUTXOW hs
+  MissingScriptWitnessesUTXOW _ -> error "Impossible: `MissingScriptWitnessesUTXOW` for SUBUTXOW"
   ScriptWitnessNotValidatingUTXOW hs -> SubScriptWitnessNotValidatingUTXOW hs
   MissingTxBodyMetadataHash dh -> SubMissingTxBodyMetadataHash dh
   MissingTxMetadata dh -> SubMissingTxMetadata dh
   ConflictingMetadataHash mm -> SubConflictingMetadataHash mm
   InvalidMetadata -> SubInvalidMetadata
-  ExtraneousScriptWitnessesUTXOW hs -> SubExtraneousScriptWitnessesUTXOW hs
+  ExtraneousScriptWitnessesUTXOW _ -> error "Impossible: `ExtraneousScriptWitnessesUTXOW` for SUBUTXOW"
   MissingRedeemers pps -> SubMissingRedeemers pps
   MissingRequiredDatums hs1 hs2 -> SubMissingRequiredDatums hs1 hs2
   NotAllowedSupplementalDatums hs1 hs2 -> SubNotAllowedSupplementalDatums hs1 hs2

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
@@ -94,7 +94,7 @@ import NoThunks.Class (
 
 -- ================================
 
--- | Predicate failure type for the Conway Era
+-- | Predicate failure type for the Dijkstra Era
 data DijkstraUtxowPredFailure era
   = UtxoFailure (PredicateFailure (EraRule "UTXO" era))
   | InvalidWitnessesUTXOW (NonEmpty (VKey Witness))

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/LedgerSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/LedgerSpec.hs
@@ -26,7 +26,8 @@ import Test.Cardano.Ledger.Imp.Common
 
 spec :: forall era. DijkstraEraImp era => SpecWith (ImpInit (LedgerSpec era))
 spec = do
-  describe "Spending sub-transaction outputs" $ do
+  -- TODO: re-enable after Imp fixup of subtransactions is implemented
+  xdescribe "Spending sub-transaction outputs" $ do
     it "Fails when top-level transaction spends output from its own sub-transaction" $ do
       (_, addr) <- freshKeyAddr
       txIn <- sendCoinTo addr (Coin 10_000_000)


### PR DESCRIPTION
# Description

This PR solves the SUBUTXOW subtask from https://github.com/IntersectMBO/cardano-ledger/issues/5500.

It follows the [SUBUTXOW formal spec](https://intersectmbo.github.io/formal-ledger-specifications/site/Ledger.Dijkstra.Specification.Utxow.html#3596), and adds 3 checks that are atm missing from the spec, but present in the UTXOW of other eras:  script integrity hash check, exact redeemers, script well-formedness. 

It is based on the PR that implements SUBLEDGER:  https://github.com/IntersectMBO/cardano-ledger/pull/5544

The PR is perhaps overly-fragmented (each check in a new commit), but this is on purpose, in order to make it easy to remove the necessary injections and constraints required by the check, if necessary. 
We can squash the commits after review, to avoid cluttering the commit tree. 

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
