### PR TITLE
Enact state constrained generator fix

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/MiniTrace.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/MiniTrace.hs
@@ -325,8 +325,9 @@ ratifyStateSpec RatifyEnv {..} =
     mconcat
       [ assert $ enacted ==. lit mempty
       , assert $ expired ==. lit mempty
-      , match ens $ \mbyCmt _ pp _ _ _ _ ->
-          [ (caseOn mbyCmt)
+      , match ens $ \mbyCmt _ pp _ _ wdrls _ ->
+          [ assert $ wdrls ==. lit mempty
+          , (caseOn mbyCmt)
               (branch $ \_ -> True)
               ( branch $ \cmt -> match cmt $ \cmtMap _ ->
                   exists


### PR DESCRIPTION
# Description

The constrained generator can generate nonempty withdrawals when generating an `EnactState`, but this is not reflective of reality, because withdrawals is always initialized as empty.

close https://github.com/IntersectMBO/cardano-ledger/issues/6007

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
