### PR TITLE
Make stake calculation consistent in `dijkstra` by moving `SNAP` to the end of the `EPOCH`

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### `testlib`
 
+* Add reusable `SNAP` voting-stake test helpers (shared with the Dijkstra testlib) to `Test.Cardano.Ledger.Conway.Imp.SnapSpec`: `getSpoVotingStake`, `getDRepVotingStake`, `getLeaderElectionStake`, `isPoolInLeaderDistr`, `isPoolInRewardSnapshot`, `setupExpiredRefundScenario`, `setupReapedPoolScenario`, `setupWithdrawalScenario`, `setupCombinedScenario`, `setupRetiredPoolInLeaderDistr`
 * Add `DecCBOR` instance for `Block`
 
 ### `cddl`

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.23.1.0
 
+* Export `applyEnactedWithdrawals`, `returnProposalDeposits`, `updateCommitteeState` and `updateNumDormantEpochs`
 * Add `EncCBOR`, `ToCBOR` for `Block`
 * Add `DecCBOR` instances for `Annotator Block`
 

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.24.0.0
 
+* Export `applyEnactedWithdrawals`, `returnProposalDeposits`, `updateCommitteeState` and `updateNumDormantEpochs`
 * Replace `StakeKeyRegisteredDELEG` constructor with `DelegAccountAlreadyRegistered` in `ConwayDelegPredFailure`, which wraps the new `AccountAlreadyRegistered` type instead of `Credential Staking`
 * Change `toPlutusV3Args` to accept `LedgerTxInfo era` and `ScriptHash` arguments instead of `ProtVer` and `Maybe (Data era)`
 * Change `transPlutusPurposeV3` and `transPlutusPurposeV1V2` to accept an extra `()` argument for `PlutusPurposeScriptHashArg`

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/SnapSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/SnapSpec.hs
@@ -4,7 +4,21 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Test.Cardano.Ledger.Conway.Imp.SnapSpec (spec, conwayOnlySpec) where
+module Test.Cardano.Ledger.Conway.Imp.SnapSpec (
+  spec,
+  conwayOnlySpec,
+  getSpoVotingStake,
+  getDRepVotingStake,
+  setupExpiredRefundScenario,
+  setupReapedPoolScenario,
+  setupWithdrawalScenario,
+  setupCombinedScenario,
+  getLeaderElectionStake,
+  getActiveProposalDeposits,
+  isPoolInLeaderDistr,
+  isPoolInRewardSnapshot,
+  setupRetiredPoolInLeaderDistr,
+) where
 
 import Cardano.Ledger.BaseTypes (EpochInterval (..), addEpochInterval)
 import Cardano.Ledger.Coin
@@ -21,69 +35,161 @@ import Lens.Micro ((&), (.~))
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Imp.Common
 
+getSpoVotingStake :: ConwayEraImp era => KeyHash StakePool -> ImpTestM era Coin
+getSpoVotingStake pool = do
+  poolDistr <- psPoolDistr . fst . finishDRepPulser <$> getsNES (nesEsL . epochStateDRepPulsingStateL)
+  pure $ fromCompact $ poolDistr Map.! pool
+
+getDRepVotingStake :: ConwayEraImp era => Credential DRepRole -> ImpTestM era Coin
+getDRepVotingStake drep = do
+  drepDistr <- getsNES $ nesEsL . epochStateDRepPulsingStateL . psDRepDistrG
+  pure $ fromCompact $ drepDistr Map.! DRepCredential drep
+
+getLeaderElectionStake :: KeyHash StakePool -> ImpTestM era Coin
+getLeaderElectionStake pool =
+  fromCompact . individualTotalPoolStake . (Map.! pool) . unPoolDistr <$> getsNES nesPdL
+
+getActiveProposalDeposits :: ConwayEraImp era => KeyHash StakePool -> ImpTestM era Coin
+getActiveProposalDeposits pool = do
+  proposals <- getsNES $ nesEsL . esLStateL . lsUTxOStateL . utxosGovStateL . proposalsGovStateL
+  accounts <- getsNES $ nesEsL . esLStateL . lsCertStateL . certDStateL . accountsL
+  pure $
+    foldMap fromCompact $
+      Map.filterWithKey
+        (\cred _ -> lookupStakePoolDelegation cred accounts == Just pool)
+        (proposalsDeposits proposals)
+
+setupDelegatorAndPool ::
+  ConwayEraImp era => ImpTestM era (KeyHash StakePool, Credential DRepRole, Credential Staking)
+setupDelegatorAndPool = do
+  (drep, cred, _) <- setupSingleDRep 500_000_000
+  pool <- freshKeyHash
+  registerPool pool
+  delegateStake cred pool
+  pure (pool, drep, cred)
+
+setupExpiredRefundScenario ::
+  ConwayEraImp era => ImpTestM era (KeyHash StakePool, Credential DRepRole, Coin)
+setupExpiredRefundScenario = do
+  modifyPParams $ \pp ->
+    pp
+      & ppGovActionLifetimeL .~ EpochInterval 1
+      & ppGovActionDepositL .~ Coin 1_000_000
+  govActionDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppGovActionDepositL
+  (pool, drep, cred) <- setupDelegatorAndPool
+  returnAddr <- getAccountAddressFor cred
+  govActionId <- submitProposal =<< mkProposalWithAccountAddress InfoAction returnAddr
+  expectPresentGovActionId govActionId
+  passNEpochs 3
+  expectMissingGovActionId govActionId
+  pure (pool, drep, govActionDeposit)
+
+setupReapedPoolScenario ::
+  ConwayEraImp era => ImpTestM era (KeyHash StakePool, Credential DRepRole, Coin)
+setupReapedPoolScenario = do
+  poolDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppPoolDepositL
+  (poolActive, drep, cred) <- setupDelegatorAndPool
+  registerAndRetirePoolToMakeReward cred
+  pure (poolActive, drep, poolDeposit)
+
+setupWithdrawalScenario ::
+  ConwayEraImp era => ImpTestM era (KeyHash StakePool, Credential DRepRole, Coin)
+setupWithdrawalScenario = do
+  modifyPParams $ \pp -> pp & ppGovActionLifetimeL .~ EpochInterval 30
+  committeeCs <- registerInitialCommittee
+  (pool, drep, cred) <- setupDelegatorAndPool
+  returnAddr <- getAccountAddressFor cred
+  submitTx_ $ mkBasicTx mkBasicTxBody & bodyTxL . treasuryDonationTxBodyL .~ Coin 1_000_000
+  govActionId <- submitTreasuryWithdrawals [(returnAddr, Coin 1_000_000)]
+  submitYesVote_ (DRepVoter drep) govActionId
+  submitYesVoteCCs_ committeeCs govActionId
+  passNEpochs 2
+  expectMissingGovActionId govActionId
+  pure (pool, drep, Coin 1_000_000)
+
+setupCombinedScenario ::
+  ConwayEraImp era => ImpTestM era (KeyHash StakePool, Credential DRepRole, Coin)
+setupCombinedScenario = do
+  modifyPParams $ \pp ->
+    pp
+      & ppGovActionLifetimeL .~ EpochInterval 1
+      & ppGovActionDepositL .~ Coin 1_000_000
+  committeeCs <- registerInitialCommittee
+  (poolActive, drep, cred) <- setupDelegatorAndPool
+  returnAddr <- getAccountAddressFor cred
+  submitTx_ $ mkBasicTx mkBasicTxBody & bodyTxL . treasuryDonationTxBodyL .~ Coin 1_000_000
+  infoActionId <- submitProposal =<< mkProposalWithAccountAddress InfoAction returnAddr
+  poolToRetire <- freshKeyHash
+  registerPoolWithAccountAddress poolToRetire returnAddr
+  passEpoch
+  curEpochNo <- getsNES nesELL
+  submitTxAnn_ "Retire the temporary pool" $
+    mkBasicTx mkBasicTxBody
+      & bodyTxL . certsTxBodyL
+        .~ SSeq.singleton (RetirePoolTxCert poolToRetire (addEpochInterval curEpochNo (EpochInterval 2)))
+  modifyPParams $ \pp -> pp & ppGovActionLifetimeL .~ EpochInterval 30
+  govActionId <- submitTreasuryWithdrawals [(returnAddr, Coin 1_000_000)]
+  submitYesVote_ (DRepVoter drep) govActionId
+  submitYesVoteCCs_ committeeCs govActionId
+  passNEpochs 2
+  expectMissingGovActionId infoActionId
+  expectMissingGovActionId govActionId
+  govActionDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppGovActionDepositL
+  poolDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppPoolDepositL
+  pure (poolActive, drep, govActionDeposit <> poolDeposit <> Coin 1_000_000)
+
+isPoolInLeaderDistr :: KeyHash StakePool -> ImpTestM era Bool
+isPoolInLeaderDistr pool = Map.member pool . unPoolDistr <$> getsNES nesPdL
+
+isPoolInRewardSnapshot :: KeyHash StakePool -> ImpTestM era Bool
+isPoolInRewardSnapshot pool =
+  Map.member pool . unPoolDistr . calculatePoolDistr <$> getsNES (nesEsL . esSnapshotsL . ssStakeGoL)
+
+setupRetiredPoolInLeaderDistr :: ConwayEraImp era => ImpTestM era (KeyHash StakePool)
+setupRetiredPoolInLeaderDistr = do
+  (pool, _, _) <- setupDelegatorAndPool
+  passNEpochs 3
+  isPoolInLeaderDistr pool `shouldReturn` True
+  curEpochNo <- getsNES nesELL
+  submitTxAnn_ "Retire the pool" $
+    mkBasicTx mkBasicTxBody
+      & bodyTxL . certsTxBodyL
+        .~ SSeq.singleton (RetirePoolTxCert pool (addEpochInterval curEpochNo (EpochInterval 1)))
+  passEpoch
+  isPoolInLeaderDistr pool `shouldReturn` True
+  pure pool
+
 spec ::
   forall era.
   ConwayEraImp era =>
   SpecWith (ImpInit (LedgerSpec era))
 spec = describe "SNAP" $ do
