### PR TITLE
Remove unused FromCBOR/ToCBOR instances

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Remove `ToCBOR` and `FromCBOR` instances for `AlonzoExtraConfig` and `AlonzoTxOut`
 * Add `ApplyTick` instance for `AlonzoEra`
 * Add `mkPlutusTxInfoFromResult` and `toPlutusTxInfoForPurpose` helpers
 * Make `PlutusPurpose` injective in the selector type.

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Genesis.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Genesis.hs
@@ -95,16 +95,10 @@ instance DecCBOR AlonzoExtraConfig where
   decCBOR = decode (RecD AlonzoExtraConfig <! D (decodeNullMaybe decodeCostModelsLenient))
   {-# INLINE decCBOR #-}
 
-instance EncCBOR AlonzoExtraConfig
-
-instance FromCBOR AlonzoExtraConfig where
-  fromCBOR = fromEraCBOR @AlonzoEra
-  {-# INLINE fromCBOR #-}
-
-instance ToCBOR AlonzoExtraConfig where
-  toCBOR x@(AlonzoExtraConfig _) =
+instance EncCBOR AlonzoExtraConfig where
+  encCBOR x@(AlonzoExtraConfig _) =
     let AlonzoExtraConfig {..} = x
-     in toEraCBOR @AlonzoEra . encode $
+     in encode $
           Rec AlonzoExtraConfig
             !> E (encodeNullMaybe encCBOR) aecCostModels
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxOut.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxOut.hs
@@ -57,9 +57,7 @@ import Cardano.Ledger.Binary (
   DecShareCBOR (Share, decShareCBOR),
   DecoderError (DecoderErrorCustom),
   EncCBOR (encCBOR),
-  FromCBOR (..),
   Interns,
-  ToCBOR (..),
   TokenType (..),
   cborError,
   decodeBreakOr,
@@ -434,14 +432,6 @@ internAlonzoTxOut internCred = \case
     TxOut_AddrHash28_AdaOnly_DataHash32 (internCred cred) addr28Extra ada dataHash32
   txOut -> txOut
 {-# INLINE internAlonzoTxOut #-}
-
-instance (Era era, Val (Value era)) => ToCBOR (AlonzoTxOut era) where
-  toCBOR = toEraCBOR @era
-  {-# INLINE toCBOR #-}
-
-instance (Era era, Val (Value era)) => FromCBOR (AlonzoTxOut era) where
-  fromCBOR = fromEraCBOR @era
-  {-# INLINE fromCBOR #-}
 
 instance (Era era, Val (Value era)) => ToJSON (AlonzoTxOut era) where
   toJSON (AlonzoTxOut addr v dataHash) =

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -81,6 +81,7 @@ import Cardano.Ledger.Binary (
   decodeMapLenOrIndef,
   decodeMapLikeEnforceNoDuplicates,
   decodeNonEmptyList,
+  decodeNonEmptySetLikeEnforceNoDuplicates,
   decodeNonEmptySetLikeEnforceNoDuplicatesAnn,
   encodeFoldableEncoder,
   encodeListLen,
@@ -607,42 +608,38 @@ instance
         txWitnessField
         []
     where
-      addrWitsSetDecoder ::
-        (Ord a, DecCBOR (Annotator a), DecCBOR a) => Decoder s (Annotator (Set a))
+      addrWitsSetDecoder :: (Ord a, DecCBOR a) => Decoder s (Set a)
       addrWitsSetDecoder = do
         let
           nonEmptyDecoder = do
             allowTag setTag
-            s <- Set.fromList . NE.toList <$> decodeNonEmptyList decCBOR
-            pure $ pure s
+            Set.fromList . NE.toList <$> decodeNonEmptyList decCBOR
 
           nonEmptyNoDuplicatesDecoder =
-            decodeNonEmptySetLikeEnforceNoDuplicatesAnn
-              Set.insert
-              (\s -> (Set.size s, s))
+            decodeNonEmptySetLikeEnforceNoDuplicates Set.insert (\s -> (Set.size s, s)) decCBOR
 
         ifDecoderVersionAtLeast (natVersion @12) nonEmptyNoDuplicatesDecoder nonEmptyDecoder
       {-# INLINE addrWitsSetDecoder #-}
 
       txWitnessField :: Word -> Field (Annotator (AlonzoTxWitsRaw era))
       txWitnessField 0 =
-        fieldAA
+        fieldA
           (\x wits -> wits {atwrAddrTxWits = x})
           ( D $
               ifDecoderVersionAtLeast
                 (natVersion @9)
                 addrWitsSetDecoder
-                (mapTraverseableDecoderA (decodeList decCBOR) Set.fromList)
+                (Set.fromList <$> decodeList decCBOR)
           )
       txWitnessField 1 = fieldAA addScriptsTxWitsRaw (D nativeScriptsDecoder)
       txWitnessField 2 =
-        fieldAA
+        fieldA
           (\x wits -> wits {atwrBootAddrTxWits = x})
           ( D $
               ifDecoderVersionAtLeast
                 (natVersion @9)
                 addrWitsSetDecoder
-                (mapTraverseableDecoderA (decodeList decCBOR) Set.fromList)
+                (Set.fromList <$> decodeList decCBOR)
           )
       txWitnessField 3 = fieldA addScriptsTxWitsRaw (decodeAlonzoPlutusScript SPlutusV1)
       txWitnessField 4 = fieldAA (\x wits -> wits {atwrDatsTxWits = x}) From

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.14.0.0
 
+* Remove `ToCBOR` and `FromCBOR` instances for `BabbageTxOut`
 * Add `ApplyTick` instance for `BabbageEra`
 * `BabbageTxInfoResult` changed its content type to `PlutusTxInfoResult`
 * Deprecate the use of `GetLedgerView`:

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
@@ -80,10 +80,8 @@ import Cardano.Ledger.Binary (
   DecoderError (..),
   EncCBOR (..),
   Encoding,
-  FromCBOR (..),
   Interns,
   Sized (..),
-  ToCBOR (..),
   TokenType (..),
   cborError,
   decodeBreakOr,
@@ -495,14 +493,6 @@ pattern TxOutCompactDH addr vl dh <-
       | otherwise = TxOutCompactDH' cAddr cVal dh
 
 {-# COMPLETE TxOutCompact, TxOutCompactDH #-}
-
-instance (EraScript era, Val (Value era)) => ToCBOR (BabbageTxOut era) where
-  toCBOR = toEraCBOR @era
-  {-# INLINE toCBOR #-}
-
-instance (EraScript era, Val (Value era)) => FromCBOR (BabbageTxOut era) where
-  fromCBOR = fromEraCBOR @era
-  {-# INLINE fromCBOR #-}
 
 instance (EraScript era, Val (Value era)) => EncCBOR (BabbageTxOut era) where
   encCBOR = \case

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.23.0.0
 
+* Remove `ToCBOR` and `FromCBOR` instances for `PulsingSnapshot`, `EnactState`, `ConwayGovPredFailure`
 * Add `validateRefScriptSize`, `updateDormantDRepExpiries`, `updateVotingDRepExpiries`
 * Add `ApplyTick` instance for `ConwayEra`
 * Add `ConwayUtxosEnv`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/DRepPulser.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/DRepPulser.hs
@@ -49,9 +49,7 @@ import Cardano.Ledger.Binary (
   DecCBOR (..),
   DecShareCBOR (..),
   EncCBOR (..),
-  FromCBOR (..),
   Interns,
-  ToCBOR (..),
   decNoShareCBOR,
   decodeMap,
   decodeStrictSeq,
@@ -173,12 +171,6 @@ instance EraPParams era => DecShareCBOR (PulsingSnapshot era) where
 
 instance EraPParams era => DecCBOR (PulsingSnapshot era) where
   decCBOR = decNoShareCBOR
-
-instance EraPParams era => ToCBOR (PulsingSnapshot era) where
-  toCBOR = toEraCBOR @era
-
-instance EraPParams era => FromCBOR (PulsingSnapshot era) where
-  fromCBOR = fromEraCBOR @era
 
 -- | We iterate over a pulse-sized chunk of the Accounts.
 --

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Internal.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Internal.hs
@@ -72,9 +72,7 @@ import Cardano.Ledger.Binary (
   DecCBOR (..),
   DecShareCBOR (..),
   EncCBOR (..),
-  FromCBOR (..),
   Interns,
-  ToCBOR (..),
   decNoShareCBOR,
   decodeMap,
   decodeSeq,
@@ -239,12 +237,6 @@ instance EraPParams era => EncCBOR (EnactState era) where
         !> To ensTreasury
         !> To ensWithdrawals
         !> To ensPrevGovActionIds
-
-instance EraPParams era => ToCBOR (EnactState era) where
-  toCBOR = toEraCBOR @era
-
-instance EraPParams era => FromCBOR (EnactState era) where
-  fromCBOR = fromEraCBOR @era
 
 instance EraPParams era => NFData (EnactState era)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -51,8 +51,6 @@ import Cardano.Ledger.BaseTypes (
 import Cardano.Ledger.Binary (
   DecCBOR (..),
   EncCBOR (..),
-  FromCBOR (..),
-  ToCBOR (..),
   internMap,
   internSet,
  )
@@ -298,12 +296,6 @@ instance EraPParams era => EncCBOR (ConwayGovPredFailure era) where
         Sum TreasuryWithdrawalReturnAccountsDoNotExist 17 !> To accounts
       UnelectedCommitteeVoters committee ->
         Sum UnelectedCommitteeVoters 18 !> To committee
-
-instance EraPParams era => ToCBOR (ConwayGovPredFailure era) where
-  toCBOR = toEraCBOR @era
-
-instance EraPParams era => FromCBOR (ConwayGovPredFailure era) where
-  fromCBOR = fromEraCBOR @era
 
 data ConwayGovEvent era
   = GovNewProposals !TxId !(Proposals era)

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0.0
 
+* Remove `ToCBOR` and `FromCBOR` instances for `DijkstraGovPredFailure`
 * Add `getDijkstraScriptsProvided`
 * Add `MissingRequiredGuards` constructor to `DijkstraUtxowPredFailure`
 * Add `DijkstraUtxoEnv` and use it as `Environemnt` in `STS` instance of `UTXOW`

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Gov.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Gov.hs
@@ -36,8 +36,6 @@ import Cardano.Ledger.BaseTypes (
 import Cardano.Ledger.Binary (
   DecCBOR (..),
   EncCBOR (..),
-  FromCBOR (..),
-  ToCBOR (..),
  )
 import Cardano.Ledger.Binary.Coders (
   Decode (..),
@@ -204,12 +202,6 @@ instance EraPParams era => EncCBOR (DijkstraGovPredFailure era) where
         Sum TreasuryWithdrawalReturnAccountsDoNotExist 17 !> To accounts
       UnelectedCommitteeVoters committee ->
         Sum UnelectedCommitteeVoters 18 !> To committee
-
-instance EraPParams era => ToCBOR (DijkstraGovPredFailure era) where
-  toCBOR = toEraCBOR @era
-
-instance EraPParams era => FromCBOR (DijkstraGovPredFailure era) where
-  fromCBOR = fromEraCBOR @era
 
 instance
   ( ConwayEraTxCert era

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Golden.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Golden.hs
@@ -15,7 +15,13 @@ import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusTxInfo, SupportedLanguage 
 import Cardano.Ledger.Alonzo.Scripts (plutusScriptBinary)
 import Cardano.Ledger.Alonzo.TxWits (Redeemers)
 import Cardano.Ledger.BaseTypes (Version)
-import Cardano.Ledger.Binary (Annotator, DecoderError (..), DeserialiseFailure (..), Tokens (..))
+import Cardano.Ledger.Binary (
+  Annotator,
+  DecoderError (..),
+  DeserialiseFailure (..),
+  Tokens (..),
+  shelleyProtVer,
+ )
 import qualified Cardano.Ledger.Binary as Binary
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Dijkstra.Core
@@ -64,11 +70,11 @@ goldenEmptyFields version =
           (DeserialiseFailure n msg)
     describe "Untagged" $ do
       it "addrTxWits" . expectFailureOnTxWitsEmptyField @era version 0 $
-        decoderFailure 4 "Empty list found, expected non-empty"
+        decoderFailure 4 "Expected a non-empty set, but got an empty set"
       it "nativeScripts" . expectFailureOnTxWitsEmptyField @era version 1 $
         decoderFailure 4 "Empty list found, expected non-empty"
       it "bootstrapWitness" . expectFailureOnTxWitsEmptyField @era version 2 $
-        decoderFailure 4 "Empty list found, expected non-empty"
+        decoderFailure 4 "Expected a non-empty set, but got an empty set"
       it "plutusV1Script" . expectFailureOnTxWitsEmptyField @era version 3 $
         decoderFailure 4 "Empty list of scripts is not allowed"
       it "plutusData" . expectFailureOnTxWitsEmptyField @era version 4 $
@@ -81,11 +87,11 @@ goldenEmptyFields version =
         decoderFailure 4 "Empty list of scripts is not allowed"
     describe "Tagged" $ do
       it "addrTxWits" . expectFailureOnTxWitsEmptyFieldWithTag @era version 0 $
-        decoderFailure 7 "Empty list found, expected non-empty"
+        decoderFailure 7 "Expected a non-empty set, but got an empty set"
       it "nativeScripts" . expectFailureOnTxWitsEmptyFieldWithTag @era version 1 $
         decoderFailure 7 "Empty list found, expected non-empty"
       it "bootstrapWitness" . expectFailureOnTxWitsEmptyFieldWithTag @era version 2 $
-        decoderFailure 7 "Empty list found, expected non-empty"
+        decoderFailure 7 "Expected a non-empty set, but got an empty set"
       it "plutusV1Script" . expectFailureOnTxWitsEmptyFieldWithTag @era version 3 $
         decoderFailure 7 "Empty list of scripts is not allowed"
       it "plutusData" . expectFailureOnTxWitsEmptyFieldWithTag @era version 4 $
@@ -104,8 +110,8 @@ witsDuplicateVKeyWits =
     , Em
         [ E $ TkTag 258
         , E $ TkListLen 2
-        , E vkeywit
-        , E vkeywit
+        , Ev shelleyProtVer vkeywit
+        , Ev shelleyProtVer vkeywit
         ]
     ]
   where
@@ -181,7 +187,13 @@ goldenDuplicateVKeyWitsDisallowed version =
     expectDecoderFailureAnn @(TxWits era)
       version
       witsDuplicateVKeyWits
-      (DecoderErrorCustom "Annotator" "Duplicates found, expected no duplicates")
+      ( DecoderErrorDeserialiseFailure
+          (Binary.label $ Proxy @(Annotator (TxWits era)))
+          ( DeserialiseFailure
+              208
+              "Final number of elements: 1 does not match the total count that was decoded: 2"
+          )
+      )
 
 goldenDuplicateNativeScriptsDisallowed :: forall era. DijkstraEraTest era => Version -> Spec
 goldenDuplicateNativeScriptsDisallowed version =

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Allegra/Translation.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Allegra/Translation.hs
@@ -9,7 +9,7 @@ module Test.Cardano.Ledger.Allegra.Translation (
 ) where
 
 import Cardano.Ledger.Allegra (AllegraEra)
-import Cardano.Ledger.Binary
+import Cardano.Ledger.Binary (EncCBOR)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Genesis (NoGenesis (..))
 import Cardano.Ledger.Shelley (ShelleyEra)
@@ -18,7 +18,7 @@ import Test.Cardano.Ledger.Binary.RoundTrip
 import Test.Cardano.Ledger.Mary.Binary.Annotator ()
 import Test.Cardano.Ledger.Shelley.Generator.ShelleyEraGen ()
 import Test.Cardano.Ledger.Shelley.Serialisation.Generators ()
-import Test.Cardano.Ledger.TranslationTools (translateEraEncCBOR, translateEraEncoding)
+import Test.Cardano.Ledger.TranslationTools (translateEraEncCBOR)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion)
 import Test.Tasty.QuickCheck (testProperty)
@@ -48,22 +48,15 @@ allegraTranslationTests :: TestTree
 allegraTranslationTests =
   testGroup
     "Allegra translation binary compatibiliby tests"
-    [ testProperty "Tx compatibility" $
-        translateEraEncoding @AllegraEra @(Tx TopTx) NoGenesis toCBOR toCBOR
+    [ testProperty "Tx compatibility" (testTranslation @(Tx TopTx))
     , testProperty "ProposedPPUpdates compatibility" (testTranslation @S.ProposedPPUpdates)
-    , testProperty "ShelleyGovState compatibility" $
-        translateEraEncoding @AllegraEra @S.ShelleyGovState NoGenesis toCBOR toCBOR
+    , testProperty "ShelleyGovState compatibility" (testTranslation @S.ShelleyGovState)
     , testProperty "TxOut compatibility" (testTranslation @S.ShelleyTxOut)
-    , testProperty "UTxO compatibility" $
-        translateEraEncoding @AllegraEra @S.UTxO NoGenesis toCBOR toCBOR
-    , testProperty "UTxOState compatibility" $
-        translateEraEncoding @AllegraEra @S.UTxOState NoGenesis toCBOR toCBOR
-    , testProperty "LedgerState compatibility" $
-        translateEraEncoding @AllegraEra @S.LedgerState NoGenesis toCBOR toCBOR
-    , testProperty "EpochState compatibility" $
-        translateEraEncoding @AllegraEra @S.EpochState NoGenesis toCBOR toCBOR
-    , testProperty "ShelleyTxWits compatibility" $
-        translateEraEncoding @AllegraEra @S.ShelleyTxWits NoGenesis toCBOR toCBOR
+    , testProperty "UTxO compatibility" (testTranslation @S.UTxO)
+    , testProperty "UTxOState compatibility" (testTranslation @S.UTxOState)
+    , testProperty "LedgerState compatibility" (testTranslation @S.LedgerState)
+    , testProperty "EpochState compatibility" (testTranslation @S.EpochState)
+    , testProperty "ShelleyTxWits compatibility" (testTranslation @S.ShelleyTxWits)
     , testProperty "Update compatibility" (testTranslation @S.Update)
     ]
 

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Translation.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Translation.hs
@@ -9,7 +9,7 @@ module Test.Cardano.Ledger.Mary.Translation (
 ) where
 
 import Cardano.Ledger.Allegra (AllegraEra)
-import Cardano.Ledger.Binary
+import Cardano.Ledger.Binary (EncCBOR)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Genesis (NoGenesis (..))
 import Cardano.Ledger.Mary (MaryEra)
@@ -22,7 +22,7 @@ import Test.Cardano.Ledger.Shelley.Generator.ShelleyEraGen ()
 import Test.Cardano.Ledger.Shelley.Serialisation.EraIndepGenerators ()
 import Test.Cardano.Ledger.Shelley.Serialisation.Generators ()
 import Test.Cardano.Ledger.ShelleyMA.Serialisation.Generators ()
-import Test.Cardano.Ledger.TranslationTools (translateEraEncCBOR, translateEraEncoding)
+import Test.Cardano.Ledger.TranslationTools (translateEraEncCBOR)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion)
 import Test.Tasty.QuickCheck (testProperty)
@@ -52,22 +52,15 @@ maryTranslationTests :: TestTree
 maryTranslationTests =
   testGroup
     "Mary translation binary compatibiliby tests"
-    [ testProperty "Tx compatibility" $
-        translateEraEncoding @MaryEra @(Tx TopTx) NoGenesis toCBOR toCBOR
+    [ testProperty "Tx compatibility" (test @(Tx TopTx))
     , testProperty "ProposedPPUpdates compatibility" (test @S.ProposedPPUpdates)
-    , testProperty "ShelleyGovState compatibility" $
-        translateEraEncoding @MaryEra @S.ShelleyGovState NoGenesis toCBOR toCBOR
+    , testProperty "ShelleyGovState compatibility" (test @S.ShelleyGovState)
     , testProperty "TxOut compatibility" (test @S.ShelleyTxOut)
-    , testProperty "UTxO compatibility" $
-        translateEraEncoding @MaryEra @S.UTxO NoGenesis toCBOR toCBOR
-    , testProperty "UTxOState compatibility" $
-        translateEraEncoding @MaryEra @S.UTxOState NoGenesis toCBOR toCBOR
-    , testProperty "LedgerState compatibility" $
-        translateEraEncoding @MaryEra @S.LedgerState NoGenesis toCBOR toCBOR
-    , testProperty "EpochState compatibility" $
-        translateEraEncoding @MaryEra @S.EpochState NoGenesis toCBOR toCBOR
-    , testProperty "ShelleyTxWits compatibility" $
-        translateEraEncoding @MaryEra @S.ShelleyTxWits NoGenesis toCBOR toCBOR
+    , testProperty "UTxO compatibility" (test @S.UTxO)
+    , testProperty "UTxOState compatibility" (test @S.UTxOState)
+    , testProperty "LedgerState compatibility" (test @S.LedgerState)
+    , testProperty "EpochState compatibility" (test @S.EpochState)
+    , testProperty "ShelleyTxWits compatibility" (test @S.ShelleyTxWits)
     , testProperty "Update compatibility" (test @S.Update)
     ]
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Remove `ToCBOR` and `FromCBOR` instances for `UTxOState`, `LedgerState`, `ShelleyTxOut`
 * Add `ApplyTick` typeclass with `applyTick` method, extracted from `ApplyBlock`.
 * Remove `validMetadata` from `SoftForks`
 * Add `updateUTxOStateNoFees`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
@@ -283,12 +283,6 @@ instance (EraTxOut era, EraGov era, EraStake era) => DecShareCBOR (UTxOState era
       utxosDonation <- decCBOR
       pure UTxOState {..}
 
-instance (EraTxOut era, EraGov era, EraStake era) => ToCBOR (UTxOState era) where
-  toCBOR = toEraCBOR @era
-
-instance (EraTxOut era, EraGov era, EraStake era) => FromCBOR (UTxOState era) where
-  fromCBOR = fromEraShareCBOR @era
-
 deriving via
   KeyValuePairs (UTxOState era)
   instance
@@ -534,12 +528,6 @@ instance
       lsCertState <- decSharePlusCBOR
       lsUTxOState <- decSharePlusCBOR
       pure LedgerState {lsUTxOState, lsCertState}
-
-instance (EraTxOut era, EraGov era, EraStake era, EraCertState era) => ToCBOR (LedgerState era) where
-  toCBOR = toEraCBOR @era
-
-instance (EraTxOut era, EraGov era, EraStake era, EraCertState era) => FromCBOR (LedgerState era) where
-  fromCBOR = fromEraShareCBOR @era
 
 deriving via
   KeyValuePairs (LedgerState era)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxOut.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxOut.hs
@@ -31,9 +31,7 @@ import Cardano.Ledger.Binary (
   DecCBOR (..),
   DecShareCBOR (..),
   EncCBOR (..),
-  FromCBOR (..),
   Interns (..),
-  ToCBOR (..),
   TokenType (..),
   decodeMemPack,
   decodeRecordNamed,
@@ -174,12 +172,6 @@ instance
       TypeBytes -> decodeMemPack
       TypeBytesIndef -> decodeMemPack
       _ -> decCBOR
-
-instance (Era era, EncCBOR (CompactForm (Value era))) => ToCBOR (ShelleyTxOut era) where
-  toCBOR = toEraCBOR @era
-
-instance (Era era, DecCBOR (CompactForm (Value era))) => FromCBOR (ShelleyTxOut era) where
-  fromCBOR = fromEraCBOR @era
 
 deriving via
   KeyValuePairs (ShelleyTxOut era)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
@@ -232,9 +232,9 @@ instance
       emptyWitnessSet = ShelleyTxWitsRaw mempty mempty mempty
       witField :: Word -> Field (Annotator (ShelleyTxWitsRaw era))
       witField 0 =
-        fieldAA
+        fieldA
           (\x wits -> wits {stwrAddrTxWits = x})
-          (D $ mapTraverseableDecoderA (decodeList decCBOR) Set.fromList)
+          (D $ Set.fromList <$> decodeList decCBOR)
       witField 1 =
         fieldAA
           (\x wits -> wits {stwrScriptTxWits = x})
@@ -244,9 +244,9 @@ instance
                 (Map.fromElems (hashScript @era))
           )
       witField 2 =
-        fieldAA
+        fieldA
           (\x wits -> wits {stwrBootAddrTxWits = x})
-          (D $ mapTraverseableDecoderA (decodeList decCBOR) Set.fromList)
+          (D $ Set.fromList <$> decodeList decCBOR)
       witField n = fieldAA (\(_ :: Void) wits -> wits) (Invalid n)
 
 mapTraverseableDecoderA ::

--- a/eras/shelley/impl/test/Test/Cardano/Ledger/Shelley/Binary/CddlSpec.hs
+++ b/eras/shelley/impl/test/Test/Cardano/Ledger/Shelley/Binary/CddlSpec.hs
@@ -36,7 +36,6 @@ spec =
     describe "Huddle" . specWithHuddle shelleyCDDL . noTwiddle $ do
       huddleRoundTripCborSpec @Addr v "address"
       huddleRoundTripArbitraryValidate @Addr v "address"
-      huddleRoundTripAnnCborSpec @BootstrapWitness v "bootstrap_witness"
       huddleRoundTripArbitraryValidate @BootstrapWitness v "bootstrap_witness"
       huddleRoundTripCborSpec @BootstrapWitness v "bootstrap_witness"
       huddleRoundTripCborSpec @AccountAddress v "reward_account"
@@ -79,7 +78,6 @@ spec =
       huddleRoundTripCborSpec @(TxWits ShelleyEra) v "transaction_witness_set"
       huddleAntiCborSpec @(TxWits ShelleyEra) v "transaction_witness_set"
       describe "DecCBOR instances equivalence via CDDL" $ do
-        huddleDecoderEquivalenceSpec @BootstrapWitness v "bootstrap_witness"
         huddleDecoderEquivalenceSpec @(TxBody TopTx ShelleyEra) v "transaction_body"
         huddleDecoderEquivalenceSpec @(TxAuxData ShelleyEra) v "metadata"
         huddleDecoderEquivalenceSpec @(MultiSig ShelleyEra) v "native_script"

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/Golden.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/Golden.hs
@@ -100,7 +100,7 @@ goldenNewEpochStateExpectation
                 , E casTreasury
                 , E casReserves
                 ]
-            , E esLState
+            , Ev ver esLState
             , Em
                 [ E (TkListLen 4)
                 , snapShotEnc ssStakeMark

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs
@@ -415,7 +415,7 @@ tests =
             )
     , case mkWitnessVKey testTxbHash testKey1 of
         w@(WitVKey vk _sig) ->
-          checkEncodingCBORAnnotated
+          checkEncodingCBOR
             shelleyProtVer
             "vkey_witnesses"
             w -- Transaction _witnessVKeySet element

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## 1.9.0.0
 
+* Add `decodeNonEmptySetLikeEnforceNoDuplicates`
 * Change `decodeIPv4`, `decodeIPv6`, `encodeIPv4`, `encodeIPv6`, `ipv4ToBytes`, `ipv6ToBytes` to work on `Cardano.Base.IP.IPv4/IPv6`
 * Remove default implementation for `DecCBOR` class
 
 ### `testlib`
 
+* Remove `roundTripFailureExpectation`, `roundTripCborExpectation`, and `cborTrip`
 * Add `noTwiddle`, `HuddleEnv`, `toGenEnv`
 * Replace `SpecWith (CTreeRoot MonoReferenced)` with `SpecWith HuddleEnv` in Huddle tests
 * Replace `CuddleData` with `CTreeRoot MonoReferenced`

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
@@ -78,6 +78,7 @@ module Cardano.Ledger.Binary.Decoding.Decoder (
   decodeListLikeWithCount,
   decodeListLikeWithCountT,
   decodeSetLikeEnforceNoDuplicates,
+  decodeNonEmptySetLikeEnforceNoDuplicates,
   decodeListLikeEnforceNoDuplicates,
   decodeMapContents,
 
@@ -1048,6 +1049,27 @@ decodeSetLikeEnforceNoDuplicates insert getFinalWithLen decodeElement = do
   allowTag setTag
   decodeListLikeEnforceNoDuplicates decodeListLenOrIndef insert getFinalWithLen decodeElement
 {-# INLINE decodeSetLikeEnforceNoDuplicates #-}
+
+-- | Same as `decodeSetLikeEnforceNoDuplicates`, but also enforces that the set is non-empty.
+decodeNonEmptySetLikeEnforceNoDuplicates ::
+  forall s a b c.
+  Monoid b =>
+  -- | Add an element into the decoded Set like data structure
+  (a -> b -> b) ->
+  -- | Get the final data structure and the number of elements it has.
+  (b -> (Int, c)) ->
+  Decoder s a ->
+  Decoder s c
+decodeNonEmptySetLikeEnforceNoDuplicates insert getFinalWithLen decodeElement = do
+  (len, result) <-
+    decodeSetLikeEnforceNoDuplicates
+      insert
+      (\b -> let (n, c) = getFinalWithLen b in (n, (n, c)))
+      decodeElement
+  when (len == 0) $
+    fail "Expected a non-empty set, but got an empty set"
+  pure result
+{-# INLINE decodeNonEmptySetLikeEnforceNoDuplicates #-}
 
 decodeContainerSkelWithReplicate ::
   -- | How to get the size of the container

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Plain/RoundTrip.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Plain/RoundTrip.hs
@@ -12,9 +12,7 @@
 -- | Defines reusable abstractions for testing RoundTrip properties of plain encoders/decoders
 module Test.Cardano.Ledger.Binary.Plain.RoundTrip (
   roundTripSpec,
-  roundTripFailureExpectation,
   roundTripExpectation,
-  roundTripCborExpectation,
   embedTripSpec,
   embedTripExpectation,
   RoundTripFailure (..),
@@ -22,7 +20,6 @@ module Test.Cardano.Ledger.Binary.Plain.RoundTrip (
   showFailedTermsWithReSerialization,
   Trip (..),
   mkTrip,
-  cborTrip,
   roundTrip,
   embedTrip,
   embedTripLabel,
@@ -36,7 +33,6 @@ import qualified Data.Text as Text
 import Data.Typeable
 import qualified Formatting.Buildable as B (Buildable (..))
 import Test.Cardano.Ledger.Binary.TreeDiff (
-  CBORBytes (..),
   ansiExprString,
   diffExprString,
   showHexBytesGrouped,
@@ -68,16 +64,6 @@ embedTripSpec trip f =
   prop ("From: " ++ show (typeRep $ Proxy @a) ++ " To " ++ show (typeRep $ Proxy @b)) $
     embedTripExpectation trip f
 
--- Tests that a decoder error happens
-roundTripFailureExpectation :: forall a. (Eq a, ToCBOR a, FromCBOR a) => a -> Expectation
-roundTripFailureExpectation x =
-  case roundTrip (cborTrip @a) x of
-    Left _ -> pure ()
-    Right _ ->
-      expectationFailure $
-        "Should not have deserialized: "
-          <> ansiExprString (CBORBytes (serialize' x))
-
 -- | Verify that round triping through the binary form holds
 roundTripExpectation ::
   (Show t, Eq t, Typeable t, HasCallStack) =>
@@ -88,13 +74,6 @@ roundTripExpectation trip t =
   case roundTrip trip t of
     Left err -> expectationFailure $ "Failed to deserialize encoded:\n" ++ show err
     Right tDecoded -> tDecoded `shouldBe` t
-
-roundTripCborExpectation ::
-  forall t.
-  (Show t, Eq t, FromCBOR t, ToCBOR t, HasCallStack) =>
-  t ->
-  Expectation
-roundTripCborExpectation = roundTripExpectation (cborTrip @t)
 
 embedTripExpectation ::
   forall a b.
@@ -174,9 +153,6 @@ data Trip a b = Trip
   { tripEncoder :: a -> Encoding
   , tripDecoder :: forall s. Decoder s b
   }
-
-cborTrip :: forall a b. (ToCBOR a, FromCBOR b) => Trip a b
-cborTrip = Trip toCBOR fromCBOR
 
 -- | Construct a `Trip` using encoder and decoder, with dropper set to the decoder which
 -- drops the value

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/RoundTrip.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/RoundTrip.hs
@@ -14,7 +14,6 @@ module Test.Cardano.Ledger.Binary.RoundTrip (
   -- * Spec
   roundTripSpec,
   roundTripCborSpec,
-  roundTripAnnCborSpec,
   roundTripRangeSpec,
 
   -- * Expectations
@@ -103,14 +102,6 @@ roundTripCborSpec ::
   (Show t, Eq t, Arbitrary t, EncCBOR t, DecCBOR t) =>
   Spec
 roundTripCborSpec = roundTripSpec (cborTrip @t)
-
--- | Tests the roundtrip property using QuickCheck generators for all possible versions
--- starting with `shelleyProtVer`.
-roundTripAnnCborSpec ::
-  forall t.
-  (Show t, Eq t, Arbitrary t, ToCBOR t, DecCBOR (Annotator t)) =>
-  Spec
-roundTripAnnCborSpec = prop (show (typeRep $ Proxy @t)) (roundTripAnnExpectation @t)
 
 -- | Tests the roundtrip property using QuickCheck generators for specific range of versions
 roundTripRangeSpec ::

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.21.0.0
 
+* Remove `ToCBOR` and `FromCBOR` instances for `TxIx`, `CertIx`, `SlotNo32`, `Ptr`, `VRFVerKeyHash`, `SafeHash`, `VoidEraRule`, `Language`, `SLanguage`
+* Remove `FromCBOR` instances for `ScriptHash`, `ChainCode`, `PlutusBinary`, `BootstrapWitness`, `WitVKey`
+* Remove `ToCBOR` and `FromCBOR` instances for `PlutusWithContext`
+  - Add `EncCBOR` and `DecCBOR` instances as replacement
+* Remove `ToCBOR (TxOut era)` superclass constraint from `EraTxOut`
 * Remove `validMetadatum`
 * Deprecate `BHeaderView` in favour `*EraBlockHeader` typeclasses.
   - Move `isOverlaySlot` to `Cardano.Ledger.Slot`.

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -871,7 +871,7 @@ newtype BlocksMade = BlocksMade
 newtype TxIx = TxIx {unTxIx :: Word16}
   deriving stock (Eq, Ord, Show, Generic)
   deriving newtype
-    (NFData, Enum, Bounded, NoThunks, FromCBOR, ToCBOR, EncCBOR, DecCBOR, ToJSON, MemPack)
+    (NFData, Enum, Bounded, NoThunks, EncCBOR, DecCBOR, ToJSON, MemPack)
 
 instance Random TxIx
 
@@ -899,7 +899,7 @@ mkTxIxPartial i =
 -- from other integral types that are larger than `Word16`
 newtype CertIx = CertIx {unCertIx :: Word16}
   deriving stock (Eq, Ord, Show)
-  deriving newtype (NFData, Enum, Bounded, NoThunks, EncCBOR, DecCBOR, ToCBOR, FromCBOR, ToJSON)
+  deriving newtype (NFData, Enum, Bounded, NoThunks, EncCBOR, DecCBOR, ToJSON)
 
 instance Random CertIx
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -278,7 +278,6 @@ class
   , DecCBOR (CompactForm (Value era))
   , MemPack (CompactForm (Value era))
   , EncCBOR (Value era)
-  , ToCBOR (TxOut era)
   , EncCBOR (TxOut era)
   , DecCBOR (TxOut era)
   , DecShareCBOR (TxOut era)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/Era.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/Era.hs
@@ -86,13 +86,8 @@ data VoidEraRule (rule :: Symbol) era
 instance NFData (VoidEraRule (rule :: Symbol) era) where
   rnf = absurdEraRule
 
-instance (KnownSymbol rule, Era era) => ToCBOR (VoidEraRule (rule :: Symbol) era) where
-  toCBOR = absurdEraRule
-
-instance (KnownSymbol rule, Era era) => EncCBOR (VoidEraRule (rule :: Symbol) era)
-
-instance (KnownSymbol rule, Era era) => FromCBOR (VoidEraRule (rule :: Symbol) era) where
-  fromCBOR = cborError DecoderErrorVoid
+instance (KnownSymbol rule, Era era) => EncCBOR (VoidEraRule (rule :: Symbol) era) where
+  encCBOR = absurdEraRule
 
 instance (KnownSymbol rule, Era era) => DecCBOR (VoidEraRule (rule :: Symbol) era) where
   decCBOR = cborError DecoderErrorVoid

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Credential.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Credential.hs
@@ -45,13 +45,14 @@ import Cardano.Ledger.Binary (
   EncCBORGroup (..),
   FromCBOR (..),
   ToCBOR (..),
+  encodeListLen,
   ifDecoderVersionAtLeast,
   natVersion,
   shelleyProtVer,
   toPlainDecoder,
+  toPlainEncoding,
  )
 import Cardano.Ledger.Binary.Coders (Decode (..), decode, (<!))
-import qualified Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Hashes (ADDRHASH, Hash, ScriptHash (..))
 import Cardano.Ledger.Keys (
   HasKeyRole (..),
@@ -230,7 +231,17 @@ instance NoThunks StakeReference
 newtype SlotNo32 = SlotNo32 Word32
   deriving stock (Show, Generic)
   deriving newtype
-    (Eq, Ord, Num, Bounded, NFData, NoThunks, EncCBOR, DecCBOR, FromCBOR, ToCBOR, FromJSON, ToJSON)
+    ( Eq
+    , Ord
+    , Num
+    , Bounded
+    , NFData
+    , NoThunks
+    , EncCBOR
+    , DecCBOR
+    , FromJSON
+    , ToJSON
+    )
 
 instance Random SlotNo32
 
@@ -271,14 +282,6 @@ mkPtrNormalized slotNo txIx certIx =
     certIx16 <- integralToBounded certIx
     pure $ Ptr (SlotNo32 slotNo32) (TxIx txIx16) (CertIx certIx16)
 
-instance ToCBOR Ptr where
-  toCBOR (Ptr slotNo txIx certIx) = toCBOR (slotNo, txIx, certIx)
-
-instance FromCBOR Ptr where
-  fromCBOR = do
-    (slotNo, txIx, certIx) <- fromCBOR
-    pure $ Ptr slotNo txIx certIx
-
 instance ToJSONKey Ptr
 
 instance ToKeyValuePairs Ptr where
@@ -314,7 +317,10 @@ ptrCertIx (Ptr _ _ cIx) = cIx
 -- NOTE: Credential serialization is unversioned, because it is needed for node-to-client
 -- communication. It would be ok to change it in the future, but that will require change
 -- in consensus
-instance Typeable kr => EncCBOR (Credential kr)
+instance EncCBOR (Credential kr) where
+  encCBOR = \case
+    KeyHashObj kh -> encodeListLen 2 <> encCBOR (0 :: Word8) <> encCBOR kh
+    ScriptHashObj hs -> encodeListLen 2 <> encCBOR (1 :: Word8) <> encCBOR hs
 
 instance Typeable kr => DecCBOR (Credential kr) where
   decCBOR =
@@ -326,9 +332,7 @@ instance Typeable kr => DecCBOR (Credential kr) where
   {-# INLINE decCBOR #-}
 
 instance Typeable kr => ToCBOR (Credential kr) where
-  toCBOR = \case
-    KeyHashObj kh -> Plain.encodeListLen 2 <> toCBOR (0 :: Word8) <> toCBOR kh
-    ScriptHashObj hs -> Plain.encodeListLen 2 <> toCBOR (1 :: Word8) <> toCBOR hs
+  toCBOR = toPlainEncoding shelleyProtVer . encCBOR
 
 instance Typeable kr => FromCBOR (Credential kr) where
   fromCBOR = toPlainDecoder Nothing shelleyProtVer decCBOR

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
@@ -203,7 +203,6 @@ newtype ScriptHash
     ( NFData
     , NoThunks
     , ToCBOR
-    , FromCBOR
     , EncCBOR
     , DecCBOR
     , ToJSON
@@ -231,8 +230,6 @@ newtype VRFVerKeyHash (r :: KeyRoleVRF) = VRFVerKeyHash
     ( NFData
     , NoThunks
     , Generic
-    , ToCBOR
-    , FromCBOR
     , EncCBOR
     , DecCBOR
     , ToJSONKey
@@ -341,8 +338,6 @@ newtype SafeHash i = SafeHash (Hash.Hash HASH i)
     , NoThunks
     , NFData
     , SafeToHash
-    , ToCBOR
-    , FromCBOR
     , EncCBOR
     , DecCBOR
     , ToJSON

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/Bootstrap.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/Bootstrap.hs
@@ -24,23 +24,18 @@ module Cardano.Ledger.Keys.Bootstrap (
 import qualified Cardano.Chain.Common as Byron
 import Cardano.Crypto.DSIGN (SignedDSIGN (..))
 import qualified Cardano.Crypto.DSIGN as DSIGN
-import qualified Cardano.Crypto.DSIGN.Class as C
+import Cardano.Crypto.DSIGN.Class ()
 import qualified Cardano.Crypto.Hash as Hash
 import qualified Cardano.Crypto.Signing as Byron
 import qualified Cardano.Crypto.Wallet as WC
 import Cardano.Ledger.Binary (
-  Annotator,
   DecCBOR (..),
   EncCBOR (..),
-  shelleyProtVer,
-  toPlainDecoder,
+  encodeListLen,
  )
 import Cardano.Ledger.Binary.Crypto (decodeSignedDSIGN)
 import Cardano.Ledger.Binary.Decoding (decodeRecordNamed)
 import Cardano.Ledger.Binary.Plain (
-  FromCBOR (..),
-  ToCBOR (..),
-  encodeListLen,
   serialize',
  )
 import Cardano.Ledger.Hashes (ADDRHASH, EraIndependentTxBody, HASH, Hash, KeyHash (..))
@@ -63,7 +58,7 @@ import Quiet
 newtype ChainCode = ChainCode {unChainCode :: ByteString}
   deriving (Eq, Generic)
   deriving (Show) via Quiet ChainCode
-  deriving newtype (NoThunks, ToCBOR, FromCBOR, EncCBOR, DecCBOR, NFData)
+  deriving newtype (NoThunks, EncCBOR, DecCBOR, NFData)
 
 data BootstrapWitness = BootstrapWitness
   { bwKey :: !(VKey Witness)
@@ -78,29 +73,19 @@ instance NFData BootstrapWitness where
 
 instance NoThunks BootstrapWitness
 
-instance ToCBOR BootstrapWitness where
-  toCBOR cwr@(BootstrapWitness _ _ _ _) =
-    let BootstrapWitness {..} = cwr
+instance EncCBOR BootstrapWitness where
+  encCBOR bw@(BootstrapWitness _ _ _ _) =
+    let BootstrapWitness {..} = bw
      in encodeListLen 4
-          <> toCBOR bwKey
-          <> C.encodeSignedDSIGN bwSignature
-          <> toCBOR bwChainCode
-          <> toCBOR bwAttributes
-
-instance EncCBOR BootstrapWitness
-
-instance FromCBOR BootstrapWitness where
-  fromCBOR = toPlainDecoder Nothing shelleyProtVer decCBOR
-  {-# INLINE fromCBOR #-}
+          <> encCBOR bwKey
+          <> encCBOR bwSignature
+          <> encCBOR bwChainCode
+          <> encCBOR bwAttributes
 
 instance DecCBOR BootstrapWitness where
   decCBOR =
     decodeRecordNamed "BootstrapWitness" (const 4) $
       BootstrapWitness <$> decCBOR <*> decodeSignedDSIGN <*> decCBOR <*> decCBOR
-  {-# INLINE decCBOR #-}
-
-instance DecCBOR (Annotator BootstrapWitness) where
-  decCBOR = pure <$> decCBOR
   {-# INLINE decCBOR #-}
 
 instance Ord BootstrapWitness where

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/WitVKey.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/WitVKey.hs
@@ -15,18 +15,14 @@ module Cardano.Ledger.Keys.WitVKey (
 
 import Cardano.Crypto.DSIGN.Class (
   SignedDSIGN,
-  encodeSignedDSIGN,
  )
 import Cardano.Ledger.Binary (
-  Annotator,
   DecCBOR (..),
   EncCBOR (..),
   decodeRecordNamed,
-  shelleyProtVer,
-  toPlainDecoder,
+  encodeListLen,
  )
 import Cardano.Ledger.Binary.Crypto (decodeSignedDSIGN)
-import qualified Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Hashes (
   EraIndependentTxBody,
   HASH,
@@ -72,26 +68,16 @@ instance Typeable kr => Ord (WitVKey kr) where
     -- compliance with Ord laws.
     comparing wvkKeyHash x y <> comparing (hashTxBodySignature . wvkSignature) x y
 
-instance Typeable kr => Plain.ToCBOR (WitVKey kr) where
-  toCBOR WitVKeyInternal {wvkKey, wvkSignature} =
-    Plain.encodeListLen 2
-      <> Plain.toCBOR wvkKey
-      <> encodeSignedDSIGN wvkSignature
-
-instance Typeable kr => Plain.FromCBOR (WitVKey kr) where
-  fromCBOR = toPlainDecoder Nothing shelleyProtVer decCBOR
-  {-# INLINE fromCBOR #-}
-
-instance Typeable kr => EncCBOR (WitVKey kr)
+instance EncCBOR (WitVKey kr) where
+  encCBOR (WitVKey k sig) =
+    encodeListLen 2
+      <> encCBOR k
+      <> encCBOR sig
 
 instance Typeable kr => DecCBOR (WitVKey kr) where
   decCBOR =
     decodeRecordNamed "WitVKey" (const 2) $
       WitVKey <$> decCBOR <*> decodeSignedDSIGN
-  {-# INLINE decCBOR #-}
-
-instance Typeable kr => DecCBOR (Annotator (WitVKey kr)) where
-  decCBOR = pure <$> decCBOR
   {-# INLINE decCBOR #-}
 
 pattern WitVKey ::

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
@@ -186,6 +186,9 @@ instance Semigroup ScriptResult where
 instance Monoid ScriptResult where
   mempty = Passes mempty
 
+-- Note: we only have ToCBOR/FromCBOR for this type and no EncCBOR/DecCBOR,
+-- because its first field is the protocol version, which is used to decode the
+-- other fields in a version-aware way.
 instance ToCBOR PlutusWithContext where
   toCBOR (PlutusWithContext {..}) =
     Plain.encodeListLen 6

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Language.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Language.hs
@@ -60,7 +60,6 @@ import Cardano.Ledger.Binary (
   DecCBOR (..),
   Decoder,
   EncCBOR (..),
-  FromCBOR (..),
   ToCBOR (..),
   Version,
   decodeEnumBounded,
@@ -73,7 +72,6 @@ import Cardano.Ledger.Binary (
   natVersion,
   unlessDecoderVersionAtLeast,
  )
-import qualified Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Hashes (SafeToHash (..), ScriptHash (..))
 import Control.DeepSeq (NFData (..), deepseq)
 import Control.Monad (when)
@@ -203,7 +201,7 @@ plutusFromRunnable = Plutus . PlutusBinary . P.serialisedScript . plutusRunnable
 -- | Binary representation of a Plutus script.
 newtype PlutusBinary = PlutusBinary {unPlutusBinary :: ShortByteString}
   deriving stock (Eq, Ord, Generic)
-  deriving newtype (ToCBOR, FromCBOR, EncCBOR, DecCBOR, NFData, NoThunks, MemPack)
+  deriving newtype (ToCBOR, EncCBOR, DecCBOR, NFData, NoThunks, MemPack)
 
 instance DecCBOR (Annotator PlutusBinary) where
   decCBOR = pure <$> decCBOR
@@ -279,13 +277,8 @@ languageFromText "PlutusV3" = pure PlutusV3
 languageFromText "PlutusV4" = pure PlutusV4
 languageFromText lang = fail $ "Error decoding Language: " ++ show lang
 
-instance ToCBOR Language where
-  toCBOR = Plain.encodeEnum
-
-instance FromCBOR Language where
-  fromCBOR = Plain.decodeEnumBounded
-
-instance EncCBOR Language
+instance EncCBOR Language where
+  encCBOR = encodeEnum
 
 instance DecCBOR Language where
   decCBOR = decodeEnumBounded
@@ -305,13 +298,8 @@ deriving instance Eq (SLanguage l)
 
 deriving instance Show (SLanguage l)
 
-instance PlutusLanguage l => ToCBOR (SLanguage l) where
-  toCBOR = toCBOR . plutusLanguage
-
-instance PlutusLanguage l => FromCBOR (SLanguage l) where
-  fromCBOR = toSLanguage =<< fromCBOR @Language
-
-instance PlutusLanguage l => EncCBOR (SLanguage l)
+instance PlutusLanguage l => EncCBOR (SLanguage l) where
+  encCBOR = encCBOR . plutusLanguage
 
 instance PlutusLanguage l => DecCBOR (SLanguage l) where
   decCBOR = toSLanguage =<< decCBOR @Language

--- a/libs/cardano-ledger-core/test/Test/Cardano/Ledger/BinarySpec.hs
+++ b/libs/cardano-ledger-core/test/Test/Cardano/Ledger/BinarySpec.hs
@@ -49,7 +49,6 @@ spec = do
     roundTripCborSpec @TxIx
     roundTripCborSpec @CertIx
     roundTripCborSpec @Anchor
-    roundTripAnnCborSpec @BootstrapWitness
     roundTripCborSpec @BootstrapWitness
     roundTripCborSpec @TxId
     roundTripCborSpec @GenDelegPair
@@ -60,6 +59,4 @@ spec = do
     roundTripCborSpec @(SafeHash EraIndependentData)
 
   describe "DecCBOR instances equivalence" $ do
-    decoderEquivalenceSpec @BootstrapWitness minBound maxBound
-    decoderEquivalenceSpec @(WitVKey Witness) minBound maxBound
     decoderEquivalenceSpec @PV1.Data minBound maxBound

--- a/libs/cardano-protocol-tpraos/CHANGELOG.md
+++ b/libs/cardano-protocol-tpraos/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.6.0.0
 
+* Remove `FromCBOR` instances for `KESPeriod`, `PrtclState`, `TicknState`
 * Deprecate `GetLedgerView` and related `LedgerView` in favour of `*EraForecast` typeclasses from Shelley and Babbage eras.
   - Add `forecastToTPraosLedgerView` for backwards compatibility.
   - Update `tickChainDepState`, `updateChainDepState`, and `reupdateChainDepState` to use the new `TPraosLedgerView`.

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/OCert.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/OCert.hs
@@ -78,7 +78,7 @@ currentIssueNo (OCertEnv stPools genDelegs) cs hk
   | otherwise = Nothing
 
 newtype KESPeriod = KESPeriod {unKESPeriod :: Word}
-  deriving (Eq, Generic, Ord, NoThunks, DecCBOR, EncCBOR, ToCBOR, FromCBOR)
+  deriving (Eq, Generic, Ord, NoThunks, DecCBOR, EncCBOR, ToCBOR)
   deriving (Show) via Quiet KESPeriod
 
 data OCert c = OCert
@@ -131,7 +131,7 @@ decodeOCertFields =
   OCert
     <$> KES.decodeVerKeyKES
     <*> Plain.fromCBOR
-    <*> Plain.fromCBOR
+    <*> (KESPeriod <$> Plain.fromCBOR)
     <*> DSIGN.decodeSignedDSIGN
 
 kesPeriod :: SlotNo -> ShelleyBase KESPeriod

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Prtcl.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Prtcl.hs
@@ -28,16 +28,16 @@ import Cardano.Ledger.BaseTypes (
   ShelleyBase,
   UnitInterval,
  )
-import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..), shelleyProtVer, toPlainEncoding)
-import Cardano.Ledger.Binary.Coders (Decode (..), decode, (<!))
-import Cardano.Ledger.Binary.Plain (
-  FromCBOR (..),
-  ToCBOR (..),
+import Cardano.Ledger.Binary (
+  DecCBOR (..),
+  EncCBOR (..),
   encodeListLen,
+  shelleyProtVer,
+  toPlainEncoding,
  )
-import Cardano.Ledger.Core (fromEraCBOR)
+import Cardano.Ledger.Binary.Coders (Decode (..), decode, (<!))
+import Cardano.Ledger.Binary.Plain (ToCBOR (..))
 import Cardano.Ledger.Keys (GenDelegs (..), KeyHash, KeyRole (..))
-import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Slot (BlockNo, SlotNo)
 import Cardano.Ledger.State (PoolDistr)
 import Cardano.Protocol.Crypto
@@ -74,24 +74,19 @@ data PrtclState
       !Nonce
   deriving (Generic, Show, Eq)
 
-instance EncCBOR PrtclState
-
 instance ToCBOR PrtclState where
-  toCBOR (PrtclState m n1 n2) =
-    mconcat
-      [ encodeListLen 3
-      , toCBOR m
-      , toPlainEncoding shelleyProtVer (encCBOR n1)
-      , toPlainEncoding shelleyProtVer (encCBOR n2)
-      ]
+  toCBOR = toPlainEncoding shelleyProtVer . encCBOR
+
+instance EncCBOR PrtclState where
+  encCBOR (PrtclState m n1 n2) =
+    encodeListLen 3
+      <> encCBOR m
+      <> encCBOR n1
+      <> encCBOR n2
 
 instance DecCBOR PrtclState where
   decCBOR = decode (RecD PrtclState <! From <! From <! From)
   {-# INLINE decCBOR #-}
-
-instance FromCBOR PrtclState where
-  fromCBOR = fromEraCBOR @ShelleyEra
-  {-# INLINE fromCBOR #-}
 
 instance NoThunks PrtclState
 

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Tickn.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Tickn.hs
@@ -12,11 +12,9 @@ module Cardano.Protocol.TPraos.Rules.Tickn (
 ) where
 
 import Cardano.Ledger.BaseTypes
-import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..), toPlainEncoding)
+import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..), encodeListLen, toPlainEncoding)
 import Cardano.Ledger.Binary.Coders (Decode (..), decode, (<!))
-import Cardano.Ledger.Binary.Plain (FromCBOR (..), ToCBOR (..), encodeListLen)
-import Cardano.Ledger.Core (fromEraCBOR)
-import Cardano.Ledger.Shelley (ShelleyEra)
+import Cardano.Ledger.Binary.Plain (ToCBOR (..))
 import Control.State.Transition
 import Data.Void (Void)
 import GHC.Generics (Generic)
@@ -43,23 +41,14 @@ instance DecCBOR TicknState where
   decCBOR = decode (RecD TicknState <! From <! From)
   {-# INLINE decCBOR #-}
 
-instance FromCBOR TicknState where
-  fromCBOR = fromEraCBOR @ShelleyEra
-  {-# INLINE fromCBOR #-}
-
-instance EncCBOR TicknState
-
 instance ToCBOR TicknState where
-  toCBOR
-    ( TicknState
-        ηv
-        ηc
-      ) =
-      mconcat
-        [ encodeListLen 2
-        , toPlainEncoding shelleyProtVer (encCBOR ηv)
-        , toPlainEncoding shelleyProtVer (encCBOR ηc)
-        ]
+  toCBOR = toPlainEncoding shelleyProtVer . encCBOR
+
+instance EncCBOR TicknState where
+  encCBOR (TicknState ηv ηc) =
+    encodeListLen 2
+      <> encCBOR ηv
+      <> encCBOR ηc
 
 instance STS TICKN where
   type State TICKN = TicknState

--- a/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-orphans -funbox-strict-fields #-}
 
@@ -15,6 +16,7 @@ module Cardano.Ledger.State.UTxO where
 import Cardano.Ledger.Address
 import Cardano.Ledger.Alonzo.TxBody
 import Cardano.Ledger.BaseTypes
+import qualified Cardano.Ledger.Binary as Binary
 import Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Conway
@@ -62,14 +64,14 @@ readHexUTxO ::
   IO (UTxO CurrentEra)
 readHexUTxO = readDecCBORHex
 
-readDecCBOR :: FromCBOR a => FilePath -> IO a
-readDecCBOR = either throwIO pure . Plain.decodeFull <=< LBS.readFile
+readDecCBOR :: Binary.DecCBOR a => FilePath -> IO a
+readDecCBOR = either throwIO pure . Binary.decodeFull (eraProtVerHigh @CurrentEra) <=< LBS.readFile
 
-readDecCBORHex :: FromCBOR a => FilePath -> IO a
+readDecCBORHex :: Binary.DecCBOR a => FilePath -> IO a
 readDecCBORHex = either throwIO pure . decodeFullHex <=< LBS.readFile
   where
     decodeFullHex =
-      Plain.decodeFull
+      Binary.decodeFull (eraProtVerHigh @CurrentEra)
         <=< first (DecoderErrorCustom "Invalid Hex encoding:" . T.pack) . Base16.decode
 
 writeEpochState :: FilePath -> EpochState CurrentEra -> IO ()


### PR DESCRIPTION
# Description

Fix #5537: this patch removes the `FromCBOR` and `ToCBOR` instances that are either unused downstream, or cause minimal disruption downstream when removed. In that case we would (should!) be able to switch downstream users to `EncCBOR`/`DecCBOR`.

To find these instances I used the strategy suggested in the ticket, i.e. commented out all the `FromCBOR`/`ToCBOR` instances, then rebuilt all the packages downstream (`consensus`, `api`, `node`) to see what broke, then reintroduced the instances that caused breakage or adjusted downstream to use the `enc`/`dec` equivalent.

I think we could even remove all of them, but that would require deeper changes downstream, so this is a good first step - there aren't many left.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
