### PR TITLE
Add ToJSON/FromJSON instances for EraTxOut

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.16.0.1
 
-*
+* Add `FromJSON` instance for `AlonzoTxOut era`
 
 ## 1.16.0.0
 

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.17.0.0
 
+* Add `FromJSON` instance for `AlonzoTxOut era`
 * Remove `AlonzoEraUTxO` constraint from `mkPlutusWithContext`
 * Add `toPlutusRedeemerPointer` and `toPlutusTxOut` methods to `EraPlutusTxInfo`
 * Add `PlutusPurposeScriptHashArg`, `PlutusRedeemerPointer` and `PlutusTxOut` type families

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxOut.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxOut.hs
@@ -77,8 +77,8 @@ import qualified Cardano.Ledger.Shelley.TxOut as Shelley
 import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData (..), rwhnf)
 import Control.Monad (guard)
-import Data.Aeson (ToJSON (..), object, (.=))
-import qualified Data.Aeson as Aeson (Value (Null, String))
+import Data.Aeson (FromJSON (..), ToJSON (..), object, (.:), (.=))
+import qualified Data.Aeson as Aeson
 import Data.Bits
 import Data.Maybe (fromMaybe)
 import Data.MemPack
@@ -444,6 +444,13 @@ instance (Era era, Val (Value era)) => ToJSON (AlonzoTxOut era) where
             Aeson.String . hashToTextAsHex $
               extractHash dHash
       ]
+
+instance (Era era, Val (Value era)) => FromJSON (AlonzoTxOut era) where
+  parseJSON = Aeson.withObject "AlonzoTxOut" $ \o ->
+    AlonzoTxOut
+      <$> o .: "address"
+      <*> o .: "value"
+      <*> o .: "datahash"
 
 pattern TxOutCompact ::
   (Era era, Val (Value era), HasCallStack) =>

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxOut.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxOut.hs
@@ -77,8 +77,8 @@ import qualified Cardano.Ledger.Shelley.TxOut as Shelley
 import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData (..), rwhnf)
 import Control.Monad (guard)
-import Data.Aeson (ToJSON (..), object, (.=))
-import qualified Data.Aeson as Aeson (Value (Null, String))
+import Data.Aeson (FromJSON (..), ToJSON (..), object, (.:), (.=))
+import qualified Data.Aeson as Aeson
 import Data.Bits
 import Data.Maybe (fromMaybe)
 import Data.MemPack
@@ -446,6 +446,13 @@ instance (Era era, Val (Value era)) => ToJSON (AlonzoTxOut era) where
             Aeson.String . hashToTextAsHex $
               extractHash dHash
       ]
+
+instance (Era era, Val (Value era)) => FromJSON (AlonzoTxOut era) where
+  parseJSON = Aeson.withObject "AlonzoTxOut" $ \o ->
+    AlonzoTxOut
+      <$> o .: "address"
+      <*> o .: "value"
+      <*> o .: "datahash"
 
 pattern TxOutCompact ::
   (Era era, Val (Value era), HasCallStack) =>

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.15.0.0
 
+* Add `FromJSON` instance for `BabbageTxOut era`
 * Change `transTxRedeemers` to accept a `UTxO era` argument
 * Change `toPlutusV2Args` to accept `LedgerTxInfo era` and `ScriptHash` arguments instead of `ProtVer` and `Maybe (Data era)`
 * Rename `transRedeemerPtr` to `transRedeemerPointerV2V3`

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.14.0.1
 
-*
+* Add `FromJSON` instance for `BabbageTxOut era`
 
 ## 1.14.0.0
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
@@ -112,7 +112,8 @@ import Cardano.Ledger.Plutus.Data (
  )
 import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData (rnf), rwhnf)
-import Data.Aeson (ToJSON (..), (.=))
+import Data.Aeson (FromJSON (..), ToJSON (..), (.:), (.=))
+import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.Maybe (fromMaybe)
 import Data.MemPack
@@ -335,6 +336,14 @@ instance (Era era, Val (Value era), ToJSON (Script era)) => ToKeyValuePairs (Bab
     , "datum" .= dat
     , "referenceScript" .= mRefScript
     ]
