### PR TITLE
Leios: Make the (leios enhanced) block decoding backwards compatible

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,4 +7,5 @@ flake.lock  @IntersectMBO/core-tech-devx
 .github     @IntersectMBO/cardano-ledger-maintainers
 
 
-* @IntersectMBO/cardano-ledger-maintainers
+# FIXME: disabled codeowners for leios-prototype
+# * @IntersectMBO/cardano-ledger-maintainers

--- a/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
+++ b/eras/alonzo/test-suite/cardano-ledger-alonzo-test.cabal
@@ -73,6 +73,7 @@ test-suite cardano-ledger-alonzo-test
     Paths_cardano_ledger_alonzo_test
     Test.Cardano.Ledger.Alonzo.ChainTrace
     Test.Cardano.Ledger.Alonzo.Golden
+    Test.Cardano.Ledger.Alonzo.Leios
     Test.Cardano.Ledger.Alonzo.Serialisation.Canonical
     Test.Cardano.Ledger.Alonzo.Serialisation.Tripping
     Test.Cardano.Ledger.Alonzo.Translation

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Leios.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Leios.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Alonzo.Leios (tests) where
+
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Binary (DecCBOR (..), decodeFullAnnotator)
+import Cardano.Ledger.Block (Block)
+import Cardano.Ledger.Core (eraProtVerHigh)
+import Cardano.Protocol.Crypto (StandardCrypto)
+import Cardano.Protocol.TPraos.BHeader (BHeader)
+import qualified Data.ByteString.Lazy as BSL
+import Data.Either (isRight)
+import Paths_cardano_ledger_alonzo_test (getDataFileName)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertBool, testCase)
+
+tests :: TestTree
+tests =
+  testGroup
+    "Leios"
+    [ testCase "backwards-compatible block decoder accepts pre-Leios Alonzo block" $ do
+        -- The Alonzo golden block was encoded before the leios block format change.
+        -- It uses the old encoding: a flat CBOR list of [header, txBodies, txWits, txMeta, txScripts]
+        -- (5 elements = 1 + numSegComponents @AlonzoEra) rather than the new leios encoding:
+        -- [header, body, mayAnnouncedEb, certifiesEb] (always 4 elements).
+        filePath <- getDataFileName "golden/block.cbor"
+        bytes <- BSL.readFile filePath
+        assertBool "Failed to decode pre-Leios Alonzo block with backwards-compat decoder" $
+          isRight $
+            decodeFullAnnotator @(Block (BHeader StandardCrypto) AlonzoEra)
+              (eraProtVerHigh @AlonzoEra)
+              "Alonzo Block"
+              decCBOR
+              bytes
+    ]

--- a/eras/alonzo/test-suite/test/Tests.hs
+++ b/eras/alonzo/test-suite/test/Tests.hs
@@ -13,6 +13,7 @@ import Data.Proxy (Proxy (..))
 import System.Environment (lookupEnv)
 import qualified Test.Cardano.Ledger.Alonzo.ChainTrace as ChainTrace
 import qualified Test.Cardano.Ledger.Alonzo.Golden as Golden
+import qualified Test.Cardano.Ledger.Alonzo.Leios as Leios
 import qualified Test.Cardano.Ledger.Alonzo.Serialisation.Canonical as Canonical
 import qualified Test.Cardano.Ledger.Alonzo.Serialisation.Tripping as Tripping
 import qualified Test.Cardano.Ledger.Alonzo.Translation as Translation
@@ -39,6 +40,7 @@ defaultTests =
     , Canonical.tests
     , Golden.tests
     , TxInfo.tests
