### PR TITLE
Adequate conformance to Version restriction

### DIFF
--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
@@ -169,6 +169,7 @@ hardForkSpec =
       it "Hardfork minorFollow" (secondHardForkFollows minorFollow)
       it "Hardfork majorFollow" (secondHardForkFollows majorFollow)
       it "Hardfork cantFollow" secondHardForkCantFollow
+      it "Hardfork cantFollow major" secondHardForkCantFollowMajor
 
 pparamUpdateSpec ::
   forall era.
@@ -1197,6 +1198,30 @@ secondHardForkCantFollow = do
               , mismatchExpected = nextProtVer
               }
       ]
+  genCantFollowCurrent >>= \case
+    Nothing ->
+      -- This is the end of the line. Next era is not even defined yet
+      pvMajor curProtVer `shouldBe` eraProtVerHigh @era
+    Just protVerMajorTooHigh -> do
+      mkProposal (HardForkInitiation (SJust (GovPurposeId gaid1)) protVerMajorTooHigh)
+        >>= flip
+          submitFailingProposal
+          [ injectFailure $
+              ProposalCantFollow (SJust (GovPurposeId gaid1)) $
+                Mismatch
+                  { mismatchSupplied = protVerMajorTooHigh
+                  , mismatchExpected = curProtVer
+                  }
+          ]
+
+secondHardForkCantFollowMajor ::
+  forall era.
+  (HasCallStack, ConwayEraImp era) =>
+  ImpTestM era ()
+secondHardForkCantFollowMajor = do
+  curProtVer <- getProtVer
+  let nextProtVer = majorFollow curProtVer
+  gaid1 <- mkProposal (HardForkInitiation SNothing nextProtVer) >>= submitProposal
   genCantFollowCurrent >>= \case
     Nothing ->
       -- This is the end of the line. Next era is not even defined yet


### PR DESCRIPTION
# Description

- Add a test to exhibit the conformance failure for recent changes in #5595
- ~Blocked by #5620~

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
