### PR TITLE
Constrain the size of leios_certificate signers

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -24,6 +24,13 @@ source-repository-package
   --sha256: sha256-h0bJTwdfJG84XrERJJoBBi5ZzRHgeVoZWS2yW/z7LiU=
   tag: 966f65f3c28cb22fc45220dbd1408baea93b53d8
 
+source-repository-package
+  type: git
+  location: https://github.com/intersectmbo/cardano-base.git
+  --sha256: sha256-WUBluY6UqvBkS5cNsJnKMOaW+1dTfL3mg8iq/kVPV0o=
+  tag: 242f1ebde40b137ac024d8b68265e2935e0eba14
+  subdir: cardano-crypto-leios
+
 -- NOTE: If you would like to update the above,
 -- see CONTRIBUTING.md#to-update-the-referenced-agda-ledger-spec
 index-state:

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -110,7 +110,7 @@ library
     bytestring,
     cardano-base >=0.1.4,
     cardano-crypto-class,
-    cardano-crypto-leios >=0.1,
+    cardano-crypto-leios >=0.3,
     cardano-data ^>=1.3.2,
     cardano-ledger-allegra,
     cardano-ledger-alonzo ^>=1.17,

--- a/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+++ b/eras/dijkstra/impl/cddl/data/dijkstra.cddl
@@ -895,8 +895,8 @@ auxiliary_data_map =
   )
 
 leios_certificate =
