### PR TITLE
Implement custom `ToExpr` instance for `Mismatch` datatype.

### DIFF
--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -6,6 +6,10 @@
   - Moved to `cardano-base:Cardano.Base.IP`
 * Remove `ToCBOR` and `FromCBOR` instances for `Nonce`
 
+### `testlib`
+
+* Modify `ToExpr` instance for `Mismatch` to display type-level `r` parameter using `Typeable`
+
 ## 1.19.0.0
 
 * In `SnapShot`, subsume `ssDelegations` into `ssActiveStake`.

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -34,11 +35,12 @@ import Cardano.Ledger.Plutus.TxInfo
 import Cardano.Ledger.State
 import Cardano.Ledger.TxIn
 import Data.Functor.Identity
-import Data.TreeDiff.OMap
+import qualified Data.TreeDiff.OMap as OMap
 import GHC.TypeLits
 import Test.Cardano.Data.TreeDiff ()
 import Test.Cardano.Ledger.Binary.TreeDiff
 import Test.Data.VMap.TreeDiff ()
+import Type.Reflection (Typeable, typeRep)
 
 -- Coin
 instance ToExpr Coin
@@ -60,7 +62,7 @@ instance ToExpr (NoUpdate a)
 -- Keys
 instance ToExpr (VKey r) where
   toExpr vk =
-    Rec "VKey" $ fromList [("VKey (hashOf)", toExpr $ hashKey vk)]
+    Rec "VKey" $ OMap.fromList [("VKey (hashOf)", toExpr $ hashKey vk)]
 
 instance ToExpr GenDelegs
 
@@ -152,7 +154,14 @@ instance ToExpr ProtVer
 
 instance ToExpr Anchor
 
-instance ToExpr a => ToExpr (Mismatch r a)
+instance (Typeable r, ToExpr a) => ToExpr (Mismatch r a) where
+  toExpr (Mismatch supplied expected) =
+    Rec
+      ("Mismatch (" <> show (typeRep @r) <> ")")
+      $ OMap.fromList
+        [ ("supplied", toExpr supplied)
+        , ("expected", toExpr expected)
+        ]
 
 instance ToExpr EpochInterval
 


### PR DESCRIPTION
Fix #5616.

# Description

The `Show` instance for Mismatch was modified to show type level information. The same thing needs to be done for the `TreeDiff` instance.

Example output:

    ```
    ghci> toExpr (Mismatch @RelEQ (42 :: Int) 100)
    Rec "Mismatch (RelEQ)" (fromList [("supplied",App "42" []),("expected",App "100" [])])
    ```

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
