### PR TITLE
Update to crypton == 1.1 and replace memory package with ram

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -92,6 +92,13 @@ package cardano-ledger-mary
 package cardano-ledger-conway
   flags: +asserts
 
+-- Workaround for GHC #27342 (speculative-evaluation correctness bug,
+-- GHC 9.10+): without this, applying the Conway CERTS STS rule to a
+-- constrained-generators-produced signal segfaults under GHC 9.12.4.
+-- See https://gitlab.haskell.org/ghc/ghc/-/issues/27342
+package constrained-generators
+  ghc-options: -fno-spec-eval
+
 -- Always write GHC env files, because they are needed for repl and by the doctests.
 write-ghc-environment-files: always
 -- Always build tests and benchmarks.

--- a/cabal.project
+++ b/cabal.project
@@ -108,9 +108,15 @@ if impl(ghc >=9.12)
 source-repository-package
   type: git
   location: https://github.com/tweag/cardano-cls.git
-  subdir: merkle-tree-incremental mempack-scls scls-cbor scls-format scls-core
-  --sha256: sha256-xngnA6A3YNjtPXYLk1vIt/aauvibzuAhngT2sPqJp0g=
-  tag: c0f41e7d3fe8e32316cb8fb8a34d7adddbe0ae0c
+  tag: b2ec4ce8c03093077782b9cf1144dc77e916a50a
+  --sha256: sha256-O2dsoHZ1ket0Wn1QcGp7MuoSvmrleUBC9jDIcVou3qQ=
+  subdir:
+    merkle-tree-incremental
+    mempack-scls
+    scls-cbor
+    scls-cardano
+    scls-format
+    scls-core
 
 constraints:
   -- Happy version 2.2.1 fails to compile haskell-src-exts

--- a/eras/byron/crypto/CHANGELOG.md
+++ b/eras/byron/crypto/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Revision history for `cardano-crypto-wrapper`
 
-## 1.7.0.1
+## 1.8.0.0
 
-*
+* Depend on `crypton ^>=1.1` and use the `ram` package instead of `memory`
 
 ## 1.7.0.0
 

--- a/eras/byron/crypto/cardano-crypto-wrapper.cabal
+++ b/eras/byron/crypto/cardano-crypto-wrapper.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-crypto-wrapper
-version: 1.7.0.0
+version: 1.8.0.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK
@@ -77,6 +77,8 @@ library
     -Wno-unsafe
     -Wunused-packages
 
+  -- crypton: We cannot make the dependency on a wider range because earlier
+  -- versions depend on `memory` and `crypton >= 1.1` depends on `ram`.
   build-depends:
     aeson,
     base >=4.18 && <5,
@@ -89,13 +91,13 @@ library
     cardano-crypto,
     cardano-ledger-binary >=1.3.1,
     cardano-prelude >=0.2.0.0,
-    crypton,
+    crypton >=1.1,
     data-default,
     deepseq,
     formatting,
     heapwords,
-    memory,
     nothunks,
+    ram,
     text,
 
 library testlib
@@ -136,7 +138,7 @@ library testlib
     cardano-prelude-test,
     crypton,
     hedgehog >=1.0.4,
-    memory,
+    ram,
 
 test-suite test
   type: exitcode-stdio-1.0

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.11.1.0
 
+* Widen `cardano-crypto-class` upper bound to `<2.7`
 * Add `FromJSON` instance for `MaryValue`
 * Add `FromJSON` and `FromJSONKey` instances for `AssetName` (hex-decoding from `ToJSON` format)
 * Add `EncCBOR`, `ToCBOR` for `Block`

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -84,7 +84,7 @@ library
     base >=4.18 && <5,
     base16-bytestring,
     bytestring,
-    cardano-crypto-class >=2.3 && <2.6,
+    cardano-crypto-class >=2.3 && <2.7,
     cardano-data ^>=1.3.2,
     cardano-ledger-allegra ^>=1.10,
     cardano-ledger-binary >=1.4,

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `era` parameter to `PoolCert`s and `StakePoolParams`
 * Replace `StakeKeyAlreadyRegisteredDELEG` constructor with `DelegAccountAlreadyRegistered` in `ShelleyDelegPredFailure`, which wraps the new `AccountAlreadyRegistered` type instead of `Credential Staking`
 * Add `AccountAlreadyRegistered` predicate failure together with `checkAccountAlreadyRegistered`
