### PR TITLE
Use Data.Vector.Strict helpers in VMap map and mapWithKey

### DIFF
--- a/libs/vector-map/src/Data/VMap.hs
+++ b/libs/vector-map/src/Data/VMap.hs
@@ -61,10 +61,10 @@ import Data.Maybe as Maybe hiding (mapMaybe)
 import qualified Data.Set as Set
 import Data.VMap.KVVector (KVVector (..))
 import qualified Data.VMap.KVVector as KV
-import qualified Data.Vector as V
 import qualified Data.Vector.Generic as VG
 import qualified Data.Vector.Primitive as VP
 import qualified Data.Vector.Storable as VS
+import qualified Data.Vector.Strict as V
 import qualified Data.Vector.Unboxed as VU
 import qualified GHC.Exts as Exts
 import GHC.Generics (Generic)
@@ -232,14 +232,11 @@ fromDistinctAscListN n = VMap . KV.fromDistinctAscListN n
 {-# INLINE fromDistinctAscListN #-}
 
 map ::
-  (VG.Vector kv k, VG.Vector vv a, VG.Vector vv b) =>
+  (VG.Vector vv a, VG.Vector vv b) =>
   (a -> b) ->
   VMap kv vv k a ->
   VMap kv vv k b
-map f (VMap vec) = VMap (VG.map (\(k, v) -> let v' = f v in v' `seq` (k, v')) vec)
--- TODO: benchmark and switch to this implementation when we switch to Data.Vector.Strict
--- VMap (KV.mapValsKVVector f vec)
---
+map f (VMap vec) = VMap (KV.mapValsKVVector f vec)
 -- This is marked as NOINLINE because there is some strange issue in `vector`, likely due to stream
 -- fusion, that prevents elements from being forced. This needs further investigation, but for now
 -- we can get away with NOINLINE. FTR. `Data.Vector.Strict` is also susceptible to this problem.
@@ -266,10 +263,10 @@ mapWithKey ::
   (k -> a -> b) ->
   VMap kv vv k a ->
   VMap kv vv k b
-mapWithKey f (VMap vec) = VMap (VG.map (\(k, v) -> (k, f k v)) vec)
--- TODO: benchmark and switch to this implementation when we switch to Data.Vector.Strict
--- VMap (KV.mapWithKeyKVVector f vec)
-{-# INLINE mapWithKey #-}
+mapWithKey f (VMap vec) = VMap (KV.mapWithKeyKVVector f vec)
+-- Keep NOINLINE for now, mirroring `map`, until strictness/benchmark behavior
+-- is re-validated for the helper-based implementation.
+{-# NOINLINE mapWithKey #-}
 
 foldMapWithKey ::
   (VG.Vector kv k, VG.Vector vv v, Monoid m) =>

--- a/libs/vector-map/src/Data/VMap/KVVector.hs
+++ b/libs/vector-map/src/Data/VMap/KVVector.hs
@@ -26,8 +26,8 @@ module Data.VMap.KVVector (
   fromDistinctAscListN,
   fromList,
   fromListN,
-  -- mapValsKVVector,
-  -- mapWithKeyKVVector,
+  mapValsKVVector,
+  mapWithKeyKVVector,
   memberKVVector,
   lookupKVVector,
   lookupDefaultKVVector,
@@ -181,28 +181,29 @@ fromAscListWithKeyN n f xs
       VG.create $ VGM.unsafeNew n >>= fillWithList xs >>= removeDuplicates (\k v1 v2 -> f k v2 v1)
 {-# INLINE fromAscListWithKeyN #-}
 
--- These guys are too lazy for the KVVector and would require `Data.Vector.Strict`
---
--- mapValsKVVector ::
---   (VG.Vector vv a, VG.Vector vv b) =>
---   (a -> b) ->
---   KVVector kv vv (k, a) ->
---   KVVector kv vv (k, b)
--- mapValsKVVector f vec =
---   KVVector {keysVector = keysVector vec, valsVector = VG.map f (valsVector vec)}
--- {-# INLINE mapValsKVVector #-}
+mapValsKVVector ::
+  (VG.Vector vv a, VG.Vector vv b) =>
+  (a -> b) ->
+  KVVector kv vv (k, a) ->
+  KVVector kv vv (k, b)
+mapValsKVVector f vec =
+  KVVector
+    { keysVector = keysVector vec
+    , valsVector = VG.map f (valsVector vec)
+    }
+{-# NOINLINE mapValsKVVector #-}
 
--- mapWithKeyKVVector ::
---   (VG.Vector kv k, VG.Vector vv a, VG.Vector vv b) =>
---   (k -> a -> b) ->
---   KVVector kv vv (k, a) ->
---   KVVector kv vv (k, b)
--- mapWithKeyKVVector f KVVector {..} =
---   KVVector
---     { keysVector = keysVector
---     , valsVector = VG.imap (\i -> f (keysVector VG.! i)) valsVector
---     }
--- {-# INLINE mapWithKeyKVVector #-}
+mapWithKeyKVVector ::
+  (VG.Vector kv k, VG.Vector vv a, VG.Vector vv b) =>
+  (k -> a -> b) ->
+  KVVector kv vv (k, a) ->
+  KVVector kv vv (k, b)
+mapWithKeyKVVector f KVVector {..} =
+  KVVector
+    { keysVector = keysVector
+    , valsVector = VG.imap (\i -> f (keysVector VG.! i)) valsVector
+    }
+{-# NOINLINE mapWithKeyKVVector #-}
 
 internKVVectorMaybe :: (VG.Vector kv k, Ord k) => k -> KVVector kv vv (k, v) -> Maybe k
 internKVVectorMaybe key (KVVector keys _values) =

--- a/libs/vector-map/test/Test/VMap.hs
+++ b/libs/vector-map/test/Test/VMap.hs
@@ -78,6 +78,16 @@ vMapTests =
         evaluate vmapKeyThunk `shouldThrow` (== ThunkException)
         evaluate vmapValueThunk `shouldThrow` (== ThunkException)
     describe "asMap" $ do
+      prop "map" $ \xs f ->
+        prop_AsMapFrom
+          (\m -> VMap.map (applyFun f) (VMap.fromMap m))
+          (Map.map (applyFun f) :: MapT -> MapT)
+          (Map.fromList xs)
+      prop "mapWithKey" $ \xs f ->
+        prop_AsMapFrom
+          (\m -> VMap.mapWithKey (applyFun2 f) (VMap.fromMap m))
+          (Map.mapWithKey (applyFun2 f) :: MapT -> MapT)
+          (Map.fromList xs)
       prop "mapMaybeWithKey" $ \xs f ->
         prop_AsMapFrom
           (\m -> VMap.mapMaybeWithKey (applyFun2 f) (VMap.fromMap m))


### PR DESCRIPTION
# Description

Fixes #5551

* switches `VMap` boxed storage to `Data.Vector.Strict`
* restores the commented-out `mapValsKVVector` and `mapWithKeyKVVector` in `Data.VMap.KVVector`
* uses those helpers in `Data.VMap.map` and `Data.VMap.mapWithKey`
* adds `asMap` tests for `map` and `mapWithKey`

I kept `NOINLINE` for `map`, and also used `NOINLINE` for `mapWithKey`, because the module already mentions
a known strictness/stream-fusion hazard, so this seemed like the safer choice here.

This turned out to be a pretty small follow-up, since most of the intended code
was already there in comments.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
