### PR TITLE
Withdrawals rework in ENTITIES

### DIFF
--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/CertsSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/CertsSpec.hs
@@ -10,15 +10,20 @@
 
 module Test.Cardano.Ledger.Conway.Imp.CertsSpec (conwayOnlySpec, spec) where
 
-import Cardano.Ledger.BaseTypes (EpochInterval (..), Mismatch (..))
+import Cardano.Ledger.Address
+import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Conway.Rules (ConwayLedgerPredFailure (..))
+import Cardano.Ledger.Conway.Rules (
+  ConwayLedgerPredFailure (..),
+  ConwayUtxoPredFailure (..),
+ )
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.DRep (DRep (..))
 import Cardano.Ledger.Plutus (SLanguage (SPlutusV3), hashPlutusScript)
 import Cardano.Ledger.Val (Val (..))
 import qualified Data.Map.NonEmpty as NEM
+import qualified Data.Set.NonEmpty as NES
 import Lens.Micro ((&), (.~))
 import Test.Cardano.Ledger.Conway.Arbitrary ()
 import Test.Cardano.Ledger.Conway.ImpTest
@@ -82,6 +87,22 @@ conwayOnlySpec = describe "CERTS" $ do
                     ]
                 }
           )
+
+    it "Withdrawing with the wrong network" $ do
+      stakeKey <- freshKeyHash
+      accountAddress <- registerStakeCredential (KeyHashObj stakeKey)
+      let wrongNetworkAccount = accountAddress & accountAddressNetworkIdL .~ Mainnet
+          withdrawals = Withdrawals [(wrongNetworkAccount, zero)]
+          tx =
+            mkBasicTx $
+              mkBasicTxBody
+                & withdrawalsTxBodyL .~ withdrawals
+          notInRewardsFailure = injectFailure . ConwayWithdrawalsMissingAccounts @era $ withdrawals
+      let wrongNetworkFailure =
+            injectFailure . WrongNetworkWithdrawal @era Testnet $ NES.singleton wrongNetworkAccount
+      void $ delegateToDRep (KeyHashObj stakeKey) (Coin 1_000_000) DRepAlwaysAbstain
+      -- when the network is wrong, missing account failure is emitted even if the stake credential is registered
+      submitFailingTx tx [wrongNetworkFailure, notInRewardsFailure]
 
 spec ::
   forall era.

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.4.0.0
 
+* Remove `WithdrawalsExceedAccountBalance` constructor from `DijkstraUtxoPredFailure`
 * Add `WithdrawalAccountsMissingFromOriginal` constructor to `EntitiesPredFailure`
 * Rename `EntitiesPredFailure` constructors:
   - `MissingAccountsInWithdrawals` to `WithdrawalAccountsMissing`

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## 0.4.0.0
 
+* Rename `EntitiesPredFailure` constructors:
+  - `MissingAccountsInWithdrawals` to `WithdrawalAccountsMissing`
+  - `IncompleteWithdrawals` to `WithdrawalAmountsInexactInLegacyMode`
+  - `ExceededBalancesInWithdrawals` to `WithdrawalAmountsExceedingOriginalBalance`
+  - `WrongNetworkInWithdrawals` to `WithdrawalAddressesWithWrongNetwork`
+  - `MissingAccountsInDirectDeposits` to `DirectDepositAccountsMissing`
+  - `WrongNetworkInDirectDeposits` to `DirectDepositAddressesWithWrongNetwork`
+* Rename `SubEntitiesPredFailure` constructors:
+  - `SubMissingAccountsInWithdrawals` to `SubWithdrawalAccountsMissing`
+  - `SubMissingOriginalAccountsInWithdrawals` to `SubWithdrawalAccountsMissingFromOriginal`
+  - `SubWrongNetworkInWithdrawals` to `SubWithdrawalAddressesWithWrongNetwork`
+  - `SubMissingAccountsInDirectDeposits` to `SubDirectDepositAccountsMissing`
+  - `SubWrongNetworkInDirectDeposits` to `SubDirectDepositAddressesWithWrongNetwork`
 * Add `POOL` rule type and add `poolTransition` to `Cardano.Ledger.Dijkstra.Rules.Pool`
 * Add `AlonzoEraTransition` instance for `DijkstraEra`
 * Re-export `GuardingPurpose` from `Cardano.Ledger.Dijkstra.Core` for consistency with prior eras.

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.4.0.0
 
+* Add `WithdrawalAccountsMissingFromOriginal` constructor to `EntitiesPredFailure`
 * Rename `EntitiesPredFailure` constructors:
   - `MissingAccountsInWithdrawals` to `WithdrawalAccountsMissing`
   - `IncompleteWithdrawals` to `WithdrawalAmountsInexactInLegacyMode`

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
@@ -301,7 +301,7 @@ dijkstraEntitiesTransition = do
 
   let directDeposits = tx ^. bodyTxL . directDepositsTxBodyL
       accountsAfterCerts = certStateAfterCerts ^. certDStateL . accountsL
-  runTest $ validateMissingAccountsInDirectDeposits directDeposits accountsAfterCerts
+  runTest $ validateMissingAccountsInDirectDeposits directDeposits network accountsAfterCerts
 
   pure $ certStateAfterCerts & certDStateL . accountsL %~ applyDirectDeposits directDeposits
 
@@ -322,11 +322,12 @@ validateWrongNetworkInDirectDeposit netId txb =
 validateMissingAccountsInDirectDeposits ::
   EraAccounts era =>
   DirectDeposits ->
+  Network ->
   Accounts era ->
   Test (EntitiesPredFailure era)
-validateMissingAccountsInDirectDeposits dds accounts =
+validateMissingAccountsInDirectDeposits dds network accounts =
   failureOnJust
-    (directDepositsMissingAccounts dds accounts)
+    (directDepositsMissingAccounts dds network accounts)
     DirectDepositAccountsMissing
 
 validateWithdrawals ::

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
@@ -97,7 +97,7 @@ instance
   ) =>
   EncCBOR (EntitiesEnv era)
   where
-  encCBOR x@(EntitiesEnv {}) =
+  encCBOR x@(EntitiesEnv _ _ _ _ _) =
     let EntitiesEnv {..} = x
      in encode $
           Rec EntitiesEnv
@@ -109,20 +109,20 @@ instance
 
 data EntitiesPredFailure era
   = CertsFailure (PredicateFailure (EraRule "CERTS" era))
-  | MissingAccountsInWithdrawals Withdrawals
-  | IncompleteWithdrawals (NonEmptyMap AccountAddress (Mismatch RelEQ Coin))
-  | ExceededBalancesInWithdrawals (NonEmptyMap AccountAddress (Mismatch RelLTEQ Coin))
-  | MissingAccountsInDirectDeposits DirectDeposits
-  | WrongNetworkInWithdrawals
+  | WithdrawalAddressesWithWrongNetwork
       -- | Expected network id
       Network
-      -- | Withdrawal accounts with wrong network id
+      -- | Withdrawal account addresses with wrong network id
       (NonEmptySet AccountAddress)
-  | WrongNetworkInDirectDeposits
+  | WithdrawalAccountsMissing Withdrawals
+  | WithdrawalAmountsInexactInLegacyMode (NonEmptyMap AccountAddress (Mismatch RelEQ Coin))
+  | WithdrawalAmountsExceedingOriginalBalance (NonEmptyMap AccountAddress (Mismatch RelLTEQ Coin))
+  | DirectDepositAddressesWithWrongNetwork
       -- | Expected network id
       Network
-      -- | Direct-deposit accounts with wrong network id
+      -- | Direct-deposit account addresses with wrong network id
       (NonEmptySet AccountAddress)
+  | DirectDepositAccountsMissing DirectDeposits
   | WrongNetworkInAccountBalanceIntervals Network (NonEmptySet AccountAddress)
   | MissingAccountsInAccountBalanceIntervals (NonEmptyMap AccountAddress (AccountBalanceInterval era))
   | BalancesOutsideAccountBalanceIntervals
@@ -156,12 +156,12 @@ instance
   encCBOR =
     encode . \case
       CertsFailure x -> Sum (CertsFailure @era) 0 !> To x
-      MissingAccountsInWithdrawals x -> Sum (MissingAccountsInWithdrawals @era) 1 !> To x
-      IncompleteWithdrawals x -> Sum (IncompleteWithdrawals @era) 2 !> To x
-      ExceededBalancesInWithdrawals x -> Sum (ExceededBalancesInWithdrawals @era) 3 !> To x
-      MissingAccountsInDirectDeposits x -> Sum (MissingAccountsInDirectDeposits @era) 4 !> To x
-      WrongNetworkInWithdrawals x y -> Sum (WrongNetworkInWithdrawals @era) 5 !> To x !> To y
-      WrongNetworkInDirectDeposits x y -> Sum (WrongNetworkInDirectDeposits @era) 6 !> To x !> To y
+      WithdrawalAddressesWithWrongNetwork x y -> Sum (WithdrawalAddressesWithWrongNetwork @era) 1 !> To x !> To y
+      WithdrawalAccountsMissing x -> Sum (WithdrawalAccountsMissing @era) 2 !> To x
+      WithdrawalAmountsInexactInLegacyMode x -> Sum (WithdrawalAmountsInexactInLegacyMode @era) 3 !> To x
+      WithdrawalAmountsExceedingOriginalBalance x -> Sum (WithdrawalAmountsExceedingOriginalBalance @era) 4 !> To x
+      DirectDepositAddressesWithWrongNetwork x y -> Sum (DirectDepositAddressesWithWrongNetwork @era) 5 !> To x !> To y
+      DirectDepositAccountsMissing x -> Sum (DirectDepositAccountsMissing @era) 6 !> To x
       WrongNetworkInAccountBalanceIntervals x y -> Sum (WrongNetworkInAccountBalanceIntervals @era) 7 !> To x !> To y
       MissingAccountsInAccountBalanceIntervals x -> Sum (MissingAccountsInAccountBalanceIntervals @era) 8 !> To x
       BalancesOutsideAccountBalanceIntervals x -> Sum (BalancesOutsideAccountBalanceIntervals @era) 9 !> To x
@@ -177,12 +177,12 @@ instance
   where
   decCBOR = decode . Summands "EntitiesPredFailure" $ \case
     0 -> SumD CertsFailure <! From
-    1 -> SumD MissingAccountsInWithdrawals <! From
-    2 -> SumD IncompleteWithdrawals <! From
-    3 -> SumD ExceededBalancesInWithdrawals <! From
-    4 -> SumD MissingAccountsInDirectDeposits <! From
-    5 -> SumD WrongNetworkInWithdrawals <! From <! From
-    6 -> SumD WrongNetworkInDirectDeposits <! From <! From
+    1 -> SumD WithdrawalAddressesWithWrongNetwork <! From <! From
+    2 -> SumD WithdrawalAccountsMissing <! From
+    3 -> SumD WithdrawalAmountsInexactInLegacyMode <! From
+    4 -> SumD WithdrawalAmountsExceedingOriginalBalance <! From
+    5 -> SumD DirectDepositAddressesWithWrongNetwork <! From <! From
+    6 -> SumD DirectDepositAccountsMissing <! From
     7 -> SumD WrongNetworkInAccountBalanceIntervals <! From <! From
     8 -> SumD MissingAccountsInAccountBalanceIntervals <! From
     9 -> SumD BalancesOutsideAccountBalanceIntervals <! From
@@ -308,7 +308,7 @@ validateWrongNetworkInDirectDeposit ::
   TxBody t era ->
   Test (EntitiesPredFailure era)
 validateWrongNetworkInDirectDeposit netId txb =
-  failureOnNonEmptySet depositsWrongNetwork (WrongNetworkInDirectDeposits netId)
+  failureOnNonEmptySet depositsWrongNetwork (DirectDepositAddressesWithWrongNetwork netId)
   where
     depositsWrongNetwork =
       Map.keysSet $
@@ -324,7 +324,7 @@ validateMissingAccountsInDirectDeposits ::
 validateMissingAccountsInDirectDeposits dds accounts =
   failureOnJust
     (directDepositsMissingAccounts dds accounts)
-    MissingAccountsInDirectDeposits
+    DirectDepositAccountsMissing
 
 validateWithdrawals ::
   EraAccounts era =>
@@ -341,17 +341,17 @@ validateWithdrawals legacyMode network withdrawals accounts = do
               case withdrawalsThatDoNotDrainAccounts withdrawals network accounts of
                 Nothing -> (Map.empty, Map.empty)
                 Just (missing, incomplete) -> (unWithdrawals missing, incomplete)
-        failOnNonEmptyMap incompleteWithdrawals IncompleteWithdrawals
+        failOnNonEmptyMap incompleteWithdrawals WithdrawalAmountsInexactInLegacyMode
         pure missingWithdrawals
       else do
         let (missingWithdrawals, exceededWithdrawals) =
               case withdrawalsThatExceedAccountBalance withdrawals network accounts of
                 Nothing -> (Map.empty, Map.empty)
                 Just (missing, exceeded) -> (unWithdrawals missing, exceeded)
-        failOnNonEmptyMap exceededWithdrawals ExceededBalancesInWithdrawals
+        failOnNonEmptyMap exceededWithdrawals WithdrawalAmountsExceedingOriginalBalance
         pure missingWithdrawals
   failOnNonEmptyMap missingWithdrawals $
