### PR TITLE
Make GenerateCBOR exit with nonzero when generation fails, retry failed attempts

### DIFF
--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Add `decodeStringIndefLen`, `decodeStringDefOrIndef`, `decodeBytesIndefLen`, `decodeBytesDefOrIndef`, `decodeByteArrayIndefLen` and `decodeByteArrayDefOrIndef`
 * Change `DecCBOR` instances for `Text` and tuples to accept indefinite-length encoding starting with protocol version 12
 
+### `testlib`
+
+*
+
 ## 1.9.0.0
 
 * Re-export `fixedSize`, `guardFixedSized`

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Cuddle/GenerateCBOR.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Cuddle/GenerateCBOR.hs
@@ -45,10 +45,10 @@ data GenerateCBOROpts = GenerateCBOROpts
   , gcboVerbose :: !Bool
   }
 
-readPositiveInt :: Opt.ReadM Int
-readPositiveInt = do
+readNonNegativeInt :: Opt.ReadM Int
+readNonNegativeInt = do
   n <- Opt.auto
-  when (n <= 0) $ Opt.readerError "Expected a positive number"
+  when (n < 0) $ Opt.readerError "Expected a nonnegative number"
   pure n
 
 optsParser :: [String] -> Opt.Parser GenerateCBOROpts
@@ -65,13 +65,13 @@ optsParser eras =
             <> Opt.help "CDDL rule names to generate CBOR for"
       )
     <*> Opt.optional
-      ( Opt.option readPositiveInt $
+      ( Opt.option readNonNegativeInt $
           Opt.long "zap"
             <> Opt.metavar "N"
             <> Opt.help "Generate corrupted (zapped) CBOR with N mistakes"
       )
     <*> Opt.option
-      Opt.auto
+      readNonNegativeInt
       ( Opt.long "count"
           <> Opt.short 'n'
           <> Opt.metavar "N"
@@ -90,7 +90,7 @@ optsParser eras =
           <> Opt.help "Output raw CBOR bytes instead of hex encoding"
       )
     <*> Opt.option
-      Opt.auto
+      readNonNegativeInt
       ( Opt.long "tries"
           <> Opt.short 't'
           <> Opt.metavar "N"
@@ -153,8 +153,10 @@ emitSample tries opts env ruleName sampleIx
           | otherwise = BS8.putStrLn (Base16.encode bs)
         validationResult = validateCBOR bs (Name ruleName) (mapIndex (heRoot env))
       case gcboZap opts of
-        Just _
-          | zrZapped == 0 -> warn "Warning: no decision points for the zapper to zap, retrying" >> retry
+        Just nZaps
+          | nZaps == 0 -> outputBinary
+          | zrZapped < nZaps ->
+              warn "Warning: not enough decision points for the zapper to zap, retrying" >> retry
           | otherwise -> case validationResult of
               Left (RuleDoesNotExist n) -> dieWithInfo $ "Failed to validate because rule does not exist: " <> show n
               Left (LeftoverBytes _) ->
@@ -172,4 +174,4 @@ emitSample tries opts env ruleName sampleIx
           hPutStrLn stderr $ msg <> extraInfo
       | otherwise = pure ()
     dieWithInfo msg =
-      dieWithInfo $ msg <> extraInfo
+      die $ msg <> extraInfo

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Cuddle/GenerateCBOR.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Cuddle/GenerateCBOR.hs
@@ -22,7 +22,7 @@ import qualified Data.ByteString.Char8 as BS8
 import Data.List (intercalate)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe, isJust)
+import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import Options.Applicative ((<**>))
 import qualified Options.Applicative as Opt
@@ -41,7 +41,15 @@ data GenerateCBOROpts = GenerateCBOROpts
   , gcboCount :: !Int
   , gcboSeed :: !(Maybe Int)
   , gcboBinary :: !Bool
+  , gcboTries :: !Int
+  , gcboVerbose :: !Bool
   }
