### PR TITLE
Remove redundant UTXO predicate failures

### DIFF
--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `SubLedgerEnv` and `SubUtxowEnv`
 * Remove `OutputTooSmallUTxO` constructor from `DijkstraUtxoPredFailure`
+* Remove `SubOutputTooSmallUTxO` constructor from `DijkstraSubUtxoPredFailure`
 
 ## 0.2.0.0
 

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for cardano-ledger-dijkstra
 
-## 0.2.1.0
+## 0.3.0.0
 
 * Add `SubLedgerEnv` and `SubUtxowEnv`
+* Remove `OutputTooSmallUTxO` constructor from `DijkstraUtxoPredFailure`
 
 ## 0.2.0.0
 

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-dijkstra
-version: 0.2.1.0
+version: 0.3.0.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
@@ -71,8 +71,6 @@ data DijkstraSubUtxoPredFailure era
       Network
       -- | the set of reward addresses with incorrect network IDs
       (NonEmptySet AccountAddress)
-  | -- | list of supplied transaction outputs that are too small
-    SubOutputTooSmallUTxO (NonEmpty (TxOut era))
   | -- | list of supplied bad transaction outputs
     SubOutputBootAddrAttrsTooBig (NonEmpty (TxOut era))
   | -- | list of supplied bad transaction output triples (actualSize,PParameterMaxValue,TxOut)
@@ -183,12 +181,11 @@ instance
       SubInputSetEmptyUTxO -> Sum SubInputSetEmptyUTxO 3
       SubWrongNetwork right wrongs -> Sum (SubWrongNetwork @era) 4 !> To right !> To wrongs
       SubWrongNetworkWithdrawal right wrongs -> Sum (SubWrongNetworkWithdrawal @era) 5 !> To right !> To wrongs