-    MissingAccountsInWithdrawals . Withdrawals . NEM.toMap
+    WithdrawalAccountsMissing . Withdrawals . NEM.toMap
 
 conwayToDijkstraEntitiesPredFailure ::
   forall era. Conway.ConwayLedgerPredFailure era -> EntitiesPredFailure era
@@ -371,7 +371,7 @@ conwayToDijkstraEntitiesPredFailure = \case
 shelleyUtxoToDijkstraEntitiesPredFailure ::
   Shelley.ShelleyUtxoPredFailure era -> EntitiesPredFailure era
 shelleyUtxoToDijkstraEntitiesPredFailure = \case
-  Shelley.WrongNetworkWithdrawal net addrs -> WrongNetworkInWithdrawals net addrs
+  Shelley.WrongNetworkWithdrawal net addrs -> WithdrawalAddressesWithWrongNetwork net addrs
   Shelley.BadInputsUTxO _ -> impossible "BadInputsUTxO"
   Shelley.ExpiredUTxO _ -> impossible "ExpiredUTxO"
   Shelley.MaxTxSizeUTxO _ -> impossible "MaxTxSizeUTxO"

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
@@ -283,7 +283,8 @@ dijkstraEntitiesTransition = do
   runTest $ validateAccountBalanceIntervals network accounts (tx ^. bodyTxL)
   runTest $ validateStartingAccountBalanceIntervals network originalAccounts (tx ^. bodyTxL)
 
-  runTest $ validateWithdrawals stAnnTx network accounts originalAccounts
+  runTest $ validateWithdrawalsAgainstOriginalAccounts stAnnTx network originalAccounts
+  runTest $ validateWithdrawalsAgainstCurrentAccounts stAnnTx network accounts
 
   let certStateBeforeCerts =
         certState
@@ -325,7 +326,11 @@ validateMissingAccountsInDirectDeposits dds network accounts =
     (directDepositsMissingAccounts dds network accounts)
     DirectDepositAccountsMissing
 
-validateWithdrawals ::
+-- | Checks that withdrawals satisfy these conditions against original Accounts:
+-- 1) normal mode: top-tx withdrawal account addresses must be registered (sub-tx ones are checked in SUBENTITIES)
+-- 2) normal mode: for each account, the sum of top- and sub-tx withdrawals must not exceed the original balance
+-- 3) legacy mode: for each account, the sum of sub-tx withdrawals must not exceed the original balance
+validateWithdrawalsAgainstOriginalAccounts ::
   ( EraAccounts era
   , DijkstraEraUTxO era
   , DijkstraEraTxBody era
@@ -333,24 +338,22 @@ validateWithdrawals ::
   StAnnTx TopTx era ->
   Network ->
   Accounts era ->
-  Accounts era ->
   Test (EntitiesPredFailure era)
-validateWithdrawals stAnnTx network accounts originalAccounts =
+validateWithdrawalsAgainstOriginalAccounts stAnnTx network originalAccounts = do
   let
     tx = stAnnTx ^. txStAnnTxG
     legacyMode = stAnnTx ^. plutusLegacyModeStAnnTxG
     topTxWithdrawals = tx ^. bodyTxL . withdrawalsTxBodyL
-    subTxWithdrawals =
+    sumOfSubTxWithdrawals =
       foldMap'
         (\subTx -> subTx ^. bodyTxL . withdrawalsTxBodyL)
         (tx ^. bodyTxL . subTransactionsTxBodyL)
-    batchWithdrawals = topTxWithdrawals <> subTxWithdrawals
-
-    -- In normal mode, all withdrawals in the batch must not exceed the pre-batch balance,
-    -- and all top tx-withdrawals must exist in the pre-batch Accounts
-    checkNonLegacyAgainstOriginal =
+    sumOfAllWithdrawals = topTxWithdrawals <> sumOfSubTxWithdrawals
+    -- In normal mode, all withdrawals in the batch must not exceed the original balance,
+    -- and all top tx-withdrawals must exist in the original Accounts
+    checkNonLegacy =
       unless legacyMode $
-        for_ (withdrawalsThatExceedAccountBalance batchWithdrawals network originalAccounts) $
+        for_ (withdrawalsThatExceedAccountBalance sumOfAllWithdrawals network originalAccounts) $
           \(Withdrawals missingAccounts, exceedingBalances) ->
             -- we only check the accounts in the top transactions here, because the subtransactions are checked in SUBENTITES
             let topMissingAccounts =
@@ -358,25 +361,40 @@ validateWithdrawals stAnnTx network accounts originalAccounts =
              in failWithdrawalsMap topMissingAccounts WithdrawalAccountsMissingFromOriginal
                   *> failureOnNonEmptyMap exceedingBalances WithdrawalAmountsExceedingOriginalBalance
 
-    -- In legacy mode, all withdrawals from subtransactions must not exceed the pre-batch balance.
-    checkLegacySubsAgainstOriginal =
+    -- In legacy mode, all withdrawals from subtransactions must not exceed the original balance.
+    checkLegacy =
       when legacyMode $
-        for_ (withdrawalsThatExceedAccountBalance subTxWithdrawals network originalAccounts) $
+        for_ (withdrawalsThatExceedAccountBalance sumOfSubTxWithdrawals network originalAccounts) $
           -- missing accounts are discarded, because they are checked in SUBENTITIES
           \(_, exceedingBalances) ->
             failureOnNonEmptyMap exceedingBalances WithdrawalAmountsExceedingOriginalBalance
 
-    -- Top-tx withdrawals must exist in current Accounts.
-    -- In legacy mode, they must drain the account.
-    checkTopAgainstCurrent =
-      for_ (withdrawalsThatDoNotDrainAccounts topTxWithdrawals network accounts) $
-        \(Withdrawals missingAccounts, inexact) ->
-          failWithdrawalsMap missingAccounts WithdrawalAccountsMissing
-            *> when legacyMode (failureOnNonEmptyMap inexact WithdrawalAmountsInexactInLegacyMode)
-   in
-    checkNonLegacyAgainstOriginal
-      *> checkLegacySubsAgainstOriginal
-      *> checkTopAgainstCurrent
+  checkNonLegacy *> checkLegacy
+  where
+    failWithdrawalsMap m mkFailure = failureOnNonEmptyMap m (mkFailure . Withdrawals . NEM.toMap)
+
+-- | Checks that withdrawals satisfy these conditions against the current Accounts:
+-- 1) top-tx withdrawal account addresses must be registered
+-- 2) legacy mode: for each account, the top-tx withdrawal must exactly drain the current balance
+validateWithdrawalsAgainstCurrentAccounts ::
+  ( EraAccounts era
+  , DijkstraEraUTxO era
+  ) =>
+  StAnnTx TopTx era ->
+  Network ->
+  Accounts era ->
+  Test (EntitiesPredFailure era)
+validateWithdrawalsAgainstCurrentAccounts stAnnTx network accounts = do
+  let
+    tx = stAnnTx ^. txStAnnTxG
+    legacyMode = stAnnTx ^. plutusLegacyModeStAnnTxG
+    topTxWithdrawals = tx ^. bodyTxL . withdrawalsTxBodyL
+  -- Top-tx withdrawals must exist in current Accounts.
+  -- In legacy mode, they must drain the account.
+  for_ (withdrawalsThatDoNotDrainAccounts topTxWithdrawals network accounts) $
+    \(Withdrawals missingAccounts, inexact) ->
+      failWithdrawalsMap missingAccounts WithdrawalAccountsMissing
+        *> when legacyMode (failureOnNonEmptyMap inexact WithdrawalAmountsInexactInLegacyMode)
   where
     failWithdrawalsMap m mkFailure = failureOnNonEmptyMap m (mkFailure . Withdrawals . NEM.toMap)
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
@@ -284,7 +284,15 @@ dijkstraEntitiesTransition = do
   runTest $ validateStartingAccountBalanceIntervals network originalAccounts (tx ^. bodyTxL)
 
   runTest $ validateWithdrawalsAgainstOriginalAccounts stAnnTx network originalAccounts
-  runTest $ validateWithdrawalsAgainstCurrentAccounts stAnnTx network accounts
+  -- Skip the current-account checks when a prior check has failed:
+  -- if aggregate withdrawal validation failed, the current accounts state
+  -- may contain underflowed balances (if the withdrawals in sub-transactions exceeded the balance),
+  -- and any failure derived from it would report garbage.
+  -- Conversely, any underflow in the threaded state implies aggregate withdrawals exceeded the original balance,
+  -- so whenever the state is corrupted the aggregate check is guaranteed to have failed.
+  whenFailureFree $
+    runTest $
+      validateWithdrawalsAgainstCurrentAccounts stAnnTx network accounts
 
   let certStateBeforeCerts =
         certState

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
@@ -44,19 +44,15 @@ import Cardano.Ledger.Dijkstra.Era (DijkstraEra, ENTITIES)
 import Cardano.Ledger.Dijkstra.Rules.Certs ()
 import Cardano.Ledger.Dijkstra.Rules.GovCert (DijkstraGovCertPredFailure)
 import Cardano.Ledger.Dijkstra.Scripts (AccountBalanceInterval (..), AccountBalanceIntervals (..))
-import Cardano.Ledger.Dijkstra.TxBody (
-  DijkstraEraTxBody,
-  accountBalanceIntervalsTxBodyL,
-  directDepositsTxBodyL,
-  startingAccountBalanceIntervalsTxBodyL,
- )
+import Cardano.Ledger.Dijkstra.TxBody
 import Cardano.Ledger.Dijkstra.UTxO (DijkstraEraUTxO (..))
 import Cardano.Ledger.Rules.ValidationMode (Test, runTest)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Control.DeepSeq (NFData)
+import Control.Monad (unless, when)
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition.Extended
-import Data.Foldable (sequenceA_)
+import Data.Foldable
 import Data.Map.NonEmpty (NonEmptyMap)
 import qualified Data.Map.NonEmpty as NEM
 import qualified Data.Map.Strict as Map
@@ -277,24 +273,23 @@ dijkstraEntitiesTransition = do
   TRC (EntitiesEnv curEpoch pp committee committeeProposals originalAccounts, certState, stAnnTx) <-
     judgmentContext
   let tx = stAnnTx ^. txStAnnTxG
-      legacyMode = stAnnTx ^. plutusLegacyModeStAnnTxG
-      withdrawals = tx ^. bodyTxL . withdrawalsTxBodyL
       accounts = certState ^. certDStateL . accountsL
       certsEnv = Conway.CertsEnv pp curEpoch committee committeeProposals
-
+      topTxWithdrawals = tx ^. bodyTxL . withdrawalsTxBodyL
   network <- liftSTS $ asks networkId
 
   runTest $ Shelley.validateWrongNetworkWithdrawal network (tx ^. bodyTxL)
   runTest $ validateWrongNetworkInDirectDeposit network (tx ^. bodyTxL)
   runTest $ validateAccountBalanceIntervals network accounts (tx ^. bodyTxL)
   runTest $ validateStartingAccountBalanceIntervals network originalAccounts (tx ^. bodyTxL)
-  validateWithdrawals legacyMode network withdrawals accounts
+
+  runTest $ validateWithdrawals stAnnTx network accounts originalAccounts
 
   let certStateBeforeCerts =
         certState
           & Conway.updateDormantDRepExpiries tx curEpoch
           & Conway.updateVotingDRepExpiries tx curEpoch (pp ^. ppDRepActivityL)
-          & certDStateL . accountsL %~ applyWithdrawals withdrawals
+          & certDStateL . accountsL %~ applyWithdrawals topTxWithdrawals
   certStateAfterCerts <-
     trans @(EraRule "CERTS" era) $
       TRC (certsEnv, certStateBeforeCerts, StrictSeq.fromStrict $ tx ^. bodyTxL . certsTxBodyL)
@@ -331,31 +326,59 @@ validateMissingAccountsInDirectDeposits dds network accounts =
     DirectDepositAccountsMissing
 
 validateWithdrawals ::
-  EraAccounts era =>
-  Bool ->
+  ( EraAccounts era
+  , DijkstraEraUTxO era
+  , DijkstraEraTxBody era
+  ) =>
+  StAnnTx TopTx era ->
   Network ->
-  Withdrawals ->
   Accounts era ->