+
+readPositiveInt :: Opt.ReadM Int
+readPositiveInt = do
+  n <- Opt.auto
+  when (n <= 0) $ Opt.readerError "Expected a positive number"
+  pure n
 
 optsParser :: [String] -> Opt.Parser GenerateCBOROpts
 optsParser eras =
@@ -57,7 +65,7 @@ optsParser eras =
             <> Opt.help "CDDL rule names to generate CBOR for"
       )
     <*> Opt.optional
-      ( Opt.option Opt.auto $
+      ( Opt.option readPositiveInt $
           Opt.long "zap"
             <> Opt.metavar "N"
             <> Opt.help "Generate corrupted (zapped) CBOR with N mistakes"
@@ -80,6 +88,19 @@ optsParser eras =
     <*> Opt.switch
       ( Opt.long "binary"
           <> Opt.help "Output raw CBOR bytes instead of hex encoding"
+      )
+    <*> Opt.option
+      Opt.auto
+      ( Opt.long "tries"
+          <> Opt.short 't'
+          <> Opt.metavar "N"
+          <> Opt.value 50
+          <> Opt.showDefault
+          <> Opt.help "Number of retries for failed sample generations"
+      )
+    <*> Opt.switch
+      ( Opt.long "verbose"
+          <> Opt.help "More verbose output"
       )
 
 generateCBORMain :: Map T.Text Cuddle.Huddle -> IO ()
@@ -110,41 +131,45 @@ generateCBORMain eraCDDLs = do
         when (multipleRules && not (gcboBinary opts)) $
           hPutStrLn stderr $
             "# " <> T.unpack ruleName
-        forM_ [0 .. gcboCount opts - 1] $ emitSample opts env ruleName
+        forM_ [0 .. gcboCount opts - 1] $ emitSample 0 opts env ruleName
   where
     eraNames = map T.unpack (Map.keys eraCDDLs)
 
-emitSample :: GenerateCBOROpts -> HuddleEnv -> T.Text -> Int -> IO ()
-emitSample opts env ruleName sampleIx = do
-  let cborGen = runCBORGen (toGenConfig env) (generateFromName (Name ruleName))
-      gen = zapAntiGenResult (fromMaybe 0 (gcboZap opts)) cborGen
-  result <- case gcboSeed opts of
-    Nothing -> generate gen
-    Just seed -> pure $ unGen gen (mkQCGen (seed + sampleIx)) 30
-  writeSample opts env ruleName sampleIx result
-
-writeSample :: GenerateCBOROpts -> HuddleEnv -> T.Text -> Int -> ZapResult CBOR.Term -> IO ()
-writeSample opts env ruleName sampleIx ZapResult {zrValue, zrZapped}
-  | isJust (gcboZap opts) =
-      if zrZapped == 0
-        then warn "produced no corruptions"
-        else case validation of
-          Left e -> warn $ "could not run validation because of malformed bytes\n" <> show e
-          Right (Evidenced SValid _) -> warn "produced a value that is still valid"
-          Right (Evidenced SInvalid _) -> outputBinary
-  | otherwise = outputBinary
+emitSample :: Int -> GenerateCBOROpts -> HuddleEnv -> T.Text -> Int -> IO ()
+emitSample tries opts env ruleName sampleIx
+  | tries > gcboTries opts =
+      dieWithInfo $ "failed to generate a sample after " <> show (gcboTries opts + 1) <> " attempts"
+  | otherwise = do
+      let cborGen = runCBORGen (toGenConfig env) (generateFromName (Name ruleName))
+          gen = zapAntiGenResult (fromMaybe 0 (gcboZap opts)) cborGen
+          retry = emitSample (tries + 1) opts env ruleName sampleIx
+      ZapResult {zrValue, zrZapped} <- case gcboSeed opts of
+        Nothing -> generate gen
+        Just seed -> pure $ unGen gen (mkQCGen (seed + sampleIx + gcboCount opts * tries)) 30
+      let
+        bs = CBOR.toStrictByteString (CBOR.encodeTerm zrValue)
+        outputBinary
+          | gcboBinary opts = BS.hPut stdout bs
+          | otherwise = BS8.putStrLn (Base16.encode bs)
+        validationResult = validateCBOR bs (Name ruleName) (mapIndex (heRoot env))
+      case gcboZap opts of
+        Just _
+          | zrZapped == 0 -> warn "Warning: no decision points for the zapper to zap, retrying" >> retry
+          | otherwise -> case validationResult of
+              Left (RuleDoesNotExist n) -> dieWithInfo $ "Failed to validate because rule does not exist: " <> show n
+              Left (LeftoverBytes _) ->
+                warn "Warning: leftover bytes after decoding generated CBOR, retrying" >> retry
+              Left (DecodingFailed e) ->
+                warn ("Warning: failed to decode generated CBOR, retrying (" <> show e <> ")") >> retry
+              Right (Evidenced SValid _) ->
+                warn "Warning: zapper failed to generate an invalid value, retrying" >> retry
+              Right (Evidenced SInvalid _) -> outputBinary
+        Nothing -> outputBinary
   where
-    outputBinary
-      | gcboBinary opts = BS.hPut stdout bs
-      | otherwise = BS8.putStrLn (Base16.encode bs)
-    bs = CBOR.toStrictByteString (CBOR.encodeTerm zrValue)
-    validation = validateCBOR bs (Name ruleName) (mapIndex (heRoot env))
-    warn reason =
-      hPutStrLn stderr $
-        "Warning: zap "
-          <> reason
-          <> " for rule "
-          <> T.unpack ruleName
-          <> " (sample "
-          <> show sampleIx
-          <> ")"
+    extraInfo = "\n(rule: " <> T.unpack ruleName <> ", index: " <> show sampleIx <> ")"
+    warn msg
+      | gcboVerbose opts =
+          hPutStrLn stderr $ msg <> extraInfo
+      | otherwise = pure ()
+    dieWithInfo msg =
+      dieWithInfo $ msg <> extraInfo

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Cuddle/GenerateCBOR.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Cuddle/GenerateCBOR.hs
@@ -22,7 +22,7 @@ import qualified Data.ByteString.Char8 as BS8
 import Data.List (intercalate)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe, isJust)
+import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import Options.Applicative ((<**>))
 import qualified Options.Applicative as Opt
@@ -41,6 +41,8 @@ data GenerateCBOROpts = GenerateCBOROpts
   , gcboCount :: !Int
   , gcboSeed :: !(Maybe Int)
   , gcboBinary :: !Bool
+  , gcboTries :: !Int
+  , gcboVerbose :: !Bool
   }
 
 optsParser :: [String] -> Opt.Parser GenerateCBOROpts
