### PR TITLE
Fix `ConwayAccountState` overhead

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,10 +1,6 @@
 # Version history for `cardano-ledger-conway`
 
-## 1.22.0.1
-
-*
-
-## 1.22.0.0
+## 1.23.0.0
 
 * Add `ApplyTick` instance for `ConwayEra`
 * Add `ConwayUtxosEnv`
@@ -34,6 +30,11 @@
   - `ConwayUtxowPredFailure`
 * Remove `NoThunks` instance for `ConwayContextError`
 * Make `ConwayContextError` constructors lazy
+
+## 1.22.0.0
+
+* Switch `ConwayAccountState` to use `Maybe` instead of `StrictMaybe`
+* Add `balanceConwayAccountStateL`, `depositConwayAccountStateL`, `stakePoolDelegationConwayAccountStateL` and `dRepDelegationConwayAccountStateL`.
 
 ## 1.21.0.0
 

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-conway
-version: 1.22.0.0
+version: 1.23.0.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/State/Account.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/State/Account.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -24,6 +25,10 @@ module Cardano.Ledger.Conway.State.Account (
     casStakePoolDelegation,
     casDRepDelegation
   ),
+  balanceConwayAccountStateL,
+  depositConwayAccountStateL,
+  stakePoolDelegationConwayAccountStateL,
+  dRepDelegationConwayAccountStateL,
   ConwayAccounts (..),
   ConwayEraAccounts (..),
   accountStateDelegatee,
@@ -174,14 +179,95 @@ instance EraAccounts ConwayEra where
 
   accountsMapL = lens caStates $ \cas asMap -> cas {caStates = asMap}
 
-  balanceAccountStateL = lens casBalance $ \cas b -> cas {casBalance = b}
+  balanceAccountStateL = balanceConwayAccountStateL
 
-  depositAccountStateL = lens casDeposit $ \cas d -> cas {casDeposit = d}
+  depositAccountStateL = depositConwayAccountStateL
 
-  stakePoolDelegationAccountStateL =
-    lens casStakePoolDelegation $ \cas d -> cas {casStakePoolDelegation = d}
+  stakePoolDelegationAccountStateL = stakePoolDelegationConwayAccountStateL
 
   unregisterAccount = unregisterConwayAccount