-  Rule (ENTITIES era) ctx ()
-validateWithdrawals legacyMode network withdrawals accounts = do
-  missingWithdrawals <-
-    if legacyMode
-      then do
-        let (missingWithdrawals, incompleteWithdrawals) =
-              case withdrawalsThatDoNotDrainAccounts withdrawals network accounts of
-                Nothing -> (Map.empty, Map.empty)
-                Just (missing, incomplete) -> (unWithdrawals missing, incomplete)
-        failOnNonEmptyMap incompleteWithdrawals WithdrawalAmountsInexactInLegacyMode
-        pure missingWithdrawals
-      else do
-        let (missingWithdrawals, exceededWithdrawals) =
-              case withdrawalsThatExceedAccountBalance withdrawals network accounts of
-                Nothing -> (Map.empty, Map.empty)
-                Just (missing, exceeded) -> (unWithdrawals missing, exceeded)
-        failOnNonEmptyMap exceededWithdrawals WithdrawalAmountsExceedingOriginalBalance
-        pure missingWithdrawals
-  failOnNonEmptyMap missingWithdrawals $
-    WithdrawalAccountsMissing . Withdrawals . NEM.toMap
+  Accounts era ->
+  Test (EntitiesPredFailure era)
+validateWithdrawals stAnnTx network accounts originalAccounts =
+  let
+    tx = stAnnTx ^. txStAnnTxG
+    legacyMode = stAnnTx ^. plutusLegacyModeStAnnTxG
+    topTxWithdrawals = tx ^. bodyTxL . withdrawalsTxBodyL
+    subTxWithdrawals =
+      foldMap'
+        (\subTx -> subTx ^. bodyTxL . withdrawalsTxBodyL)
+        (tx ^. bodyTxL . subTransactionsTxBodyL)
+    batchWithdrawals = topTxWithdrawals <> subTxWithdrawals
+
+    -- In normal mode, all withdrawals in the batch must not exceed the pre-batch balance,
+    -- and all top tx-withdrawals must exist in the pre-batch Accounts
+    checkNonLegacyAgainstOriginal =
+      unless legacyMode $
+        for_ (withdrawalsThatExceedAccountBalance batchWithdrawals network originalAccounts) $
+          \(Withdrawals missingAccounts, exceedingBalances) ->
+            -- we only check the accounts in the top transactions here, because the subtransactions are checked in SUBENTITES
+            let topMissingAccounts =
+                  Map.intersection (unWithdrawals topTxWithdrawals) missingAccounts
+             in failWithdrawalsMap topMissingAccounts WithdrawalAccountsMissingFromOriginal
+                  *> failureOnNonEmptyMap exceedingBalances WithdrawalAmountsExceedingOriginalBalance
+
+    -- In legacy mode, all withdrawals from subtransactions must not exceed the pre-batch balance.
+    checkLegacySubsAgainstOriginal =
+      when legacyMode $
+        for_ (withdrawalsThatExceedAccountBalance subTxWithdrawals network originalAccounts) $
+          -- missing accounts are discarded, because they are checked in SUBENTITIES
+          \(_, exceedingBalances) ->
+            failureOnNonEmptyMap exceedingBalances WithdrawalAmountsExceedingOriginalBalance
+
+    -- Top-tx withdrawals must exist in current Accounts.
+    -- In legacy mode, they must drain the account.
+    checkTopAgainstCurrent =
+      for_ (withdrawalsThatDoNotDrainAccounts topTxWithdrawals network accounts) $
+        \(Withdrawals missingAccounts, inexact) ->
+          failWithdrawalsMap missingAccounts WithdrawalAccountsMissing
+            *> when legacyMode (failureOnNonEmptyMap inexact WithdrawalAmountsInexactInLegacyMode)
+   in
+    checkNonLegacyAgainstOriginal
+      *> checkLegacySubsAgainstOriginal
+      *> checkTopAgainstCurrent
+  where
+    failWithdrawalsMap m mkFailure = failureOnNonEmptyMap m (mkFailure . Withdrawals . NEM.toMap)
 
 conwayToDijkstraEntitiesPredFailure ::
   forall era. Conway.ConwayLedgerPredFailure era -> EntitiesPredFailure era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
@@ -115,6 +115,7 @@ data EntitiesPredFailure era
       -- | Withdrawal account addresses with wrong network id
       (NonEmptySet AccountAddress)
   | WithdrawalAccountsMissing Withdrawals
+  | WithdrawalAccountsMissingFromOriginal Withdrawals
   | WithdrawalAmountsInexactInLegacyMode (NonEmptyMap AccountAddress (Mismatch RelEQ Coin))
   | WithdrawalAmountsExceedingOriginalBalance (NonEmptyMap AccountAddress (Mismatch RelLTEQ Coin))
   | DirectDepositAddressesWithWrongNetwork
@@ -158,16 +159,17 @@ instance
       CertsFailure x -> Sum (CertsFailure @era) 0 !> To x
       WithdrawalAddressesWithWrongNetwork x y -> Sum (WithdrawalAddressesWithWrongNetwork @era) 1 !> To x !> To y
       WithdrawalAccountsMissing x -> Sum (WithdrawalAccountsMissing @era) 2 !> To x