@@ -81,6 +83,19 @@ optsParser eras =
       ( Opt.long "binary"
           <> Opt.help "Output raw CBOR bytes instead of hex encoding"
       )
+    <*> Opt.option
+      Opt.auto
+      ( Opt.long "tries"
+          <> Opt.short 't'
+          <> Opt.metavar "N"
+          <> Opt.value 50
+          <> Opt.showDefault
+          <> Opt.help "Number of retries for failed sample generations"
+      )
+    <*> Opt.switch
+      ( Opt.long "verbose"
+          <> Opt.help "More verbose output"
+      )
 
 generateCBORMain :: Map T.Text Cuddle.Huddle -> IO ()
 generateCBORMain eraCDDLs = do
@@ -110,41 +125,40 @@ generateCBORMain eraCDDLs = do
         when (multipleRules && not (gcboBinary opts)) $
           hPutStrLn stderr $
             "# " <> T.unpack ruleName
-        forM_ [0 .. gcboCount opts - 1] $ emitSample opts env ruleName
+        forM_ [0 .. gcboCount opts - 1] $ emitSample 0 opts env ruleName
   where
     eraNames = map T.unpack (Map.keys eraCDDLs)
 
-emitSample :: GenerateCBOROpts -> HuddleEnv -> T.Text -> Int -> IO ()
-emitSample opts env ruleName sampleIx = do
-  let cborGen = runCBORGen (toGenConfig env) (generateFromName (Name ruleName))
-      gen = zapAntiGenResult (fromMaybe 0 (gcboZap opts)) cborGen
-  result <- case gcboSeed opts of
-    Nothing -> generate gen
-    Just seed -> pure $ unGen gen (mkQCGen (seed + sampleIx)) 30
-  writeSample opts env ruleName sampleIx result
-
-writeSample :: GenerateCBOROpts -> HuddleEnv -> T.Text -> Int -> ZapResult CBOR.Term -> IO ()
-writeSample opts env ruleName sampleIx ZapResult {zrValue, zrZapped}
-  | isJust (gcboZap opts) =
-      if zrZapped == 0
-        then warn "produced no corruptions"
-        else case validation of
-          Left e -> warn $ "could not run validation because of malformed bytes\n" <> show e
-          Right (Evidenced SValid _) -> warn "produced a value that is still valid"
-          Right (Evidenced SInvalid _) -> outputBinary
-  | otherwise = outputBinary
-  where
-    outputBinary
-      | gcboBinary opts = BS.hPut stdout bs
-      | otherwise = BS8.putStrLn (Base16.encode bs)
-    bs = CBOR.toStrictByteString (CBOR.encodeTerm zrValue)
-    validation = validateCBOR bs (Name ruleName) (mapIndex (heRoot env))
-    warn reason =
-      hPutStrLn stderr $
-        "Warning: zap "
-          <> reason
-          <> " for rule "
-          <> T.unpack ruleName
-          <> " (sample "
-          <> show sampleIx
-          <> ")"
+emitSample :: Int -> GenerateCBOROpts -> HuddleEnv -> T.Text -> Int -> IO ()
+emitSample tries opts env ruleName sampleIx
+  | tries > gcboTries opts =
+      die $ "failed to generate a sample after " <> show (gcboTries opts + 1) <> " attempts"
+  | otherwise = do
+      let cborGen = runCBORGen (toGenConfig env) (generateFromName (Name ruleName))
+          gen = zapAntiGenResult (fromMaybe 0 (gcboZap opts)) cborGen
+          retry = emitSample (tries + 1) opts env ruleName sampleIx
+      ZapResult {zrValue, zrZapped} <- case gcboSeed opts of
+        Nothing -> generate gen
+        Just seed -> pure $ unGen gen (mkQCGen (seed + sampleIx + gcboCount opts * tries)) 30
+      let
+        bs = CBOR.toStrictByteString (CBOR.encodeTerm zrValue)
+        outputBinary
+          | gcboBinary opts = BS.hPut stdout bs
+          | otherwise = BS8.putStrLn (Base16.encode bs)
+        validationResult = validateCBOR bs (Name ruleName) (mapIndex (heRoot env))
+        warn msg
+          | gcboVerbose opts = hPutStrLn stderr msg
+          | otherwise = pure ()
+      case gcboZap opts of
+        Just _
+          | zrZapped == 0 -> warn "Warning: no decision points for the zapper to zap, retrying" >> retry
+          | otherwise -> case validationResult of
+              Left (RuleDoesNotExist n) -> die $ "Failed to validate because rule does not exist: " <> show n
+              Left (LeftoverBytes _) ->
+                warn "Warning: leftover bytes after decoding generated CBOR, retrying" >> retry
+              Left (DecodingFailed e) ->
+                warn ("Warning: failed to decode generated CBOR, retrying (" <> show e <> ")") >> retry
+              Right (Evidenced SValid _) ->
+                warn "Warning: zapper failed to generate an invalid value, retrying" >> retry
+              Right (Evidenced SInvalid _) -> outputBinary
+        Nothing -> outputBinary


### PR DESCRIPTION
# Description

This PR makes the CBOR generator executable exit with a nonzero exit code when generation fails after a specified number of attempts.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
