### PR TITLE
Integration branch for cardano-node 11.2 release

### DIFF
--- a/eras/byron/crypto/cardano-crypto-wrapper.cabal
+++ b/eras/byron/crypto/cardano-crypto-wrapper.cabal
@@ -94,8 +94,8 @@ library
     deepseq,
     formatting,
     heapwords,
-    memory,
     nothunks,
+    ram,
     text,
 
 library testlib
@@ -136,7 +136,7 @@ library testlib
     cardano-prelude-test,
     crypton,
     hedgehog >=1.0.4,
-    memory,
+    ram,
 
 test-suite test
   type: exitcode-stdio-1.0

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -84,7 +84,7 @@ library
     base >=4.18 && <5,
     base16-bytestring,
     bytestring,
-    cardano-crypto-class >=2.3 && <2.6,
+    cardano-crypto-class >=2.3 && <2.7,
     cardano-data ^>=1.3,
     cardano-ledger-allegra ^>=1.10,
     cardano-ledger-binary >=1.4,

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -119,7 +119,7 @@ library
     base >=4.18 && <5,
     bytestring,
     cardano-base >=0.1.1.0,
-    cardano-crypto-class >=2.3 && <2.6,
+    cardano-crypto-class >=2.3 && <2.7,
     cardano-crypto-wrapper,
     cardano-data ^>=1.3,
     cardano-ledger-binary ^>=1.9,

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -57,7 +57,7 @@ library
     bytestring,
     cardano-base >=0.1.2,
     cardano-binary >=1.9.1,
-    cardano-crypto-class >=2.3 && <2.6,
+    cardano-crypto-class >=2.3 && <2.7,
     cardano-crypto-leios >=0.2.0,
     cardano-crypto-praos >=2.2.2,
     cardano-slotting >=0.2,

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -119,7 +119,7 @@ library
     bytestring >=0.10 && <0.11.3 || >=0.11.4,
     cardano-base >=0.1.6,
     cardano-crypto,
-    cardano-crypto-class >=2.4 && <2.6,
+    cardano-crypto-class >=2.4 && <2.7,
     cardano-crypto-wrapper,
     cardano-data >=1.3,
     cardano-ledger-binary ^>=1.9,

--- a/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
+++ b/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
@@ -45,7 +45,7 @@ library
       -Wredundant-constraints
   build-depends:
     base >=4.18 && <5,
-    cardano-crypto-class >=2.5 && <2.6,
+    cardano-crypto-class >=2.5 && <2.7,
     cardano-ledger-allegra >=1.10,
     cardano-ledger-alonzo >=1.16,
     cardano-ledger-babbage >=1.13.1,

--- a/libs/cardano-protocol/cardano-protocol.cabal
+++ b/libs/cardano-protocol/cardano-protocol.cabal
@@ -42,7 +42,7 @@ library
     bytestring,
     cardano-base >=0.1.2,
     cardano-binary,
-    cardano-crypto-class >=2.5 && <2.6,
+    cardano-crypto-class >=2.5 && <2.7,
     cardano-crypto-praos ^>=2.2,
     cardano-ledger-binary >=1.8,
     cardano-ledger-core >=1.21,


### PR DESCRIPTION
## Summary

- Update `cardano-crypto-class` bounds from `<2.6` to `<2.7` for node 11.2 integration
- Fix: replace `memory` package import with `ram` in `cardano-crypto-wrapper` for crypto-class 2.6 compatibility

## Test plan

- [ ] `cabal build all` passes in cardano-node with this SRP active
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)