### PR TITLE
Backport: revert `ConwayAccountState` type unrolling

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-conway`
 
+## 1.21.1.0
+
+* Fix performance regression that was introduced in [#5449](https://github.com/IntersectMBO/cardano-ledger/pull/5449)
+
 ## 1.21.0.0
 
 * Add `validateTreasuryValue`, `validateWithdrawalsDelegated`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-conway
-version: 1.21.0.0
+version: 1.21.1.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/State/Account.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/State/Account.hs
@@ -51,64 +51,17 @@ import Lens.Micro
 import NoThunks.Class (NoThunks (..))
 
 data ConwayAccountState era
-  = CASNoDelegation
-      -- | Current balance of the account
-      {-# UNPACK #-} !(CompactForm Coin)
-      -- | Deposit amount that was left when staking credential was registered
-      {-# UNPACK #-} !(CompactForm Coin)
-  | CASStakePool
-      -- | Current balance of the account
-      {-# UNPACK #-} !(CompactForm Coin)
-      -- | Deposit amount that was left when staking credential was registered
-      {-# UNPACK #-} !(CompactForm Coin)
-      -- | Delegation to a stake pool
-      !(KeyHash StakePool)
-  | CASDRep
-      -- | Current balance of the account
-      {-# UNPACK #-} !(CompactForm Coin)
-      -- | Deposit amount that was left when staking credential was registered
-      {-# UNPACK #-} !(CompactForm Coin)
-      -- | Delegation to a DRep
-      !DRep
-  | CASStakePoolAndDRep
-      -- | Current balance of the account
-      {-# UNPACK #-} !(CompactForm Coin)
-      {-# UNPACK #-} !(CompactForm Coin)
-      -- | Delegation to a stake pool
-      -- ^ Deposit amount that was left when staking credential was registered
-      !(KeyHash StakePool)
-      -- | Delegation to a DRep
-      !DRep
+  = ConwayAccountState
+  { casBalance :: {-# UNPACK #-} !(CompactForm Coin)
+  -- ^ Current balance of the account
+  , casDeposit :: {-# UNPACK #-} !(CompactForm Coin)
+  -- ^ Deposit amount that was left when staking credential was registered
+  , casStakePoolDelegation :: !(StrictMaybe (KeyHash StakePool))
+  -- ^ Potential delegation to a stake pool
+  , casDRepDelegation :: !(StrictMaybe DRep)
+  -- ^ Potential delegation to a DRep
+  }
   deriving (Show, Eq, Generic)
-
-viewConwayAccountState ::
-  ConwayAccountState era ->
-  (CompactForm Coin, CompactForm Coin, StrictMaybe (KeyHash StakePool), StrictMaybe DRep)
-viewConwayAccountState (CASNoDelegation x y) = (x, y, SNothing, SNothing)
-viewConwayAccountState (CASStakePool x y z) = (x, y, SJust z, SNothing)
-viewConwayAccountState (CASDRep x y w) = (x, y, SNothing, SJust w)
-viewConwayAccountState (CASStakePoolAndDRep x y z w) = (x, y, SJust z, SJust w)
-
-pattern ConwayAccountState ::
-  CompactForm Coin ->
-  CompactForm Coin ->
-  StrictMaybe (KeyHash StakePool) ->
-  StrictMaybe DRep ->
-  ConwayAccountState era
-pattern ConwayAccountState
-  { casBalance
-  , casDeposit
-  , casStakePoolDelegation
-  , casDRepDelegation
-  } <-
-  (viewConwayAccountState -> (casBalance, casDeposit, casStakePoolDelegation, casDRepDelegation))
-  where
-    ConwayAccountState x y SNothing SNothing = CASNoDelegation x y
-    ConwayAccountState x y (SJust z) SNothing = CASStakePool x y z
-    ConwayAccountState x y SNothing (SJust w) = CASDRep x y w
-    ConwayAccountState x y (SJust z) (SJust w) = CASStakePoolAndDRep x y z w
-
-{-# COMPLETE ConwayAccountState #-}
 
 instance NoThunks (ConwayAccountState era)
 


### PR DESCRIPTION
# Description

This is a backport of a fix to a performance regression reported in cardano-node-10.7, which simply reverts this PR: #5449
This PR has no changes to visible API and no semantic changes. The only change is to in-memory representation.
Fix for `master` is coming later, since it will likely be different from this PR. We will try to preserve this optimization while also fixing this performance regression.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