-      WithdrawalAmountsInexactInLegacyMode x -> Sum (WithdrawalAmountsInexactInLegacyMode @era) 3 !> To x
-      WithdrawalAmountsExceedingOriginalBalance x -> Sum (WithdrawalAmountsExceedingOriginalBalance @era) 4 !> To x
-      DirectDepositAddressesWithWrongNetwork x y -> Sum (DirectDepositAddressesWithWrongNetwork @era) 5 !> To x !> To y
-      DirectDepositAccountsMissing x -> Sum (DirectDepositAccountsMissing @era) 6 !> To x
-      WrongNetworkInAccountBalanceIntervals x y -> Sum (WrongNetworkInAccountBalanceIntervals @era) 7 !> To x !> To y
-      MissingAccountsInAccountBalanceIntervals x -> Sum (MissingAccountsInAccountBalanceIntervals @era) 8 !> To x
-      BalancesOutsideAccountBalanceIntervals x -> Sum (BalancesOutsideAccountBalanceIntervals @era) 9 !> To x
-      WrongNetworkInStartingAccountBalanceIntervals x y -> Sum (WrongNetworkInStartingAccountBalanceIntervals @era) 10 !> To x !> To y
-      MissingAccountsInStartingAccountBalanceIntervals x -> Sum (MissingAccountsInStartingAccountBalanceIntervals @era) 11 !> To x
-      BalancesOutsideStartingAccountBalanceIntervals x -> Sum (BalancesOutsideStartingAccountBalanceIntervals @era) 12 !> To x
+      WithdrawalAccountsMissingFromOriginal x -> Sum (WithdrawalAccountsMissingFromOriginal @era) 3 !> To x
+      WithdrawalAmountsInexactInLegacyMode x -> Sum (WithdrawalAmountsInexactInLegacyMode @era) 4 !> To x
+      WithdrawalAmountsExceedingOriginalBalance x -> Sum (WithdrawalAmountsExceedingOriginalBalance @era) 5 !> To x
+      DirectDepositAddressesWithWrongNetwork x y -> Sum (DirectDepositAddressesWithWrongNetwork @era) 6 !> To x !> To y
+      DirectDepositAccountsMissing x -> Sum (DirectDepositAccountsMissing @era) 7 !> To x
+      WrongNetworkInAccountBalanceIntervals x y -> Sum (WrongNetworkInAccountBalanceIntervals @era) 8 !> To x !> To y
+      MissingAccountsInAccountBalanceIntervals x -> Sum (MissingAccountsInAccountBalanceIntervals @era) 9 !> To x
+      BalancesOutsideAccountBalanceIntervals x -> Sum (BalancesOutsideAccountBalanceIntervals @era) 10 !> To x
+      WrongNetworkInStartingAccountBalanceIntervals x y -> Sum (WrongNetworkInStartingAccountBalanceIntervals @era) 11 !> To x !> To y
+      MissingAccountsInStartingAccountBalanceIntervals x -> Sum (MissingAccountsInStartingAccountBalanceIntervals @era) 12 !> To x
+      BalancesOutsideStartingAccountBalanceIntervals x -> Sum (BalancesOutsideStartingAccountBalanceIntervals @era) 13 !> To x
 
 instance
   ( Era era
@@ -179,16 +181,17 @@ instance
     0 -> SumD CertsFailure <! From
     1 -> SumD WithdrawalAddressesWithWrongNetwork <! From <! From
     2 -> SumD WithdrawalAccountsMissing <! From
-    3 -> SumD WithdrawalAmountsInexactInLegacyMode <! From
-    4 -> SumD WithdrawalAmountsExceedingOriginalBalance <! From
-    5 -> SumD DirectDepositAddressesWithWrongNetwork <! From <! From
-    6 -> SumD DirectDepositAccountsMissing <! From
-    7 -> SumD WrongNetworkInAccountBalanceIntervals <! From <! From
-    8 -> SumD MissingAccountsInAccountBalanceIntervals <! From
-    9 -> SumD BalancesOutsideAccountBalanceIntervals <! From
-    10 -> SumD WrongNetworkInStartingAccountBalanceIntervals <! From <! From
-    11 -> SumD MissingAccountsInStartingAccountBalanceIntervals <! From
-    12 -> SumD BalancesOutsideStartingAccountBalanceIntervals <! From
+    3 -> SumD WithdrawalAccountsMissingFromOriginal <! From
+    4 -> SumD WithdrawalAmountsInexactInLegacyMode <! From
+    5 -> SumD WithdrawalAmountsExceedingOriginalBalance <! From
+    6 -> SumD DirectDepositAddressesWithWrongNetwork <! From <! From
+    7 -> SumD DirectDepositAccountsMissing <! From
+    8 -> SumD WrongNetworkInAccountBalanceIntervals <! From <! From
+    9 -> SumD MissingAccountsInAccountBalanceIntervals <! From
+    10 -> SumD BalancesOutsideAccountBalanceIntervals <! From
+    11 -> SumD WrongNetworkInStartingAccountBalanceIntervals <! From <! From
+    12 -> SumD MissingAccountsInStartingAccountBalanceIntervals <! From
+    13 -> SumD BalancesOutsideStartingAccountBalanceIntervals <! From
     n -> Invalid n
 
 newtype EntitiesEvent era = CertsEvent (Event (EraRule "CERTS" era))

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -535,8 +535,8 @@ conwayToDijkstraLedgerPredFailure = \case
   Conway.ConwayTreasuryValueMismatch mm -> DijkstraTreasuryValueMismatch mm
   Conway.ConwayTxRefScriptsSizeTooBig mm -> DijkstraTxRefScriptsSizeTooBig mm
   Conway.ConwayMempoolFailure _ -> error "Impossible: MempoolFailure has been moved to MEMPOOL rule in Dijkstra"
-  Conway.ConwayWithdrawalsMissingAccounts ws -> DijkstraEntitiesFailure (MissingAccountsInWithdrawals ws)
-  Conway.ConwayIncompleteWithdrawals ws -> DijkstraEntitiesFailure (IncompleteWithdrawals ws)
+  Conway.ConwayWithdrawalsMissingAccounts ws -> DijkstraEntitiesFailure (WithdrawalAccountsMissing ws)
+  Conway.ConwayIncompleteWithdrawals ws -> DijkstraEntitiesFailure (WithdrawalAmountsInexactInLegacyMode ws)
 
 shelleyToDijkstraLedgerPredFailure ::
   forall era.
@@ -545,8 +545,8 @@ shelleyToDijkstraLedgerPredFailure ::
 shelleyToDijkstraLedgerPredFailure = \case
   Shelley.UtxowFailure x -> DijkstraUtxowFailure x
   Shelley.DelegsFailure _ -> error "Impossible: DELEGS has been removed in Dijkstra"
-  Shelley.ShelleyWithdrawalsMissingAccounts x -> DijkstraEntitiesFailure (MissingAccountsInWithdrawals x)
-  Shelley.ShelleyIncompleteWithdrawals x -> DijkstraEntitiesFailure (IncompleteWithdrawals x)
+  Shelley.ShelleyWithdrawalsMissingAccounts x -> DijkstraEntitiesFailure (WithdrawalAccountsMissing x)
+  Shelley.ShelleyIncompleteWithdrawals x -> DijkstraEntitiesFailure (WithdrawalAmountsInexactInLegacyMode x)
 
 instance
   ( STS (ENTITIES era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
@@ -272,7 +272,7 @@ dijkstraSubEntitiesTransition = do
       TRC (subCertsEnv, certStateBeforeSubCerts, StrictSeq.fromStrict $ tx ^. bodyTxL . certsTxBodyL)
 
   let accountsAfterSubCerts = certStateAfterSubCerts ^. certDStateL . accountsL
-  runTest $ validateMissingAccountsInDirectDeposits directDeposits accountsAfterSubCerts
+  runTest $ validateMissingAccountsInDirectDeposits directDeposits network accountsAfterSubCerts
 
   let appliedDirectDeposits = applyDirectDeposits directDeposits accountsAfterSubCerts
   pure $ certStateAfterSubCerts & certDStateL . accountsL .~ appliedDirectDeposits

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
@@ -320,6 +320,7 @@ entitiesToSubEntitiesPredFailure = \case
   DirectDepositAccountsMissing dds -> SubDirectDepositAccountsMissing dds
   CertsFailure _ -> impossible "CertsFailure"
   WithdrawalAccountsMissing _ -> impossible "WithdrawalAccountsMissing"
+  WithdrawalAccountsMissingFromOriginal _ -> impossible "WithdrawalAccountsMissingFromOriginal"
   WithdrawalAmountsInexactInLegacyMode _ -> impossible "WithdrawalAmountsInexactInLegacyMode"
   WithdrawalAmountsExceedingOriginalBalance _ -> impossible "WithdrawalAmountsExceedingOriginalBalance"
   WrongNetworkInAccountBalanceIntervals net addrs -> SubWrongNetworkInAccountBalanceIntervals net addrs

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
@@ -258,8 +258,8 @@ dijkstraSubEntitiesTransition = do
   runTest $ Shelley.validateWrongNetworkWithdrawal network (tx ^. bodyTxL)
   runTest $ validateWrongNetworkInDirectDeposit network (tx ^. bodyTxL)
   runTest $ validateAccountBalanceIntervals network accounts (tx ^. bodyTxL)
-  runTest $ validateMissingOriginalAccountsInWithdrawals withdrawals originalAccounts
-  runTest $ validateMissingAccountsInWithdrawals withdrawals accounts
+  runTest $ validateMissingOriginalAccountsInWithdrawals withdrawals network originalAccounts
+  runTest $ validateMissingAccountsInWithdrawals withdrawals network accounts
 
   let appliedWithdrawals = applyWithdrawals withdrawals accounts
   let certStateBeforeSubCerts =
@@ -280,21 +280,23 @@ dijkstraSubEntitiesTransition = do
 validateMissingOriginalAccountsInWithdrawals ::
   EraAccounts era =>
   Withdrawals ->
+  Network ->
   Accounts era ->
   Test (SubEntitiesPredFailure era)
-validateMissingOriginalAccountsInWithdrawals wdrls originalAccounts =
+validateMissingOriginalAccountsInWithdrawals wdrls network originalAccounts =
   failureOnJust
-    (withdrawalsMissingAccounts wdrls originalAccounts)
+    (withdrawalsMissingAccounts wdrls network originalAccounts)
     SubWithdrawalAccountsMissingFromOriginal
 
 validateMissingAccountsInWithdrawals ::
   EraAccounts era =>
   Withdrawals ->
+  Network ->
   Accounts era ->
   Test (SubEntitiesPredFailure era)
-validateMissingAccountsInWithdrawals wdrls accounts =
+validateMissingAccountsInWithdrawals wdrls network accounts =
   failureOnJust
-    (withdrawalsMissingAccounts wdrls accounts)
+    (withdrawalsMissingAccounts wdrls network accounts)
     SubWithdrawalAccountsMissing
 
 conwayToDijkstraSubEntitiesPredFailure ::

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -105,19 +106,19 @@ instance
 
 data SubEntitiesPredFailure era
   = SubCertsFailure (PredicateFailure (EraRule "SUBCERTS" era))
-  | SubMissingAccountsInWithdrawals Withdrawals
-  | SubMissingOriginalAccountsInWithdrawals Withdrawals
-  | SubMissingAccountsInDirectDeposits DirectDeposits
-  | SubWrongNetworkInWithdrawals
+  | SubWithdrawalAddressesWithWrongNetwork
       -- | Expected network id
       Network
-      -- | Withdrawal accounts with wrong network id
+      -- | Withdrawal account addresses with wrong network id
       (NonEmptySet AccountAddress)
-  | SubWrongNetworkInDirectDeposits
+  | SubWithdrawalAccountsMissing Withdrawals
+  | SubWithdrawalAccountsMissingFromOriginal Withdrawals
+  | SubDirectDepositAddressesWithWrongNetwork
       -- | Expected network id
       Network
-      -- | Direct-deposit accounts with wrong network id
+      -- | Direct-deposit account addresses with wrong network id
       (NonEmptySet AccountAddress)
+  | SubDirectDepositAccountsMissing DirectDeposits
   | SubBalancesOutsideAccountBalanceIntervals
       (NonEmptyMap AccountAddress (Coin, AccountBalanceInterval era))
   | SubMissingAccountsInAccountBalanceIntervals
@@ -147,11 +148,11 @@ instance
   encCBOR =
     encode . \case
       SubCertsFailure x -> Sum (SubCertsFailure @era) 0 !> To x
-      SubMissingAccountsInWithdrawals x -> Sum (SubMissingAccountsInWithdrawals @era) 1 !> To x
-      SubMissingOriginalAccountsInWithdrawals x -> Sum (SubMissingOriginalAccountsInWithdrawals @era) 2 !> To x
-      SubMissingAccountsInDirectDeposits x -> Sum (SubMissingAccountsInDirectDeposits @era) 3 !> To x
-      SubWrongNetworkInWithdrawals expected wrongs -> Sum (SubWrongNetworkInWithdrawals @era) 4 !> To expected !> To wrongs
-      SubWrongNetworkInDirectDeposits expected wrongs -> Sum (SubWrongNetworkInDirectDeposits @era) 5 !> To expected !> To wrongs
+      SubWithdrawalAddressesWithWrongNetwork expected wrongs -> Sum (SubWithdrawalAddressesWithWrongNetwork @era) 1 !> To expected !> To wrongs
+      SubWithdrawalAccountsMissing x -> Sum (SubWithdrawalAccountsMissing @era) 2 !> To x
+      SubWithdrawalAccountsMissingFromOriginal x -> Sum (SubWithdrawalAccountsMissingFromOriginal @era) 3 !> To x
+      SubDirectDepositAddressesWithWrongNetwork expected wrongs -> Sum (SubDirectDepositAddressesWithWrongNetwork @era) 4 !> To expected !> To wrongs
+      SubDirectDepositAccountsMissing x -> Sum (SubDirectDepositAccountsMissing @era) 5 !> To x
       SubBalancesOutsideAccountBalanceIntervals x -> Sum (SubBalancesOutsideAccountBalanceIntervals @era) 6 !> To x
       SubMissingAccountsInAccountBalanceIntervals x -> Sum (SubMissingAccountsInAccountBalanceIntervals @era) 7 !> To x
       SubWrongNetworkInAccountBalanceIntervals expected wrongs -> Sum (SubWrongNetworkInAccountBalanceIntervals @era) 8 !> To expected !> To wrongs
@@ -164,11 +165,11 @@ instance
   where
   decCBOR = decode . Summands "SubEntitiesPredFailure" $ \case
     0 -> SumD SubCertsFailure <! From
-    1 -> SumD SubMissingAccountsInWithdrawals <! From
-    2 -> SumD SubMissingOriginalAccountsInWithdrawals <! From
-    3 -> SumD SubMissingAccountsInDirectDeposits <! From
-    4 -> SumD SubWrongNetworkInWithdrawals <! From <! From
-    5 -> SumD SubWrongNetworkInDirectDeposits <! From <! From
+    1 -> SumD SubWithdrawalAddressesWithWrongNetwork <! From <! From
+    2 -> SumD SubWithdrawalAccountsMissing <! From
+    3 -> SumD SubWithdrawalAccountsMissingFromOriginal <! From
+    4 -> SumD SubDirectDepositAddressesWithWrongNetwork <! From <! From
+    5 -> SumD SubDirectDepositAccountsMissing <! From
     6 -> SumD SubBalancesOutsideAccountBalanceIntervals <! From
     7 -> SumD SubMissingAccountsInAccountBalanceIntervals <! From
     8 -> SumD SubWrongNetworkInAccountBalanceIntervals <! From <! From
@@ -284,7 +285,7 @@ validateMissingOriginalAccountsInWithdrawals ::
 validateMissingOriginalAccountsInWithdrawals wdrls originalAccounts =
   failureOnJust
     (withdrawalsMissingAccounts wdrls originalAccounts)
-    SubMissingOriginalAccountsInWithdrawals
+    SubWithdrawalAccountsMissingFromOriginal
 
 validateMissingAccountsInWithdrawals ::
   EraAccounts era =>
@@ -294,7 +295,7 @@ validateMissingAccountsInWithdrawals ::
 validateMissingAccountsInWithdrawals wdrls accounts =
   failureOnJust
     (withdrawalsMissingAccounts wdrls accounts)
-    SubMissingAccountsInWithdrawals
+    SubWithdrawalAccountsMissing
 
 conwayToDijkstraSubEntitiesPredFailure ::
   forall era. Conway.ConwayLedgerPredFailure era -> SubEntitiesPredFailure era
@@ -314,16 +315,16 @@ conwayToDijkstraSubEntitiesPredFailure = \case
 entitiesToSubEntitiesPredFailure ::
   EntitiesPredFailure era -> SubEntitiesPredFailure era
 entitiesToSubEntitiesPredFailure = \case
-  WrongNetworkInWithdrawals net addrs -> SubWrongNetworkInWithdrawals net addrs
-  WrongNetworkInDirectDeposits net addrs -> SubWrongNetworkInDirectDeposits net addrs
+  WithdrawalAddressesWithWrongNetwork net addrs -> SubWithdrawalAddressesWithWrongNetwork net addrs
+  DirectDepositAddressesWithWrongNetwork net addrs -> SubDirectDepositAddressesWithWrongNetwork net addrs
+  DirectDepositAccountsMissing dds -> SubDirectDepositAccountsMissing dds
+  CertsFailure _ -> impossible "CertsFailure"
+  WithdrawalAccountsMissing _ -> impossible "WithdrawalAccountsMissing"
+  WithdrawalAmountsInexactInLegacyMode _ -> impossible "WithdrawalAmountsInexactInLegacyMode"
+  WithdrawalAmountsExceedingOriginalBalance _ -> impossible "WithdrawalAmountsExceedingOriginalBalance"
   WrongNetworkInAccountBalanceIntervals net addrs -> SubWrongNetworkInAccountBalanceIntervals net addrs
   MissingAccountsInAccountBalanceIntervals x -> SubMissingAccountsInAccountBalanceIntervals x
   BalancesOutsideAccountBalanceIntervals x -> SubBalancesOutsideAccountBalanceIntervals x
-  CertsFailure _ -> impossible "CertsFailure"
-  MissingAccountsInWithdrawals _ -> impossible "MissingAccountsInWithdrawals"
-  IncompleteWithdrawals _ -> impossible "IncompleteWithdrawals"
-  ExceededBalancesInWithdrawals _ -> impossible "ExceededBalancesInWithdrawals"
-  MissingAccountsInDirectDeposits dds -> SubMissingAccountsInDirectDeposits dds
   WrongNetworkInStartingAccountBalanceIntervals _ _ ->
     impossible "WrongNetworkInStartingAccountBalanceIntervals"
   MissingAccountsInStartingAccountBalanceIntervals _ ->

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
@@ -387,7 +387,7 @@ conwayToDijkstraSubLedgerPredFailure = \case
   Conway.ConwayCertsFailure f -> SubEntitiesFailure (injectFailure @"SUBENTITIES" f)
   Conway.ConwayGovFailure f -> SubGovFailure (injectFailure @"SUBGOV" f)
   Conway.ConwayWdrlNotDelegatedToDRep _ -> error "Impossible: `ConwayWdrlNotDelegatedToDRep` for SUBLEDGER"
-  Conway.ConwayWithdrawalsMissingAccounts x -> SubEntitiesFailure (SubMissingAccountsInWithdrawals x)
+  Conway.ConwayWithdrawalsMissingAccounts x -> SubEntitiesFailure (SubWithdrawalAccountsMissing x)
   Conway.ConwayTreasuryValueMismatch x -> SubTreasuryValueMismatch x
   Conway.ConwayTxRefScriptsSizeTooBig _ -> error "Impossible: `ConwayTxRefScriptsSizeTooBig` for SUBLEDGER"
   Conway.ConwayMempoolFailure _ -> error "Impossible: `ConwayMempoolFailure` for SUBLEDGER"

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
@@ -329,5 +329,4 @@ dijkstraUtxoToDijkstraSubUtxoPredFailure = \case
   BabbageOutputTooSmallUTxO outs -> SubBabbageOutputTooSmallUTxO outs
   BabbageNonDisjointRefInputs _ -> error "Impossible: `BabbageNonDisjointRefInputs` for SUBUTXO"
   PtrPresentInCollateralReturn _ -> error "Impossible: `PtrPresentInCollateralReturn` for SUBUTXO"
-  WithdrawalsExceedAccountBalance _ -> error "Impossible: `WithdrawalsExceedAccountBalance` for SUBUTXO"
   ValueNotConservedInLegacyMode _ -> error "Impossible: `ValueNotConservedInLegacyMode` for SUBUTXO"

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -56,7 +56,6 @@ import Cardano.Ledger.Binary.Coders (
   (<!),
  )
 import Cardano.Ledger.Coin (Coin, DeltaCoin)
-import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Conway.Core
 import qualified Cardano.Ledger.Conway.Rules as Conway
 import Cardano.Ledger.Conway.State
@@ -84,7 +83,6 @@ import Control.State.Transition.Extended (
   STS (..),
   TRC (..),
   TransitionRule,
-  failureOnNonEmptyMap,
   judgmentContext,
   liftSTS,
   trans,
@@ -94,11 +92,10 @@ import Data.Bifunctor
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map.NonEmpty (NonEmptyMap)
 import qualified Data.Map.Strict as Map
-import qualified Data.OMap.Strict as OMap
 import Data.Set.NonEmpty (NonEmptySet)
 import Data.Word (Word16, Word32)
 import GHC.Generics (Generic)
-import Lens.Micro ((&), (.~), (^.))
+import Lens.Micro
 import Validation (failureUnless)
 
 data UtxoEnv era = UtxoEnv
@@ -168,8 +165,6 @@ data DijkstraUtxoPredFailure era
   | -- | TxIns that appear in both inputs and reference inputs
     BabbageNonDisjointRefInputs (NonEmpty TxIn)
   | PtrPresentInCollateralReturn (TxOut era)
-  | -- | Total withdrawals per account that exceed the original account balance
-    WithdrawalsExceedAccountBalance (NonEmptyMap AccountAddress (Mismatch RelLTEQ Coin))
   | -- | Legacy-mode top-level transaction does not self-balance
     ValueNotConservedInLegacyMode
       (Mismatch RelEQ (Value era))
@@ -260,39 +255,6 @@ validateNoPtrInCollateralReturn txBody = do
         Just collateralReturn
   failOnJustStatic hasCollateralTxOut (injectFailure . PtrPresentInCollateralReturn)
 
--- | For each account, the total withdrawals across the entire batch should not exceed the original account balance.
--- Unregistered accounts are treated as having 0 balance.
-validateBatchWithdrawals ::
-  ( EraTx era
-  , EraAccounts era
-  , DijkstraEraTxBody era
-  ) =>
-  Accounts era ->
-  Tx TopTx era ->
-  Test (DijkstraUtxoPredFailure era)
-validateBatchWithdrawals accounts tx =
-  let allWithdrawals =
-        Map.unionsWith (<>) $
-          unWithdrawals (tx ^. bodyTxL . withdrawalsTxBodyL)
-            : [ unWithdrawals $ subTx ^. bodyTxL . withdrawalsTxBodyL
-              | subTx <- OMap.elems $ tx ^. bodyTxL . subTransactionsTxBodyL
-              ]
-      badWithdrawals =
-        Map.mapMaybeWithKey
-          ( \acctAddr withdrawn ->
-              let balance = getAccountBalance acctAddr
-               in if withdrawn > balance
-                    then Just Mismatch {mismatchSupplied = withdrawn, mismatchExpected = balance}
-                    else Nothing
-          )
-          allWithdrawals
-   in failureOnNonEmptyMap badWithdrawals WithdrawalsExceedAccountBalance
-  where
-    getAccountBalance (AccountAddress _ (AccountId cred)) =
-      case lookupAccountState cred accounts of
-        Nothing -> mempty -- unregistered account, 0 balance
-        Just accountState -> fromCompact $ accountState ^. balanceAccountStateL
-
 -- | Validate collateral if any transaction in the batch has redeemers.
 validateBatchCollateral ::
   forall era rule.
@@ -365,8 +327,6 @@ dijkstraUtxoTransition = do
   TRC (UtxoEnv slot pp postSubsPState originalCertState originalUtxo, utxos, stAnnTx) <-
     judgmentContext
   let tx = stAnnTx ^. txStAnnTxG
-  -- this is the original Accounts, before any transactions were applied
-  let accounts = originalCertState ^. certDStateL . accountsL
   let originalPState = originalCertState ^. certPStateL
 
   let txBody = tx ^. bodyTxL
@@ -396,8 +356,6 @@ dijkstraUtxoTransition = do
 
   {- (RedeemersOf txTop ≠ ∅ ⊎ Any (λ txSub → RedeemersOf txSub ≠ ∅) subtxs) → collateralCheck -}
   validate $ validateBatchCollateral pp tx originalUtxo
-
-  runTest $ validateBatchWithdrawals accounts tx
 
   {- consumed pp utxo₀ txb = produced pp certState txb -}
   runTest $
@@ -553,8 +511,7 @@ instance
       BabbageOutputTooSmallUTxO x -> Sum BabbageOutputTooSmallUTxO 20 !> To x
       BabbageNonDisjointRefInputs x -> Sum BabbageNonDisjointRefInputs 21 !> To x
       PtrPresentInCollateralReturn x -> Sum PtrPresentInCollateralReturn 22 !> To x
-      WithdrawalsExceedAccountBalance mm -> Sum WithdrawalsExceedAccountBalance 23 !> To mm
-      ValueNotConservedInLegacyMode mm -> Sum ValueNotConservedInLegacyMode 24 !> To mm
+      ValueNotConservedInLegacyMode mm -> Sum ValueNotConservedInLegacyMode 23 !> To mm
 
 instance
   ( Era era
@@ -588,8 +545,7 @@ instance
     20 -> SumD BabbageOutputTooSmallUTxO <! From
     21 -> SumD BabbageNonDisjointRefInputs <! From
     22 -> SumD PtrPresentInCollateralReturn <! From
-    23 -> SumD WithdrawalsExceedAccountBalance <! From
-    24 -> SumD ValueNotConservedInLegacyMode <! From
+    23 -> SumD ValueNotConservedInLegacyMode <! From
     n -> Invalid n
 
 -- =====================================================

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
@@ -51,7 +51,7 @@ spec = describe "ENTITIES" $ do
           WithdrawalsExceedAccountBalance @era $
             NE.singleton account1 $
               Mismatch amountX mempty
-      , injectFailure . MissingAccountsInWithdrawals @era $
+      , injectFailure . WithdrawalAccountsMissing @era $
           Withdrawals [(account1, amountX), (account2, zero)]
       ]
 
@@ -71,15 +71,15 @@ spec = describe "ENTITIES" $ do
                   [ (account1, Mismatch (amountX <> amountX) mempty)
                   , (account3, Mismatch amountY mempty)
                   ]
-      , injectFailure . MissingAccountsInWithdrawals @era $
+      , injectFailure . WithdrawalAccountsMissing @era $
           Withdrawals [(account1, amountX), (account2, zero)]
-      , injectFailure . SubMissingOriginalAccountsInWithdrawals @era $
+      , injectFailure . SubWithdrawalAccountsMissingFromOriginal @era $
           Withdrawals [(account1, amountX), (account2, zero)]
-      , injectFailure . SubMissingAccountsInWithdrawals @era $
+      , injectFailure . SubWithdrawalAccountsMissing @era $
           Withdrawals [(account1, amountX), (account2, zero)]
-      , injectFailure . SubMissingOriginalAccountsInWithdrawals @era $
+      , injectFailure . SubWithdrawalAccountsMissingFromOriginal @era $
           Withdrawals [(account3, amountY)]
-      , injectFailure . SubMissingAccountsInWithdrawals @era $
+      , injectFailure . SubWithdrawalAccountsMissing @era $
           Withdrawals [(account3, amountY)]
       ]
 
@@ -92,7 +92,7 @@ spec = describe "ENTITIES" $ do
       txBody = mkBasicTxBody & directDepositsTxBodyL .~ DirectDeposits [(account, amountX)]
     submitFailingTx
       (mkBasicTx txBody)
-      [ injectFailure . MissingAccountsInDirectDeposits @era $
+      [ injectFailure . DirectDepositAccountsMissing @era $
           DirectDeposits [(account, amountX)]
       ]
 
@@ -105,11 +105,11 @@ spec = describe "ENTITIES" $ do
             mkBasicTxBody & directDepositsTxBodyL .~ DirectDeposits [(account, amountY), (account2, amountZ)]
     submitFailingTx
       (mkBasicTx $ txBody & subTransactionsTxBodyL .~ [mkBasicTx txBody, subTxOnlyDirectDeposit])
-      [ injectFailure . MissingAccountsInDirectDeposits @era $
+      [ injectFailure . DirectDepositAccountsMissing @era $
           DirectDeposits [(account, amountX)]
-      , injectFailure . SubMissingAccountsInDirectDeposits @era $
+      , injectFailure . SubDirectDepositAccountsMissing @era $
           DirectDeposits [(account, amountX)]
-      , injectFailure . SubMissingAccountsInDirectDeposits @era $
+      , injectFailure . SubDirectDepositAccountsMissing @era $
           DirectDeposits [(account, amountY), (account2, amountZ)]
       ]
 
@@ -134,12 +134,12 @@ spec = describe "ENTITIES" $ do
             NE.singleton accountAddress1 $
               Mismatch (reward1 <+> Coin 1) reward1
       , injectFailure $
-          ExceededBalancesInWithdrawals @era $
+          WithdrawalAmountsExceedingOriginalBalance @era $
             NE.singleton accountAddress1 $
               Mismatch (reward1 <+> Coin 1) reward1
       ]
 
-    -- in legacy mode, we produce `IncompleteWithdrawals` failure
+    -- in legacy mode, we produce `WithdrawalAmountsInexactInLegacyMode` failure
     txIn <- produceScript . hashPlutusScript $ alwaysSucceedsWithDatum SPlutusV2
     submitFailingTx
       ( mkBasicTx $
@@ -149,7 +149,7 @@ spec = describe "ENTITIES" $ do
                 [(accountAddress1, zero)]
             & inputsTxBodyL .~ [txIn]
       )
-      [ injectFailure . IncompleteWithdrawals @era $
+      [ injectFailure . WithdrawalAmountsInexactInLegacyMode @era $
           NE.singleton accountAddress1 $
             Mismatch zero reward1
       ]
@@ -175,18 +175,22 @@ spec = describe "ENTITIES" $ do
 
     submitFailingTx
       (mkBasicTx txBody)
-      [ injectFailure . WrongNetworkInWithdrawals @era Testnet $ NES.singleton wrongNetworkAccount
-      , injectFailure . WrongNetworkInDirectDeposits @era Testnet $ NES.singleton wrongNetworkAccount
-      , injectFailure . MissingAccountsInWithdrawals @era $ Withdrawals [(wrongNetworkAccount, mempty)]
+      [ injectFailure . WithdrawalAddressesWithWrongNetwork @era Testnet $ NES.singleton wrongNetworkAccount
+      , injectFailure . DirectDepositAddressesWithWrongNetwork @era Testnet $
+          NES.singleton wrongNetworkAccount
+      , injectFailure . WithdrawalAccountsMissing @era $ Withdrawals [(wrongNetworkAccount, mempty)]
       ]
 
     submitFailingTx
       (mkBasicTx $ txBody & subTransactionsTxBodyL .~ [mkBasicTx txBody])
-      [ injectFailure . WrongNetworkInWithdrawals @era Testnet $ NES.singleton wrongNetworkAccount
-      , injectFailure . WrongNetworkInDirectDeposits @era Testnet $ NES.singleton wrongNetworkAccount
-      , injectFailure . MissingAccountsInWithdrawals @era $ Withdrawals [(wrongNetworkAccount, mempty)]
-      , injectFailure . SubWrongNetworkInWithdrawals @era Testnet $ NES.singleton wrongNetworkAccount
-      , injectFailure . SubWrongNetworkInDirectDeposits @era Testnet $ NES.singleton wrongNetworkAccount
+      [ injectFailure . WithdrawalAddressesWithWrongNetwork @era Testnet $ NES.singleton wrongNetworkAccount
+      , injectFailure . DirectDepositAddressesWithWrongNetwork @era Testnet $
+          NES.singleton wrongNetworkAccount
+      , injectFailure . WithdrawalAccountsMissing @era $ Withdrawals [(wrongNetworkAccount, mempty)]
+      , injectFailure . SubWithdrawalAddressesWithWrongNetwork @era Testnet $
+          NES.singleton wrongNetworkAccount
+      , injectFailure . SubDirectDepositAddressesWithWrongNetwork @era Testnet $
+          NES.singleton wrongNetworkAccount
       ]
 
   describe "Account balance intervals" $ do

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
@@ -24,7 +24,6 @@ import qualified Data.Map.NonEmpty as NEM
 import Data.Maybe (fromJust)
 import qualified Data.OMap.Strict as OMap
 import qualified Data.Set.NonEmpty as NES
-import Data.Word (Word64)
 import Lens.Micro
 import Test.Cardano.Ledger.Dijkstra.ImpTest
 import Test.Cardano.Ledger.Imp.Common
@@ -115,8 +114,6 @@ spec = describe "ENTITIES" $ do
       (mkBasicTx txBody)
       [ injectFailure . WithdrawalAccountsMissingFromOriginal @era $
           Withdrawals [(account1, amountX), (account2, zero)]
-      , injectFailure . WithdrawalAccountsMissing @era $
-          Withdrawals [(account1, amountX), (account2, zero)]
       ]
 
     account3 <- freshKeyHash >>= getAccountAddressFor . KeyHashObj
@@ -128,8 +125,6 @@ spec = describe "ENTITIES" $ do
     submitFailingTx
       (mkBasicTx $ txBody & subTransactionsTxBodyL .~ [mkBasicTx txBody, subTxOnlyWithdrawal])
       [ injectFailure . WithdrawalAccountsMissingFromOriginal @era $
-          Withdrawals [(account1, amountX), (account2, zero)]
-      , injectFailure . WithdrawalAccountsMissing @era $
           Withdrawals [(account1, amountX), (account2, zero)]
       , injectFailure . SubWithdrawalAccountsMissingFromOriginal @era $
           Withdrawals [(account1, amountX), (account2, zero)]
@@ -188,7 +183,6 @@ spec = describe "ENTITIES" $ do
           NES.singleton wrongNetworkAccount
       , injectFailure . WithdrawalAccountsMissingFromOriginal @era $
           Withdrawals [(wrongNetworkAccount, mempty)]
-      , injectFailure . WithdrawalAccountsMissing @era $ Withdrawals [(wrongNetworkAccount, mempty)]
       , injectFailure . DirectDepositAccountsMissing @era $ dd
       ]
 
@@ -199,8 +193,6 @@ spec = describe "ENTITIES" $ do
       , injectFailure . DirectDepositAddressesWithWrongNetwork @era Testnet $
           NES.singleton wrongNetworkAccount
       , injectFailure . WithdrawalAccountsMissingFromOriginal @era $
-          Withdrawals [(wrongNetworkAccount, mempty)]
-      , injectFailure . WithdrawalAccountsMissing @era $
           Withdrawals [(wrongNetworkAccount, mempty)]
       , injectFailure . DirectDepositAccountsMissing @era $ dd
       , injectFailure . SubWithdrawalAddressesWithWrongNetwork @era Testnet $
@@ -262,9 +254,6 @@ spec = describe "ENTITIES" $ do
           WithdrawalAmountsExceedingOriginalBalance @era $
             fromJust $
               NEM.fromMap [(account, Mismatch (subAmount1 <+> subAmount2) balance)]
-      , injectFailure . WithdrawalAmountsInexactInLegacyMode @era $
-          NEM.singleton account $
-            Mismatch zero (computeUnderflowedBalance balance (subAmount1 <+> subAmount2))
       ]
 
   it "Individual withdrawal exceeds account balance" $ do
@@ -294,9 +283,6 @@ spec = describe "ENTITIES" $ do
           WithdrawalAmountsExceedingOriginalBalance @era $
             fromJust $
               NEM.fromMap [(account, Mismatch moreThanBalance balance)]
-      , injectFailure . WithdrawalAmountsInexactInLegacyMode @era $
-          NEM.singleton account $
-            Mismatch atMostBalance (computeUnderflowedBalance balance moreThanBalance)
       ]
 
     -- The top transaction overdraws
@@ -549,9 +535,6 @@ spec = describe "ENTITIES" $ do
       a <- choose (1, maxSum)
       b <- choose (maxSum - a + 1, maxSum)
       pure (Coin a, Coin b)
-
-    computeUnderflowedBalance balance amount =
-      Coin . toInteger $ (fromInteger (unCoin balance) :: Word64) - fromInteger (unCoin amount)
 
     unregisteredAccount :: ImpTestM era AccountAddress
     unregisteredAccount = freshKeyHash >>= getAccountAddressFor . KeyHashObj

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
@@ -13,24 +13,93 @@ import Cardano.Ledger.Address
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Credential (Credential (..))
-import Cardano.Ledger.DRep (DRep (..))
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Rules (
   EntitiesPredFailure (..),
   SubEntitiesPredFailure (..),
  )
 import Cardano.Ledger.Dijkstra.Scripts (AccountBalanceInterval (..), AccountBalanceIntervals (..))
-import Cardano.Ledger.Plutus
 import Cardano.Ledger.Val (Val (..))
-import qualified Data.Map.NonEmpty as NE
+import qualified Data.Map.NonEmpty as NEM
+import Data.Maybe (fromJust)
+import qualified Data.OMap.Strict as OMap
 import qualified Data.Set.NonEmpty as NES
+import Data.Word (Word64)
 import Lens.Micro ((&), (.~))
 import Test.Cardano.Ledger.Dijkstra.ImpTest
 import Test.Cardano.Ledger.Imp.Common
-import Test.Cardano.Ledger.Plutus.Examples (alwaysSucceedsWithDatum)
 
 spec :: forall era. DijkstraEraImp era => SpecWith (ImpInit (LedgerSpec era))
 spec = describe "ENTITIES" $ do
+  it "Batch with successful withdrawals and direct deposits" $ do
+    modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
+    (acc1, balance1, kh1) <- setupAccountAddress
+    (acc2, balance2, kh2) <- setupAccountAddress
+    (acc3, balance3, kh3) <- setupAccountAddress
+
+    let depositAmount = Coin 50
+        partialWithdrawal = balance3 <-> Coin 10
+        subDeposit =
+          mkBasicTx $
+            mkBasicTxBody
+              & directDepositsTxBodyL .~ DirectDeposits [(acc1, depositAmount)]
+        subWithdraw =
+          mkBasicTx $
+            mkBasicTxBody
+              & withdrawalsTxBodyL .~ Withdrawals [(acc2, balance2)]
+        topTx =
+          mkBasicTx $
+            mkBasicTxBody
+              & withdrawalsTxBodyL .~ Withdrawals [(acc3, partialWithdrawal)]
+              & subTransactionsTxBodyL .~ [subDeposit, subWithdraw]
+    submitTx_ topTx
+
+    finalBalance1 <- getBalance (KeyHashObj kh1)
+    finalBalance2 <- getBalance (KeyHashObj kh2)
+    finalBalanceD <- getBalance (KeyHashObj kh3)
+
+    finalBalance1 `shouldBe` balance1 <+> depositAmount
+    finalBalance2 `shouldBe` mempty
+    finalBalanceD `shouldBe` (balance3 <-> partialWithdrawal)
+
+  it "Partial withdrawals" $ do
+    modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
+
+    (account1, balance1, kh1) <- setupAccountAddress
+    (account2, balance2, kh2) <- setupAccountAddress
+    lessThanBalance1 <- Coin <$> choose (1, unCoin balance1 - 1)
+    atMostBalance2 <- Coin <$> choose (1, unCoin balance2)
+    let tx =
+          mkTxWithBatchWithdrawals
+            (Withdrawals [(account1, lessThanBalance1)])
+            [Withdrawals [(account2, atMostBalance2)]]
+    submitTx_ tx
+    getBalance (KeyHashObj kh1) `shouldReturn` (balance1 <-> lessThanBalance1)
+    getBalance (KeyHashObj kh2) `shouldReturn` (balance2 <-> atMostBalance2)
+
+    -- restore balances, to test legacy mode
+    submitTx_ $
+      mkBasicTx $
+        mkBasicTxBody
+          & directDepositsTxBodyL .~ DirectDeposits [(account1, lessThanBalance1), (account2, atMostBalance2)]
+    legacyTx <- switchTxToLegacyMode tx
+    submitFailingTx
+      legacyTx
+      [ injectFailure . WithdrawalAmountsInexactInLegacyMode @era $
+          NEM.singleton account1 $
+            Mismatch lessThanBalance1 balance1
+      ]
+
+    -- drain top withdrawal
+    submitTx_
+      =<< switchTxToLegacyMode
+        ( mkTxWithBatchWithdrawals
+            (Withdrawals [(account1, balance1)])
+            [Withdrawals [(account2, atMostBalance2)]]
+        )
+    getBalance (KeyHashObj kh1) `shouldReturn` zero
+    getBalance (KeyHashObj kh2) `shouldReturn` (balance2 <-> atMostBalance2)
+
   it "Withdrawals from an unregistered staking address" $ do
     modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
 
@@ -102,50 +171,6 @@ spec = describe "ENTITIES" $ do
           DirectDeposits [(account, amountY), (account2, amountZ)]
       ]
 
-  it "Withdrawals of the wrong amount" $ do
-    modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
-
-    (accountAddress1, reward1, stakeKey1) <- setupAccountAddress
-    (accountAddress2, reward2, stakeKey2) <- setupAccountAddress
-    void $ delegateToDRep (KeyHashObj stakeKey1) (Coin 1_000_000) DRepAlwaysAbstain
-    void $ delegateToDRep (KeyHashObj stakeKey2) (Coin 1_000_000) DRepAlwaysAbstain
-    submitFailingTx
-      ( mkBasicTx $
-          mkBasicTxBody
-            & withdrawalsTxBodyL
-              .~ Withdrawals
-                [ (accountAddress1, reward1 <+> Coin 1)
-                , (accountAddress2, reward2)
-                ]
-      )
-      [ injectFailure $
-          WithdrawalAmountsExceedingOriginalBalance @era $
-            NE.singleton accountAddress1 $
-              Mismatch (reward1 <+> Coin 1) reward1
-      ]
-
-    -- in legacy mode, we produce `WithdrawalAmountsInexactInLegacyMode` failure
-    txIn <- produceScript . hashPlutusScript $ alwaysSucceedsWithDatum SPlutusV2
-    submitFailingTx
-      ( mkBasicTx $
-          mkBasicTxBody
-            & withdrawalsTxBodyL
-              .~ Withdrawals
-                [(accountAddress1, zero)]
-            & inputsTxBodyL .~ [txIn]
-      )
-      [ injectFailure . WithdrawalAmountsInexactInLegacyMode @era $
-          NE.singleton accountAddress1 $
-            Mismatch zero reward1
-      ]
-
-    submitTx_ $
-      mkBasicTx $
-        mkBasicTxBody
-          & withdrawalsTxBodyL
-            .~ Withdrawals
-              [(accountAddress1, zero)]
-
   it "Withdrawals and direct deposits with wrong network id" $ do
     stakeKey <- freshKeyHash
     accountAddress <- registerStakeCredential (KeyHashObj stakeKey)
@@ -189,6 +214,60 @@ spec = describe "ENTITIES" $ do
       , injectFailure . SubWithdrawalAccountsMissing @era $
           Withdrawals [(wrongNetworkAccount, mempty)]
       , injectFailure . SubDirectDepositAccountsMissing @era $ dd
+      ]
+  it "Aggregate of top and sub withdrawals exceeds account balance" $ do
+    modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
+    (account, reward, _) <- setupAccountAddress
+    let subAmount = reward <-> Coin 1
+    let tx =
+          mkTxWithBatchWithdrawals
+            (Withdrawals [(account, reward)])
+            [Withdrawals [(account, subAmount)]]
+    submitFailingTx
+      tx
+      [ injectFailure $
+          WithdrawalAmountsExceedingOriginalBalance @era $
+            fromJust $
+              NEM.fromMap [(account, Mismatch (reward <+> subAmount) reward)]
+      ]
+    -- legacy mode
+    legacyTx <- switchTxToLegacyMode tx
+    submitFailingTx
+      legacyTx
+      [ injectFailure . WithdrawalAmountsInexactInLegacyMode @era $
+          NEM.singleton account $
+            Mismatch reward (reward <-> subAmount)
+      ]
+
+  it "Underflow of applied withdrawal amount is observable in legacy mode" $ do
+    modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
+    (account, reward, _) <- setupAccountAddress
+
+    let moreThanReward = reward <+> Coin 1
+    let tx =
+          mkTxWithBatchWithdrawals
+            (Withdrawals [(account, reward)])
+            [Withdrawals [(account, moreThanReward)]]
+    submitFailingTx
+      tx
+      [ injectFailure $
+          WithdrawalAmountsExceedingOriginalBalance @era $
+            fromJust $
+              NEM.fromMap [(account, Mismatch (reward <+> moreThanReward) reward)]
+      ]
+    legacyTx <- switchTxToLegacyMode tx
+    let underflowedBalance =
+          -- 18446744073709551615
+          Coin . toInteger $ (fromInteger (unCoin reward) :: Word64) - fromInteger (unCoin moreThanReward)
+    submitFailingTx
+      legacyTx
+      [ injectFailure $
+          WithdrawalAmountsExceedingOriginalBalance @era $
+            fromJust $
+              NEM.fromMap [(account, Mismatch moreThanReward reward)]
+      , injectFailure . WithdrawalAmountsInexactInLegacyMode @era $
+          NEM.singleton account $
+            Mismatch reward underflowedBalance
       ]
 
   describe "Account balance intervals" $ do
@@ -242,10 +321,10 @@ spec = describe "ENTITIES" $ do
         [ injectFailure $
             WrongNetworkInAccountBalanceIntervals @era Testnet (NES.singleton onWrongNetwork)
         , injectFailure $
-            MissingAccountsInAccountBalanceIntervals @era (NE.singleton unregistered violated)
+            MissingAccountsInAccountBalanceIntervals @era (NEM.singleton unregistered violated)
         , injectFailure $
             BalancesOutsideAccountBalanceIntervals @era
-              (NE.singleton accountAddr (balance, violated))
+              (NEM.singleton accountAddr (balance, violated))
         ]
 
     it
@@ -265,7 +344,7 @@ spec = describe "ENTITIES" $ do
                 (txWith modifyBody interval)
                 [ injectFailure $
                     BalancesOutsideAccountBalanceIntervals @era
-                      (NE.singleton accountAddr (balance, interval))
+                      (NEM.singleton accountAddr (balance, interval))
                 ]
         expectOutside drains (AccountBalanceExact zero)
         expectOutside deposits (AccountBalanceExact (balance <+> deposit))
@@ -282,7 +361,7 @@ spec = describe "ENTITIES" $ do
           )
           [ injectFailure $
               SubBalancesOutsideAccountBalanceIntervals @era
-                (NE.singleton accountAddr (balance, AccountBalanceExact zero))
+                (NEM.singleton accountAddr (balance, AccountBalanceExact zero))
           ]
         submitTx_ $ txWith drains (AccountBalanceExact balance)
 
@@ -298,7 +377,7 @@ spec = describe "ENTITIES" $ do
               (withInterval interval)
               [ injectFailure $
                   BalancesOutsideAccountBalanceIntervals @era
-                    (NE.singleton accountAddr (balance, interval))
+                    (NEM.singleton accountAddr (balance, interval))
               ]
       intervalHolds $ AccountBalanceExact balance
       intervalViolated $ AccountBalanceExact (balance <+> Coin 1)
@@ -330,10 +409,10 @@ spec = describe "ENTITIES" $ do
         submitFailingTx
           (txWithIntervals drained original)
           [ injectFailure $
-              BalancesOutsideAccountBalanceIntervals @era (NE.singleton accountAddr (zero, original))
+              BalancesOutsideAccountBalanceIntervals @era (NEM.singleton accountAddr (zero, original))
           , injectFailure $
               BalancesOutsideStartingAccountBalanceIntervals @era
-                (NE.singleton accountAddr (balance, drained))
+                (NEM.singleton accountAddr (balance, drained))
           ]
         submitTx_ $ txWithIntervals original drained
   where
@@ -345,6 +424,16 @@ spec = describe "ENTITIES" $ do
       submitAndExpireProposalToMakeReward cred
       b <- getBalance cred
       pure (ra, b, kh)
+
+    mkTxWithBatchWithdrawals :: Withdrawals -> [Withdrawals] -> Tx TopTx era
+    mkTxWithBatchWithdrawals topWdrls subs =
+      mkBasicTx $
+        mkBasicTxBody
+          & withdrawalsTxBodyL .~ topWdrls
+          & subTransactionsTxBodyL .~ OMap.fromFoldable (fmap mkSubTx subs)
+      where
+        mkSubTx :: Withdrawals -> Tx SubTx era
+        mkSubTx w = mkBasicTx (mkBasicTxBody & withdrawalsTxBodyL .~ w)
 
     unregisteredAccount :: ImpTestM era AccountAddress
     unregisteredAccount = freshKeyHash >>= getAccountAddressFor . KeyHashObj
@@ -360,8 +449,8 @@ spec = describe "ENTITIES" $ do
     accountBalanceIntervalCases ::
       (AccountBalanceIntervals era -> t era -> ImpTestM era ()) ->
       (Network -> NES.NonEmptySet AccountAddress -> t era) ->
-      (NE.NonEmptyMap AccountAddress (AccountBalanceInterval era) -> t era) ->
-      (NE.NonEmptyMap AccountAddress (Coin, AccountBalanceInterval era) -> t era) ->
+      (NEM.NonEmptyMap AccountAddress (AccountBalanceInterval era) -> t era) ->
+      (NEM.NonEmptyMap AccountAddress (Coin, AccountBalanceInterval era) -> t era) ->
       ImpTestM era ()
     accountBalanceIntervalCases submitFailing mkWrongNetwork mkMissingAccounts mkBalancesOutside = do
       (accountAddr, balance, _) <- setupAccountAddress
@@ -373,7 +462,7 @@ spec = describe "ENTITIES" $ do
       unregistered <- unregisteredAccount
       submitFailing
         (AccountBalanceIntervals [(unregistered, violated)])
-        (mkMissingAccounts (NE.singleton unregistered violated))
+        (mkMissingAccounts (NEM.singleton unregistered violated))
       submitFailing
         (AccountBalanceIntervals [(accountAddr, violated)])
-        (mkBalancesOutside (NE.singleton accountAddr (balance, violated)))
+        (mkBalancesOutside (NEM.singleton accountAddr (balance, violated)))

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
@@ -165,13 +165,13 @@ spec = describe "ENTITIES" $ do
     stakeKey <- freshKeyHash
     accountAddress <- registerStakeCredential (KeyHashObj stakeKey)
     let wrongNetworkAccount = accountAddress & accountAddressNetworkIdL .~ Mainnet
+    let dd = DirectDeposits [(wrongNetworkAccount, Coin 50)]
     let txBody :: forall l. Typeable l => TxBody l era
         txBody =
           mkBasicTxBody
             & withdrawalsTxBodyL
               .~ Withdrawals [(wrongNetworkAccount, mempty)]
-            & directDepositsTxBodyL
-              .~ DirectDeposits [(wrongNetworkAccount, Coin 50)]
+            & directDepositsTxBodyL .~ dd
 
     submitFailingTx
       (mkBasicTx txBody)
@@ -179,6 +179,7 @@ spec = describe "ENTITIES" $ do
       , injectFailure . DirectDepositAddressesWithWrongNetwork @era Testnet $
           NES.singleton wrongNetworkAccount
       , injectFailure . WithdrawalAccountsMissing @era $ Withdrawals [(wrongNetworkAccount, mempty)]
+      , injectFailure . DirectDepositAccountsMissing @era $ dd
       ]
 
     submitFailingTx
@@ -187,6 +188,7 @@ spec = describe "ENTITIES" $ do
       , injectFailure . DirectDepositAddressesWithWrongNetwork @era Testnet $
           NES.singleton wrongNetworkAccount
       , injectFailure . WithdrawalAccountsMissing @era $ Withdrawals [(wrongNetworkAccount, mempty)]
+      , injectFailure . DirectDepositAccountsMissing @era $ dd
       , injectFailure . SubWithdrawalAddressesWithWrongNetwork @era Testnet $
           NES.singleton wrongNetworkAccount
       , injectFailure . SubDirectDepositAddressesWithWrongNetwork @era Testnet $
@@ -194,6 +196,7 @@ spec = describe "ENTITIES" $ do
       , injectFailure . SubWithdrawalAccountsMissingFromOriginal @era $
           Withdrawals [(wrongNetworkAccount, mempty)]
       , injectFailure . SubWithdrawalAccountsMissing @era $ Withdrawals [(wrongNetworkAccount, mempty)]
+      , injectFailure . SubDirectDepositAccountsMissing @era $ dd
       ]
 
   describe "Account balance intervals" $ do

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
@@ -51,6 +51,8 @@ spec = describe "ENTITIES" $ do
           WithdrawalsExceedAccountBalance @era $
             NE.singleton account1 $
               Mismatch amountX mempty
