### PR TITLE
Normalize `StakeRefPtr` addresses better and improve UTxO decoding

### DIFF
--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
@@ -46,6 +46,7 @@ import Cardano.Ledger.Address (
   CompactAddr,
   compactAddr,
   decompactAddr,
+  fromCborBackwardsBothAddr,
   fromCborBothAddr,
  )
 import Cardano.Ledger.Alonzo (AlonzoEra)
@@ -528,7 +529,7 @@ instance
       peekTokenType >>= \case
         TypeBytes -> decodeMemPack
         TypeBytesIndef -> decodeMemPack
-        _ -> decCBOR
+        _ -> decodeBabbageTxOut fromCborBackwardsBothAddr
     pure $! internBabbageTxOut (interns credsInterns) txOut
   {-# INLINEABLE decShareCBOR #-}
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
@@ -458,14 +458,21 @@ fromCborCompactAddr = snd <$> fromCborBothAddr
 -- that it was encoded as.
 fromCborBothAddr :: Decoder s (Addr, CompactAddr)
 fromCborBothAddr = do
-  ifDecoderVersionAtLeast
-    (natVersion @7)
-    ( ifDecoderVersionAtLeast
-        (natVersion @9)
-        (fromCborRigorousBothAddr False)
-        (fromCborRigorousBothAddr True)
-    )
-    fromCborBackwardsBothAddr
+  (addr, cAddr) <-
+    ifDecoderVersionAtLeast
+      (natVersion @7)
+      ( ifDecoderVersionAtLeast
+          (natVersion @9)
+          (fromCborRigorousBothAddr False)
+          (fromCborRigorousBothAddr True)
+      )
+      fromCborBackwardsBothAddr
+  let
+    -- `addr` will have been normalized if it's a `Ptr`, so we need to make `cAddr` match it
+    cAddrNormalized = case addr of
+      Addr _ _ (StakeRefPtr _) -> compactAddr addr
+      _ -> cAddr
+  pure (addr, cAddrNormalized)
 {-# INLINE fromCborBothAddr #-}
 
 -- | Starting with Babbage we no longer allow addresses with garbage in them.

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/UTxO.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/UTxO.hs
@@ -92,10 +92,13 @@ instance CanSetUTxO UTxO where
 newtype UTxO era = UTxO {unUTxO :: Map.Map TxIn (TxOut era)}
   deriving (Default, Generic, Semigroup)
 
-instance (EncCBOR (TxOut era), Era era) => ToCBOR (UTxO era) where
+instance (Era era, EncCBOR (TxOut era)) => ToCBOR (UTxO era) where
   toCBOR = toEraCBOR @era
 
-instance (DecCBOR (TxOut era), Era era) => FromCBOR (UTxO era) where
+instance
+  (Era era, DecShareCBOR (TxOut era), Share (TxOut era) ~ Interns (Credential Staking)) =>
+  FromCBOR (UTxO era)
+  where
   fromCBOR = fromEraCBOR @era
 
 deriving instance NoThunks (TxOut era) => NoThunks (UTxO era)
@@ -108,7 +111,11 @@ deriving newtype instance Era era => Monoid (UTxO era)
 
 deriving newtype instance (Era era, EncCBOR (TxOut era)) => EncCBOR (UTxO era)
 
-deriving newtype instance (Era era, DecCBOR (TxOut era)) => DecCBOR (UTxO era)
+instance
+  (Era era, DecShareCBOR (TxOut era), Share (TxOut era) ~ Interns (Credential Staking)) =>
+  DecCBOR (UTxO era)
+  where
+  decCBOR = decNoShareCBOR
 
 instance
   ( DecShareCBOR (TxOut era)


### PR DESCRIPTION
# Description

These changes affect the decoding of UTxO queries in `cardano-cli` (and only that)

*  **Ensure compact addresses match their normalized addresses**

   Without this, some garbage pointers sneak through in pre-Alonzo eras
   because `CompactAddr` is the form that's stored in the UTxO and the
   expanded form isn't stored permanently.

* **Make `DecShareCBOR BabbageTxOut` lenient and `decCBOR = decNoShareCBOR` for UTxO**

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