-  let getSpoVotingStake :: KeyHash StakePool -> ImpTestM era Coin
-      getSpoVotingStake pool = do
-        poolDistr <- psPoolDistr . fst . finishDRepPulser <$> getsNES (nesEsL . epochStateDRepPulsingStateL)
-        pure $ fromCompact $ poolDistr Map.! pool
   it "SPO voting stake exceeds leader election stake by the active proposal deposit" $ do
     modifyPParams $ \pp ->
       pp
         & ppGovActionLifetimeL .~ EpochInterval 10
         & ppGovActionDepositL .~ Coin 1_000_000
-    govActionDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppGovActionDepositL
-
     (pool, _paymentCred, stakingCred) <- setupPoolWithStake (Coin 500_000_000)
     returnAddr <- getAccountAddressFor stakingCred
     _govActionId <- submitProposal =<< mkProposalWithAccountAddress InfoAction returnAddr
-
     passEpoch
     spoVotingStakeThisEpoch <- getSpoVotingStake pool
+    activeProposalDeposits <- getActiveProposalDeposits pool
     passEpoch
-    leaderElectionStakeNextEpoch <-
-      fromCompact . individualTotalPoolStake . (Map.! pool) . unPoolDistr <$> getsNES nesPdL
-    (spoVotingStakeThisEpoch <-> leaderElectionStakeNextEpoch) `shouldBe` govActionDeposit
+    leaderElectionStakeNextEpoch <- getLeaderElectionStake pool
+    (spoVotingStakeThisEpoch <-> leaderElectionStakeNextEpoch) `shouldBe` activeProposalDeposits
 
 conwayOnlySpec ::
   forall era.
   ConwayEraImp era =>
   SpecWith (ImpInit (LedgerSpec era))
 conwayOnlySpec = describe "SNAP" $ do
-  let getSpoVotingStake :: KeyHash StakePool -> ImpTestM era Coin
-      getSpoVotingStake pool = do
-        poolDistr <- psPoolDistr . fst . finishDRepPulser <$> getsNES (nesEsL . epochStateDRepPulsingStateL)
-        pure $ fromCompact $ poolDistr Map.! pool
-      getDRepVotingStake :: Credential DRepRole -> ImpTestM era Coin
-      getDRepVotingStake drep = do
-        drepDistr <- getsNES $ nesEsL . epochStateDRepPulsingStateL . psDRepDistrG
-        pure $ fromCompact $ drepDistr Map.! DRepCredential drep
   it "Reproduces #5014: SPO voting stake lags DRep voting stake by the refunded deposit" $ do
-    modifyPParams $ \pp ->
-      pp
-        & ppGovActionLifetimeL .~ EpochInterval 1
-        & ppGovActionDepositL .~ Coin 1_000_000
-    govActionDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppGovActionDepositL
-
-    (drep, cred, _) <- setupSingleDRep 500_000_000
-    pool <- freshKeyHash
-    registerPool pool
-    delegateStake cred pool
-    returnAddr <- getAccountAddressFor cred
-
-    govActionId <- submitProposal =<< mkProposalWithAccountAddress InfoAction returnAddr
-    expectPresentGovActionId govActionId
-    passNEpochs 3
-    expectMissingGovActionId govActionId
-
+    (pool, drep, govActionDeposit) <- setupExpiredRefundScenario
     drepVotingStake <- getDRepVotingStake drep
     spoVotingStake <- getSpoVotingStake pool
     impAnn "SPO voting stake is behind by the refunded deposit" $
       (drepVotingStake <-> spoVotingStake) `shouldBe` govActionDeposit
-
     passEpoch
     spoVotingStakeNextEpoch <- getSpoVotingStake pool
     drepVotingStakeNextEpoch <- getDRepVotingStake drep
@@ -91,65 +197,38 @@ conwayOnlySpec = describe "SNAP" $ do
       spoVotingStakeNextEpoch `shouldBe` drepVotingStakeNextEpoch
 
   it "Reproduces #5014: SPO voting stake lags DRep voting stake by a reaped pool's refunded deposit" $ do
-    poolDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppPoolDepositL
-    (drep, cred, _) <- setupSingleDRep 500_000_000
-    poolActive <- freshKeyHash
-    registerPool poolActive
-    delegateStake cred poolActive
-    registerAndRetirePoolToMakeReward cred
+    (poolActive, drep, poolDeposit) <- setupReapedPoolScenario
     drepVotingStake <- getDRepVotingStake drep
     spoVotingStake <- getSpoVotingStake poolActive
     (drepVotingStake <-> spoVotingStake) `shouldBe` poolDeposit
 
   it "Reproduces #5014: SPO voting stake lags DRep voting stake by an enacted treasury withdrawal" $
     whenPostBootstrap $ do
-      modifyPParams $ \pp -> pp & ppGovActionLifetimeL .~ EpochInterval 30
-      committeeCs <- registerInitialCommittee
-      (drep, cred, _) <- setupSingleDRep 500_000_000
-      pool <- freshKeyHash
-      registerPool pool
-      delegateStake cred pool
-      returnAddr <- getAccountAddressFor cred
-      submitTx_ $ mkBasicTx mkBasicTxBody & bodyTxL . treasuryDonationTxBodyL .~ Coin 1_000_000
-      govActionId <- submitTreasuryWithdrawals [(returnAddr, Coin 1_000_000)]
-      submitYesVote_ (DRepVoter drep) govActionId
-      submitYesVoteCCs_ committeeCs govActionId
-      passNEpochs 2
+      (pool, drep, amount) <- setupWithdrawalScenario
       drepVotingStake <- getDRepVotingStake drep
       spoVotingStake <- getSpoVotingStake pool
