### PR TITLE
Fix and re-enable `BbodysSec`

### DIFF
--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/BbodySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/BbodySpec.hs
@@ -40,7 +40,7 @@ spec ::
   forall era.
   ConwayEraImp era => SpecWith (ImpInit (LedgerSpec era))
 spec = do
-  xit "BodyRefScriptsSizeTooBig" $ do
+  it "BodyRefScriptsSizeTooBig" $ do
     plutusScript <- mkPlutusScript @era $ purposeIsWellformedNoDatum SPlutusV2
     let scriptSize = originalBytesSize plutusScript
     pp <- getsPParams id
@@ -83,7 +83,7 @@ spec = do
           )
       ]
 
-  xit "BodyRefScriptsSizeTooBig with reference scripts in the same block" $
+  it "BodyRefScriptsSizeTooBig with reference scripts in the same block" $
     whenMajorVersionAtLeast @11 $ do
       Just plutusScript <- pure $ mkPlutusScript @era $ purposeIsWellformedNoDatum SPlutusV2
       let scriptSize = originalBytesSize plutusScript

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/BbodySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/BbodySpec.hs
@@ -46,17 +46,21 @@ spec = do
     pp <- getsPParams id
 
     -- Determine a number of transactions and a number of times the reference script
-    -- needs to be included as an input in each transaction,
-    -- in order for the total to exceed the maximum allowed refScript size per block,
-    -- while the refScript size per individual transaction doesn't exceed maxRefScriptSizePerTx
+    -- needs to be included as an input in each transaction, such that:
+    --  * the total exceeds the maximum allowed refScript size per block
+    --  * the refScript size per individual transaction doesn't exceed maxRefScriptSizePerTx
+    --  * the number of reference inputs doesn't make the transaction exceed maxTxSize
     let
       maxRefScriptSizePerTx = fromIntegral @Word32 @Int $ pp ^. ppMaxRefScriptSizePerTxG
       maxRefScriptSizePerBlock = fromIntegral @Word32 @Int $ pp ^. ppMaxRefScriptSizePerBlockG
+      -- we're capping the number of scripts per transaction so that we don't exceed transaction ppMaxTxSizeL
+      maxScriptsPerTx = 100
+      maxSingle = min maxRefScriptSizePerTx (maxScriptsPerTx * scriptSize)
 
     txScriptCounts <-
       genNumAdditionsExceeding
         scriptSize
-        maxRefScriptSizePerTx
+        maxSingle
         maxRefScriptSizePerBlock
 
     txs <- for txScriptCounts $ \n -> do
@@ -88,10 +92,12 @@ spec = do
       let
         maxRefScriptSizePerTx = fromIntegral @Word32 @Int $ pp ^. ppMaxRefScriptSizePerTxG
         maxRefScriptSizePerBlock = fromIntegral @Word32 @Int $ pp ^. ppMaxRefScriptSizePerBlockG
+        maxScriptsPerTx = 100
+        maxSingle = min maxRefScriptSizePerTx (maxScriptsPerTx * scriptSize)
       txScriptCounts <-
         genNumAdditionsExceeding
           scriptSize
-          maxRefScriptSizePerTx
+          maxSingle
           maxRefScriptSizePerBlock
 
       let


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

Fixes https://github.com/IntersectMBO/cardano-ledger/issues/5735

Plutus scripts from our examples became smaller with the latest plutus version -  so our test that checks max ref script size needs more scripts to reach this limit. This means the transactions it creates get bigger, and sometimes bigger than ppMaxTxSizeL - which creates a failure that is correct, but not expected by the test. 

At the moment in master, we compute the number of scripts per transaction and the number of transactions needed to reach the limit, ignoring  ppMaxTxSizeL - and this is the cause of this test failure, which has happened in the past. 

One solution would be to take the maxTxSize into account,  but I believe this is not only more complicated, but not necessarily more robust:  it would involve estimating CBOR encoding sizes, which are implementation details that could change. If these estimates drift, we're back to the same problem. 

Instead of this, In this PR, I'm capping the number of scripts per transaction to 100 (I have noticed that in with the new plutus version,  the maxtx size is reached at around 400 scripts).  This will have the effect of creating more but smaller transactions.
So even though it's not a number determined dynamically by the maxTxSize parameter, I think it's robust enough against encoding changes, and doesn't create extra complexity in the code. 


# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
