### PR TITLE
Bump HLS to 2.14.0.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -139,7 +139,7 @@
                 cabal-gild = "1.5.0.1";
                 cuddle = "latest";
                 fourmolu = fourmoluVersion;
-                haskell-language-server = "2.12.0.0";
+                haskell-language-server = "2.14.0.0";
                 hlint = "3.8";
                 nixfmt = nixfmtVersion;
               };


### PR DESCRIPTION
# Description

Bump HLS to `2.14.0.0`. This should fix the reconfiguration bug when building after using HLS.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