-      (drepVotingStake <-> spoVotingStake) `shouldBe` Coin 1_000_000
+      (drepVotingStake <-> spoVotingStake) `shouldBe` amount
 
   it
     "Reproduces #5014: SPO voting stake lags DRep voting stake by the combined refunds and withdrawal"
     $ whenPostBootstrap
     $ do
-      modifyPParams $ \pp ->
-        pp
-          & ppGovActionLifetimeL .~ EpochInterval 1
-          & ppGovActionDepositL .~ Coin 1_000_000
-      committeeCs <- registerInitialCommittee
-      (drep, cred, _) <- setupSingleDRep 500_000_000
-      poolActive <- freshKeyHash
-      registerPool poolActive
-      delegateStake cred poolActive
-      returnAddr <- getAccountAddressFor cred
-      submitTx_ $ mkBasicTx mkBasicTxBody & bodyTxL . treasuryDonationTxBodyL .~ Coin 1_000_000
-      _ <- submitProposal =<< mkProposalWithAccountAddress InfoAction returnAddr
-      poolToRetire <- freshKeyHash
-      registerPoolWithAccountAddress poolToRetire returnAddr
-      passEpoch
-      curEpochNo <- getsNES nesELL
-      submitTxAnn_ "Retire the temporary pool" $
-        mkBasicTx mkBasicTxBody
-          & bodyTxL . certsTxBodyL
-            .~ SSeq.singleton (RetirePoolTxCert poolToRetire (addEpochInterval curEpochNo (EpochInterval 2)))
-      modifyPParams $ \pp -> pp & ppGovActionLifetimeL .~ EpochInterval 30
-      govActionId <- submitTreasuryWithdrawals [(returnAddr, Coin 1_000_000)]
-      submitYesVote_ (DRepVoter drep) govActionId
-      submitYesVoteCCs_ committeeCs govActionId
-      passNEpochs 2
-      govActionDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppGovActionDepositL
-      poolDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppPoolDepositL
+      (poolActive, drep, combinedDeposit) <- setupCombinedScenario
       drepVotingStake <- getDRepVotingStake drep
       spoVotingStake <- getSpoVotingStake poolActive
-      (drepVotingStake <-> spoVotingStake) `shouldBe` (govActionDeposit <> poolDeposit <> Coin 1_000_000)
+      (drepVotingStake <-> spoVotingStake) `shouldBe` combinedDeposit
+
+  it "A reaped pool remains in the leader-election distribution for an extra epoch" $ do
+    pool <- setupRetiredPoolInLeaderDistr
+    passEpoch
+    isPoolInLeaderDistr pool `shouldReturn` True
+    passEpoch
+    isPoolInLeaderDistr pool `shouldReturn` False
+
+  it "A reaped pool remains in the reward stake snapshot for an extra epoch" $ do
+    pool <- setupRetiredPoolInLeaderDistr
+    isPoolInRewardSnapshot pool `shouldReturn` True
+    passNEpochs 2
+    isPoolInRewardSnapshot pool `shouldReturn` True
+    passEpoch
+    isPoolInRewardSnapshot pool `shouldReturn` False

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/SnapSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/SnapSpec.hs
@@ -6,7 +6,7 @@
 
 module Test.Cardano.Ledger.Conway.Imp.SnapSpec (spec, conwayOnlySpec) where
 
-import Cardano.Ledger.BaseTypes (EpochInterval (..))
+import Cardano.Ledger.BaseTypes (EpochInterval (..), addEpochInterval)
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Conway.Core
@@ -16,6 +16,7 @@ import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Val ((<->))
 import qualified Data.Map.Strict as Map
+import qualified Data.Sequence.Strict as SSeq
 import Lens.Micro ((&), (.~))
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Imp.Common
@@ -88,3 +89,67 @@ conwayOnlySpec = describe "SNAP" $ do
     drepVotingStakeNextEpoch <- getDRepVotingStake drep
     impAnn "SPO voting stake catches up in the next epoch" $
       spoVotingStakeNextEpoch `shouldBe` drepVotingStakeNextEpoch
+
+  it "Reproduces #5014: SPO voting stake lags DRep voting stake by a reaped pool's refunded deposit" $ do
+    poolDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppPoolDepositL
+    (drep, cred, _) <- setupSingleDRep 500_000_000
+    poolActive <- freshKeyHash
+    registerPool poolActive
+    delegateStake cred poolActive
+    registerAndRetirePoolToMakeReward cred
+    drepVotingStake <- getDRepVotingStake drep
+    spoVotingStake <- getSpoVotingStake poolActive
+    (drepVotingStake <-> spoVotingStake) `shouldBe` poolDeposit
+
+  it "Reproduces #5014: SPO voting stake lags DRep voting stake by an enacted treasury withdrawal" $
+    whenPostBootstrap $ do
+      modifyPParams $ \pp -> pp & ppGovActionLifetimeL .~ EpochInterval 30
+      committeeCs <- registerInitialCommittee
+      (drep, cred, _) <- setupSingleDRep 500_000_000
+      pool <- freshKeyHash
+      registerPool pool
+      delegateStake cred pool
+      returnAddr <- getAccountAddressFor cred
+      submitTx_ $ mkBasicTx mkBasicTxBody & bodyTxL . treasuryDonationTxBodyL .~ Coin 1_000_000
+      govActionId <- submitTreasuryWithdrawals [(returnAddr, Coin 1_000_000)]
+      submitYesVote_ (DRepVoter drep) govActionId
+      submitYesVoteCCs_ committeeCs govActionId
+      passNEpochs 2
+      drepVotingStake <- getDRepVotingStake drep
+      spoVotingStake <- getSpoVotingStake pool
+      (drepVotingStake <-> spoVotingStake) `shouldBe` Coin 1_000_000
+
+  it
+    "Reproduces #5014: SPO voting stake lags DRep voting stake by the combined refunds and withdrawal"
+    $ whenPostBootstrap
+    $ do
+      modifyPParams $ \pp ->
+        pp
+          & ppGovActionLifetimeL .~ EpochInterval 1
+          & ppGovActionDepositL .~ Coin 1_000_000
+      committeeCs <- registerInitialCommittee
+      (drep, cred, _) <- setupSingleDRep 500_000_000
+      poolActive <- freshKeyHash
+      registerPool poolActive
+      delegateStake cred poolActive
+      returnAddr <- getAccountAddressFor cred
+      submitTx_ $ mkBasicTx mkBasicTxBody & bodyTxL . treasuryDonationTxBodyL .~ Coin 1_000_000
+      _ <- submitProposal =<< mkProposalWithAccountAddress InfoAction returnAddr
+      poolToRetire <- freshKeyHash
+      registerPoolWithAccountAddress poolToRetire returnAddr
+      passEpoch
+      curEpochNo <- getsNES nesELL
+      submitTxAnn_ "Retire the temporary pool" $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . certsTxBodyL
+            .~ SSeq.singleton (RetirePoolTxCert poolToRetire (addEpochInterval curEpochNo (EpochInterval 2)))
+      modifyPParams $ \pp -> pp & ppGovActionLifetimeL .~ EpochInterval 30
+      govActionId <- submitTreasuryWithdrawals [(returnAddr, Coin 1_000_000)]
+      submitYesVote_ (DRepVoter drep) govActionId
+      submitYesVoteCCs_ committeeCs govActionId
+      passNEpochs 2
+      govActionDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppGovActionDepositL
+      poolDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppPoolDepositL
+      drepVotingStake <- getDRepVotingStake drep
+      spoVotingStake <- getSpoVotingStake poolActive
+      (drepVotingStake <-> spoVotingStake) `shouldBe` (govActionDeposit <> poolDeposit <> Coin 1_000_000)

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.4.0.0
 
