### PR TITLE
Fix infinite loop in initialLedgerState, re-enable UTXO/UTXOW/LEDGER/LEDGERS conformance

### DIFF
--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
@@ -55,8 +55,7 @@ spec = do
                 , ccecWithdrawals = ccccWithdrawals
                 }
       prop "GOV" $ conformsToImplConstrained_ constrainedGov
-      -- UTXO is disabled due to: https://github.com/IntersectMBO/cardano-ledger/issues/4876
-      xprop "UTXO" $ conformsToImplConstrained constrainedUtxo $ \_ _ _ _ -> genUtxoExecContext
-      xprop "UTXOW" $ conformsToImplConstrained constrainedUtxo $ \_ _ _ _ -> genUtxoExecContext
-      xprop "LEDGER" $ conformsToImplConstrained constrainedUtxo $ \_ _ _ _ -> genUtxoExecContext
-      xprop "LEDGERS" $ conformsToImplConstrained constrainedUtxo $ \_ _ _ _ -> genUtxoExecContext
+      prop "UTXO" $ conformsToImplConstrained constrainedUtxo $ \_ _ _ _ -> genUtxoExecContext
+      prop "UTXOW" $ conformsToImplConstrained constrainedUtxo $ \_ _ _ _ -> genUtxoExecContext
+      prop "LEDGER" $ conformsToImplConstrained constrainedUtxo $ \_ _ _ _ -> genUtxoExecContext
+      prop "LEDGERS" $ conformsToImplConstrained constrainedUtxo $ \_ _ _ _ -> genUtxoExecContext

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
@@ -250,6 +250,6 @@ genUtxoExecContext = do
     uePParams =
       gePParams (gsGenEnv gs)
         & ppMaxTxSizeL .~ fromIntegral txSize
-        & ppProtocolVersionL .~ ProtVer (natVersion @10) 0
+        & ppProtocolVersionL .~ ProtVer (natVersion @11) 0
     uecUtxoEnv = UtxoEnv {..}
   pure UtxoExecContext {..}

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
@@ -101,7 +101,6 @@ import Cardano.Ledger.Shelley.LedgerState (
   LedgerState (..),
   smartUTxOState,
   totalObligation,
-  utxosGovStateL,
  )
 import Cardano.Ledger.Shelley.Scripts (
   MultiSig,
@@ -688,8 +687,12 @@ initialLedgerState gstate = LedgerState utxostate dpstate
         )
         Map.empty
         Map.empty
-    -- In a wellformed LedgerState the deposited equals the obligation
-    deposited = totalObligation dpstate (utxostate ^. utxosGovStateL)
+    -- In a wellformed LedgerState the deposited equals the obligation.
+    -- NOTE: this must not go through `utxostate` (e.g. via `utxosGovStateL`) --
+    -- `utxostate` is defined above in terms of `deposited`, so routing back
+    -- through it creates a self-reference that only terminated by accident
+    -- while `utxosDeposited` was a lazy field.
+    deposited = totalObligation dpstate emptyGovState
     pools = gsInitialStakePoolParams gstate
     pp = mPParams (gsModel gstate)
     poolDeposit = pp ^. ppPoolDepositCompactL


### PR DESCRIPTION
# Description

## Summary
- Fix the `initialLedgerState` self-referential knot (`GenState.hs`) that caused an infinite loop in the `UTXO`/`UTXOW`/`LEDGER`/`LEDGERS` constrained-generator conformance properties.
- Bump the protocol version `genUtxoExecContext` (`Utxo.hs`) pins its generated transactions to, from 10 to 11 - still within Conway's currently-supported range (`ProtVerLow ConwayEra = 9`, `ProtVerHigh ConwayEra = 11`).
- Re-enable `UTXO`, `UTXOW`, `LEDGER`, and `LEDGERS` in `Conway.hs` (`xprop` -> `prop`).

## Test plan
- [x] Full `cardano-ledger-conformance` test suite: 846 examples, 0 failures.
- [x] Full `cardano-ledger-test` test suite: 58 examples, 0 failures.
- [x] No changelog/version bump needed - both touched packages (`cardano-ledger-test`, `cardano-ledger-conformance`) are excluded from the release process per `RELEASING.md`.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary.
- [ ] Version bounds in `.cabal` files updated when necessary.
- [ ] Code formatted (use `scripts/fourmolize.sh`).
- [ ] Cabal files formatted (use `scripts/cabal-format.sh`).
- [ ] CDDL files are up to date.
- [ ] `hie.yaml` updated.
- [x] Self-reviewed the diff.