-  [ signers              : bytes           ;bitfield
-  , aggregated_signature : leios_signature
+  [ signers   : bytes .size (0 .. 8192) ;bitfield with up to 65537 entries
+  , signature : leios_signature
   ]
 
 leios_signature = bytes .size 48

--- a/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+++ b/eras/dijkstra/impl/cddl/data/dijkstra.cddl
@@ -909,8 +909,8 @@ auxiliary_data_map =
 starting_account_balance_intervals = {+ credential => account_balance_interval}
 
 leios_certificate =
-  [ signers              : bytes           ;bitfield
-  , aggregated_signature : leios_signature
+  [ signers   : bytes .size (0 .. 8192) ;bitfield with up to 65536 entries
+  , signature : leios_signature
   ]
 
 leios_signature = bytes .size 48

--- a/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
+++ b/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
@@ -59,6 +59,7 @@ import Data.Function ((&))
 import Data.List (nub)
 import Data.Maybe (mapMaybe)
 import Data.Proxy (Proxy (..))
+import Data.String (fromString)
 import Data.Text ()
 import Data.Text qualified as T
 import Data.Word (Word16, Word64)
@@ -1004,9 +1005,12 @@ instance HuddleRule "leios_certificate" DijkstraEra where
   huddleRuleNamed pname era =
     pname
       =.= arr
-        [ "signers" ==> VBytes & comment "bitfield"
-        , "aggregated_signature" ==> huddleRule @"leios_signature" era
+        [ "signers" ==> VBytes `sized` (0 :: Word64, maxSigners `div` 8 :: Word64)
+            & comment (fromString $ "bitfield with up to " <> show maxSigners <> " entries")
+        , "signature" ==> huddleRule @"leios_signature" era
         ]
+    where
+      maxSigners = 2 ^ (16 :: Word) + 1
 
 instance HuddleRule "leios_signature" DijkstraEra where
   huddleRuleNamed pname _era =

--- a/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
+++ b/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
@@ -33,7 +33,7 @@ module Cardano.Ledger.Dijkstra.HuddleSpec (
 ) where
 
 import Cardano.Crypto.Leios (leiosSignatureSize, leiosSignatureToBytes)
-import Cardano.Ledger.Binary (rawEncodeFixedSized)
+import Cardano.Ledger.Binary (maxLeiosCertSignersBytes, rawEncodeFixedSized)
 import Cardano.Ledger.Conway.HuddleSpec hiding (poolParamsGroup)
 import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Huddle.Gen (
@@ -63,6 +63,7 @@ import Data.Function ((&))
 import Data.List (nub)
 import Data.Maybe (mapMaybe)
 import Data.Proxy (Proxy (..))
+import Data.String (fromString)
 import Data.Text ()
 import Data.Text qualified as T
 import Data.Word (Word16, Word64)
@@ -1057,9 +1058,12 @@ instance HuddleRule "leios_certificate" DijkstraEra where
   huddleRuleNamed pname era =
     pname
       =.= arr
-        [ "signers" ==> VBytes & comment "bitfield"
-        , "aggregated_signature" ==> huddleRule @"leios_signature" era
+        [ "signers" ==> VBytes `sized` (0 :: Word64, maxBytes)
+            & comment (fromString $ "bitfield with up to " <> show (maxBytes * 8) <> " entries")
+        , "signature" ==> huddleRule @"leios_signature" era
         ]
+    where
+      maxBytes = fromIntegral @Int @Word64 maxLeiosCertSignersBytes
 
 instance HuddleRule "leios_signature" DijkstraEra where
   huddleRuleNamed pname _era =

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add `decodeStringIndefLen`, `decodeStringDefOrIndef`, `decodeBytesIndefLen`, `decodeBytesDefOrIndef`, `decodeByteArrayIndefLen` and `decodeByteArrayDefOrIndef`
 * Change `DecCBOR` instances for `Text` and tuples to accept indefinite-length encoding starting with protocol version 12
 * Add `EncCBOR` and `DecCBOR` instances for `ScriptContext` for PlutusV4
+* Change `DecCBOR` instance for `LeiosCert` to reject a signers bitfield larger than `maxLeiosCertSignersBytes`
 
 ### `testlib`
 

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -58,7 +58,7 @@ library
     cardano-base >=0.1.2,
     cardano-binary >=1.9.1,
     cardano-crypto-class >=2.3 && <2.6,
-    cardano-crypto-leios >=0.2.0,
+    cardano-crypto-leios >=0.3,
     cardano-crypto-praos >=2.2.2,
     cardano-slotting >=0.2,
     cardano-strict-containers >=0.1.2,

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs
@@ -18,6 +18,7 @@ module Cardano.Ledger.Binary.Decoding.DecCBOR (
   fromByronCBOR,
   decodeScriptContextFromData,
   decodeIntegralRational,
+  maxLeiosCertSignersBytes,
 
   -- *** Network
   decodeIPv4,
@@ -69,7 +70,7 @@ import Data.ByteString.Short (ShortByteString(SBS))
 import Data.ByteString.Short.Internal (ShortByteString(SBS))
 #endif
 import Cardano.Base.IP (IPv4, IPv6, toIPv4w, toIPv6w)
-import Cardano.Crypto.Leios (BitField (..), LeiosCert (..))
+import Cardano.Crypto.Leios (BitField (..), LeiosCert (..), maxLeiosCommitteeSize)
 import Control.Monad (when)
 import Data.Binary.Get (Get, getWord32le, runGetOrFail)
 import Data.Fixed (Fixed (..))
@@ -686,6 +687,13 @@ decodeScriptContextFromData scriptContextData =
 -- Leios
 --------------------------------------------------------------------------------
 
+-- | Ceiling on a certificate's signers bitfield, for want of the committee that
+-- would pin its length exactly: enough bits for the largest committee a
+-- 'Cardano.Crypto.Leios.LeiosSeatId' can address.
+-- 'Cardano.Crypto.Leios.verifyLeiosCert' does the exact check.
+maxLeiosCertSignersBytes :: Int
+maxLeiosCertSignersBytes = (maxLeiosCommitteeSize + 7) `div` 8
+
 instance DecCBOR BitField where
   decCBOR = BitField <$> decCBOR
 
@@ -693,5 +701,16 @@ instance DecCBOR LeiosCert where
   decCBOR =
     decodeRecordNamed "LeiosCert" (const 2) $
       LeiosCert
-        <$> decCBOR
+        <$> decodeSigners
         <*> decCBOR
+    where
+      decodeSigners = do
+        signers <- decCBOR
+        let numBytes = Prim.sizeofByteArray (bitFieldBytes signers)
+        when (numBytes > maxLeiosCertSignersBytes) $
+          fail $
+            "LeiosCert signers of "
+              <> show numBytes
+              <> " bytes exceeds the maximum of "
+              <> show maxLeiosCertSignersBytes
+        pure signers


### PR DESCRIPTION
The maximum length is determined by the maximum LeiosVoterId. As this is a Word16, the max number of entries is 65535 bits = 8192 bytes

This is now based on the upcoming `cardano-crypto-leios 0.3` and requires https://github.com/IntersectMBO/cardano-base/pull/697
 
# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
