### PR TITLE
Post test failures summary to a PR comment as well as to CI

### DIFF
--- a/.github/actions/pr-comment/action.yml
+++ b/.github/actions/pr-comment/action.yml
@@ -1,0 +1,60 @@
+name: PR Comment
+description: Create or update a PR comment identified by a hidden marker
+
+inputs:
+  marker:
+    description: Hidden marker text for identifying the comment
+    required: true
+  body:
+    description: Markdown body of the comment
+    required: false
+    default: ''
+  body-path:
+    description: Path to a file containing the comment body
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/github-script@v7
+      env:
+        COMMENT_MARKER: ${{ inputs.marker }}
+        COMMENT_BODY: ${{ inputs.body }}
+        COMMENT_BODY_PATH: ${{ inputs.body-path }}
+      with:
+        script: |
+          const fs = require('fs');
+          const bodyPath = process.env.COMMENT_BODY_PATH;
+          const rawBody = bodyPath
+            ? fs.readFileSync(bodyPath, 'utf8')
+            : process.env.COMMENT_BODY;
+
+          if (!rawBody) return;
+
+          const marker = '<-- ${process.env.COMMENT_MARKER} -->';
+          const body = marker + '\n\n' + process.env.COMMENT_BODY;
+
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+          });
+
+          const existing = comments.find(c => c.body.includes(marker));
+
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+          }

--- a/.github/actions/pr-comment/action.yml
+++ b/.github/actions/pr-comment/action.yml
@@ -1,0 +1,60 @@
+name: PR Comment
+description: Create or update a PR comment identified by a hidden marker
+
+inputs:
+  marker:
+    description: Hidden marker text for identifying the comment
+    required: true
+  body:
+    description: Markdown body of the comment
+    required: false
+    default: ''
+  body-path:
+    description: Path to a file containing the comment body
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/github-script@v7
+      env:
+        COMMENT_MARKER: ${{ inputs.marker }}
+        COMMENT_BODY: ${{ inputs.body }}
+        COMMENT_BODY_PATH: ${{ inputs.body-path }}
+      with:
+        script: |
+          const fs = require('fs');
+          const bodyPath = process.env.COMMENT_BODY_PATH;
+          const rawBody = bodyPath
+            ? fs.readFileSync(bodyPath, 'utf8')
+            : process.env.COMMENT_BODY;
+
+          if (!rawBody) return;
+
+          const marker = `<!-- ${process.env.COMMENT_MARKER} -->`;
+          const body = marker + '\n\n' + rawBody;
+
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+          });
+
+          const existing = comments.find(c => c.body.includes(marker));
+
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+          }

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -308,6 +308,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: failure() && needs.test.result == 'failure'
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -311,7 +311,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-      sparse-checkout: .github
+      with:
+        sparse-checkout: |
+          .github
 
     - name: Install cleret
       # Tag should match the one that's used in flake.nix
@@ -329,7 +331,7 @@ jobs:
         cat failures-summary.md >"$GITHUB_STEP_SUMMARY"
 
     - name: Post PR comment
-      if: github.event.pull_request
+      if: github.event.pull_request && !github.event.pull_request.draft
       uses: ./.github/actions/pr-comment
       with:
         marker: 'failures summary'

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -310,6 +310,9 @@ jobs:
     if: failure() && needs.test.result == 'failure'
 
     steps:
+    - uses: actions/checkout@v6
+      sparse-checkout: .github
+
     - name: Install cleret
       # Tag should match the one that's used in flake.nix
       uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.5.0.0
@@ -321,7 +324,16 @@ jobs:
         path: failures
 
     - name: Generate summary
-      run: cleret failures render $(find failures -name failures.json) -o "$GITHUB_STEP_SUMMARY"
+      run: |
+        cleret failures render $(find failures -name failures.json) -o failures-summary.md
+        cat failures-summary.md >"$GITHUB_STEP_SUMMARY"
+
+    - name: Post PR comment
+      if: github.event.pull_request
+      uses: ./.github/actions/pr-comment
+      with:
+        marker: 'failures summary'
+        body-path: failures-summary.md
 
   complete:
     name: Tests completed

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -291,14 +291,15 @@ jobs:
       run: tar -xf state.tzst && rm state.tzst
 
     - name: Run tests
+      id: tests
       run: cleret cabal test '${{ matrix.package }}'
 
     - name: Record test failures
-      if: failure()
+      if: failure() && steps.tests.conclusion == 'failure'
       run: cleret failures extract -v -o failures.json
 
     - name: Upload test failures artifact
-      if: failure()
+      if: failure() && steps.tests.conclusion == 'failure'
       uses: actions/upload-artifact@v7
       with:
         name: failures-${{ matrix.package }}-${{ matrix.ghc }}-${{ matrix.os }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -310,8 +310,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: failure() && needs.test.result == 'failure'
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
+    - uses: actions/checkout@v6
+      with:
+        sparse-checkout: |
+          .github
+
     - name: Install cleret
       # Tag should match the one that's used in flake.nix
       uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.5.2.0
@@ -323,7 +331,16 @@ jobs:
         path: failures
 
     - name: Generate summary
-      run: cleret failures render $(find failures -name failures.json) -o "$GITHUB_STEP_SUMMARY"
+      run: |
+        cleret failures render $(find failures -name failures.json) -o failures-summary.md
+        cat failures-summary.md >"$GITHUB_STEP_SUMMARY"
+
+    - name: Post PR comment
+      if: github.event.pull_request && !github.event.pull_request.draft
+      uses: ./.github/actions/pr-comment
+      with:
+        marker: 'failures summary'
+        body-path: failures-summary.md
 
   complete:
     name: Tests completed

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -49,6 +49,7 @@ spec era = do
   Babbage.spec era
   describe "ConwayEra Onwards" $ withImpInitEachEraVersion era $ do
     BBODY.spec
+    CERTS.spec
     DELEG.spec
     ENACT.spec
     EPOCH.spec
@@ -64,6 +65,4 @@ spec era = do
 conwayEraSpecificSpec :: Spec
 conwayEraSpecificSpec = do
   describe "ConwayEra Specific" $ withImpInitEachEraVersion (Proxy @ConwayEra) $ do
-    -- TODO: move to `spec` when ready: https://github.com/IntersectMBO/cardano-ledger/issues/5805
-    CERTS.spec
     UTXO.conwayEraSpecificSpec


### PR DESCRIPTION
# Description

We already have a summary test failures being posted to the CI summary view. This posts a copy to a PR comment as well (if the CI is for a PR).

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
