### PR TITLE
Make `ContextError` constructors from Alonzo to Dijkstra era lazy

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Remove `NoThunks` instance for `AlonzoContextError`
 * Remove `NoThunks (ContextError era)` constraint from `EraPlutusContext` class
 * Remove `NoThunks` deriving instance for `CollectError`
+* Make `AlonzoContextError` constructors lazy
 
 ### `testlib`
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
@@ -180,8 +180,8 @@ instance EraPlutusContext AlonzoEra where
   mkPlutusWithContext (AlonzoPlutusV1 p) = toPlutusWithContext (Left p)
 
 data AlonzoContextError era
-  = TranslationLogicMissingInput !TxIn
-  | TimeTranslationPastHorizon !Text
+  = TranslationLogicMissingInput TxIn
+  | TimeTranslationPastHorizon Text
   deriving (Eq, Show, Generic)
 
 instance Era era => NFData (AlonzoContextError era)

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -16,6 +16,7 @@
   - `BabbageUtxoPredFailure`
   - `BabbageUtxowPredFailure`
 * Remove `NoThunks` instance for `BabbageContextError`
+* Make `BabbageContextError` constructors lazy
 
 ## 1.13.0.0
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
@@ -246,12 +246,12 @@ instance EraPlutusContext BabbageEra where
     BabbagePlutusV2 p -> toPlutusWithContext $ Left p
 
 data BabbageContextError era
-  = AlonzoContextError !(AlonzoContextError era)
-  | ByronTxOutInContext !TxOutSource
-  | RedeemerPointerPointsToNothing !(PlutusPurpose AsIx era)
-  | InlineDatumsNotSupported !TxOutSource
-  | ReferenceScriptsNotSupported !TxOutSource
-  | ReferenceInputsNotSupported !(Set.Set TxIn)
+  = AlonzoContextError (AlonzoContextError era)
+  | ByronTxOutInContext TxOutSource
+  | RedeemerPointerPointsToNothing (PlutusPurpose AsIx era)
+  | InlineDatumsNotSupported TxOutSource
+  | ReferenceScriptsNotSupported TxOutSource
+  | ReferenceInputsNotSupported (Set.Set TxIn)
   deriving (Generic)
 
 deriving instance

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -28,6 +28,7 @@
   - `ConwayUtxosPredFailure`
   - `ConwayUtxowPredFailure`
 * Remove `NoThunks` instance for `ConwayContextError`
+* Make `ConwayContextError` constructors lazy
 
 ## 1.21.0.0
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
@@ -170,14 +170,14 @@ instance EraPlutusContext ConwayEra where
     ConwayPlutusV3 p -> toPlutusWithContext $ Left p
 
 data ConwayContextError era
-  = BabbageContextError !(BabbageContextError era)
-  | CertificateNotSupported !(TxCert era)
-  | PlutusPurposeNotSupported !(PlutusPurpose AsItem era)
-  | CurrentTreasuryFieldNotSupported !Coin
-  | VotingProceduresFieldNotSupported !(VotingProcedures era)
-  | ProposalProceduresFieldNotSupported !(OSet.OSet (ProposalProcedure era))
-  | TreasuryDonationFieldNotSupported !Coin
-  | ReferenceInputsNotDisjointFromInputs !(NonEmpty TxIn)
+  = BabbageContextError (BabbageContextError era)
+  | CertificateNotSupported (TxCert era)
+  | PlutusPurposeNotSupported (PlutusPurpose AsItem era)
+  | CurrentTreasuryFieldNotSupported Coin
+  | VotingProceduresFieldNotSupported (VotingProcedures era)
+  | ProposalProceduresFieldNotSupported (OSet.OSet (ProposalProcedure era))
+  | TreasuryDonationFieldNotSupported Coin
+  | ReferenceInputsNotDisjointFromInputs (NonEmpty TxIn)
   deriving (Generic)
 
 deriving instance

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -32,6 +32,7 @@
   - `DijkstraUtxoPredFailure`
   - `DijkstraUtxowPredFailure`
 * Remove `NoThunks` instance for `DijkstraContextError`
+* Make `DijkstraContextError` constructors lazy
 
 ## 0.2.0.0
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
@@ -86,10 +86,10 @@ import qualified PlutusLedgerApi.V2 as PV2
 import qualified PlutusLedgerApi.V3 as PV3
 
 data DijkstraContextError era
-  = ConwayContextError !(ConwayContextError era)
-  | PointerPresentInOutput !(NonEmpty (TxOut era))
+  = ConwayContextError (ConwayContextError era)
+  | PointerPresentInOutput (NonEmpty (TxOut era))
   | -- | Attempt to use PlutusV1-V3 in a sub-transaction will result in this failure
-    SubTxIsNotSupported !TxId
+    SubTxIsNotSupported TxId
   deriving (Generic)
 
 deriving instance


### PR DESCRIPTION
# Description

Since `ContextError`s are never stored and their reporting doesn't need to be efficient (we always optimize for the positive case with valid transactions, as invalid transactions don't propagate through the network), there's no need for strictness annotations on the error constructors.

This change removes the bang patterns (!) from:
- AlonzoContextError
- BabbageContextError
- ConwayContextError
- DijkstraContextError

Closes #5644 

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