+
+instance (Era era, Val (Value era), FromJSON (Script era)) => FromJSON (BabbageTxOut era) where
+  parseJSON = Aeson.withObject "BabbageTxOut" $ \o ->
+    BabbageTxOut
+      <$> o .: "address"
+      <*> o .: "value"
+      <*> o .: "datum"
+      <*> o .: "referenceScript"
 
 viewCompactTxOut ::
   forall era.

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxOut.hs
@@ -112,7 +112,8 @@ import Cardano.Ledger.Plutus.Data (
  )
 import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData (rnf), rwhnf)
-import Data.Aeson (ToJSON (..), (.=))
+import Data.Aeson (FromJSON (..), ToJSON (..), (.:), (.=))
+import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.Maybe (fromMaybe)
 import Data.MemPack
@@ -339,6 +340,14 @@ instance (Era era, Val (Value era), ToJSON (Script era)) => ToKeyValuePairs (Bab
     , "datum" .= dat
     , "referenceScript" .= mRefScript
     ]
+
+instance (Era era, Val (Value era), FromJSON (Script era)) => FromJSON (BabbageTxOut era) where
+  parseJSON = Aeson.withObject "BabbageTxOut" $ \o ->
+    BabbageTxOut
+      <$> o .: "address"
+      <*> o .: "value"
+      <*> o .: "datum"
+      <*> o .: "referenceScript"
 
 viewCompactTxOut ::
   forall era.

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.11.0.1
 
-*
+* Add `FromJSON` instance for `MaryValue`
+* Add `FromJSON` and `FromJSONKey` instances for `AssetName` (hex-decoding from `ToJSON` format)
 
 ## 1.11.0.0
 

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.11.1.0
 
+* Add `FromJSON` instance for `MaryValue`
+* Add `FromJSON` and `FromJSONKey` instances for `AssetName` (hex-decoding from `ToJSON` format)
 * Add `EncCBOR`, `ToCBOR` for `Block`
 * Add `DecCBOR` instances for `Annotator Block`
 

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Value.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Value.hs
@@ -68,7 +68,7 @@ import Control.DeepSeq (NFData (..), deepseq, rwhnf)
 import Control.Exception (assert)
 import Control.Monad (forM_, guard, unless, when)
 import Control.Monad.ST (runST)
-import Data.Aeson (FromJSON, FromJSONKey, ToJSON (..), (.=))
+import Data.Aeson (FromJSON, FromJSONKey (..), ToJSON (..), (.:), (.=))
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (ToJSONKey (..), toJSONKeyText)
 import qualified Data.ByteString as BS
@@ -98,7 +98,7 @@ import qualified Data.Semigroup as Semigroup (Sum (..))
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
-import Data.Text.Encoding (decodeLatin1)
+import Data.Text.Encoding (decodeLatin1, encodeUtf8)
 import Data.Word (Word16, Word32, Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..), OnlyCheckWhnfNamed (..))
@@ -122,6 +122,10 @@ assetNameToBytesAsHex = BS16.encode . SBS.fromShort . assetNameBytes
 
 assetNameToTextAsHex :: AssetName -> Text
 assetNameToTextAsHex = decodeLatin1 . assetNameToBytesAsHex
+
+assetNameFromText :: Text -> Either String AssetName
+assetNameFromText t =
+  AssetName . SBS.toShort <$> BS16.decode (encodeUtf8 t)
 
 instance DecCBOR AssetName where
   decCBOR = do
@@ -153,7 +157,7 @@ newtype PolicyID = PolicyID {policyID :: ScriptHash}
 
 -- | The MultiAssets map
 newtype MultiAsset = MultiAsset (Map PolicyID (Map AssetName Integer))
-  deriving (Show, Generic, ToJSON, EncCBOR)
+  deriving (Show, Generic, FromJSON, ToJSON, EncCBOR)
 
 instance Eq MultiAsset where
   MultiAsset x == MultiAsset y = pointWise (pointWise (==)) x y
@@ -383,6 +387,12 @@ decodeIntegerBounded64 = do
 -- ========================================================================
 -- JSON
 