+* Add a Dijkstra `EPOCH` rule
+  - Take the stake snapshot at the end of the transition after stake pool and governance-action refunds and treasury withdrawals are applied, so that stake pool voting stake is consistent with DRep voting stake (#5014)
 * Add `EncCBOR`, `ToCBOR` for `Block`
 * Add `DecCBOR` instances for `Annotator Block`
 * Remove `EncCBORGroup` instance for `DijkstraBlockBody`

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.4.0.0
 
+* Add a Dijkstra `EPOCH` rule
+  - Take the stake snapshot at the end of the transition after stake pool and governance-action refunds and treasury withdrawals are applied, so that stake pool voting stake is consistent with DRep voting stake (#5014)
 * Add `localProducedValue` helper in `UTxO` module
 * Add `ValueNotConservedInLegacyInLegacyMode` constructor to `DijkstraUtxoPredFailure`
 * Rename:

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -153,6 +153,7 @@ library testlib
     Test.Cardano.Ledger.Dijkstra.Imp.EntitiesSpec
     Test.Cardano.Ledger.Dijkstra.Imp.LedgerSpec
     Test.Cardano.Ledger.Dijkstra.Imp.PoolSpec
+    Test.Cardano.Ledger.Dijkstra.Imp.SnapSpec
     Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec
     Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec
     Test.Cardano.Ledger.Dijkstra.ImpTest

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -117,7 +117,7 @@ library
     cardano-ledger-alonzo ^>=1.16,
     cardano-ledger-babbage ^>=1.14,
     cardano-ledger-binary ^>=1.9,
-    cardano-ledger-conway ^>=1.23,
+    cardano-ledger-conway ^>=1.23.1,
     cardano-ledger-core:{cardano-ledger-core, internal} ^>=1.22,
     cardano-ledger-mary,
     cardano-ledger-shelley ^>=1.19.1,

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -58,6 +58,7 @@ library
     Cardano.Ledger.Dijkstra.Rules.Certs
     Cardano.Ledger.Dijkstra.Rules.Deleg
     Cardano.Ledger.Dijkstra.Rules.Entities
+    Cardano.Ledger.Dijkstra.Rules.Epoch
     Cardano.Ledger.Dijkstra.Rules.Gov
     Cardano.Ledger.Dijkstra.Rules.GovCert
     Cardano.Ledger.Dijkstra.Rules.Ledger

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -154,6 +154,7 @@ library testlib
     Test.Cardano.Ledger.Dijkstra.Imp.EntitiesSpec
     Test.Cardano.Ledger.Dijkstra.Imp.LedgerSpec
     Test.Cardano.Ledger.Dijkstra.Imp.PoolSpec
+    Test.Cardano.Ledger.Dijkstra.Imp.SnapSpec
     Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec
     Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec
     Test.Cardano.Ledger.Dijkstra.ImpTest

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Era.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Era.hs
@@ -14,6 +14,7 @@ module Cardano.Ledger.Dijkstra.Era (
   BBODY,
   CERT,
   ENTITIES,
+  EPOCH,
   GOV,
   GOVCERT,
   LEDGER,
@@ -208,7 +209,9 @@ type instance EraRule "GOV" DijkstraEra = GOV DijkstraEra
 
 type instance EraRule "NEWEPOCH" DijkstraEra = Conway.NEWEPOCH DijkstraEra
 
-type instance EraRule "EPOCH" DijkstraEra = Conway.EPOCH DijkstraEra
+data EPOCH era
+
+type instance EraRule "EPOCH" DijkstraEra = EPOCH DijkstraEra
 
 type instance EraRule "ENACT" DijkstraEra = Conway.ENACT DijkstraEra
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules.hs
@@ -35,6 +35,7 @@ import Cardano.Ledger.Dijkstra.Rules.Cert ()
 import Cardano.Ledger.Dijkstra.Rules.Certs ()
 import Cardano.Ledger.Dijkstra.Rules.Deleg ()
 import Cardano.Ledger.Dijkstra.Rules.Entities
+import Cardano.Ledger.Dijkstra.Rules.Epoch ()
 import Cardano.Ledger.Dijkstra.Rules.Gov
 import Cardano.Ledger.Dijkstra.Rules.GovCert
 import Cardano.Ledger.Dijkstra.Rules.Ledger

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Epoch.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Epoch.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -11,37 +8,20 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Cardano.Ledger.Conway.Rules.Epoch (
-  EPOCH,
-  PredicateFailure,
-  ConwayEpochEvent (..),
-  applyEnactedWithdrawals,
-  returnProposalDeposits,
-  updateCommitteeState,
-  updateNumDormantEpochs,
-) where
+module Cardano.Ledger.Dijkstra.Rules.Epoch () where
 
-import Cardano.Ledger.Address (accountAddressCredentialL)
 import Cardano.Ledger.BaseTypes (ProtVer, ShelleyBase)
-import Cardano.Ledger.Coin (Coin, compactCoinOrError)
-import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Conway.Era (ConwayEra, EPOCH, HARDFORK, RATIFY)
 import Cardano.Ledger.Conway.Governance (
-  Committee,
   ConwayEraGov (..),
   ConwayGovState,
   EnactState (..),
-  GovActionId,
-  GovActionState (..),
-  Proposals,
   RatifyEnv (..),
   RatifySignal (..),
   RatifyState (..),
@@ -52,22 +32,26 @@ import Cardano.Ledger.Conway.Governance (
   cgsFuturePParamsL,
   cgsPrevPParamsL,
   cgsProposalsL,
-  ensTreasuryL,
-  ensWithdrawalsL,
   epochStateDRepPulsingStateL,
   extractDRepPulsingState,
-  gasDeposit,
-  gasReturnAddr,
-  pPropsL,
   proposalsApplyEnactment,
   proposalsGovStateL,
   setFreshDRepPulsingState,
  )
-import Cardano.Ledger.Conway.Governance.Procedures (Committee (..))
-import Cardano.Ledger.Conway.Rules.HardFork (
-  ConwayHardForkEvent (..),
+import Cardano.Ledger.Conway.Rules (
+  ConwayEpochEvent (..),
+  ConwayHardForkEvent,
+  ConwayNewEpochEvent (EpochEvent),
+  HARDFORK,
+  NEWEPOCH,
+  RATIFY,
+  applyEnactedWithdrawals,
+  returnProposalDeposits,
+  updateCommitteeState,
+  updateNumDormantEpochs,
  )
 import Cardano.Ledger.Conway.State
+import Cardano.Ledger.Dijkstra.Era (EPOCH)
 import Cardano.Ledger.Shelley.LedgerState (
   EpochState (..),
   LedgerState (..),
@@ -86,9 +70,7 @@ import Cardano.Ledger.Shelley.LedgerState (
 import Cardano.Ledger.Shelley.Rewards ()
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Cardano.Ledger.Slot (EpochNo)
-import Cardano.Ledger.Val (zero, (<->))
-import Control.DeepSeq (NFData)
-import Control.Monad (guard)
+import Cardano.Ledger.Val (zero)
 import Control.State.Transition (
   Embed (..),
   STS (..),
@@ -99,49 +81,11 @@ import Control.State.Transition (
   tellEvent,
   trans,
  )
-import Data.Foldable (Foldable (..))
+import Data.Foldable (fold)
 import qualified Data.Map.Strict as Map
-import Data.Maybe.Strict (StrictMaybe (..))
-import qualified Data.OMap.Strict as OMap
-import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Void (Void, absurd)
-import GHC.Generics (Generic)
 import Lens.Micro ((%~), (&), (.~), (<>~), (^.))
-
-data ConwayEpochEvent era
-  = PoolReapEvent (Event (EraRule "POOLREAP" era))
-  | SnapEvent (Event (EraRule "SNAP" era))
-  | EpochBoundaryRatifyState (RatifyState era)
-  | GovInfoEvent
-      -- | Enacted actions
-      (Set (GovActionState era))
-      -- | Actions that were removed as conflicting due to enactment
-      (Set (GovActionState era))
-      -- | Actions that were removed due to expiration together with their dependees
-      (Set (GovActionState era))
-      -- | Map of removed governance action ids that had an unregistered account address to their unclaimed deposits so they can be transferred to the treasury.
-      (Map.Map GovActionId Coin)
-  | HardForkEvent (Event (EraRule "HARDFORK" era))
-  deriving (Generic)
-
-type instance EraRuleEvent "EPOCH" ConwayEra = ConwayEpochEvent ConwayEra
-
-deriving instance
-  ( EraPParams era
-  , Eq (Event (EraRule "POOLREAP" era))
-  , Eq (Event (EraRule "SNAP" era))
-  , Eq (Event (EraRule "HARDFORK" era))
-  ) =>
-  Eq (ConwayEpochEvent era)
-
-instance
-  ( EraPParams era
-  , NFData (Event (EraRule "POOLREAP" era))
-  , NFData (Event (EraRule "SNAP" era))
-  , NFData (Event (EraRule "HARDFORK" era))
-  ) =>
-  NFData (ConwayEpochEvent era)
 
 instance
   ( EraTxOut era
@@ -174,76 +118,9 @@ instance
   type Signal (EPOCH era) = EpochNo
   type Environment (EPOCH era) = ()
   type BaseM (EPOCH era) = ShelleyBase
-
-  -- EPOCH rule can never fail
   type PredicateFailure (EPOCH era) = Void
   type Event (EPOCH era) = ConwayEpochEvent era
   transitionRules = [epochTransition]
-
-returnProposalDeposits ::
-  (Foldable f, EraAccounts era) =>
-  f (GovActionState era) ->
-  Accounts era ->
-  (Accounts era, Map.Map GovActionId Coin)
-returnProposalDeposits removedProposals oldAccounts =
-  foldr' processProposal (oldAccounts, mempty) removedProposals
-  where
-    processProposal gas (!accounts, !unclaimed)
-      | (Just _accountState, newAccounts) <- updateLookupAccountState addRefund cred accounts =
-          (newAccounts, unclaimed)
-      | otherwise = (accounts, Map.insert (gasId gas) (gasDeposit gas) unclaimed)
-      where
-        addRefund = balanceAccountStateL <>~ compactCoinOrError (gasDeposit gas)
-        cred = gasReturnAddr gas ^. accountAddressCredentialL
-
--- | When there have been zero governance proposals to vote on in the previous epoch
--- increase the dormant-epoch counter by one.
-updateNumDormantEpochs :: EpochNo -> Proposals era -> VState era -> VState era
-updateNumDormantEpochs currentEpoch ps vState =
-  if null $ OMap.filter ((currentEpoch <=) . gasExpiresAfter) $ ps ^. pPropsL
-    then vState & vsNumDormantEpochsL %~ succ
-    else vState
-
--- | Apply TreasuryWithdrawals to the EpochState
---
---   acnt' = record acnt { treasury = treasury + UTxOState.fees utxoSt
---                                  + getCoin unclaimed + donations ∸ totWithdrawals }
---
--- The utxo fees and donations are applied in the remaining body of EPOCH transition
-applyEnactedWithdrawals ::
-  EraAccounts era =>
-  ChainAccountState ->
-  DState era ->
-  EnactState era ->
-  (ChainAccountState, DState era, EnactState era)
-applyEnactedWithdrawals chainAccountState dState enactedState =
-  let enactedWithdrawals = enactedState ^. ensWithdrawalsL
-      accounts = dState ^. accountsL
-      -- The use of the partial function `compactCoinOrError` is justified here because
-      -- 1. the decoder for coin at the proposal-submission boundary has already
-      --    confirmed we have a compactible value
-      -- 2. the refunds and unsuccessful refunds together do not exceed the
-      --    current treasury value, as enforced by the `ENACT` rule.
-      successfulWithdrawls =
-        Map.mapMaybeWithKey
-          (\cred w -> compactCoinOrError w <$ guard (isAccountRegistered cred accounts))
-          enactedWithdrawals
-      chainAccountState' =
-        chainAccountState
-          -- Subtract `successfulWithdrawals` from the treasury, and add them to the rewards UMap
-          -- `unclaimed` withdrawals remain in the treasury.
-          -- Compared to the spec, instead of adding `unclaimed` and subtracting `totWithdrawals`
-          --   + unclaimed - totWithdrawals
-          -- we just subtract the `refunds`
-          --   - refunds
-          & casTreasuryL %~ (<-> fromCompact (fold successfulWithdrawls))
-      dState' = dState & accountsL %~ addToBalanceAccounts successfulWithdrawls
-      -- Reset enacted withdrawals:
-      enactedState' =
-        enactedState
-          & ensWithdrawalsL .~ Map.empty
-          & ensTreasuryL .~ mempty
-   in (chainAccountState', dState', enactedState')
 
 epochTransition ::
   forall era.
@@ -303,22 +180,9 @@ epochTransition = do
     (chainAccountState2, dState2, EnactState {..}) =
       applyEnactedWithdrawals chainAccountState1 (certState1 ^. certDStateL) rsEnactState
 
-    -- NOTE: It is important that we apply the results of ratification
-    -- and enactment from the pulser to the working copy of proposals.
-    -- The proposals in the pulser are a subset of the current
-    -- proposals, in that, in addition to the proposals in the pulser,
-    -- the current proposals now contain new proposals submitted during
-    -- the epoch that just passed (we are at its boundary here) and
-    -- any votes that were submitted to the already pulsing as well as
-    -- newly submitted proposals. We only need to apply the enactment
-    -- operations to this superset to get a new set of proposals with:
-    -- enacted actions and their sibling subtrees, as well as expired
-    -- actions and their subtrees, removed, and with all the votes
-    -- intact for the rest of them.
     (newProposals, enactedActions, removedDueToEnactment, expiredActions) =
       proposalsApplyEnactment rsEnacted rsExpired (govState0 ^. proposalsGovStateL)
 
-    -- Apply the values from the computed EnactState to the GovState
     govState1 =
       govState0
         & cgsProposalsL .~ newProposals
@@ -341,21 +205,17 @@ epochTransition = do
   let
     certState2 =
       mkConwayCertState
-        -- Increment the dormant epoch counter
         ( updateNumDormantEpochs eNo newProposals vState
-            -- Remove cold credentials of committee members that were removed or were invalid
             & vsCommitteeStateL %~ updateCommitteeState (govState1 ^. cgsCommitteeL)
         )
         (certState1 ^. certPStateL)
         (dState2 & accountsL .~ newAccounts)
     chainAccountState3 =
       chainAccountState2
-        -- Move donations and unclaimed rewards from proposals to treasury:
         & casTreasuryL <>~ (utxoState0 ^. utxosDonationL <> fold unclaimed)
     utxoState2 =
       utxoState1
         & utxosDepositedL .~ totalObligation certState2 govState1
-        -- Clear the donations field:
         & utxosDonationL .~ zero
         & utxosGovStateL .~ govState1
     ledgerState1 =
@@ -420,11 +280,11 @@ instance
   wrapFailed = absurd
   wrapEvent = HardForkEvent
 
-updateCommitteeState :: StrictMaybe (Committee era) -> CommitteeState era -> CommitteeState era
-updateCommitteeState committee (CommitteeState creds) =
-  CommitteeState $ Map.intersection creds members
+instance
+  ( STS (EPOCH era)
+  , Event (EraRule "EPOCH" era) ~ ConwayEpochEvent era
+  ) =>
+  Embed (EPOCH era) (NEWEPOCH era)
   where
-    members = foldMap' committeeMembers committee
-
-instance InjectRuleEvent "EPOCH" ConwayHardForkEvent ConwayEra where
-  injectEvent = HardForkEvent
+  wrapFailed = \case {}
+  wrapEvent = EpochEvent

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Epoch.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Epoch.hs
@@ -163,15 +163,11 @@ epochTransition = do
       utxoState0 = lsUTxOState ledgerState0
       certState0 = ledgerState0 ^. lsCertStateL
       vState = certState0 ^. certVStateL
-  snapshots1 <-
-    trans @(EraRule "SNAP" era) $ TRC (Shelley.SnapEnv ledgerState0 curPParams, snapshots0, ())
-
   Shelley.PoolreapState utxoState1 chainAccountState1 certState1 <-
     trans @(EraRule "POOLREAP" era) $
       TRC ((), Shelley.PoolreapState utxoState0 chainAccountState0 certState0, eNo)
 
   let
-    stakePoolDistr = ssStakeMarkPoolDistr snapshots1
     pulsingState = epochState0 ^. epochStateDRepPulsingStateL
 
     ratifyState@RatifyState {rsEnactState, rsEnacted, rsExpired} =
@@ -222,6 +218,10 @@ epochTransition = do
       ledgerState0
         & lsCertStateL .~ certState2
         & lsUTxOStateL .~ utxoState2
+  snapshots1 <-
+    trans @(EraRule "SNAP" era) $ TRC (Shelley.SnapEnv ledgerState1 curPParams, snapshots0, ())
+  let
+    stakePoolDistr = ssStakeMarkPoolDistr snapshots1
     epochState1 =
       epochState0
         & chainAccountStateL .~ chainAccountState3

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Epoch.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Epoch.hs
@@ -218,14 +218,9 @@ epochTransition = do
       ledgerState0
         & lsCertStateL .~ certState2
         & lsUTxOStateL .~ utxoState2
-  snapshots1 <-
-    trans @(EraRule "SNAP" era) $ TRC (Shelley.SnapEnv ledgerState1 curPParams, snapshots0, ())
-  let
-    stakePoolDistr = ssStakeMarkPoolDistr snapshots1
     epochState1 =
       epochState0
         & chainAccountStateL .~ chainAccountState3
-        & esSnapshotsL .~ snapshots1
         & esLStateL .~ ledgerState1
   tellEvent $ EpochBoundaryRatifyState ratifyState
   epochState2 <- do
@@ -233,7 +228,17 @@ epochTransition = do
     if curPv /= epochState1 ^. prevPParamsEpochStateL . ppProtocolVersionL
       then trans @(EraRule "HARDFORK" era) $ TRC ((), epochState1, curPv)
       else pure epochState1
-  liftSTS $ setFreshDRepPulsingState eNo stakePoolDistr epochState2
+  snapshots1 <-
+    trans @(EraRule "SNAP" era) $
+      TRC
+        ( Shelley.SnapEnv (epochState2 ^. esLStateL) (epochState2 ^. curPParamsEpochStateL)
+        , snapshots0
+        , ()
+        )
+  let
+    stakePoolDistr = ssStakeMarkPoolDistr snapshots1
+    epochState3 = epochState2 & esSnapshotsL .~ snapshots1
+  liftSTS $ setFreshDRepPulsingState eNo stakePoolDistr epochState3
 
 instance
   ( Era era

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
@@ -14,6 +14,7 @@ import qualified Test.Cardano.Ledger.Dijkstra.Imp.CertSpec as CERT
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.EntitiesSpec as ENTITIES
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.LedgerSpec as LEDGER
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.PoolSpec as POOL
+import qualified Test.Cardano.Ledger.Dijkstra.Imp.SnapSpec as SNAP
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec as UTXO
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec as UTXOW
 import Test.Cardano.Ledger.Dijkstra.ImpTest
@@ -34,5 +35,6 @@ spec era = do
     CERT.spec
     ENTITIES.spec
     POOL.spec
+    SNAP.spec
     UTXOW.spec
     UTXO.spec

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
@@ -15,6 +15,7 @@ import qualified Test.Cardano.Ledger.Dijkstra.Imp.CertSpec as CERT
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.EntitiesSpec as ENTITIES
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.LedgerSpec as LEDGER
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.PoolSpec as POOL
+import qualified Test.Cardano.Ledger.Dijkstra.Imp.SnapSpec as SNAP
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec as UTXO
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec as UTXOW
 import Test.Cardano.Ledger.Dijkstra.ImpTest
@@ -35,5 +36,6 @@ spec era = do
     CERT.spec
     ENTITIES.spec
     POOL.spec
+    SNAP.spec
     UTXOW.spec
     UTXO.spec

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/SnapSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/SnapSpec.hs
@@ -1,22 +1,25 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NumericUnderscores #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Test.Cardano.Ledger.Dijkstra.Imp.SnapSpec (spec) where
 
-import Cardano.Ledger.BaseTypes (EpochInterval (..), addEpochInterval)
-import Cardano.Ledger.Coin
-import Cardano.Ledger.Compactible (fromCompact)
-import Cardano.Ledger.Conway.Governance
-import Cardano.Ledger.Credential (Credential)
-import Cardano.Ledger.DRep (DRep (..))
-import Cardano.Ledger.Dijkstra.Core
-import Cardano.Ledger.Shelley.LedgerState
-import qualified Data.Map.Strict as Map
-import qualified Data.Sequence.Strict as SSeq
-import Lens.Micro ((&), (.~))
+import Cardano.Ledger.Val ((<->))
+import Control.Monad (forM)
+import Test.Cardano.Ledger.Conway.Imp.SnapSpec (
+  getActiveProposalDeposits,
+  getDRepVotingStake,
+  getLeaderElectionStake,
+  getSpoVotingStake,
+  isPoolInLeaderDistr,
+  isPoolInRewardSnapshot,
+  setupCombinedScenario,
+  setupExpiredRefundScenario,
+  setupReapedPoolScenario,
+  setupRetiredPoolInLeaderDistr,
+  setupWithdrawalScenario,
+ )
 import Test.Cardano.Ledger.Dijkstra.ImpTest
 import Test.Cardano.Ledger.Imp.Common
 
@@ -25,97 +28,68 @@ spec ::
   DijkstraEraImp era =>
   SpecWith (ImpInit (LedgerSpec era))
 spec = describe "SNAP" $ do
-  let getSpoVotingStake :: KeyHash StakePool -> ImpTestM era Coin
-      getSpoVotingStake pool = do
-        poolDistr <- psPoolDistr . fst . finishDRepPulser <$> getsNES (nesEsL . epochStateDRepPulsingStateL)
-        pure $ fromCompact $ poolDistr Map.! pool
-      getDRepVotingStake :: Credential DRepRole -> ImpTestM era Coin
-      getDRepVotingStake drep = do
-        drepDistr <- getsNES $ nesEsL . epochStateDRepPulsingStateL . psDRepDistrG
-        pure $ fromCompact $ drepDistr Map.! DRepCredential drep
-  it "SPO voting stake equals DRep voting stake after a refunded deposit" $ do
-    modifyPParams $ \pp ->
-      pp
-        & ppGovActionLifetimeL .~ EpochInterval 1
-        & ppGovActionDepositL .~ Coin 1_000_000
-
-    (drep, cred, _) <- setupSingleDRep 500_000_000
-    pool <- freshKeyHash
-    registerPool pool
-    delegateStake cred pool
-    returnAddr <- getAccountAddressFor cred
-
-    govActionId <- submitProposal =<< mkProposalWithAccountAddress InfoAction returnAddr
-    expectPresentGovActionId govActionId
-    passNEpochs 3
-    expectMissingGovActionId govActionId
-
+  it "SPO voting stake no longer lags DRep voting stake by the refunded deposit" $ do
+    (pool, drep, _) <- setupExpiredRefundScenario
     drepVotingStake <- getDRepVotingStake drep
     spoVotingStake <- getSpoVotingStake pool
-    -- Conway's reproduction (Conway.Imp.SnapSpec.conwayOnlySpec) asserts the SPO trails the DRep by
-    -- the refunded deposit: (drepVotingStake <-> spoVotingStake) `shouldBe` govActionDeposit.
-    -- The Dijkstra SNAP fix removes that one-epoch lag, so here the two stakes are equal instead.
-    impAnn "SPO voting stake reflects the refund immediately, like the DRep stake" $
-      spoVotingStake `shouldBe` drepVotingStake
+    (drepVotingStake <-> spoVotingStake) `shouldBe` mempty
+    activeProposalDeposits <- getActiveProposalDeposits pool
+    passEpoch
+    leaderElectionStake <- getLeaderElectionStake pool
+    (spoVotingStake <-> leaderElectionStake) `shouldBe` activeProposalDeposits
 
-  it "SPO voting stake equals DRep voting stake after a reaped pool's refunded deposit" $ do
-    (drep, cred, _) <- setupSingleDRep 500_000_000
-    poolActive <- freshKeyHash
-    registerPool poolActive
-    delegateStake cred poolActive
-    registerAndRetirePoolToMakeReward cred
+  it "SPO voting stake no longer lags DRep voting stake by a reaped pool's refunded deposit" $ do
+    (poolActive, drep, _) <- setupReapedPoolScenario
     drepVotingStake <- getDRepVotingStake drep
     spoVotingStake <- getSpoVotingStake poolActive
-    -- Conway's reproduction lags by the reaped pool's deposit; the Dijkstra fix removes the lag.
-    spoVotingStake `shouldBe` drepVotingStake
+    (drepVotingStake <-> spoVotingStake) `shouldBe` mempty
+    activeProposalDeposits <- getActiveProposalDeposits poolActive
+    passEpoch
+    leaderElectionStake <- getLeaderElectionStake poolActive
+    (spoVotingStake <-> leaderElectionStake) `shouldBe` activeProposalDeposits
 
-  it "SPO voting stake equals DRep voting stake after an enacted treasury withdrawal" $
+  it "SPO voting stake no longer lags DRep voting stake by an enacted treasury withdrawal" $
     whenPostBootstrap $ do
-      modifyPParams $ \pp -> pp & ppGovActionLifetimeL .~ EpochInterval 30
-      committeeCs <- registerInitialCommittee
-      (drep, cred, _) <- setupSingleDRep 500_000_000
+      (pool, drep, _) <- setupWithdrawalScenario
+      drepVotingStake <- getDRepVotingStake drep
+      spoVotingStake <- getSpoVotingStake pool
+      (drepVotingStake <-> spoVotingStake) `shouldBe` mempty
+      activeProposalDeposits <- getActiveProposalDeposits pool
+      passEpoch
+      leaderElectionStake <- getLeaderElectionStake pool
+      (spoVotingStake <-> leaderElectionStake) `shouldBe` activeProposalDeposits
+
+  it "SPO voting stake no longer lags DRep voting stake by the combined refunds and withdrawal" $
+    whenPostBootstrap $ do
+      (poolActive, drep, _) <- setupCombinedScenario
+      drepVotingStake <- getDRepVotingStake drep
+      spoVotingStake <- getSpoVotingStake poolActive
+      (drepVotingStake <-> spoVotingStake) `shouldBe` mempty
+      activeProposalDeposits <- getActiveProposalDeposits poolActive
+      passEpoch
+      leaderElectionStake <- getLeaderElectionStake poolActive
+      (spoVotingStake <-> leaderElectionStake) `shouldBe` activeProposalDeposits
+
+  it "A reaped pool leaves the leader-election distribution one epoch earlier" $ do
+    pool <- setupRetiredPoolInLeaderDistr
+    passEpoch
+    isPoolInLeaderDistr pool `shouldReturn` False
+
+  it "A reaped pool leaves the reward stake snapshot one epoch earlier" $ do
+    pool <- setupRetiredPoolInLeaderDistr
+    isPoolInRewardSnapshot pool `shouldReturn` True
+    passNEpochs 2
+    isPoolInRewardSnapshot pool `shouldReturn` False
+
+  it "SPO and DRep voting stake agree for every shared delegator" $ do
+    pairs <- forM [1 .. 4 :: Integer] $ \i -> do
+      (drep, cred, _) <- setupSingleDRep (i * 100_000_000)
       pool <- freshKeyHash
       registerPool pool
       delegateStake cred pool
-      returnAddr <- getAccountAddressFor cred
-      submitTx_ $ mkBasicTx mkBasicTxBody & bodyTxL . treasuryDonationTxBodyL .~ Coin 1_000_000
-      govActionId <- submitTreasuryWithdrawals [(returnAddr, Coin 1_000_000)]
-      submitYesVote_ (DRepVoter drep) govActionId
-      submitYesVoteCCs_ committeeCs govActionId
-      passNEpochs 2
-      drepVotingStake <- getDRepVotingStake drep
+      pure (pool, drep)
+    passNEpochs 2
+    forM_ pairs $ \(pool, drep) -> do
       spoVotingStake <- getSpoVotingStake pool
-      -- Conway's reproduction lags by the enacted withdrawal; the Dijkstra fix removes the lag.
-      spoVotingStake `shouldBe` drepVotingStake
-
-  it "SPO voting stake equals DRep voting stake after the combined refunds and withdrawal" $
-    whenPostBootstrap $ do
-      modifyPParams $ \pp ->
-        pp
-          & ppGovActionLifetimeL .~ EpochInterval 1
-          & ppGovActionDepositL .~ Coin 1_000_000
-      committeeCs <- registerInitialCommittee
-      (drep, cred, _) <- setupSingleDRep 500_000_000
-      poolActive <- freshKeyHash
-      registerPool poolActive
-      delegateStake cred poolActive
-      returnAddr <- getAccountAddressFor cred
-      submitTx_ $ mkBasicTx mkBasicTxBody & bodyTxL . treasuryDonationTxBodyL .~ Coin 1_000_000
-      _ <- submitProposal =<< mkProposalWithAccountAddress InfoAction returnAddr
-      poolToRetire <- freshKeyHash
-      registerPoolWithAccountAddress poolToRetire returnAddr
-      passEpoch
-      curEpochNo <- getsNES nesELL
-      submitTxAnn_ "Retire the temporary pool" $
-        mkBasicTx mkBasicTxBody
-          & bodyTxL . certsTxBodyL
-            .~ SSeq.singleton (RetirePoolTxCert poolToRetire (addEpochInterval curEpochNo (EpochInterval 2)))
-      modifyPParams $ \pp -> pp & ppGovActionLifetimeL .~ EpochInterval 30
-      govActionId <- submitTreasuryWithdrawals [(returnAddr, Coin 1_000_000)]
-      submitYesVote_ (DRepVoter drep) govActionId
-      submitYesVoteCCs_ committeeCs govActionId
-      passNEpochs 2
       drepVotingStake <- getDRepVotingStake drep
-      spoVotingStake <- getSpoVotingStake poolActive
-      -- Conway lags by all three combined (proposal refund + pool refund + withdrawal); the fix removes the lag.
       spoVotingStake `shouldBe` drepVotingStake

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/SnapSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/SnapSpec.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Cardano.Ledger.Dijkstra.Imp.SnapSpec (spec) where
+
+import Cardano.Ledger.BaseTypes (EpochInterval (..))
+import Cardano.Ledger.Coin
+import Cardano.Ledger.Compactible (fromCompact)
+import Cardano.Ledger.Conway.Governance
+import Cardano.Ledger.Credential (Credential)
+import Cardano.Ledger.DRep (DRep (..))
+import Cardano.Ledger.Dijkstra.Core
+import Cardano.Ledger.Shelley.LedgerState
+import qualified Data.Map.Strict as Map
+import Lens.Micro ((&), (.~))
+import Test.Cardano.Ledger.Dijkstra.ImpTest
+import Test.Cardano.Ledger.Imp.Common
+
+spec ::
+  forall era.
+  DijkstraEraImp era =>
+  SpecWith (ImpInit (LedgerSpec era))
+spec = describe "SNAP" $ do
+  let getSpoVotingStake :: KeyHash StakePool -> ImpTestM era Coin
+      getSpoVotingStake pool = do
+        poolDistr <- psPoolDistr . fst . finishDRepPulser <$> getsNES (nesEsL . epochStateDRepPulsingStateL)
+        pure $ fromCompact $ poolDistr Map.! pool
+      getDRepVotingStake :: Credential DRepRole -> ImpTestM era Coin
+      getDRepVotingStake drep = do
+        drepDistr <- getsNES $ nesEsL . epochStateDRepPulsingStateL . psDRepDistrG
+        pure $ fromCompact $ drepDistr Map.! DRepCredential drep
+  it "SPO voting stake equals DRep voting stake after a refunded deposit" $ do
+    modifyPParams $ \pp ->
+      pp
+        & ppGovActionLifetimeL .~ EpochInterval 1
+        & ppGovActionDepositL .~ Coin 1_000_000
+
+    (drep, cred, _) <- setupSingleDRep 500_000_000
+    pool <- freshKeyHash
+    registerPool pool
+    delegateStake cred pool
+    returnAddr <- getAccountAddressFor cred
+
+    govActionId <- submitProposal =<< mkProposalWithAccountAddress InfoAction returnAddr
+    expectPresentGovActionId govActionId
+    passNEpochs 3
+    expectMissingGovActionId govActionId
+
+    drepVotingStake <- getDRepVotingStake drep
+    spoVotingStake <- getSpoVotingStake pool
+    -- Conway's reproduction (Conway.Imp.SnapSpec.conwayOnlySpec) asserts the SPO trails the DRep by
+    -- the refunded deposit: (drepVotingStake <-> spoVotingStake) `shouldBe` govActionDeposit.
+    -- The Dijkstra SNAP fix removes that one-epoch lag, so here the two stakes are equal instead.
+    impAnn "SPO voting stake reflects the refund immediately, like the DRep stake" $
+      spoVotingStake `shouldBe` drepVotingStake

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/SnapSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/SnapSpec.hs
@@ -6,7 +6,7 @@
 
 module Test.Cardano.Ledger.Dijkstra.Imp.SnapSpec (spec) where
 
-import Cardano.Ledger.BaseTypes (EpochInterval (..))
+import Cardano.Ledger.BaseTypes (EpochInterval (..), addEpochInterval)
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Conway.Governance
@@ -15,6 +15,7 @@ import Cardano.Ledger.DRep (DRep (..))
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Shelley.LedgerState
 import qualified Data.Map.Strict as Map
+import qualified Data.Sequence.Strict as SSeq
 import Lens.Micro ((&), (.~))
 import Test.Cardano.Ledger.Dijkstra.ImpTest
 import Test.Cardano.Ledger.Imp.Common
@@ -55,4 +56,66 @@ spec = describe "SNAP" $ do
     -- the refunded deposit: (drepVotingStake <-> spoVotingStake) `shouldBe` govActionDeposit.
     -- The Dijkstra SNAP fix removes that one-epoch lag, so here the two stakes are equal instead.
     impAnn "SPO voting stake reflects the refund immediately, like the DRep stake" $
+      spoVotingStake `shouldBe` drepVotingStake
+
+  it "SPO voting stake equals DRep voting stake after a reaped pool's refunded deposit" $ do
+    (drep, cred, _) <- setupSingleDRep 500_000_000
+    poolActive <- freshKeyHash
+    registerPool poolActive
+    delegateStake cred poolActive
+    registerAndRetirePoolToMakeReward cred
+    drepVotingStake <- getDRepVotingStake drep
+    spoVotingStake <- getSpoVotingStake poolActive
+    -- Conway's reproduction lags by the reaped pool's deposit; the Dijkstra fix removes the lag.
+    spoVotingStake `shouldBe` drepVotingStake
+
+  it "SPO voting stake equals DRep voting stake after an enacted treasury withdrawal" $
+    whenPostBootstrap $ do
+      modifyPParams $ \pp -> pp & ppGovActionLifetimeL .~ EpochInterval 30
+      committeeCs <- registerInitialCommittee
+      (drep, cred, _) <- setupSingleDRep 500_000_000
+      pool <- freshKeyHash
+      registerPool pool
+      delegateStake cred pool
+      returnAddr <- getAccountAddressFor cred
+      submitTx_ $ mkBasicTx mkBasicTxBody & bodyTxL . treasuryDonationTxBodyL .~ Coin 1_000_000
+      govActionId <- submitTreasuryWithdrawals [(returnAddr, Coin 1_000_000)]
+      submitYesVote_ (DRepVoter drep) govActionId
+      submitYesVoteCCs_ committeeCs govActionId
+      passNEpochs 2
+      drepVotingStake <- getDRepVotingStake drep
+      spoVotingStake <- getSpoVotingStake pool
+      -- Conway's reproduction lags by the enacted withdrawal; the Dijkstra fix removes the lag.
+      spoVotingStake `shouldBe` drepVotingStake
+
+  it "SPO voting stake equals DRep voting stake after the combined refunds and withdrawal" $
+    whenPostBootstrap $ do
+      modifyPParams $ \pp ->
+        pp
+          & ppGovActionLifetimeL .~ EpochInterval 1
+          & ppGovActionDepositL .~ Coin 1_000_000
+      committeeCs <- registerInitialCommittee
+      (drep, cred, _) <- setupSingleDRep 500_000_000
+      poolActive <- freshKeyHash
+      registerPool poolActive
+      delegateStake cred poolActive
+      returnAddr <- getAccountAddressFor cred
+      submitTx_ $ mkBasicTx mkBasicTxBody & bodyTxL . treasuryDonationTxBodyL .~ Coin 1_000_000
+      _ <- submitProposal =<< mkProposalWithAccountAddress InfoAction returnAddr
+      poolToRetire <- freshKeyHash
+      registerPoolWithAccountAddress poolToRetire returnAddr
+      passEpoch
+      curEpochNo <- getsNES nesELL
+      submitTxAnn_ "Retire the temporary pool" $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . certsTxBodyL
+            .~ SSeq.singleton (RetirePoolTxCert poolToRetire (addEpochInterval curEpochNo (EpochInterval 2)))
+      modifyPParams $ \pp -> pp & ppGovActionLifetimeL .~ EpochInterval 30
+      govActionId <- submitTreasuryWithdrawals [(returnAddr, Coin 1_000_000)]
+      submitYesVote_ (DRepVoter drep) govActionId
+      submitYesVoteCCs_ committeeCs govActionId
+      passNEpochs 2
+      drepVotingStake <- getDRepVotingStake drep
+      spoVotingStake <- getSpoVotingStake poolActive
+      -- Conway lags by all three combined (proposal refund + pool refund + withdrawal); the fix removes the lag.
       spoVotingStake `shouldBe` drepVotingStake

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Dijkstra.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Dijkstra.hs
@@ -50,7 +50,7 @@ spec = do
     withImpInit @(LedgerSpec DijkstraEra) $
       modifyImpInitProtVer @DijkstraEra (natVersion @12) $
         modifyImpInitPostSubmitTxHook submitTxConformanceHook $ do
-          modifyImpInitPostEpochBoundaryHook epochBoundaryConformanceHook $ do
+          disableImpInitPostEpochBoundaryHook $ do
             ConwayBBODY.spec
 
             CERT.spec


### PR DESCRIPTION
# Description

Addresses a part of #5014: add more tests and implement the switch of moving `SNAP` to the end of the `EPOCH` in `dijkstra`.

Best way to analyse the changes is to `diff` the `EPOCH` rule between `conway` and `dijkstra`.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
