### PR TITLE
Add `toPlutusTxOut` to `EraPlutusTxInfo` typeclass with instances for all eras

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Version history for `cardano-ledger-alonzo`
 
+## 1.17.0.0
+
+* Add `PlutusTxOut` type family to `Cardano.Ledger.Alonzo.Plutus.Context`
+* Add `toPlutusTxOut` method to `EraPlutusTxInfo` typeclass
+* Add `EraPlutusTxInfo 'PlutusV1 AlonzoEra` instance for `toPlutusTxOut`
+
 ## 1.16.0.0
 
 * Add `ApplyTick` instance for `AlonzoEra`

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
@@ -36,6 +36,7 @@ module Cardano.Ledger.Alonzo.Plutus.Context (
   PlutusScriptPurpose,
   PlutusScriptContext,
   PlutusTxInInfo,
+  PlutusTxOut,
 ) where
 
 import Cardano.Ledger.Alonzo.Era (AlonzoEra)
@@ -66,6 +67,7 @@ import Cardano.Ledger.Plutus (
   PlutusScriptContext,
   PlutusWithContext (..),
   SLanguage (..),
+  TxOutSource,
   asSLanguage,
   isLanguage,
   plutusLanguage,
@@ -137,6 +139,12 @@ class
     UTxO era ->
     TxIn ->
     Either (ContextError era) (PlutusTxInInfo era l)
+
+  toPlutusTxOut ::
+    proxy l ->
+    TxOutSource ->
+    TxOut era ->
+    Either (ContextError era) (PlutusTxOut era l)
 
 -- | This is the helper type that captures translation of `Tx` to `PlutusTxInfo`.
 --
@@ -287,6 +295,15 @@ type family PlutusTxInInfo era (l :: Language) where
   PlutusTxInInfo _ 'PlutusV2 = PV2.TxInInfo
   PlutusTxInInfo _ 'PlutusV3 = PV3.TxInInfo
   PlutusTxInInfo _ 'PlutusV4 = PV3.TxInInfo
+
+type family PlutusTxOut era (l :: Language) where
+  -- This special case is here because Alonzo does not have a ContextError
+  -- for the case where it encounters a Byron address in a TxOut
+  PlutusTxOut AlonzoEra 'PlutusV1 = Maybe PV1.TxOut
+  PlutusTxOut _ 'PlutusV1 = PV1.TxOut
+  PlutusTxOut _ 'PlutusV2 = PV2.TxOut
+  PlutusTxOut _ 'PlutusV3 = PV3.TxOut
+  PlutusTxOut _ 'PlutusV4 = PV3.TxOut
 
 -- | This is just like `mkPlutusScript`, except it is guaranteed to be total through the enforcement
 -- of support by the type system and `EraPlutusTxInfo` type class instances for supported plutus

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
@@ -134,6 +134,10 @@ instance EraPlutusTxInfo 'PlutusV1 AlonzoEra where
     txOut <- transLookupTxOut utxo txIn
     pure $ PV1.TxInInfo (transTxIn txIn) <$> transTxOut txOut
 
+  -- PlutusTxOut AlonzoEra 'PlutusV1 = Maybe PV1.TxOut
+  -- transTxOut returns Nothing for Byron addresses (preserved historical behavior)
+  toPlutusTxOut _ _ txOut = Right (transTxOut txOut)
+
 toPlutusV1Args ::
   EraPlutusTxInfo 'PlutusV1 era =>
   proxy 'PlutusV1 ->

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-babbage`
 
+## 1.15.0.0
+
+* Add `EraPlutusTxInfo 'PlutusV1 BabbageEra` and `EraPlutusTxInfo 'PlutusV2 BabbageEra` instances for `toPlutusTxOut`
+
 ## 1.14.0.0
 
 * Add `ApplyTick` instance for `BabbageEra`

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
@@ -353,6 +353,8 @@ instance EraPlutusTxInfo 'PlutusV1 BabbageEra where
 
   toPlutusTxInInfo _ = transTxInInfoV1
 
+  toPlutusTxOut _ = transTxOutV1
+
 instance EraPlutusTxInfo 'PlutusV2 BabbageEra where
   toPlutusTxCert _ _ = pure . Alonzo.transTxCert
 
@@ -394,6 +396,8 @@ instance EraPlutusTxInfo 'PlutusV2 BabbageEra where
   toPlutusArgs = toPlutusV2Args
 
   toPlutusTxInInfo _ = transTxInInfoV2
+
+  toPlutusTxOut _ = transTxOutV2
 
 toPlutusV2Args ::
   EraPlutusTxInfo 'PlutusV2 era =>

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-conway`
 
+## 1.24.0.0
+
+* Add `EraPlutusTxInfo 'PlutusV1 ConwayEra`, `EraPlutusTxInfo 'PlutusV2 ConwayEra` and `EraPlutusTxInfo 'PlutusV3 ConwayEra` instances for `toPlutusTxOut`
+
 ## 1.23.0.0
 
 * Add `ApplyTick` instance for `ConwayEra`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
@@ -428,6 +428,8 @@ instance EraPlutusTxInfo 'PlutusV1 ConwayEra where
 
   toPlutusTxInInfo _ = transTxInInfoV1
 
+  toPlutusTxOut _ = transTxOutV1
+
 instance EraPlutusTxInfo 'PlutusV2 ConwayEra where
   toPlutusTxCert _ _ = transTxCertV1V2
 
@@ -470,6 +472,8 @@ instance EraPlutusTxInfo 'PlutusV2 ConwayEra where
   toPlutusArgs = Babbage.toPlutusV2Args
 
   toPlutusTxInInfo _ = Babbage.transTxInInfoV2
+
+  toPlutusTxOut _ = Babbage.transTxOutV2
 
 instance EraPlutusTxInfo 'PlutusV3 ConwayEra where
   toPlutusTxCert _ pv = pure . transTxCert pv
@@ -524,6 +528,8 @@ instance EraPlutusTxInfo 'PlutusV3 ConwayEra where
   toPlutusArgs = toPlutusV3Args
 
   toPlutusTxInInfo _ = transTxInInfoV3
+
+  toPlutusTxOut _ = Babbage.transTxOutV2
 
 transTxId :: TxId -> PV3.TxId
 transTxId txId = PV3.TxId (transSafeHash (unTxId txId))

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for cardano-ledger-dijkstra
 
+## 0.4.0.0
+
+* Add `EraPlutusTxInfo 'PlutusV1 DijkstraEra`, `EraPlutusTxInfo 'PlutusV2 DijkstraEra`, `EraPlutusTxInfo 'PlutusV3 DijkstraEra` and `EraPlutusTxInfo 'PlutusV4 DijkstraEra` instances for `toPlutusTxOut`
+
 ## 0.3.0.0
 
 * Add `ApplyTick` instance for `DijkstraEra`

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
@@ -42,8 +42,6 @@ import Cardano.Ledger.Conway.TxCert (Delegatee (..))
 import Cardano.Ledger.Conway.TxInfo (
   ConwayContextError (..),
   ConwayEraPlutusTxInfo (..),
-  transTxInInfoV1,
-  transTxInInfoV3,
  )
 import qualified Cardano.Ledger.Conway.TxInfo as Conway
 import Cardano.Ledger.Credential (StakeReference (..))
@@ -237,7 +235,9 @@ instance EraPlutusTxInfo 'PlutusV1 DijkstraEra where
 
   toPlutusArgs = Alonzo.toPlutusV1Args
 
-  toPlutusTxInInfo _ = transTxInInfoV1
+  toPlutusTxInInfo _ = Conway.transTxInInfoV1
+
+  toPlutusTxOut _ = Conway.transTxOutV1
 
 transTxCertV1V2 ::
   ( ConwayEraTxCert era
@@ -304,6 +304,8 @@ instance EraPlutusTxInfo 'PlutusV2 DijkstraEra where
 
   toPlutusTxInInfo _ = Babbage.transTxInInfoV2
 
+  toPlutusTxOut _ = Babbage.transTxOutV2
+
 instance EraPlutusTxInfo 'PlutusV3 DijkstraEra where
   toPlutusTxCert _ _ = pure . transTxCert
 
@@ -357,7 +359,9 @@ instance EraPlutusTxInfo 'PlutusV3 DijkstraEra where
 
   toPlutusArgs = Conway.toPlutusV3Args
 
-  toPlutusTxInInfo _ = transTxInInfoV3
+  toPlutusTxInInfo _ = Conway.transTxInInfoV3
+
+  toPlutusTxOut _ = Babbage.transTxOutV2
 
 transFailSubTxIsNotSupported ::
   forall l era.
@@ -473,7 +477,9 @@ instance EraPlutusTxInfo 'PlutusV4 DijkstraEra where
 
   toPlutusArgs = toPlutusV4Args
 
-  toPlutusTxInInfo _ = transTxInInfoV3
+  toPlutusTxInInfo _ = Conway.transTxInInfoV3
+
+  toPlutusTxOut _ = Babbage.transTxOutV2
 
 toPlutusV4Args ::
   EraPlutusTxInfo 'PlutusV4 era =>


### PR DESCRIPTION
# Description

Add `PlutusTxOut era l` type family to `Cardano.Ledger.Alonzo.Plutus.Context`, mirroring the existing `PlutusTxInInfo era l` pattern. The Alonzo era requires a special case `PlutusTxOut AlonzoEra 'PlutusV1 = Maybe PV1.TxOut` because `transTxOut` silently drops Byron addresses (no `ContextError` for this case), preserving historical behavior.

Add `toPlutusTxOut :: proxy l -> TxOutSource -> TxOut era -> Either (ContextError era) (PlutusTxOut era l)` to `EraPlutusTxInfo` and implement instances across all eras:
- Alonzo V1: wraps `transTxOut` result in `Right`
- Babbage V1/V2: delegates to `transTxOutV1`/`transTxOutV2`
- Conway V1/V2/V3: delegates to `transTxOutV1`/`transTxOutV2`
- Dijkstra V1/V2/V3/V4: delegates to `transTxOutV1`/`transTxOutV2`

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
