### PR TITLE
Update formal-ledger-spec and enable Utxos conformance tests

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
   subdir: hs
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `*-artifacts` BEFORE MERGE!
-  tag: 5ed76f93a6c71ef7450d540d5a3ca836b67e5253
+  tag: 6158038b8ee2574c04e164aa9bdfd4db4f505793
 
 source-repository-package
   type: git

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxosSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxosSpec.hs
@@ -63,7 +63,9 @@ spec = do
   conwayFeaturesPlutusV1V2FailureSpec
   describe "Spending script without a Datum" $ do
     forM_ ([minBound .. eraMaxLanguage @era] :: [Language]) $ \lang -> do
-      it (show lang) $ do
+      -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/1103
+      -- TODO: Re-enable after issue is resolved, by removing this override
+      disableInConformanceIt (show lang) $ do
         let scriptHash = withSLanguage lang (hashPlutusScript . evenRedeemerNoDatum)
             addr = Addr Testnet (ScriptHashObj scriptHash) StakeRefNull
         amount <- uniformRM (Coin 10_000_000, Coin 100_000_000)
@@ -457,7 +459,9 @@ govPolicySpec = do
         let govAction = TreasuryWithdrawals withdrawals (SJust alwaysSucceedsSh)
         mkProposal govAction >>= submitProposal_
 
-    it "alwaysFails Plutus govPolicy does not validate" $ whenPostBootstrap $ do
+    -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/1091
+    -- TODO: Re-enable after issue is resolved, by removing this override
+    disableInConformanceIt "alwaysFails Plutus govPolicy does not validate" $ whenPostBootstrap $ do
       let alwaysFailsSh = hashPlutusScript (alwaysFailsNoDatum SPlutusV3)
       committeeMembers' <- registerInitialCommittee
       (dRep, _, _) <- setupSingleDRep 1_000_000
@@ -485,7 +489,9 @@ costModelsSpec =
   -- These tests rely on the script in the constitution, but we can only change the constitution after bootstrap.
   -- So we cannot run these tests during bootstrap
   describe "PlutusV3 Initialization" $ do
-    it "Updating CostModels with alwaysFails govPolicy does not validate" $ whenPostBootstrap $ do
+    -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/1104
+    -- TODO: Re-enable after issue is resolved, by removing this override
+    disableInConformanceIt "Updating CostModels with alwaysFails govPolicy does not validate" $ whenPostBootstrap $ do
       -- no initial PlutusV3 CostModels
       modifyPParams $ ppCostModelsL .~ testingCostModels [PlutusV1 .. PlutusV2]
 
@@ -533,7 +539,9 @@ costModelsSpec =
 
         submitFailingGovAction govAction [injectFailure $ CollectErrors [NoCostModel PlutusV3]]
 
-    it "Updating CostModels and setting the govPolicy afterwards succeeds" $ whenPostBootstrap $ do
+    -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/1104
+    -- TODO: Re-enable after issue is resolved, by removing this override
+    disableInConformanceIt "Updating CostModels and setting the govPolicy afterwards succeeds" $ whenPostBootstrap $ do
       modifyPParams $ ppCostModelsL .~ testingCostModels [PlutusV1 .. PlutusV2]
 
       committeeMembers' <- registerInitialCommittee