+      , injectFailure . WithdrawalAccountsMissingFromOriginal @era $
+          Withdrawals [(account1, amountX), (account2, zero)]
       , injectFailure . WithdrawalAccountsMissing @era $
           Withdrawals [(account1, amountX), (account2, zero)]
       ]
@@ -71,6 +73,8 @@ spec = describe "ENTITIES" $ do
                   [ (account1, Mismatch (amountX <> amountX) mempty)
                   , (account3, Mismatch amountY mempty)
                   ]
+      , injectFailure . WithdrawalAccountsMissingFromOriginal @era $
+          Withdrawals [(account1, amountX), (account2, zero)]
       , injectFailure . WithdrawalAccountsMissing @era $
           Withdrawals [(account1, amountX), (account2, zero)]
       , injectFailure . SubWithdrawalAccountsMissingFromOriginal @era $
@@ -178,16 +182,22 @@ spec = describe "ENTITIES" $ do
       [ injectFailure . WithdrawalAddressesWithWrongNetwork @era Testnet $ NES.singleton wrongNetworkAccount
       , injectFailure . DirectDepositAddressesWithWrongNetwork @era Testnet $
           NES.singleton wrongNetworkAccount
+      , injectFailure . WithdrawalAccountsMissingFromOriginal @era $
+          Withdrawals [(wrongNetworkAccount, mempty)]
       , injectFailure . WithdrawalAccountsMissing @era $ Withdrawals [(wrongNetworkAccount, mempty)]
       , injectFailure . DirectDepositAccountsMissing @era $ dd
       ]
 
     submitFailingTx
       (mkBasicTx $ txBody & subTransactionsTxBodyL .~ [mkBasicTx txBody])