+
+-- /Note/ - Lenses below do not use pattern synonym in order to guarantee optimal performance
+
+balanceConwayAccountStateL :: Lens' (ConwayAccountState era) (CompactForm Coin)
+balanceConwayAccountStateL =
+  lens
+    ( \case
+        CASNoDelegation balance _ -> balance
+        CASStakePool balance _ _ -> balance
+        CASDRep balance _ _ -> balance
+        CASStakePoolAndDRep balance _ _ _ -> balance
+    )
+    $ \cas balance ->
+      case cas of
+        CASNoDelegation _ deposit -> CASNoDelegation balance deposit
+        CASStakePool _ deposit stakePool -> CASStakePool balance deposit stakePool
+        CASDRep _ deposit dRep -> CASDRep balance deposit dRep
+        CASStakePoolAndDRep _ deposit stakePool dRep -> CASStakePoolAndDRep balance deposit stakePool dRep
+
+depositConwayAccountStateL :: Lens' (ConwayAccountState era) (CompactForm Coin)
+depositConwayAccountStateL =
+  lens
+    ( \case
+        CASNoDelegation _ deposit -> deposit
+        CASStakePool _ deposit _ -> deposit
+        CASDRep _ deposit _ -> deposit
+        CASStakePoolAndDRep _ deposit _ _ -> deposit
+    )
+    $ \cas deposit ->
+      case cas of
+        CASNoDelegation balance _ -> CASNoDelegation balance deposit
+        CASStakePool balance _ stakePool -> CASStakePool balance deposit stakePool
+        CASDRep balance _ dRep -> CASDRep balance deposit dRep
+        CASStakePoolAndDRep balance _ stakePool dRep -> CASStakePoolAndDRep balance deposit stakePool dRep
+
+stakePoolDelegationConwayAccountStateL :: Lens' (ConwayAccountState era) (Maybe (KeyHash StakePool))
+stakePoolDelegationConwayAccountStateL =
+  lens
+    ( \case
+        CASNoDelegation _ _ -> Nothing
+        CASStakePool _ _ stakePool -> Just stakePool
+        CASDRep _ _ _ -> Nothing
+        CASStakePoolAndDRep _ _ stakePool _ -> Just stakePool
+    )
+    $ \cas mStakePool ->
+      case cas of
+        CASNoDelegation balance deposit
+          | Just stakePool <- mStakePool -> CASStakePool balance deposit stakePool
+          | otherwise -> CASNoDelegation balance deposit
+        CASStakePool balance deposit _
+          | Just stakePool <- mStakePool -> CASStakePool balance deposit stakePool
+          | otherwise -> CASNoDelegation balance deposit
+        CASDRep balance deposit dRep
+          | Just stakePool <- mStakePool -> CASStakePoolAndDRep balance deposit stakePool dRep
+          | otherwise -> CASDRep balance deposit dRep
+        CASStakePoolAndDRep balance deposit _ dRep
+          | Just stakePool <- mStakePool -> CASStakePoolAndDRep balance deposit stakePool dRep
+          | otherwise -> CASDRep balance deposit dRep
+
+dRepDelegationConwayAccountStateL :: Lens' (ConwayAccountState era) (Maybe DRep)
+dRepDelegationConwayAccountStateL =
+  lens
+    ( \case
+        CASNoDelegation _ _ -> Nothing
+        CASStakePool _ _ _ -> Nothing
+        CASDRep _ _ dRep -> Just dRep
+        CASStakePoolAndDRep _ _ _ dRep -> Just dRep
+    )
+    $ \cas mDRep ->
+      case cas of
+        CASNoDelegation balance deposit
+          | Just dRep <- mDRep -> CASDRep balance deposit dRep
+          | otherwise -> CASNoDelegation balance deposit
+        CASStakePool balance deposit stakePool
+          | Just dRep <- mDRep -> CASStakePoolAndDRep balance deposit stakePool dRep
+          | otherwise -> CASStakePool balance deposit stakePool
+        CASDRep balance deposit _
+          | Just dRep <- mDRep -> CASDRep balance deposit dRep
+          | otherwise -> CASNoDelegation balance deposit
+        CASStakePoolAndDRep balance deposit stakePool _
+          | Just dRep <- mDRep -> CASStakePoolAndDRep balance deposit stakePool dRep
+          | otherwise -> CASStakePool balance deposit stakePool
 
 class EraAccounts era => ConwayEraAccounts era where
   mkConwayAccountState :: CompactForm Coin -> AccountState era
@@ -200,8 +286,7 @@ class EraAccounts era => ConwayEraAccounts era where
   dRepDelegationAccountStateL :: Lens' (AccountState era) (Maybe DRep)
 
 instance ConwayEraAccounts ConwayEra where
-  dRepDelegationAccountStateL =
-    lens casDRepDelegation $ \cas d -> cas {casDRepDelegation = d}
+  dRepDelegationAccountStateL = dRepDelegationConwayAccountStateL
 
 lookupDRepDelegation :: ConwayEraAccounts era => Credential Staking -> Accounts era -> Maybe DRep
 lookupDRepDelegation cred accounts = do

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/State/Account.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/State/Account.hs
@@ -85,17 +85,17 @@ data ConwayAccountState era
 
 viewConwayAccountState ::
   ConwayAccountState era ->
-  (CompactForm Coin, CompactForm Coin, StrictMaybe (KeyHash StakePool), StrictMaybe DRep)
-viewConwayAccountState (CASNoDelegation x y) = (x, y, SNothing, SNothing)
-viewConwayAccountState (CASStakePool x y z) = (x, y, SJust z, SNothing)
-viewConwayAccountState (CASDRep x y w) = (x, y, SNothing, SJust w)
-viewConwayAccountState (CASStakePoolAndDRep x y z w) = (x, y, SJust z, SJust w)
+  (CompactForm Coin, CompactForm Coin, Maybe (KeyHash StakePool), Maybe DRep)
+viewConwayAccountState (CASNoDelegation x y) = (x, y, Nothing, Nothing)
+viewConwayAccountState (CASStakePool x y z) = (x, y, Just z, Nothing)
+viewConwayAccountState (CASDRep x y w) = (x, y, Nothing, Just w)
+viewConwayAccountState (CASStakePoolAndDRep x y z w) = (x, y, Just z, Just w)
 
 pattern ConwayAccountState ::
   CompactForm Coin ->
   CompactForm Coin ->