+    , Leios.tests
     ]
 
 nightlyTests :: TestTree

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Block.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Block.hs
@@ -41,7 +41,6 @@ import Cardano.Ledger.Binary (
   EncCBORGroup (encCBORGroup, listLen),
   annotatorSlice,
   decodeListLen,
-  decodeRecordNamed,
   decodeWord8,
   encodeListLen,
   encodeWord8,
@@ -190,19 +189,14 @@ instance
   ( EraSegWits era
   , DecCBOR (Annotator h)
   , DecCBOR (Annotator (Body era))
+  , DecCBOR (Annotator (TxSeq era))
   , Typeable h
   ) =>
   DecCBOR (Annotator (Block h era))
   where
-  decCBOR = annotatorSlice $
-    decodeRecordNamed "Block" (const blockSize) $ do
-      header <- decCBOR
-      body <- decCBOR
-      pure $ Block' <$> header <*> body
-    where
-      blockSize =
-        1 -- header
-          + 1 -- body -- NOTE(bladyjoker): This might be wrong
+  decCBOR = annotatorSlice $ do
+    braw <- decCBOR @(Annotator (BlockRaw h era))
+    pure $ (\(BlockRaw h body) -> Block' h body) <$> braw
 
 data BlockRaw h era = BlockRaw
   { _blockRawHeader :: !h
@@ -213,18 +207,66 @@ instance
   ( EraSegWits era
   , DecCBOR h
   , DecCBOR (Body era)
+  , DecCBOR (TxSeq era)
   ) =>
   DecCBOR (BlockRaw h era)
   where
-  decCBOR =
-    decodeRecordNamed "Block" (const blockSize) $ do
-      header <- decCBOR
-      body <- decCBOR
-      pure $ BlockRaw header body
-    where
-      blockSize =
-        1 -- header
-          + 1 -- body -- NOTE: Is this correct???
+  decCBOR = do
+    len <- decodeListLen
+    let oldLen = 1 + fromIntegral (numSegComponents @era)
+    if len == 2
+      then do
+        -- New leios format: [header, body]
+        header <- decCBOR @h
+        body <- decCBOR @(Body era)
+        pure $ BlockRaw header body
+      else
+        if len == oldLen
+          then do
+            -- Old pre-leios format: [header, txseq_components...]
+            header <- decCBOR @h
+            txSeq <- decCBOR @(TxSeq era)
+            pure $ BlockRaw header (BodyInline txSeq)
+          else
+            fail $
+              "Block: unexpected list length "
+                ++ show len
+                ++ ". Expected 2 (leios) or "
+                ++ show oldLen
+                ++ " (pre-leios)"
+
+instance
+  ( EraSegWits era
+  , DecCBOR (Annotator h)
+  , DecCBOR (Annotator (Body era))
+  , DecCBOR (Annotator (TxSeq era))
+  , Typeable h
+  ) =>
+  DecCBOR (Annotator (BlockRaw h era))
+  where
+  decCBOR = do
+    len <- decodeListLen
+    let oldLen = 1 + fromIntegral (numSegComponents @era)
+    if len == 2
+      then do
+        -- New leios format: [header, body]
+        header <- decCBOR @(Annotator h)
+        body <- decCBOR @(Annotator (Body era))
+        pure $ BlockRaw <$> header <*> body
+      else
+        if len == oldLen
+          then do
+            -- Old pre-leios format: [header, txseq_components...]
+            header <- decCBOR @(Annotator h)
+            txSeq <- decCBOR @(Annotator (TxSeq era))
+            pure $ BlockRaw <$> header <*> fmap BodyInline txSeq
+          else
+            fail $
+              "Block: unexpected list length "
+                ++ show len
+                ++ ". Expected 2 (leios) or "
+                ++ show oldLen
+                ++ " (pre-leios)"
 
 instance
   (DecCBOR (TxSeq era), EraSegWits era) =>
@@ -276,6 +318,7 @@ instance
   ( EraSegWits era
   , DecCBOR h
   , DecCBOR (Body era)
+  , DecCBOR (TxSeq era)
   ) =>
   DecCBOR (Block h era)
   where


### PR DESCRIPTION
Allows to decode normal blocks as "inline txs" blocks in the Leios-enabled world. This is useful to replay old praos blocks and be able to still decode them in this (hackily patched) era.