-      [ injectFailure . WithdrawalAddressesWithWrongNetwork @era Testnet $ NES.singleton wrongNetworkAccount
+      [ injectFailure . WithdrawalAddressesWithWrongNetwork @era Testnet $
+          NES.singleton wrongNetworkAccount
       , injectFailure . DirectDepositAddressesWithWrongNetwork @era Testnet $
           NES.singleton wrongNetworkAccount
-      , injectFailure . WithdrawalAccountsMissing @era $ Withdrawals [(wrongNetworkAccount, mempty)]
+      , injectFailure . WithdrawalAccountsMissingFromOriginal @era $
+          Withdrawals [(wrongNetworkAccount, mempty)]
+      , injectFailure . WithdrawalAccountsMissing @era $
+          Withdrawals [(wrongNetworkAccount, mempty)]
       , injectFailure . DirectDepositAccountsMissing @era $ dd
       , injectFailure . SubWithdrawalAddressesWithWrongNetwork @era Testnet $
           NES.singleton wrongNetworkAccount
@@ -195,7 +205,8 @@ spec = describe "ENTITIES" $ do
           NES.singleton wrongNetworkAccount
       , injectFailure . SubWithdrawalAccountsMissingFromOriginal @era $
           Withdrawals [(wrongNetworkAccount, mempty)]
-      , injectFailure . SubWithdrawalAccountsMissing @era $ Withdrawals [(wrongNetworkAccount, mempty)]
+      , injectFailure . SubWithdrawalAccountsMissing @era $
+          Withdrawals [(wrongNetworkAccount, mempty)]
       , injectFailure . SubDirectDepositAccountsMissing @era $ dd
       ]
 

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
@@ -25,7 +25,7 @@ import Data.Maybe (fromJust)
 import qualified Data.OMap.Strict as OMap
 import qualified Data.Set.NonEmpty as NES
 import Data.Word (Word64)
-import Lens.Micro ((&), (.~))
+import Lens.Micro
 import Test.Cardano.Ledger.Dijkstra.ImpTest
 import Test.Cardano.Ledger.Imp.Common
 
@@ -319,6 +319,66 @@ spec = describe "ENTITIES" $ do
           NEM.singleton account $
             Mismatch moreThanBalance (balance <-> atMostBalance)
       ]
