### PR TITLE
Implement subtransaction-fixup in Imp framework (except Plutus scripts)

### DIFF
--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
@@ -22,8 +22,6 @@ import Cardano.Ledger.Dijkstra.Rules (
  )
 import Cardano.Ledger.Plutus
 import Cardano.Ledger.Val (Val (..))
-import qualified Data.Foldable as Foldable
-import Data.List ((\\))
 import qualified Data.Map.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromJust)
@@ -62,23 +60,25 @@ spec = describe "ENTITIES" $ do
           mkBasicTx $
             mkBasicTxBody
               & withdrawalsTxBodyL .~ Withdrawals [(account3, amountY)]
-    submitFailingTxIncluding
+    submitFailingTx
       (mkBasicTx $ txBody & subTransactionsTxBodyL .~ [mkBasicTx txBody, subTxOnlyWithdrawal])
-      [ injectFailure . SubMissingAccountsInWithdrawals @era $
-          Withdrawals [(account1, amountX), (account2, zero)]
-      , injectFailure . SubMissingOriginalAccountsInWithdrawals @era $
-          Withdrawals [(account1, amountX), (account2, zero)]
-      , injectFailure $
+      [ injectFailure $
           WithdrawalsExceedAccountBalance @era $
             fromJust $
               NE.fromMap $
                 Map.fromList
-                  [ (account1, Mismatch (amountX <> amountX) mempty) -- accumulated from top and sub transaction
+                  [ (account1, Mismatch (amountX <> amountX) mempty)
                   , (account3, Mismatch amountY mempty)
                   ]
-      , injectFailure . SubMissingAccountsInWithdrawals @era $
-          Withdrawals [(account3, amountY)]
+      , injectFailure . MissingAccountsInWithdrawals @era $
+          Withdrawals [(account1, amountX), (account2, zero)]
       , injectFailure . SubMissingOriginalAccountsInWithdrawals @era $
+          Withdrawals [(account1, amountX), (account2, zero)]
+      , injectFailure . SubMissingAccountsInWithdrawals @era $
+          Withdrawals [(account1, amountX), (account2, zero)]
+      , injectFailure . SubMissingOriginalAccountsInWithdrawals @era $
+          Withdrawals [(account3, amountY)]
+      , injectFailure . SubMissingAccountsInWithdrawals @era $
           Withdrawals [(account3, amountY)]
       ]
 
@@ -102,9 +102,11 @@ spec = describe "ENTITIES" $ do
     let subTxOnlyDirectDeposit =
           mkBasicTx $
             mkBasicTxBody & directDepositsTxBodyL .~ DirectDeposits [(account, amountY), (account2, amountZ)]
-    submitFailingTxIncluding
+    submitFailingTx
       (mkBasicTx $ txBody & subTransactionsTxBodyL .~ [mkBasicTx txBody, subTxOnlyDirectDeposit])
-      [ injectFailure . SubMissingAccountsInDirectDeposits @era $
+      [ injectFailure . MissingAccountsInDirectDeposits @era $
+          DirectDeposits [(account, amountX)]
+      , injectFailure . SubMissingAccountsInDirectDeposits @era $
           DirectDeposits [(account, amountX)]
       , injectFailure . SubMissingAccountsInDirectDeposits @era $
           DirectDeposits [(account, amountY), (account2, amountZ)]
@@ -177,9 +179,12 @@ spec = describe "ENTITIES" $ do
       , injectFailure . MissingAccountsInWithdrawals @era $ Withdrawals [(wrongNetworkAccount, mempty)]
       ]
 
-    submitFailingTxIncluding
+    submitFailingTx
       (mkBasicTx $ txBody & subTransactionsTxBodyL .~ [mkBasicTx txBody])
-      [ injectFailure . SubWrongNetworkInWithdrawals @era Testnet $ NES.singleton wrongNetworkAccount
+      [ injectFailure . WrongNetworkInWithdrawals @era Testnet $ NES.singleton wrongNetworkAccount
+      , injectFailure . WrongNetworkInDirectDeposits @era Testnet $ NES.singleton wrongNetworkAccount
+      , injectFailure . MissingAccountsInWithdrawals @era $ Withdrawals [(wrongNetworkAccount, mempty)]
+      , injectFailure . SubWrongNetworkInWithdrawals @era Testnet $ NES.singleton wrongNetworkAccount
       , injectFailure . SubWrongNetworkInDirectDeposits @era Testnet $ NES.singleton wrongNetworkAccount
       ]
   where
@@ -191,13 +196,3 @@ spec = describe "ENTITIES" $ do
       submitAndExpireProposalToMakeReward cred
       b <- getBalance cred
       pure (ra, b, kh)
-
-    -- Poor man's `submitFailingTx` - only checking that the given predicate failures
-    -- are part of all the failures returned by submitting the transaction.
-    -- TOOD: to be replaced by `submitFailingTx` when the Imp fixup for nested transaction is done.
-    submitFailingTxIncluding tx expected = do
-      result <- trySubmitTx tx
-      case result of
-        Left (predFailures, _) ->
-          (expected \\ Foldable.toList predFailures) `shouldBe` []
-        Right _ -> expectationFailure "Expected submission to fail, but it succeeded"

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/LedgerSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/LedgerSpec.hs
@@ -10,9 +10,7 @@ module Test.Cardano.Ledger.Dijkstra.Imp.LedgerSpec (spec) where
 
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Dijkstra.Core
-import Cardano.Ledger.Dijkstra.Rules (
-  DijkstraUtxoPredFailure (BadInputsUTxO),
- )
+import Cardano.Ledger.Dijkstra.Rules
 import Cardano.Ledger.TxIn (mkTxInPartial)
 import qualified Data.OMap.Strict as OMap
 import qualified Data.Set as Set
@@ -23,25 +21,27 @@ import Test.Cardano.Ledger.Imp.Common
 
 spec :: forall era. DijkstraEraImp era => SpecWith (ImpInit (LedgerSpec era))
 spec = describe "LEDGER" $ do
-  -- TODO: re-enable after Imp fixup of subtransactions is implemented
-  xdescribe "Spending sub-transaction outputs" $ do
+  describe "Spending sub-transaction outputs" $ do
     it "Fails when top-level transaction spends output from its own sub-transaction" $ do
-      (_, addr) <- freshKeyAddr
-      txIn <- sendCoinTo addr (Coin 10_000_000)
+      txIn <- (`sendCoinTo` Coin 10_000_000) =<< freshKeyAddr_
+      subTxIn <- (`sendCoinTo` Coin 5_000_000) =<< freshKeyAddr_
 
       let subTx :: Tx SubTx era
-          subTx = mkBasicTx mkBasicTxBody
-          subTxId = txIdTx subTx
-
+          -- consume an input, to avoid the fixup adding one, which would throw off the test conditions
+          subTx = mkBasicTx (mkBasicTxBody & inputsTxBodyL .~ [subTxIn])
+          subTxId = txIdTx subTx -- now stable through fixup
           badInput = mkTxInPartial subTxId 0
           tx =
             mkBasicTx mkBasicTxBody
-              & bodyTxL . inputsTxBodyL .~ Set.fromList [txIn, badInput]
-              & bodyTxL . subTransactionsTxBodyL .~ OMap.singleton subTx
+              & bodyTxL . inputsTxBodyL .~ [txIn, badInput]
+              & bodyTxL . subTransactionsTxBodyL .~ [subTx]
 
       submitFailingTx
         tx
-        [injectFailure $ BadInputsUTxO $ NES.singleton badInput]
+        -- the failure is produced twice - checking against the origin and threaded state, respectively
+        [ injectFailure $ BadInputsUTxO $ NES.singleton badInput
+        , injectFailure $ BadInputsUTxO $ NES.singleton badInput
+        ]
 
     it "Fails when sub-transaction spends output from another sub-transaction" $ do
       (_, addr1) <- freshKeyAddr
@@ -52,22 +52,24 @@ spec = describe "LEDGER" $ do
       let subTx1 :: Tx SubTx era
           subTx1 =
             mkBasicTx mkBasicTxBody
-              & bodyTxL . inputsTxBodyL .~ Set.singleton txIn1
+              & bodyTxL . inputsTxBodyL .~ [txIn1]
           subTx1Id = txIdTx subTx1
 
           badInput = mkTxInPartial subTx1Id 0
           subTx2 :: Tx SubTx era
           subTx2 =
             mkBasicTx mkBasicTxBody
-              & bodyTxL . inputsTxBodyL .~ Set.fromList [txIn2, badInput]
+              & bodyTxL . inputsTxBodyL .~ [txIn2, badInput]
 
           tx =
             mkBasicTx mkBasicTxBody
-              & bodyTxL . subTransactionsTxBodyL .~ OMap.fromFoldable ([subTx1, subTx2] :: [Tx SubTx era])
+              & bodyTxL . subTransactionsTxBodyL .~ [subTx1, subTx2]
 
       submitFailingTx
         tx
-        [injectFailure $ BadInputsUTxO $ NES.singleton badInput]
+        [ injectFailure $ SubBadInputsUTxO $ NES.singleton badInput
+        , injectFailure $ SubBadInputsUTxO $ NES.singleton badInput
+        ]
 
     it "Succeeds when inputs don't reference sub-transaction outputs" $ do
       (_, addr1) <- freshKeyAddr

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxowSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxowSpec.hs
@@ -114,12 +114,9 @@ spec = describe "UTXOW" $ do
             tx =
               mkBasicTx mkBasicTxBody
                 & bodyTxL . subTransactionsTxBodyL .~ OMap.singleton subTx
-        result <- trySubmitTx tx
-        let present = case result of
-              Left (predFailures, _) ->
-                injectFailure (MissingRequiredGuards (NES.singleton guardKeyHash)) `elem` predFailures
-              Right _ -> False
-        present `shouldBe` True
+        submitFailingTx
+          tx
+          [injectFailure (MissingRequiredGuards (NES.singleton guardKeyHash))]
 
     describe "MalformedGuardDatums" $ do
       it "A key-hash guard carrying a datum is a predicate failure" $ do
@@ -159,6 +156,7 @@ spec = describe "UTXOW" $ do
                 & bodyTxL . guardsTxBodyL .~ [guardCred]
                 & witsTxL . hashScriptTxWitsL .~ [guardScript]
                 & bodyTxL . requiredTopLevelGuardsL .~ [(guardCred, mDatum)]
+            -- TODO replace with `submitFailingTx` once we have fixup support for plutus scripts
             hasMalformed tx = do
               result <- trySubmitTx tx
               pure $ case result of

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
@@ -202,7 +202,12 @@ fixupSubTransactions tx = impAnn "fixupSubTransactions" $ do
       (OMap.elems (tx ^. bodyTxL . subTransactionsTxBodyL))
   pure $ tx & bodyTxL . subTransactionsTxBodyL .~ OMap.fromFoldable fixedup
   where
-    fixupSubTransaction = addSubTxIn
+    fixupSubTransaction =
+      addSubTxIn
+        >=> addNativeScriptTxWits
+        >=> fixupAuxDataHash
+        >=> fixupTxOuts
+        >=> updateAddrTxWits
     addSubTxIn subTx
       | not (Set.null (subTx ^. bodyTxL . inputsTxBodyL)) = pure subTx
       | otherwise = do

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
@@ -100,6 +100,7 @@ class
   , InjectRuleFailure "LEDGER" DijkstraUtxowPredFailure era
   , InjectRuleFailure "MEMPOOL" DijkstraMempoolPredFailure era
   , InjectRuleFailure "MEMPOOL" DijkstraUtxoPredFailure era
+  , InjectRuleFailure "LEDGER" DijkstraSubUtxoPredFailure era
   , Inject (NonEmpty (Conway.PredicateFailure (EraRule "MEMPOOL" era))) (ApplyTxError era)
   ) =>
   DijkstraEraImp era
@@ -124,6 +125,13 @@ instance InjectRuleFailure "DELEG" Shelley.ShelleyDelegPredFailure DijkstraEra w
   injectFailure (Shelley.StakeKeyNotRegisteredDELEG c) = Conway.StakeKeyNotRegisteredDELEG c
   injectFailure (Shelley.StakeKeyNonZeroAccountBalanceDELEG c) = Conway.StakeKeyHasNonZeroAccountBalanceDELEG c
   injectFailure _ = error "Cannot inject ShelleyDelegPredFailure into DijkstraEra"
+
+instance InjectRuleFailure "LEDGER" DijkstraSubUtxoPredFailure DijkstraEra where
+  injectFailure =
+    injectFailure @"LEDGER" @DijkstraSubLedgersPredFailure
+      . SubLedgerFailure
+      . SubUtxowFailure
+      . SubUtxoFailure
 
 impDijkstraSatisfyNativeScript ::
   ( DijkstraEraImp era

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
@@ -22,6 +22,7 @@ import Cardano.Ledger.Allegra.Scripts (
   pattern RequireTimeStart,
  )
 import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.Coin
 import Cardano.Ledger.Compactible
 import Cardano.Ledger.Conway.Governance (ConwayEraGov (..), committeeMembersL)
 import qualified Cardano.Ledger.Conway.Rules as Conway
@@ -29,14 +30,7 @@ import Cardano.Ledger.Conway.TxCert
 import Cardano.Ledger.Credential
 import Cardano.Ledger.Dijkstra (ApplyTxError, DijkstraEra)
 import Cardano.Ledger.Dijkstra.Core
-import Cardano.Ledger.Dijkstra.Rules (
-  DijkstraLedgerPredFailure (..),
-  DijkstraMempoolPredFailure,
-  DijkstraUtxoPredFailure,
-  DijkstraUtxowPredFailure,
-  EntitiesPredFailure (..),
-  SubEntitiesPredFailure (..),
- )
+import Cardano.Ledger.Dijkstra.Rules
 import Cardano.Ledger.Dijkstra.Scripts (
   DijkstraNativeScript,
   evalDijkstraNativeScript,
@@ -54,6 +48,7 @@ import Cardano.Ledger.Shelley.Scripts (
 import Cardano.Ledger.State
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
+import qualified Data.OMap.Strict as OMap
 import qualified Data.Set as Set
 import Lens.Micro
 import Test.Cardano.Ledger.Conway.ImpTest
@@ -76,7 +71,7 @@ instance ShelleyEraImp DijkstraEra where
 
   modifyPParams = conwayModifyPParams
 
-  fixupTx = babbageFixupTx
+  fixupTx = dijkstraFixupTx
   expectTxSuccess = impBabbageExpectTxSuccess
   modifyImpInitProtVer = conwayModifyImpInitProtVer
   genRegTxCert = dijkstraGenRegTxCert
@@ -184,3 +179,33 @@ dijkstraGenUnRegTxCert stakingCredential = do
     Nothing -> getsNES $ nesEsL . curPParamsEpochStateL . ppKeyDepositL
     Just accountState -> pure (fromCompact (accountState ^. depositAccountStateL))
   pure $ UnRegDepositTxCert stakingCredential deposit
+
+dijkstraFixupTx ::
+  ( HasCallStack
+  , DijkstraEraImp era
+  ) =>
+  Tx TopTx era ->
+  ImpTestM era (Tx TopTx era)
+dijkstraFixupTx =
+  fixupSubTransactions >=> babbageFixupTx
+
+fixupSubTransactions ::
+  ( HasCallStack
+  , DijkstraEraImp era
+  ) =>
+  Tx TopTx era ->
+  ImpTestM era (Tx TopTx era)
+fixupSubTransactions tx = impAnn "fixupSubTransactions" $ do
+  fixedup <-
+    traverse
+      fixupSubTransaction
+      (OMap.elems (tx ^. bodyTxL . subTransactionsTxBodyL))
+  pure $ tx & bodyTxL . subTransactionsTxBodyL .~ OMap.fromFoldable fixedup
+  where
+    fixupSubTransaction = addSubTxIn
+    addSubTxIn subTx
+      | not (Set.null (subTx ^. bodyTxL . inputsTxBodyL)) = pure subTx
+      | otherwise = do
+          addr <- freshKeyAddr_
+          newTxIn <- sendCoinTo addr (Coin 1_000_000)
+          pure $ subTx & bodyTxL . inputsTxBodyL .~ Set.singleton newTxIn

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### `testlib`
 
+* Make `fixupTxOuts` parametric on level
 * Add `DecCBOR` instance for `Block`
 * Add `registerPoolWithParams`, which registers a stake pool with adjusted parameters
 

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -1149,7 +1149,7 @@ impNativeScriptKeyPairs tx = do
   keyPairs <- mapM (impSatisfyNativeScript curAddrWits $ tx ^. bodyTxL) nativeScripts
   pure . mconcat $ catMaybes keyPairs
 
-fixupTxOuts :: (ShelleyEraImp era, HasCallStack) => Tx TopTx era -> ImpTestM era (Tx TopTx era)
+fixupTxOuts :: (ShelleyEraImp era, HasCallStack) => Tx l era -> ImpTestM era (Tx l era)
 fixupTxOuts tx = do
   pp <- getsNES $ nesEsL . curPParamsEpochStateL
   let


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

This PR enables us to write Imp tests that submit transactions with subtransactions that have all features except consuming Plutus scripts.
Fixup up for plutus scripts depends on implementing plutus translation (in progress), so this will come in a future PR. 

Everything else should work. 

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