-  StrictMaybe (KeyHash StakePool) ->
-  StrictMaybe DRep ->
+  Maybe (KeyHash StakePool) ->
+  Maybe DRep ->
   ConwayAccountState era
 pattern ConwayAccountState
   { casBalance
@@ -105,10 +105,10 @@ pattern ConwayAccountState
   } <-
   (viewConwayAccountState -> (casBalance, casDeposit, casStakePoolDelegation, casDRepDelegation))
   where
-    ConwayAccountState x y SNothing SNothing = CASNoDelegation x y
-    ConwayAccountState x y (SJust z) SNothing = CASStakePool x y z
-    ConwayAccountState x y SNothing (SJust w) = CASDRep x y w
-    ConwayAccountState x y (SJust z) (SJust w) = CASStakePoolAndDRep x y z w
+    ConwayAccountState x y Nothing Nothing = CASNoDelegation x y
+    ConwayAccountState x y (Just z) Nothing = CASStakePool x y z
+    ConwayAccountState x y Nothing (Just w) = CASDRep x y w
+    ConwayAccountState x y (Just z) (Just w) = CASStakePoolAndDRep x y z w
 
 {-# COMPLETE ConwayAccountState #-}
 
@@ -123,8 +123,8 @@ instance EncCBOR (ConwayAccountState era) where
      in encodeListLen 4
           <> encCBOR casBalance
           <> encCBOR casDeposit
-          <> encodeNullStrictMaybe encCBOR casStakePoolDelegation
-          <> encodeNullStrictMaybe encCBOR casDRepDelegation
+          <> encodeNullMaybe encCBOR casStakePoolDelegation
+          <> encodeNullMaybe encCBOR casDRepDelegation
 
 instance Typeable era => DecShareCBOR (ConwayAccountState era) where
   type
@@ -135,8 +135,8 @@ instance Typeable era => DecShareCBOR (ConwayAccountState era) where
       ConwayAccountState
         <$> decCBOR
         <*> decCBOR
-        <*> decodeNullStrictMaybe (interns ks <$> decCBOR)
-        <*> decodeNullStrictMaybe (decShareCBOR cd)
+        <*> decodeNullMaybe (interns ks <$> decCBOR)
+        <*> decodeNullMaybe (decShareCBOR cd)
 
 instance ToKeyValuePairs (ConwayAccountState era) where
   toKeyValuePairs cas@ConwayAccountState {..} =
@@ -179,8 +179,7 @@ instance EraAccounts ConwayEra where
   depositAccountStateL = lens casDeposit $ \cas d -> cas {casDeposit = d}
 
   stakePoolDelegationAccountStateL =
-    lens (strictMaybeToMaybe . casStakePoolDelegation) $ \cas d ->
-      cas {casStakePoolDelegation = maybeToStrictMaybe d}
+    lens casStakePoolDelegation $ \cas d -> cas {casStakePoolDelegation = d}
 
   unregisterAccount = unregisterConwayAccount
 
@@ -194,16 +193,15 @@ class EraAccounts era => ConwayEraAccounts era where
     ConwayAccountState
       { casBalance = mempty
       , casDeposit = deposit
-      , casStakePoolDelegation = SNothing
-      , casDRepDelegation = SNothing
+      , casStakePoolDelegation = Nothing
+      , casDRepDelegation = Nothing
       }
 
   dRepDelegationAccountStateL :: Lens' (AccountState era) (Maybe DRep)
 
 instance ConwayEraAccounts ConwayEra where
   dRepDelegationAccountStateL =
-    lens (strictMaybeToMaybe . casDRepDelegation) $ \cas d ->
-      cas {casDRepDelegation = maybeToStrictMaybe d}
+    lens casDRepDelegation $ \cas d -> cas {casDRepDelegation = d}
 
 lookupDRepDelegation :: ConwayEraAccounts era => Credential Staking -> Accounts era -> Maybe DRep
 lookupDRepDelegation cred accounts = do

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/State/Account.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/State/Account.hs
@@ -117,6 +117,8 @@ pattern ConwayAccountState
 
 {-# COMPLETE ConwayAccountState #-}
 
+{-# INLINE ConwayAccountState #-}
+
 instance NoThunks (ConwayAccountState era)
 
 instance NFData (ConwayAccountState era) where
@@ -180,10 +182,13 @@ instance EraAccounts ConwayEra where
   accountsMapL = lens caStates $ \cas asMap -> cas {caStates = asMap}
 
   balanceAccountStateL = balanceConwayAccountStateL
+  {-# INLINE balanceAccountStateL #-}
 
   depositAccountStateL = depositConwayAccountStateL
+  {-# INLINE depositAccountStateL #-}
 
   stakePoolDelegationAccountStateL = stakePoolDelegationConwayAccountStateL
+  {-# INLINE stakePoolDelegationAccountStateL #-}
 
   unregisterAccount = unregisterConwayAccount
 
@@ -204,6 +209,7 @@ balanceConwayAccountStateL =
         CASStakePool _ deposit stakePool -> CASStakePool balance deposit stakePool
         CASDRep _ deposit dRep -> CASDRep balance deposit dRep
         CASStakePoolAndDRep _ deposit stakePool dRep -> CASStakePoolAndDRep balance deposit stakePool dRep
+{-# INLINE balanceConwayAccountStateL #-}
 
 depositConwayAccountStateL :: Lens' (ConwayAccountState era) (CompactForm Coin)
 depositConwayAccountStateL =
@@ -220,6 +226,7 @@ depositConwayAccountStateL =
         CASStakePool balance _ stakePool -> CASStakePool balance deposit stakePool
         CASDRep balance _ dRep -> CASDRep balance deposit dRep
         CASStakePoolAndDRep balance _ stakePool dRep -> CASStakePoolAndDRep balance deposit stakePool dRep
+{-# INLINE depositConwayAccountStateL #-}
 
 stakePoolDelegationConwayAccountStateL :: Lens' (ConwayAccountState era) (Maybe (KeyHash StakePool))
 stakePoolDelegationConwayAccountStateL =
@@ -244,6 +251,7 @@ stakePoolDelegationConwayAccountStateL =
         CASStakePoolAndDRep balance deposit _ dRep
           | Just stakePool <- mStakePool -> CASStakePoolAndDRep balance deposit stakePool dRep
           | otherwise -> CASDRep balance deposit dRep
+{-# INLINE stakePoolDelegationConwayAccountStateL #-}
 
 dRepDelegationConwayAccountStateL :: Lens' (ConwayAccountState era) (Maybe DRep)
 dRepDelegationConwayAccountStateL =
@@ -268,6 +276,7 @@ dRepDelegationConwayAccountStateL =
         CASStakePoolAndDRep balance deposit stakePool _
           | Just dRep <- mDRep -> CASStakePoolAndDRep balance deposit stakePool dRep
           | otherwise -> CASStakePool balance deposit stakePool
+{-# INLINE dRepDelegationConwayAccountStateL #-}
 
 class EraAccounts era => ConwayEraAccounts era where
   mkConwayAccountState :: CompactForm Coin -> AccountState era
@@ -287,6 +296,7 @@ class EraAccounts era => ConwayEraAccounts era where
 
 instance ConwayEraAccounts ConwayEra where
   dRepDelegationAccountStateL = dRepDelegationConwayAccountStateL
+  {-# INLINE dRepDelegationAccountStateL #-}
 
 lookupDRepDelegation :: ConwayEraAccounts era => Credential Staking -> Accounts era -> Maybe DRep
 lookupDRepDelegation cred accounts = do

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/State/Account.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/State/Account.hs
@@ -12,7 +12,9 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
+-- `unused-pattern-binds` warning is disabled to preserve safety of `RecordWildCards` "trick" while
+-- avoiding unnecessary pattern matching that is not zero cost with pattern synonyms.
+{-# OPTIONS_GHC -Wno-orphans -Wno-unused-pattern-binds #-}
 
 module Cardano.Ledger.Conway.State.Account (
   ConwayAccountState (
@@ -116,8 +118,8 @@ instance NFData (ConwayAccountState era) where
   rnf = rwhnf
 
 instance EncCBOR (ConwayAccountState era) where
-  encCBOR cas@(ConwayAccountState _ _ _ _) =
-    let ConwayAccountState {..} = cas
+  encCBOR cas@ConwayAccountState {..} =
+    let ConwayAccountState _ _ _ _ = cas
      in encodeListLen 4
           <> encCBOR casBalance
           <> encCBOR casDeposit
@@ -137,8 +139,8 @@ instance Typeable era => DecShareCBOR (ConwayAccountState era) where
         <*> decodeNullStrictMaybe (decShareCBOR cd)
 
 instance ToKeyValuePairs (ConwayAccountState era) where
-  toKeyValuePairs cas@(ConwayAccountState _ _ _ _) =
-    let ConwayAccountState {..} = cas
+  toKeyValuePairs cas@ConwayAccountState {..} =
+    let ConwayAccountState _ _ _ _ = cas
      in [ "reward" .= casBalance -- deprecated
         , "balance" .= casBalance
         , "deposit" .= casDeposit

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
@@ -15,6 +15,7 @@
 module Cardano.Ledger.Conway.Translation () where
 
 import Cardano.Ledger.Babbage (BabbageEra)
+import Cardano.Ledger.BaseTypes (strictMaybeToMaybe)
 import Cardano.Ledger.Binary (DecoderError)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Era (ConwayEra)
@@ -134,8 +135,8 @@ instance TranslateEra ConwayEra DState where
         ConwayAccountState
           { casBalance = sasBalance
           , casDeposit = sasDeposit
-          , casStakePoolDelegation = sasStakePoolDelegation
-          , casDRepDelegation = SNothing
+          , casStakePoolDelegation = strictMaybeToMaybe sasStakePoolDelegation
+          , casDRepDelegation = Nothing
           }
 
 instance TranslateEra ConwayEra PState where

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -110,7 +110,7 @@ library
     cardano-ledger-alonzo ^>=1.16,
     cardano-ledger-babbage ^>=1.14,
     cardano-ledger-binary ^>=1.9,
-    cardano-ledger-conway ^>=1.22,
+    cardano-ledger-conway ^>=1.23,
     cardano-ledger-core:{cardano-ledger-core, internal} >=1.20,
     cardano-ledger-mary,
     cardano-ledger-shelley,

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/Account.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/Account.hs
@@ -16,15 +16,13 @@ instance EraAccounts DijkstraEra where
 
   accountsMapL = lens caStates $ \cas asMap -> cas {caStates = asMap}
 
-  balanceAccountStateL = lens casBalance $ \cas b -> cas {casBalance = b}
+  balanceAccountStateL = balanceConwayAccountStateL
 
-  depositAccountStateL = lens casDeposit $ \cas d -> cas {casDeposit = d}
+  depositAccountStateL = depositConwayAccountStateL
 
-  stakePoolDelegationAccountStateL =
-    lens casStakePoolDelegation $ \cas d -> cas {casStakePoolDelegation = d}
+  stakePoolDelegationAccountStateL = stakePoolDelegationConwayAccountStateL
 
   unregisterAccount = unregisterConwayAccount
 
 instance ConwayEraAccounts DijkstraEra where
-  dRepDelegationAccountStateL =
-    lens casDRepDelegation $ \cas d -> cas {casDRepDelegation = d}
+  dRepDelegationAccountStateL = dRepDelegationConwayAccountStateL

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/Account.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/Account.hs
@@ -17,12 +17,16 @@ instance EraAccounts DijkstraEra where
   accountsMapL = lens caStates $ \cas asMap -> cas {caStates = asMap}
 
   balanceAccountStateL = balanceConwayAccountStateL
+  {-# INLINE balanceAccountStateL #-}
 
   depositAccountStateL = depositConwayAccountStateL
+  {-# INLINE depositAccountStateL #-}
 
   stakePoolDelegationAccountStateL = stakePoolDelegationConwayAccountStateL
+  {-# INLINE stakePoolDelegationAccountStateL #-}
 
   unregisterAccount = unregisterConwayAccount
 
 instance ConwayEraAccounts DijkstraEra where
   dRepDelegationAccountStateL = dRepDelegationConwayAccountStateL
+  {-# INLINE dRepDelegationAccountStateL #-}

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/Account.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/Account.hs
@@ -3,7 +3,6 @@
 
 module Cardano.Ledger.Dijkstra.State.Account () where
 
-import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Dijkstra.Era
 import qualified Data.Map.Strict as Map
@@ -22,12 +21,10 @@ instance EraAccounts DijkstraEra where
   depositAccountStateL = lens casDeposit $ \cas d -> cas {casDeposit = d}
 
   stakePoolDelegationAccountStateL =
-    lens (strictMaybeToMaybe . casStakePoolDelegation) $ \cas d ->
-      cas {casStakePoolDelegation = maybeToStrictMaybe d}
+    lens casStakePoolDelegation $ \cas d -> cas {casStakePoolDelegation = d}
 
   unregisterAccount = unregisterConwayAccount
 
 instance ConwayEraAccounts DijkstraEra where
   dRepDelegationAccountStateL =
-    lens (strictMaybeToMaybe . casDRepDelegation) $ \cas d ->
-      cas {casDRepDelegation = maybeToStrictMaybe d}
+    lens casDRepDelegation $ \cas d -> cas {casDRepDelegation = d}

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
@@ -94,7 +94,7 @@ conwayAccountsSpec univ poolreg = constrained $ \ [var|conwayAccounts|] ->
           , witness univ accountstate
           , match accountstate $ \ [var|_rewardbal|] [var|_depositbal|] [var|mStakeDelegKeyhash|] [var|mDRep|] ->
               [ ( caseOn
-                    (mStakeDelegKeyhash :: Term (StrictMaybe (KeyHash StakePool)))
+                    (mStakeDelegKeyhash :: Term (Maybe (KeyHash StakePool)))
                     (branchW 1 $ \_ -> True)
                     (branchW 3 $ \ [var|stakekeyhash|] -> mapMember_ stakekeyhash poolreg)
                 )

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -1092,8 +1092,8 @@ instance Typeable era => HasSpec (ShelleyAccounts era)
 type ConwayAccountStateTypes era =
   '[ CompactForm Coin
    , CompactForm Coin
-   , StrictMaybe (KeyHash StakePool)
-   , StrictMaybe DRep
+   , Maybe (KeyHash StakePool)
+   , Maybe DRep
    ]
 
 instance HasSimpleRep (ConwayAccountState era) where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
@@ -341,8 +341,8 @@ conwayAccountMapSpec univ whoDelegates poolreg wdrl =
                   [ dependsOn deposit cred
                   , dependsOn bal cred
                   , satisfies deposit (geqSpec 0)
-                  , onCon @"SJust" mpool $ \ [var|khashStakePool|] -> member_ khashStakePool (dom_ poolreg)
-                  , reify cred isKeyHash $ \bool -> whenTrue bool [assert $ onCon @"SJust" mdrep $ \x -> member_ x (lit (dRepsOf whoDelegates))]
+                  , onCon @"Just" mpool $ \ [var|khashStakePool|] -> member_ khashStakePool (dom_ poolreg)
+                  , reify cred isKeyHash $ \bool -> whenTrue bool [assert $ onCon @"Just" mdrep $ \x -> member_ x (lit (dRepsOf whoDelegates))]
                   , (caseOn (lookup_ cred (lit withdrawalMap)))
                       -- Nothing
                       ( branch $ \_ ->
@@ -363,15 +363,15 @@ conwayAccountMapSpec univ whoDelegates poolreg wdrl =
                       (member_ cred (lit withdrawalKeys))
                       ( satisfies
                           mdrep
-                          ( constrained $ \(x :: Term (StrictMaybe DRep)) ->
+                          ( constrained $ \(x :: Term (Maybe DRep)) ->
                               (caseOn x)
-                                -- SNothing
+                                -- Nothing
                                 (branch $ \_ -> False)
-                                -- SJust
+                                -- Just
                                 (branch $ \drep -> member_ drep (lit (dRepsOf whoDelegates)))
                           )
                       )
-                      (onCon @"SJust" mdrep $ \ [var|drep|] -> member_ drep (lit (dRepsOf whoDelegates)))
+                      (onCon @"Just" mdrep $ \ [var|drep|] -> member_ drep (lit (dRepsOf whoDelegates)))
                   ]
               ]
         ]


### PR DESCRIPTION
# Description

Instead of reverting the efficient type unrolling released in #5704 this PR properly fixes it by avoiding usage of pattern synonym, as well as  changing to efficient implementation for lenses and inlining them.

This PR also updates changelog and version in a way that is compatible with backport in #5728

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
