### PR TITLE
Make Conway CERTS test era-generic

### DIFF
--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -54,6 +54,7 @@ spec era = do
   Babbage.spec era
   describe "ConwayEra Onwards" $ withImpInitEachEraVersion era $ do
     BBODY.spec
+    CERTS.spec
     DELEG.spec
     ENACT.spec
     EPOCH.spec
@@ -70,7 +71,6 @@ spec era = do
 conwayOnlySpec :: Spec
 conwayOnlySpec = do
   describe "ConwayEra Specific" $ withImpInitEachEraVersion (Proxy @ConwayEra) $ do
-    -- TODO: move to `spec` when ready: https://github.com/IntersectMBO/cardano-ledger/issues/5805
-    CERTS.spec
+    CERTS.conwayOnlySpec
     SNAP.conwayOnlySpec
     UTXO.conwayOnlySpec

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/CertsSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/CertsSpec.hs
@@ -17,12 +17,14 @@ import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Rules (ConwayCertsPredFailure (..), ConwayLedgerPredFailure (..))
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.DRep (DRep (..))
+import Cardano.Ledger.Plutus (SLanguage (SPlutusV3), hashPlutusScript)
 import Cardano.Ledger.Val (Val (..))
 import qualified Data.Map.NonEmpty as NEM
 import Lens.Micro ((&), (.~))
 import Test.Cardano.Ledger.Conway.Arbitrary ()
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Imp.Common
+import Test.Cardano.Ledger.Plutus.Examples (alwaysSucceedsNoDatum)
 
 spec ::
   forall era.
@@ -51,7 +53,7 @@ spec = describe "CERTS" $ do
        in
         submitBootstrapAware
           (submitTx_ tx)
-          (submitFailingTx tx)
+          (submitFailingSubsetTx tx)
           ( FailBootstrapAndPostBootstrap $
               FailBoth
                 { bootstrapFailures = [notInRewardsFailure]
@@ -78,7 +80,7 @@ spec = describe "CERTS" $ do
        in
         submitBootstrapAware
           (submitTx_ tx)
-          (submitFailingTx tx)
+          (submitFailingSubsetTx tx)
           ( FailBootstrapAndPostBootstrap $
               FailBoth
                 { bootstrapFailures = [notInRewardsFailure]
@@ -97,9 +99,15 @@ spec = describe "CERTS" $ do
       (accountAddress2, reward2, stakeKey2) <- setupAccountAddress
       void $ delegateToDRep (KeyHashObj stakeKey1) (Coin 1_000_000) DRepAlwaysAbstain
       void $ delegateToDRep (KeyHashObj stakeKey2) (Coin 1_000_000) DRepAlwaysAbstain
-      submitFailingTx
+
+      -- Force legacy mode by including a PV3 script in our Tx's
+      txIn <- produceScript . hashPlutusScript $ alwaysSucceedsNoDatum SPlutusV3
+
+      submitFailingSubsetTx
         ( mkBasicTx $
             mkBasicTxBody
+              & inputsTxBodyL
+                .~ [txIn]
               & withdrawalsTxBodyL
                 .~ Withdrawals
                   [ (accountAddress1, reward1 <+> Coin 1)
@@ -108,18 +116,19 @@ spec = describe "CERTS" $ do
         )
         [ if hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule pv
             then
-              injectFailure $
-                ConwayIncompleteWithdrawals @era $
-                  NEM.singleton accountAddress1 $
-                    Mismatch (reward1 <+> Coin 1) reward1
+              injectFailure . ConwayIncompleteWithdrawals @era $
+                NEM.singleton accountAddress1 $
+                  Mismatch (reward1 <+> Coin 1) reward1
             else
               injectFailure . WithdrawalsNotInRewardsCERTS @era $
                 Withdrawals [(accountAddress1, reward1 <+> Coin 1)]
         ]
 
-      submitFailingTx
+      submitFailingSubsetTx
         ( mkBasicTx $
             mkBasicTxBody
+              & inputsTxBodyL
+                .~ [txIn]
               & withdrawalsTxBodyL
                 .~ Withdrawals
                   [(accountAddress1, zero)]
@@ -129,7 +138,9 @@ spec = describe "CERTS" $ do
               injectFailure . ConwayIncompleteWithdrawals @era $
                 NEM.singleton accountAddress1 $
                   Mismatch zero reward1
-            else injectFailure . WithdrawalsNotInRewardsCERTS @era $ Withdrawals [(accountAddress1, zero)]
+            else
+              injectFailure . WithdrawalsNotInRewardsCERTS @era $
+                Withdrawals [(accountAddress1, zero)]
         ]
   where
     setupAccountAddress = do

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/CertsSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/CertsSpec.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Test.Cardano.Ledger.Conway.Imp.CertsSpec (spec) where
+module Test.Cardano.Ledger.Conway.Imp.CertsSpec (conwayOnlySpec, spec) where
 
 import Cardano.Ledger.BaseTypes (EpochInterval (..), Mismatch (..))
 import Cardano.Ledger.Coin (Coin (..))
@@ -26,11 +26,11 @@ import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Imp.Common
 import Test.Cardano.Ledger.Plutus.Examples (alwaysSucceedsNoDatum)
 
-spec ::
+conwayOnlySpec ::
   forall era.
   ConwayEraImp era =>
   SpecWith (ImpInit (LedgerSpec era))
-spec = describe "CERTS" $ do
+conwayOnlySpec = describe "CERTS" $ do
   describe "Withdrawals" $ do
     it "Withdrawing from an unregistered staking address" $ do
       modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
@@ -91,6 +91,12 @@ spec = describe "CERTS" $ do
                 }
           )
 
+spec ::
+  forall era.
+  ConwayEraImp era =>
+  SpecWith (ImpInit (LedgerSpec era))
+spec = describe "CERTS" $ do
+  describe "Withdrawals" $ do
     it "Withdrawing the wrong amount" $ do
       modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
       pv <- getsPParams @era ppProtocolVersionL
@@ -142,11 +148,15 @@ spec = describe "CERTS" $ do
               injectFailure . WithdrawalsNotInRewardsCERTS @era $
                 Withdrawals [(accountAddress1, zero)]
         ]
-  where
-    setupAccountAddress = do
-      kh <- freshKeyHash
-      let cred = KeyHashObj kh
-      ra <- registerStakeCredential cred
-      submitAndExpireProposalToMakeReward cred
-      b <- getBalance cred
-      pure (ra, b, kh)
+
+setupAccountAddress ::
+  forall era.
+  ConwayEraImp era =>
+  ImpM (LedgerSpec era) (AccountAddress, Coin, KeyHash Staking)
+setupAccountAddress = do
+  kh <- freshKeyHash
+  let cred = KeyHashObj kh
+  ra <- registerStakeCredential cred
+  submitAndExpireProposalToMakeReward cred
+  b <- getBalance cred
+  pure (ra, b, kh)


### PR DESCRIPTION
# Description

The Conway CERTS test produces additional predicate failures in Dijkstra, so previously it was necessary to duplicate the code in a separate test for Dijkstra. By using the new test helper, `submitFailingSubsetTx`, it's possible for the Conway test to check that the given predicate failures are a subset of those actually produced, ie that all of the given failures are present. This enables the test to run in post-Conway eras.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