+instance FromJSON MaryValue where
+  parseJSON = Aeson.withObject "MaryValue" $ \o ->
+    MaryValue
+      <$> o .: "lovelace"
+      <*> o .: "policies"
+
 instance ToKeyValuePairs MaryValue where
   toKeyValuePairs (MaryValue l ps) =
     [ "lovelace" .= l
@@ -394,6 +404,18 @@ instance ToJSON AssetName where
 
 instance ToJSONKey AssetName where
   toJSONKey = toJSONKeyText assetNameToTextAsHex
+
+instance FromJSON AssetName where
+  parseJSON = Aeson.withText "AssetName" $ \t ->
+    case assetNameFromText t of
+      Left e -> fail $ "AssetName: invalid hex: " <> e
+      Right bs -> pure bs
+
+instance FromJSONKey AssetName where
+  fromJSONKey = Aeson.FromJSONKeyTextParser $ \t ->
+    case assetNameFromText t of
+      Left e -> fail $ "AssetName: invalid hex: " <> e
+      Right bs -> pure bs
 
 -- ========================================================================
 -- Compactible

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Value.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Value.hs
@@ -68,7 +68,7 @@ import Control.DeepSeq (NFData (..), deepseq, rwhnf)
 import Control.Exception (assert)
 import Control.Monad (forM_, guard, unless, when)
 import Control.Monad.ST (runST)
-import Data.Aeson (FromJSON, FromJSONKey, ToJSON (..), (.=))
+import Data.Aeson (FromJSON, FromJSONKey (..), ToJSON (..), (.:), (.=))
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (ToJSONKey (..), toJSONKeyText)
 import qualified Data.ByteString as BS
@@ -98,7 +98,7 @@ import Data.Proxy (Proxy (..))
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
-import Data.Text.Encoding (decodeLatin1)
+import Data.Text.Encoding (decodeLatin1, encodeUtf8)
 import Data.Word (Word16, Word32, Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..), OnlyCheckWhnfNamed (..))
@@ -122,6 +122,10 @@ assetNameToBytesAsHex = BS16.encode . SBS.fromShort . assetNameBytes
 
 assetNameToTextAsHex :: AssetName -> Text
 assetNameToTextAsHex = decodeLatin1 . assetNameToBytesAsHex
+
+assetNameFromText :: Text -> Either String AssetName
+assetNameFromText t =
+  AssetName . SBS.toShort <$> BS16.decode (encodeUtf8 t)
 
 instance DecCBOR AssetName where
   decCBOR = do
@@ -157,7 +161,7 @@ newtype PolicyID = PolicyID {policyID :: ScriptHash}
 -- to satisfy constraints on Haskell containers such as `Set` and `Map`.
 -- Do not use it for any purpose that would directly affect chain behavior.
 newtype MultiAsset = MultiAsset (Map PolicyID (Map AssetName Integer))
-  deriving (Show, Ord, Generic, ToJSON, EncCBOR)
+  deriving (Show, Ord, Generic, FromJSON, ToJSON, EncCBOR)
 
 instance Eq MultiAsset where
   MultiAsset x == MultiAsset y = CM.pointwise (CM.pointwise (==)) x y
@@ -391,6 +395,12 @@ decodeIntegerBounded64 = do
 -- ========================================================================
 -- JSON
 