-      SubOutputTooSmallUTxO outs -> Sum (SubOutputTooSmallUTxO @era) 6 !> To outs
-      SubOutputBootAddrAttrsTooBig outs -> Sum (SubOutputBootAddrAttrsTooBig @era) 7 !> To outs
-      SubOutputTooBigUTxO outs -> Sum (SubOutputTooBigUTxO @era) 8 !> To outs
-      SubWrongNetworkInTxBody mm -> Sum SubWrongNetworkInTxBody 9 !> To mm
-      SubOutsideForecast a -> Sum SubOutsideForecast 10 !> To a
-      SubBabbageOutputTooSmallUTxO x -> Sum SubBabbageOutputTooSmallUTxO 11 !> To x
+      SubOutputBootAddrAttrsTooBig outs -> Sum (SubOutputBootAddrAttrsTooBig @era) 6 !> To outs
+      SubOutputTooBigUTxO outs -> Sum (SubOutputTooBigUTxO @era) 7 !> To outs
+      SubWrongNetworkInTxBody mm -> Sum SubWrongNetworkInTxBody 8 !> To mm
+      SubOutsideForecast a -> Sum SubOutsideForecast 9 !> To a
+      SubBabbageOutputTooSmallUTxO x -> Sum SubBabbageOutputTooSmallUTxO 10 !> To x
 
 instance
   ( Era era
@@ -205,12 +202,11 @@ instance
     3 -> SumD SubInputSetEmptyUTxO
     4 -> SumD SubWrongNetwork <! From <! From
     5 -> SumD SubWrongNetworkWithdrawal <! From <! From
-    6 -> SumD SubOutputTooSmallUTxO <! From
-    7 -> SumD SubOutputBootAddrAttrsTooBig <! From
-    8 -> SumD SubOutputTooBigUTxO <! From
-    9 -> SumD SubWrongNetworkInTxBody <! From
-    10 -> SumD SubOutsideForecast <! From
-    11 -> SumD SubBabbageOutputTooSmallUTxO <! From
+    6 -> SumD SubOutputBootAddrAttrsTooBig <! From
+    7 -> SumD SubOutputTooBigUTxO <! From
+    8 -> SumD SubWrongNetworkInTxBody <! From
+    9 -> SumD SubOutsideForecast <! From
+    10 -> SumD SubBabbageOutputTooSmallUTxO <! From
     n -> Invalid n
 
 dijkstraUtxoToDijkstraSubUtxoPredFailure ::
@@ -225,7 +221,6 @@ dijkstraUtxoToDijkstraSubUtxoPredFailure = \case
   ValueNotConservedUTxO _ -> error "Impossible: `ValueNotConservedUTxO` for SUBUTXO"
   WrongNetwork x y -> SubWrongNetwork x y
   WrongNetworkWithdrawal x y -> SubWrongNetworkWithdrawal x y
-  OutputTooSmallUTxO x -> SubOutputTooSmallUTxO x
   OutputBootAddrAttrsTooBig xs -> SubOutputBootAddrAttrsTooBig xs
   OutputTooBigUTxO xs -> SubOutputTooBigUTxO xs
   InsufficientCollateral _ _ -> error "Impossible: `InsufficientCollateral` for SUBUTXO"

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -130,8 +130,6 @@ data DijkstraUtxoPredFailure era
       Network
       -- | the set of reward addresses with incorrect network IDs
       (NonEmptySet AccountAddress)
-  | -- | list of supplied transaction outputs that are too small
-    OutputTooSmallUTxO (NonEmpty (TxOut era))
   | -- | list of supplied bad transaction outputs
     OutputBootAddrAttrsTooBig (NonEmpty (TxOut era))
   | -- | list of supplied bad transaction output triples (actualSize,PParameterMaxValue,TxOut)
@@ -361,21 +359,20 @@ instance
       ValueNotConservedUTxO mm -> Sum (ValueNotConservedUTxO @era) 6 !> To mm
       WrongNetwork right wrongs -> Sum (WrongNetwork @era) 7 !> To right !> To wrongs
       WrongNetworkWithdrawal right wrongs -> Sum (WrongNetworkWithdrawal @era) 8 !> To right !> To wrongs
-      OutputTooSmallUTxO outs -> Sum (OutputTooSmallUTxO @era) 9 !> To outs
-      OutputBootAddrAttrsTooBig outs -> Sum (OutputBootAddrAttrsTooBig @era) 10 !> To outs
-      OutputTooBigUTxO outs -> Sum (OutputTooBigUTxO @era) 11 !> To outs
-      InsufficientCollateral a b -> Sum InsufficientCollateral 12 !> To a !> To b
-      ScriptsNotPaidUTxO a -> Sum ScriptsNotPaidUTxO 13 !> To a
-      ExUnitsTooBigUTxO mm -> Sum ExUnitsTooBigUTxO 14 !> To mm
-      CollateralContainsNonADA a -> Sum CollateralContainsNonADA 15 !> To a
-      WrongNetworkInTxBody mm -> Sum WrongNetworkInTxBody 16 !> To mm
-      OutsideForecast a -> Sum OutsideForecast 17 !> To a
-      TooManyCollateralInputs mm -> Sum TooManyCollateralInputs 18 !> To mm
-      NoCollateralInputs -> Sum NoCollateralInputs 19
-      IncorrectTotalCollateralField c1 c2 -> Sum IncorrectTotalCollateralField 20 !> To c1 !> To c2
-      BabbageOutputTooSmallUTxO x -> Sum BabbageOutputTooSmallUTxO 21 !> To x
-      BabbageNonDisjointRefInputs x -> Sum BabbageNonDisjointRefInputs 22 !> To x
-      PtrPresentInCollateralReturn x -> Sum PtrPresentInCollateralReturn 23 !> To x
+      OutputBootAddrAttrsTooBig outs -> Sum (OutputBootAddrAttrsTooBig @era) 9 !> To outs
+      OutputTooBigUTxO outs -> Sum (OutputTooBigUTxO @era) 10 !> To outs
+      InsufficientCollateral a b -> Sum InsufficientCollateral 11 !> To a !> To b
+      ScriptsNotPaidUTxO a -> Sum ScriptsNotPaidUTxO 12 !> To a
+      ExUnitsTooBigUTxO mm -> Sum ExUnitsTooBigUTxO 13 !> To mm
+      CollateralContainsNonADA a -> Sum CollateralContainsNonADA 14 !> To a
+      WrongNetworkInTxBody mm -> Sum WrongNetworkInTxBody 15 !> To mm
+      OutsideForecast a -> Sum OutsideForecast 16 !> To a
+      TooManyCollateralInputs mm -> Sum TooManyCollateralInputs 17 !> To mm
+      NoCollateralInputs -> Sum NoCollateralInputs 18
+      IncorrectTotalCollateralField c1 c2 -> Sum IncorrectTotalCollateralField 19 !> To c1 !> To c2
+      BabbageOutputTooSmallUTxO x -> Sum BabbageOutputTooSmallUTxO 20 !> To x
+      BabbageNonDisjointRefInputs x -> Sum BabbageNonDisjointRefInputs 21 !> To x
+      PtrPresentInCollateralReturn x -> Sum PtrPresentInCollateralReturn 22 !> To x
 
 instance
   ( Era era
@@ -396,21 +393,20 @@ instance
     6 -> SumD ValueNotConservedUTxO <! From
     7 -> SumD WrongNetwork <! From <! From
     8 -> SumD WrongNetworkWithdrawal <! From <! From
-    9 -> SumD OutputTooSmallUTxO <! From
-    10 -> SumD OutputBootAddrAttrsTooBig <! From
-    11 -> SumD OutputTooBigUTxO <! From
-    12 -> SumD InsufficientCollateral <! From <! From
-    13 -> SumD ScriptsNotPaidUTxO <! From
-    14 -> SumD ExUnitsTooBigUTxO <! From
-    15 -> SumD CollateralContainsNonADA <! From
-    16 -> SumD WrongNetworkInTxBody <! From
-    17 -> SumD OutsideForecast <! From
-    18 -> SumD TooManyCollateralInputs <! From
-    19 -> SumD NoCollateralInputs
-    20 -> SumD IncorrectTotalCollateralField <! From <! From
-    21 -> SumD BabbageOutputTooSmallUTxO <! From
-    22 -> SumD BabbageNonDisjointRefInputs <! From
-    23 -> SumD PtrPresentInCollateralReturn <! From
+    9 -> SumD OutputBootAddrAttrsTooBig <! From
+    10 -> SumD OutputTooBigUTxO <! From
+    11 -> SumD InsufficientCollateral <! From <! From
+    12 -> SumD ScriptsNotPaidUTxO <! From
+    13 -> SumD ExUnitsTooBigUTxO <! From
+    14 -> SumD CollateralContainsNonADA <! From
+    15 -> SumD WrongNetworkInTxBody <! From
+    16 -> SumD OutsideForecast <! From
+    17 -> SumD TooManyCollateralInputs <! From
+    18 -> SumD NoCollateralInputs
+    19 -> SumD IncorrectTotalCollateralField <! From <! From
+    20 -> SumD BabbageOutputTooSmallUTxO <! From
+    21 -> SumD BabbageNonDisjointRefInputs <! From
+    22 -> SumD PtrPresentInCollateralReturn <! From
     n -> Invalid n
 
 -- =====================================================
@@ -429,7 +425,7 @@ conwayToDijkstraUtxoPredFailure = \case
   Conway.ValueNotConservedUTxO m -> ValueNotConservedUTxO m
   Conway.WrongNetwork x y -> WrongNetwork x y
   Conway.WrongNetworkWithdrawal x y -> WrongNetworkWithdrawal x y
-  Conway.OutputTooSmallUTxO x -> OutputTooSmallUTxO x
+  Conway.OutputTooSmallUTxO _ -> error "Impossible: `OutputTooSmallUTxO` for DijkstraUTXO"
   Conway.UtxosFailure x -> UtxosFailure x
   Conway.OutputBootAddrAttrsTooBig xs -> OutputBootAddrAttrsTooBig xs
   Conway.OutputTooBigUTxO xs -> OutputTooBigUTxO xs


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

When we defined `DijkstraUtxoPredFailure`, we copied from Conway  definition both `OutputTooSmallUTxO` and `BabbageOutputTooSmallUTxO`.  Only the latter gets produced from checks, so the former is redundant. This PR removes it.
Same mistake was made in SUBUTXO, and this PR corrects that as well.

This predicate failure is redundant in Conway too, but we'll keep it there until Dijkstra era, to avoid breaking clients.  

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