--- a/flake.lock
+++ b/flake.lock
@@ -204,11 +204,11 @@
     "formal-ledger-specifications": {
       "flake": false,
       "locked": {
-        "lastModified": 1771861769,
-        "narHash": "sha256-TFqWQ7/VykbS62qc4+5MzMRpblelcohVCnBbkAO5BMw=",
+        "lastModified": 1773729185,
+        "narHash": "sha256-8erTBXhv+m6kbDLTtt6oouniB97T2ZW2Ui2QAqwTxGQ=",
         "owner": "IntersectMBO",
         "repo": "formal-ledger-specifications",
-        "rev": "5ed76f93a6c71ef7450d540d5a3ca836b67e5253",
+        "rev": "6158038b8ee2574c04e164aa9bdfd4db4f505793",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
@@ -57,3 +57,5 @@ externalFunctions = Agda.MkExternalFunctions {..}
             . fromMaybe
               (error "Failed to decode the signature")
             $ signatureFromInteger sig
+
+    extValidPlutusScript = True

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
@@ -47,7 +47,6 @@ import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
   SpecTRC (..),
   runFromAgdaFunction,
  )
-import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Utxow ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway ()
 import Test.Cardano.Ledger.Constrained.Conway (UtxoExecContext (..))
 import Test.Cardano.Ledger.Conway.Arbitrary ()

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
@@ -38,8 +38,13 @@ import qualified Data.Text as T
 import GHC.Generics (Generic)
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Common (NFData, ToExpr)
-import Test.Cardano.Ledger.Conformance (
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base (
+  externalFunctions,
+ )
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Utxow ()
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
   ExecSpecRule (..),
+  SpecTRC (..),
   runFromAgdaFunction,
  )
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Utxow ()
@@ -102,7 +107,9 @@ instance
 instance ExecSpecRule "LEDGER" ConwayEra where
   type ExecContext "LEDGER" ConwayEra = ConwayLedgerExecContext ConwayEra
 
-  runAgdaRule = runFromAgdaFunction Agda.ledgerStep
+  runAgdaRule trc =
+    let externalFunctions' = externalFunctions {Agda.extValidPlutusScript = Agda.isValid (strcSignal trc)}
+     in runFromAgdaFunction (Agda.ledgerStep externalFunctions') trc
 
   extraInfo globals ConwayLedgerExecContext {..} (TRC (LedgerEnv {..}, LedgerState {..}, sig)) _ =
     extraInfo @"UTXOW" @ConwayEra

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledgers.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledgers.hs
@@ -11,7 +11,10 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Ledgers () where
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Governance (EnactState)
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
-import Test.Cardano.Ledger.Conformance (
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base (
+  externalFunctions,
+ )
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
   ExecSpecRule (..),
   runFromAgdaFunction,
  )
@@ -21,4 +24,4 @@ import Test.Cardano.Ledger.Conway.ImpTest ()
 instance ExecSpecRule "LEDGERS" ConwayEra where
   type ExecContext "LEDGERS" ConwayEra = EnactState ConwayEra
 
-  runAgdaRule = runFromAgdaFunction Agda.ledgersStep
+  runAgdaRule = runFromAgdaFunction (Agda.ledgersStep externalFunctions)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -10,7 +10,7 @@ module Test.Cardano.Ledger.Conformance.Orphans where
 import Cardano.Ledger.Hashes (standardAddrHashSize)
 import Data.Bifunctor (Bifunctor (..))
 import Data.Default (Default)
-import Data.List (nub, sort, sortOn)
+import Data.List (nub, sortOn)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -29,6 +29,8 @@ deriving instance Ord DepositPurpose
 deriving instance Ord Tag
 
 deriving instance Ord HSLanguage
+
+deriving instance Ord LanguageCostModels
 
 deriving instance Ord Credential
 
@@ -71,6 +73,8 @@ instance NFData Timelock
 instance NFData HSTimelock
 
 instance NFData HSLanguage
+
+instance NFData LanguageCostModels
 
 instance NFData HSPlutusScript
 
@@ -222,6 +226,8 @@ instance ToExpr HSTimelock
 
 instance ToExpr HSLanguage
 
+instance ToExpr LanguageCostModels
+
 instance ToExpr HSPlutusScript
 
 instance ToExpr TxBody
@@ -326,8 +332,8 @@ instance SpecNormalize Timelock
 
 instance SpecNormalize HSTimelock
 
-instance {-# OVERLAPPING #-} SpecNormalize Agda.LanguageCostModels where
-  specNormalize l = sort l
+instance SpecNormalize Agda.LanguageCostModels where
+  specNormalize = MkLanguageCostModels . sortOn fst . lcmLanguageCostModels
 
 instance SpecNormalize HSLanguage
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -10,7 +10,7 @@ module Test.Cardano.Ledger.Conformance.Orphans where
 import Cardano.Ledger.Hashes (standardAddrHashSize)
 import Data.Bifunctor (Bifunctor (..))
 import Data.Default (Default)
-import Data.List (nub, sortOn)
+import Data.List (nub, sort, sortOn)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -27,6 +27,8 @@ deriving instance Generic HsRewardUpdate
 deriving instance Ord DepositPurpose
 
 deriving instance Ord Tag
+
+deriving instance Ord HSLanguage
 
 deriving instance Ord Credential
 
@@ -67,6 +69,8 @@ instance NFData BootstrapAddr
 instance NFData Timelock
 
 instance NFData HSTimelock
+
+instance NFData HSLanguage
 
 instance NFData HSPlutusScript
 
@@ -216,6 +220,8 @@ instance ToExpr Timelock
 
 instance ToExpr HSTimelock
 
+instance ToExpr HSLanguage
+
 instance ToExpr HSPlutusScript
 
 instance ToExpr TxBody
@@ -319,6 +325,11 @@ instance SpecNormalize BootstrapAddr
 instance SpecNormalize Timelock
 
 instance SpecNormalize HSTimelock
+
+instance {-# OVERLAPPING #-} SpecNormalize Agda.LanguageCostModels where
+  specNormalize l = sort l
+
+instance SpecNormalize HSLanguage
 
 instance SpecNormalize HSPlutusScript
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -31,7 +31,7 @@ import Cardano.Ledger.Allegra.Scripts (
  )
 import Cardano.Ledger.Alonzo (AlonzoTxAuxData, MaryValue)
 import Cardano.Ledger.Alonzo.PParams (OrdExUnits (OrdExUnits))
-import Cardano.Ledger.Alonzo.Scripts (AlonzoPlutusPurpose (..))
+import Cardano.Ledger.Alonzo.Scripts (AlonzoPlutusPurpose (..), plutusScriptLanguage)
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), Redeemers (..), TxDats (..), unTxDats)
 import Cardano.Ledger.Babbage.TxOut (BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes
@@ -121,6 +121,7 @@ instance
     Agda.MkHSPlutusScript
       <$> toSpecRep (hashScript $ PlutusScript ps)
       <*> pure (fromIntegral $ originalBytesSize ps)
+      <*> toSpecRep (plutusScriptLanguage ps)
 
 instance
   ( AlonzoEraScript era

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -59,9 +60,10 @@ import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import Cardano.Ledger.Keys (VKey (..))
 import Cardano.Ledger.Keys.WitVKey (WitVKey (..))
-import Cardano.Ledger.Plutus.CostModels (CostModels)
+import Cardano.Ledger.Plutus.CostModels (CostModels, costModelsValid)
 import Cardano.Ledger.Plutus.Data (BinaryData, Data, Datum (..), hashBinaryData)
 import Cardano.Ledger.Plutus.ExUnits (ExUnits (..), Prices)
+import Cardano.Ledger.Plutus.Language (Language (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import Control.Monad (forM)
 import Control.Monad.Except (throwError)
@@ -155,10 +157,22 @@ instance SpecTranslate ctx ProtVer where
 
   toSpecRep (ProtVer ver minor) = pure (getVersion ver, toInteger minor)
 
-instance SpecTranslate ctx CostModels where
-  type SpecRep CostModels = [((), ())]
+instance SpecTranslate ctx Language where
+  type SpecRep Language = Agda.HSLanguage
 
-  toSpecRep _ = pure [((), ())]
+  toSpecRep l = case l of
+    PlutusV1 -> return Agda.PV1
+    PlutusV2 -> return Agda.PV2
+    PlutusV3 -> return Agda.PV3
+    PlutusV4 -> error "PlutusV4 not supported"
+
+instance SpecTranslate ctx CostModels where
+  type SpecRep CostModels = [(Agda.HSLanguage, ())]
+
+  toSpecRep cm =
+    -- filter out PlutusV4 language
+    let validCostModels = filter ((/= PlutusV4) . fst) $ Map.toList (costModelsValid cm)
+     in mapM (\(l, _) -> (,()) <$> toSpecRep l) validCostModels
 
 instance SpecTranslate ctx Prices where
   type SpecRep Prices = ()

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
@@ -167,12 +167,12 @@ instance SpecTranslate ctx Language where
     PlutusV4 -> error "PlutusV4 not supported"
 
 instance SpecTranslate ctx CostModels where
-  type SpecRep CostModels = [(Agda.HSLanguage, ())]
+  type SpecRep CostModels = Agda.LanguageCostModels
 
   toSpecRep cm =
     -- filter out PlutusV4 language
     let validCostModels = filter ((/= PlutusV4) . fst) $ Map.toList (costModelsValid cm)
-     in mapM (\(l, _) -> (,()) <$> toSpecRep l) validCostModels
+     in Agda.MkLanguageCostModels <$> mapM (\(l, _) -> (,()) <$> toSpecRep l) validCostModels
 
 instance SpecTranslate ctx Prices where
   type SpecRep Prices = ()

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Conway.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Conway.hs
@@ -48,6 +48,6 @@ spec = do
             describe "RATIFY" Ratify.spec
             describe "UTXO" Utxo.spec
             describe "UTXOW" Utxow.spec
-            xdescribe "UTXOS" Utxos.spec
+            describe "UTXOS" Utxos.spec
   describe "Imp (only spec)" $ do
     RatifySpec.spec


### PR DESCRIPTION
# Description

In addition it updates `cardano-ledger-conformance` to "execute" phase-2 scripts by using the tx validity flag as result.

~Blocked by https://github.com/IntersectMBO/formal-ledger-specifications/pull/1106.~
~Blocked by https://github.com/IntersectMBO/formal-ledger-specifications/pull/1107.~

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