+instance FromJSON MaryValue where
+  parseJSON = Aeson.withObject "MaryValue" $ \o ->
+    MaryValue
+      <$> o .: "lovelace"
+      <*> o .: "policies"
+
 instance ToKeyValuePairs MaryValue where
   toKeyValuePairs (MaryValue l ps) =
     [ "lovelace" .= l
@@ -402,6 +412,18 @@ instance ToJSON AssetName where
 
 instance ToJSONKey AssetName where
   toJSONKey = toJSONKeyText assetNameToTextAsHex
+
+instance FromJSON AssetName where
+  parseJSON = Aeson.withText "AssetName" $ \t ->
+    case assetNameFromText t of
+      Left e -> fail $ "AssetName: invalid hex: " <> e
+      Right bs -> pure bs
+
+instance FromJSONKey AssetName where
+  fromJSONKey = Aeson.FromJSONKeyTextParser $ \t ->
+    case assetNameFromText t of
+      Left e -> fail $ "AssetName: invalid hex: " <> e
+      Right bs -> pure bs
 
 -- ========================================================================
 -- Compactible

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Cap the reward pot of an over-leveraged stake pool in `mkPoolRewardInfo`, whenever the
   maximum pledge leverage is set in the protocol parameters
+* Add `FromJSON` instance for `ShelleyTxOut era`
 
 ### `testlib`
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add `DecCBOR` instances for `Annotator Block`
 * Cap the reward pot of an over-leveraged stake pool in `mkPoolRewardInfo`, whenever the
   maximum pledge leverage is set in the protocol parameters
+* Add `FromJSON` instance for `ShelleyTxOut era`
 
 ### `testlib`
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxOut.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxOut.hs
@@ -45,7 +45,8 @@ import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.PParams ()
 import Cardano.Ledger.Val (Val)
 import Control.DeepSeq (NFData (rnf))
-import Data.Aeson (ToJSON (..), (.=))
+import Data.Aeson (FromJSON (..), ToJSON (..), (.:), (.=))
+import qualified Data.Aeson as Aeson
 import Data.Maybe (fromMaybe)
 import Data.MemPack
 import GHC.Generics (Generic)
@@ -183,3 +184,9 @@ instance (Era era, Val (Value era)) => ToKeyValuePairs (ShelleyTxOut era) where
     [ "address" .= addr
     , "amount" .= amount
     ]
+
+instance (Era era, Val (Value era)) => FromJSON (ShelleyTxOut era) where
+  parseJSON = Aeson.withObject "ShelleyTxOut" $ \o ->
+    ShelleyTxOut
+      <$> o .: "address"
+      <*> o .: "amount"

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxOut.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxOut.hs
@@ -45,7 +45,8 @@ import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.PParams ()
 import Cardano.Ledger.Val (Val)
 import Control.DeepSeq (NFData (rnf))
-import Data.Aeson (ToJSON (..), (.=))
+import Data.Aeson (FromJSON (..), ToJSON (..), (.:), (.=))
+import qualified Data.Aeson as Aeson
 import Data.Maybe (fromMaybe)
 import Data.MemPack
 import GHC.Generics (Generic)
@@ -185,3 +186,9 @@ instance (Era era, Val (Value era)) => ToKeyValuePairs (ShelleyTxOut era) where
     [ "address" .= addr
     , "amount" .= amount
     ]
+
+instance (Era era, Val (Value era)) => FromJSON (ShelleyTxOut era) where
+  parseJSON = Aeson.withObject "ShelleyTxOut" $ \o ->
+    ShelleyTxOut
+      <$> o .: "address"
+      <*> o .: "amount"

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -42,6 +42,9 @@
 * Add `ToPlutusData` instance for `OrdExUnits`
 * Add `Milliseconds32`, a duration in whole milliseconds bounded by `Word32`
 * Add `ToPlutusData` instance for `Milliseconds32`
+* Add `FromJSON (TxOut era)` as `EraTxOut` superclass constraint
+* Add `FromJSON t` as `Val t` superclass constraint
+* Add `ToJSON` and `FromJSON` instances for `Datum era`
 
 ### `testlib`
 
@@ -173,6 +176,7 @@
 * Add round-trip JSON property test for `NativeScript era` and `Script era` to the shared era spec
 * Add round-trip JSON property test for `TxAuxData era` to the shared era spec
 * Add round-trip JSON property test for `TxWits era` to the shared era spec
+* Add round-trip JSON property test for `TxOut era` to the shared era spec
 
 ## 1.20.0.0
 

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -19,6 +19,9 @@
 * Add `FromJSON` instance for `TxIn`; fix `txInToText` to use `unTxIx` instead of `show`
 * Add `FromJSON` instance for `PoolCert`
 * Add `ppMinPoolMarginG` to `EraPParams` with default returning `minBound` for pre-Dijkstra eras (CIP-0023)
+* Add `FromJSON (TxOut era)` as `EraTxOut` superclass constraint
+* Add `FromJSON t` as `Val t` superclass constraint
+* Add `ToJSON` and `FromJSON` instances for `Datum era`
 
 ### `testlib`
 
@@ -135,6 +138,7 @@
 * Add round-trip JSON property test for `NativeScript era` and `Script era` to the shared era spec
 * Add round-trip JSON property test for `TxAuxData era` to the shared era spec
 * Add round-trip JSON property test for `TxWits era` to the shared era spec
+* Add round-trip JSON property test for `TxOut era` to the shared era spec
 
 ## 1.20.0.0
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -296,6 +296,7 @@ class
 -- | Abstract interface into specific fields of a `TxOut`
 class
   ( Val (Value era)
+  , FromJSON (TxOut era)
   , ToJSON (TxOut era)
   , DecCBOR (Value era)
   , DecCBOR (CompactForm (Value era))

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Data.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Data.hs
@@ -67,7 +67,7 @@ import Cardano.Ledger.MemoBytes (
  )
 import Cardano.Ledger.MemoBytes.Internal (mkMemoBytesShort)
 import qualified Codec.Serialise as Cborg (Serialise (..))
-import Control.Applicative (asum)
+import Control.Applicative (asum, (<|>))
 import Control.DeepSeq (NFData)
 import Control.Monad ((<$!>))
 import Data.Aeson (FromJSON (..), ToJSON (..), Value (Null), object, withObject, (.:), (.=))
@@ -318,14 +318,15 @@ instance Era era => DecCBOR (Datum era) where
         k -> invalidKey k
 
 instance Era era => ToJSON (Datum era) where
-  toJSON d =
-    case datumDataHash d of
-      SNothing -> Null
-      SJust dh -> toJSON dh
-  toEncoding d =
-    case datumDataHash d of
-      SNothing -> toEncoding Null
-      SJust dh -> toEncoding dh
+  toJSON NoDatum = Null
+  toJSON (DatumHash dh) = object ["datumhash" .= dh]
+  toJSON (Datum bd) = object ["datum" .= binaryDataToData @era bd]
+
+instance Era era => FromJSON (Datum era) where
+  parseJSON Null = pure NoDatum
+  parseJSON v =
+    withObject "DatumHash" (\o -> DatumHash <$> o .: "datumhash") v
+      <|> withObject "Datum" (\o -> Datum . dataToBinaryData <$> o .: "datum") v
 
 mkInlineDatum :: forall era. Era era => PV1.Data -> Datum era
 mkInlineDatum = Datum . dataToBinaryData . Data @era

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Val.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Val.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | This module defines a generalised notion of a "value" - that is, something
@@ -21,7 +20,7 @@ import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Coin (Coin (..), CompactForm (..), DeltaCoin (..))
 import Cardano.Ledger.Compactible (Compactible (..))
 import Control.DeepSeq (NFData)
-import Data.Aeson (ToJSON)
+import Data.Aeson (FromJSON, ToJSON)
 import Data.Coerce
 import Data.Foldable as F (foldl')
 import Data.Group (Abelian)
@@ -36,6 +35,7 @@ class
   , NoThunks t
   , EncCBOR t
   , DecCBOR t
+  , FromJSON t
   , ToJSON t
   , NFData t
   , Show t

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Era.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Era.hs
@@ -176,6 +176,8 @@ ledgerEraTestMain extraEraSpec =
           roundTripAesonProperty @(TxAuxData era)
         prop (show $ typeRep $ Proxy @(TxWits era)) $
           roundTripAesonProperty @(TxWits era)
+        prop (show $ typeRep $ Proxy @(TxOut era)) $
+          roundTripAesonProperty @(TxOut era)
       describe "Era-specific spec" extraEraSpec
 
 -- | This is a helper function that uses `mkTestAccountState` to register an account.


### PR DESCRIPTION
# Description

* Add FromJSON (TxOut era) as EraTxOut superclass constraint
* Add FromJSON t as Val t superclass constraint
* Add ToJSON/FromJSON for Datum era
* Add FromJSON for ShelleyTxOut, AlonzoTxOut, BabbageTxOut
* Add FromJSON for MaryValue; fix FromJSON/FromJSONKey for AssetName to hex-decode
* Add round-trip JSON property test for TxOut era

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