+
+  it "Direct deposits cannot fund withdrawals in subsequent sub-transactions" $ do
+    account <- registerStakeCredential . KeyHashObj =<< freshKeyHash
+    depositAmount <- Coin . getPositive <$> arbitrary
+    let subDeposit =
+          mkBasicTx $
+            mkBasicTxBody
+              & directDepositsTxBodyL
+                .~ DirectDeposits [(account, depositAmount)]
+        subWithdraw =
+          mkBasicTx $
+            mkBasicTxBody
+              & withdrawalsTxBodyL
+                .~ Withdrawals [(account, depositAmount)]
+        tx =
+          mkBasicTx $
+            mkBasicTxBody
+              & subTransactionsTxBodyL .~ [subDeposit, subWithdraw]
+
+    submitFailingTx
+      tx
+      [ injectFailure $
+          WithdrawalAmountsExceedingOriginalBalance @era $
+            fromJust $
+              NEM.fromMap [(account, Mismatch depositAmount zero)]
+      ]
+
+    legacyTx <- switchTxToLegacyMode tx
+    submitFailingTx
+      legacyTx
+      [ injectFailure $
+          WithdrawalAmountsExceedingOriginalBalance @era $
+            fromJust $
+              NEM.fromMap [(account, Mismatch depositAmount zero)]
+      ]
+
+  it "Top transaction can drain an account funded by a sub-transaction direct deposit, in legacy mode" $ do
+    account <- registerStakeCredential . KeyHashObj =<< freshKeyHash
+    depositAmount <- Coin . getPositive <$> arbitrary
+    let subDeposit =
+          mkBasicTx $
+            mkBasicTxBody
+              & directDepositsTxBodyL .~ DirectDeposits [(account, depositAmount)]
+        tx =
+          mkBasicTx $
+            mkBasicTxBody
+              & withdrawalsTxBodyL .~ Withdrawals [(account, depositAmount)]
+              & subTransactionsTxBodyL .~ [subDeposit]
+
+    submitFailingTx
+      tx
+      [ injectFailure $
+          WithdrawalAmountsExceedingOriginalBalance @era $
+            fromJust $
+              NEM.fromMap [(account, Mismatch depositAmount zero)]
+      ]
+
+    legacyTx <- switchTxToLegacyMode tx
+    submitTx_ legacyTx
+    getBalance (account ^. accountAddressCredentialL) `shouldReturn` zero
 
   describe "Account balance intervals" $ do
     it "Account balance intervals for the top-level transaction" $

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
@@ -191,6 +191,9 @@ spec = describe "ENTITIES" $ do
           NES.singleton wrongNetworkAccount
       , injectFailure . SubDirectDepositAddressesWithWrongNetwork @era Testnet $
           NES.singleton wrongNetworkAccount
+      , injectFailure . SubWithdrawalAccountsMissingFromOriginal @era $
+          Withdrawals [(wrongNetworkAccount, mempty)]
+      , injectFailure . SubWithdrawalAccountsMissing @era $ Withdrawals [(wrongNetworkAccount, mempty)]
       ]
 
   describe "Account balance intervals" $ do

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
@@ -145,7 +145,6 @@ spec = describe "ENTITIES" $ do
     account <- freshKeyHash >>= getAccountAddressFor . KeyHashObj
     amountX <- Coin . getPositive <$> arbitrary
     let
-    let
       txBody :: forall l. Typeable l => TxBody l era
       txBody = mkBasicTxBody & directDepositsTxBodyL .~ DirectDeposits [(account, amountX)]
     submitFailingTx
@@ -157,7 +156,6 @@ spec = describe "ENTITIES" $ do
     account2 <- freshKeyHash >>= getAccountAddressFor . KeyHashObj
     amountY <- Coin . getPositive <$> arbitrary
     amountZ <- Coin . getPositive <$> arbitrary
-    let
     let subTxOnlyDirectDeposit =
           mkBasicTx $
             mkBasicTxBody & directDepositsTxBodyL .~ DirectDeposits [(account, amountY), (account2, amountZ)]
@@ -215,20 +213,21 @@ spec = describe "ENTITIES" $ do
           Withdrawals [(wrongNetworkAccount, mempty)]
       , injectFailure . SubDirectDepositAccountsMissing @era $ dd
       ]
+
   it "Aggregate of top and sub withdrawals exceeds account balance" $ do
     modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
-    (account, reward, _) <- setupAccountAddress
-    let subAmount = reward <-> Coin 1
+    (account, balance, _) <- setupAccountAddress
+    (topAmount, subAmount) <- genCoinPairExceeding balance
     let tx =
           mkTxWithBatchWithdrawals
-            (Withdrawals [(account, reward)])
+            (Withdrawals [(account, topAmount)])
             [Withdrawals [(account, subAmount)]]
     submitFailingTx
       tx
       [ injectFailure $
           WithdrawalAmountsExceedingOriginalBalance @era $
             fromJust $
-              NEM.fromMap [(account, Mismatch (reward <+> subAmount) reward)]
+              NEM.fromMap [(account, Mismatch (topAmount <+> subAmount) balance)]
       ]
     -- legacy mode
     legacyTx <- switchTxToLegacyMode tx