+* Widen `cardano-crypto-class` upper bound to `<2.7`
 * Add `EncCBOR`, `ToCBOR` for `Block`
 * Add `DecCBOR` instances for `Annotator Block`
 * Cap the reward pot of an over-leveraged stake pool in `mkPoolRewardInfo`, whenever the

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -119,7 +119,7 @@ library
     base >=4.18 && <5,
     bytestring,
     cardano-base >=0.1.1.0,
-    cardano-crypto-class >=2.3 && <2.6,
+    cardano-crypto-class >=2.3 && <2.7,
     cardano-crypto-wrapper,
     cardano-data ^>=1.3.2,
     cardano-ledger-binary ^>=1.10,

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Change `DecCBOR` instances for `Text` and tuples to accept indefinite-length encoding starting with protocol version 12
 * Add `EncCBOR` and `DecCBOR` instances for `ScriptContext` for PlutusV4
 * Change `DecCBOR` instance for `LeiosCert` to reject a signers bitfield larger than `maxLeiosCertSignersBytes`
+* Widen `cardano-crypto-class` upper bound to `<2.7`
 
 ### `testlib`
 

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Add `Ord` instance for `TxOutSource`
 * Change `PlutusArgs 'PlutusV4` to contain `PV4.ScriptContext` instead of `PV3.ScriptContext`
 * Add `NFData` instance for `PV4.ScriptContext`
+* Widen `cardano-crypto-class` upper bound to `<2.7`
 * Remove `numSegComponents` from `EraBlockBody`
 * Remove generic `EncCBOR`, `ToCBOR`, and `DecCBOR` instances for `Block` in favor of per-era instances
 * Change `decodeMetadatum` to require definite-length chunks in indefinite-length bytestrings

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -119,7 +119,7 @@ library
     bytestring >=0.10 && <0.11.3 || >=0.11.4,
     cardano-base >=0.1.6,
     cardano-crypto,
-    cardano-crypto-class >=2.4 && <2.6,
+    cardano-crypto-class >=2.4 && <2.7,
     cardano-crypto-wrapper,
     cardano-data >=1.3,
     cardano-ledger-binary ^>=1.10,

--- a/libs/cardano-protocol-tpraos/CHANGELOG.md
+++ b/libs/cardano-protocol-tpraos/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.6.0.1
 
-*
+* Widen `cardano-crypto-class` upper bound to `<2.7`
 
 ## 1.6.0.0
 

--- a/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
+++ b/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-protocol-tpraos
-version: 1.6.0.0
+version: 1.6.0.1
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK
@@ -45,7 +45,7 @@ library
       -Wredundant-constraints
   build-depends:
     base >=4.18 && <5,
-    cardano-crypto-class >=2.5 && <2.6,
+    cardano-crypto-class >=2.5 && <2.7,
     cardano-ledger-allegra >=1.10,
     cardano-ledger-alonzo >=1.16,
     cardano-ledger-babbage >=1.13.1,

--- a/libs/cardano-protocol/CHANGELOG.md
+++ b/libs/cardano-protocol/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.1.0
 
+* Widen `cardano-crypto-class` upper bound to `<2.7`
 * Export `HeaderConstr` from `Cardano.Protocol.Praos.BlockHeader` and `Cardano.Protocol.Leios.BlockHeader`
 
 ### `testlib`

--- a/libs/cardano-protocol/cardano-protocol.cabal
+++ b/libs/cardano-protocol/cardano-protocol.cabal
@@ -42,7 +42,7 @@ library
     bytestring,
     cardano-base >=0.1.2,
     cardano-binary,
-    cardano-crypto-class >=2.5 && <2.6,
+    cardano-crypto-class >=2.5 && <2.7,
     cardano-crypto-praos ^>=2.2,
     cardano-ledger-binary >=1.8,
     cardano-ledger-core >=1.21,


### PR DESCRIPTION
# Description

* Depends on updated cardano-cls SRP.
* Replace (unmaintained) memory package with ram.
* Widen bounds on cardano-crypto-class dependency.

Will be using this as a SRP on a experimental branch of `cardano-node`.


# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