@@ -236,38 +235,89 @@ spec = describe "ENTITIES" $ do
       legacyTx
       [ injectFailure . WithdrawalAmountsInexactInLegacyMode @era $
           NEM.singleton account $
-            Mismatch reward (reward <-> subAmount)
+            Mismatch topAmount (balance <-> subAmount)
       ]
 
-  it "Underflow of applied withdrawal amount is observable in legacy mode" $ do
+  it "Aggregate of sub withdrawals exceeds account balance" $ do
     modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
-    (account, reward, _) <- setupAccountAddress
+    (account, balance, _) <- setupAccountAddress
+    (subAmount1, subAmount2) <- genCoinPairExceeding balance
+    (subAmount1 <+> subAmount2) `shouldSatisfy` (> balance)
 
-    let moreThanReward = reward <+> Coin 1
     let tx =
           mkTxWithBatchWithdrawals
-            (Withdrawals [(account, reward)])
-            [Withdrawals [(account, moreThanReward)]]
+            (Withdrawals [(account, zero)])
+            [Withdrawals [(account, subAmount1)], Withdrawals [(account, subAmount2)]]
     submitFailingTx
       tx
       [ injectFailure $
           WithdrawalAmountsExceedingOriginalBalance @era $
             fromJust $
-              NEM.fromMap [(account, Mismatch (reward <+> moreThanReward) reward)]
+              NEM.fromMap [(account, Mismatch (subAmount1 <+> subAmount2) balance)]
       ]
     legacyTx <- switchTxToLegacyMode tx
-    let underflowedBalance =
-          -- 18446744073709551615
-          Coin . toInteger $ (fromInteger (unCoin reward) :: Word64) - fromInteger (unCoin moreThanReward)
     submitFailingTx
       legacyTx
       [ injectFailure $
           WithdrawalAmountsExceedingOriginalBalance @era $
             fromJust $
-              NEM.fromMap [(account, Mismatch moreThanReward reward)]
+              NEM.fromMap [(account, Mismatch (subAmount1 <+> subAmount2) balance)]
       , injectFailure . WithdrawalAmountsInexactInLegacyMode @era $
           NEM.singleton account $
-            Mismatch reward underflowedBalance
+            Mismatch zero (computeUnderflowedBalance balance (subAmount1 <+> subAmount2))
+      ]
+
+  it "Individual withdrawal exceeds account balance" $ do
+    modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
+    (account, balance, _) <- setupAccountAddress
+    atMostBalance <- Coin <$> choose (1, unCoin balance)
+    moreThanBalance <- (balance <+>) . Coin . getPositive <$> arbitrary
+
+    -- A sub-transaction overdraws
+    let subTxOverdraws =
+          mkTxWithBatchWithdrawals
+            (Withdrawals [(account, atMostBalance)])
+            [Withdrawals [(account, moreThanBalance)]]
+    submitFailingTx
+      subTxOverdraws
+      [ injectFailure $
+          WithdrawalAmountsExceedingOriginalBalance @era $
+            fromJust $
+              NEM.fromMap [(account, Mismatch (atMostBalance <+> moreThanBalance) balance)]
+      ]
+
+    legacySubTxOverdraws <- switchTxToLegacyMode subTxOverdraws
+
+    submitFailingTx
+      legacySubTxOverdraws
+      [ injectFailure $
+          WithdrawalAmountsExceedingOriginalBalance @era $
+            fromJust $
+              NEM.fromMap [(account, Mismatch moreThanBalance balance)]
+      , injectFailure . WithdrawalAmountsInexactInLegacyMode @era $
+          NEM.singleton account $
+            Mismatch atMostBalance (computeUnderflowedBalance balance moreThanBalance)
+      ]
+
+    -- The top transaction overdraws
+    let topTxOverdraws =
+          mkTxWithBatchWithdrawals
+            (Withdrawals [(account, moreThanBalance)])
+            [Withdrawals [(account, atMostBalance)]]
+    submitFailingTx
+      topTxOverdraws
+      [ injectFailure $
+          WithdrawalAmountsExceedingOriginalBalance @era $
+            fromJust $
+              NEM.fromMap
+                [(account, Mismatch (atMostBalance <+> moreThanBalance) balance)]
+      ]
+    legacyTopTxOverdraws <- switchTxToLegacyMode topTxOverdraws
+    submitFailingTx
+      legacyTopTxOverdraws
+      [ injectFailure . WithdrawalAmountsInexactInLegacyMode @era $
+          NEM.singleton account $
+            Mismatch moreThanBalance (balance <-> atMostBalance)
       ]
 
   describe "Account balance intervals" $ do
@@ -434,6 +484,14 @@ spec = describe "ENTITIES" $ do
       where
         mkSubTx :: Withdrawals -> Tx SubTx era
         mkSubTx w = mkBasicTx (mkBasicTxBody & withdrawalsTxBodyL .~ w)
+
+    genCoinPairExceeding (Coin maxSum) = do
+      a <- choose (1, maxSum)
+      b <- choose (maxSum - a + 1, maxSum)
+      pure (Coin a, Coin b)
+
+    computeUnderflowedBalance balance amount =
+      Coin . toInteger $ (fromInteger (unCoin balance) :: Word64) - fromInteger (unCoin amount)
 
     unregisteredAccount :: ImpTestM era AccountAddress
     unregisteredAccount = freshKeyHash >>= getAccountAddressFor . KeyHashObj

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
@@ -16,7 +16,6 @@ import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.DRep (DRep (..))
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Rules (
-  DijkstraUtxoPredFailure (..),
   EntitiesPredFailure (..),
   SubEntitiesPredFailure (..),
  )
@@ -24,8 +23,6 @@ import Cardano.Ledger.Dijkstra.Scripts (AccountBalanceInterval (..), AccountBala
 import Cardano.Ledger.Plutus
 import Cardano.Ledger.Val (Val (..))
 import qualified Data.Map.NonEmpty as NE
-import qualified Data.Map.Strict as Map
-import Data.Maybe (fromJust)
 import qualified Data.Set.NonEmpty as NES
 import Lens.Micro ((&), (.~))
 import Test.Cardano.Ledger.Dijkstra.ImpTest
@@ -47,11 +44,7 @@ spec = describe "ENTITIES" $ do
           & withdrawalsTxBodyL .~ Withdrawals [(account1, amountX), (account2, zero)]
     submitFailingTx
       (mkBasicTx txBody)
-      [ injectFailure $
-          WithdrawalsExceedAccountBalance @era $
-            NE.singleton account1 $
-              Mismatch amountX mempty
-      , injectFailure . WithdrawalAccountsMissingFromOriginal @era $
+      [ injectFailure . WithdrawalAccountsMissingFromOriginal @era $
           Withdrawals [(account1, amountX), (account2, zero)]
       , injectFailure . WithdrawalAccountsMissing @era $
           Withdrawals [(account1, amountX), (account2, zero)]
@@ -65,15 +58,7 @@ spec = describe "ENTITIES" $ do
               & withdrawalsTxBodyL .~ Withdrawals [(account3, amountY)]
     submitFailingTx
       (mkBasicTx $ txBody & subTransactionsTxBodyL .~ [mkBasicTx txBody, subTxOnlyWithdrawal])
-      [ injectFailure $
-          WithdrawalsExceedAccountBalance @era $
-            fromJust $
-              NE.fromMap $
-                Map.fromList
-                  [ (account1, Mismatch (amountX <> amountX) mempty)
-                  , (account3, Mismatch amountY mempty)
-                  ]
-      , injectFailure . WithdrawalAccountsMissingFromOriginal @era $
+      [ injectFailure . WithdrawalAccountsMissingFromOriginal @era $
           Withdrawals [(account1, amountX), (account2, zero)]
       , injectFailure . WithdrawalAccountsMissing @era $
           Withdrawals [(account1, amountX), (account2, zero)]
@@ -134,10 +119,6 @@ spec = describe "ENTITIES" $ do
                 ]
       )
       [ injectFailure $
-          WithdrawalsExceedAccountBalance @era $
-            NE.singleton accountAddress1 $
-              Mismatch (reward1 <+> Coin 1) reward1
-      , injectFailure $
           WithdrawalAmountsExceedingOriginalBalance @era $
             NE.singleton accountAddress1 $
               Mismatch (reward1 <+> Coin 1) reward1

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.22.0.0
 
+* Change `withdrawalsMissingAccounts` in `Account` to take a `Network` argument and match Conway-style network-aware semantics
 * Bump `plutus-ledger-api` lower bound to `>=1.68`
 * Add `era` parameter to `StakePoolParams`, `PoolCert`
 * Add new helpers with predicate failure injection. List below also shows direct mapping to older helpers without injection:

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.22.0.0
 
+* Change `directDepositsMissingAccounts` in `Account` to take a `Network` argument and match Conway-style network-aware semantics
 * Change `withdrawalsMissingAccounts` in `Account` to take a `Network` argument and match Conway-style network-aware semantics
 * Bump `plutus-ledger-api` lower bound to `>=1.68`
 * Add `era` parameter to `StakePoolParams`, `PoolCert`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/Account.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/Account.hs
@@ -341,16 +341,18 @@ directDepositsMissingAccounts ::
 directDepositsMissingAccounts (DirectDeposits dds) accounts =
   DirectDeposits <$> missingAccounts dds accounts
 
--- | Returns `Nothing` iff every credential targeted by the supplied
--- `Withdrawals` is a registered account. Otherwise it returns the subset of
--- withdrawals whose target credential is not registered.
+-- | Returns `Nothing` iff every withdrawal address resolves to a registered
+-- account on the supplied network. Otherwise returns the subset of withdrawals
+-- whose address does not resolve — either because the network id does not
+-- match, or because the credential is not registered.
 withdrawalsMissingAccounts ::
   EraAccounts era =>
   Withdrawals ->
+  Network ->
   Accounts era ->
   Maybe Withdrawals
-withdrawalsMissingAccounts (Withdrawals wdrls) accounts =
-  Withdrawals <$> missingAccounts wdrls accounts
+withdrawalsMissingAccounts withdrawals network accounts =
+  fst <$> categorizeWithdrawals (\_ _ -> True) withdrawals network accounts
 
 missingAccounts ::
   EraAccounts era =>

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/Account.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/Account.hs
@@ -330,16 +330,27 @@ updateAccountBalances updateBalance balanceMap =
       balanceMap
 {-# INLINE updateAccountBalances #-}
 
--- | Returns `Nothing` iff every credential targeted by the supplied
--- `DirectDeposits` is a registered account. Otherwise it returns the subset of
--- direct deposits whose target credential is not registered.
+-- | Returns `Nothing` iff every direct-deposit address is on the supplied
+-- network and its credential is registered. Otherwise returns the subset of
+-- direct deposits whose address does not resolve — either because the network
+-- id does not match, or because the credential is not registered.
 directDepositsMissingAccounts ::
   EraAccounts era =>
   DirectDeposits ->
+  Network ->
   Accounts era ->
   Maybe DirectDeposits
-directDepositsMissingAccounts (DirectDeposits dds) accounts =
-  DirectDeposits <$> missingAccounts dds accounts
+directDepositsMissingAccounts (DirectDeposits dds) network accounts
+  | Map.foldrWithKey' checkResolves True dds = Nothing
+  | otherwise = Just $ DirectDeposits $ Map.foldrWithKey' collectMissing Map.empty dds
+  where
+    isAccountAddressRegistered (AccountAddress aaNet (AccountId cred))
+      | aaNet == network = isAccountRegistered cred accounts
+      | otherwise = False
+    checkResolves addr _ acc = acc && isAccountAddressRegistered addr
+    collectMissing addr amount acc
+      | isAccountAddressRegistered addr = acc
+      | otherwise = Map.insert addr amount acc
 
 -- | Returns `Nothing` iff every withdrawal address resolves to a registered
 -- account on the supplied network. Otherwise returns the subset of withdrawals
@@ -353,22 +364,6 @@ withdrawalsMissingAccounts ::
   Maybe Withdrawals
 withdrawalsMissingAccounts withdrawals network accounts =
   fst <$> categorizeWithdrawals (\_ _ -> True) withdrawals network accounts
-
-missingAccounts ::
-  EraAccounts era =>
-  Map AccountAddress a ->
-  Accounts era ->
-  Maybe (Map AccountAddress a)
-missingAccounts accountAddresses accounts
-  | Map.foldrWithKey' checkRegistered True accountAddresses = Nothing
-  | otherwise = Just $ Map.foldrWithKey' collectMissing Map.empty accountAddresses
-  where
-    isRegistered (AccountAddress _ (AccountId cred)) =
-      isAccountRegistered cred accounts
-    checkRegistered addr _ acc = acc && isRegistered addr
-    collectMissing addr amount acc
-      | isRegistered addr = acc
-      | otherwise = Map.insert addr amount acc
 
 -- | Remove delegations of supplied credentials
 removeStakePoolDelegations ::


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

According to the spec, ENTITIES has the following responsibilities with respect to withdrawals:

1. Network check
2. Threaded existence (every withdrawal cred exists in the accounts state as it stands)
3. Legacy only: full drain (each top withdrawal must equal the account's threaded balance exactly)
4. Legacy only:  sub-aggregate cap (sub-tx withdrawals per account, aggregated across subs, must not exceed pre-batch balance.)
5. Non-legacy only: pre-batch existence (every withdrawal cred exists in original accounts)
6. Non-legacy only: aggregate cap (batch): top + all subs, per account, aggregated, capped against pre-batch balance.
7. Apply withdrawals

This is what this PR is achieving, alongside some tests and some clean-up.


# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
