### PR TITLE
Conservation of value in legacy mode

### DIFF
--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### `testlib`
 
+* Expose `fixupCollateralReturn`
 * Add `DecCBOR` instance for `Block`
 
 ## 1.14.0.0

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/ImpTest.hs
@@ -13,6 +13,7 @@
 module Test.Cardano.Ledger.Babbage.ImpTest (
   BabbageEraImp,
   babbageFixupTx,
+  fixupCollateralReturn,
   impBabbageExpectTxSuccess,
   module Test.Cardano.Ledger.Alonzo.ImpTest,
   produceRefScript,

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -45,7 +45,8 @@
 
 ### testlib
 
-* Expose `fixupSubtransactions`
+* Add `balanceSubTransactions`
+* Expose `fixupSubTransactions`
 * Add `Inject (DijkstraContextError era) (ContextError era)` as a superclass of `DijkstraEraTest`
 * Add `DecCBOR` instance for `Block`
 * Add `DijkstraEraPParams` as a superclass of `DijkstraEraTest`

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.4.0.0
 
+* Add `ValueNotConservedInLegacyInLegacyMode` constructor to `DijkstraUtxoPredFailure`
 * Rename:
   - `DijkstraUtxoEnv` -> `UtxoEnv` and add `uePState` field
   - `dueSlot` -> `ueSlot`

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 ### testlib
 
+* Add `switchTxToLegacyMode` helper
 * Add `balanceSubTransactions`
 * Expose `fixupSubTransactions`
 * Add `Inject (DijkstraContextError era) (ContextError era)` as a superclass of `DijkstraEraTest`

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -44,6 +44,7 @@
 
 ### testlib
 
+* Expose `fixupSubtransactions`
 * Add `Inject (DijkstraContextError era) (ContextError era)` as a superclass of `DijkstraEraTest`
 * Add `DecCBOR` instance for `Block`
 * Add `DijkstraEraPParams` as a superclass of `DijkstraEraTest`

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.4.0.0
 
+* Add `localProducedValue` helper in `UTxO` module
 * Add `ValueNotConservedInLegacyInLegacyMode` constructor to `DijkstraUtxoPredFailure`
 * Rename:
   - `DijkstraUtxoEnv` -> `UtxoEnv` and add `uePState` field

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.4.0.0
 
+* Rename:
+  - `DijkstraUtxoEnv` -> `UtxoEnv` and add `uePState` field
+  - `dueSlot` -> `ueSlot`
+  - `duePParams` -> `uePParams`
+  - `dueCertState` -> `ueOriginalCertState`
+  - `dueOriginalUtxo` -> `ueOriginalUtxo`
 * Add `ScriptHashNotFoundForPurpose` constructor to `DijkstraContextError`
 * Change `PointerPresentInOutput` constructor of `DijkstraContextError` to contain a `NonEmptySet TxOutSource` instead of `NonEmpty (TxOut era)`
 * Add `udppPlutusV4CostModel` field to `UpgradeDijkstraPParams`

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -200,6 +200,7 @@ library testlib
     containers,
     generic-random,
     microlens,
+    mtl,
     plutus-ledger-api,
     small-steps,
     tree-diff,

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -72,7 +72,7 @@ import Cardano.Ledger.Dijkstra.Rules.GovCert (DijkstraGovCertPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubEntities (SubEntitiesPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubLedger
 import Cardano.Ledger.Dijkstra.Rules.SubLedgers
-import Cardano.Ledger.Dijkstra.Rules.Utxo (DijkstraUtxoEnv (..), DijkstraUtxoPredFailure)
+import Cardano.Ledger.Dijkstra.Rules.Utxo (DijkstraUtxoPredFailure, UtxoEnv (..))
 import Cardano.Ledger.Dijkstra.Rules.Utxow (DijkstraUtxowPredFailure)
 import Cardano.Ledger.Dijkstra.TxBody
 import Cardano.Ledger.Dijkstra.UTxO (DijkstraEraUTxO (..), batchNonDistinctRefScriptsSize)
@@ -311,7 +311,7 @@ instance
   , State (EraRule "UTXOW" era) ~ UTxOState era
   , State (EraRule "ENTITIES" era) ~ CertState era
   , State (EraRule "GOV" era) ~ Proposals era
-  , Environment (EraRule "UTXOW" era) ~ DijkstraUtxoEnv era
+  , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , Environment (EraRule "ENTITIES" era) ~ EntitiesEnv era
   , Environment (EraRule "GOV" era) ~ Conway.GovEnv era
   , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
@@ -374,7 +374,7 @@ dijkstraLedgerTransition ::
   , State (EraRule "UTXOW" era) ~ UTxOState era
   , State (EraRule "ENTITIES" era) ~ CertState era
   , State (EraRule "GOV" era) ~ Proposals era
-  , Environment (EraRule "UTXOW" era) ~ DijkstraUtxoEnv era
+  , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , Environment (EraRule "GOV" era) ~ Conway.GovEnv era
   , Environment (EraRule "ENTITIES" era) ~ EntitiesEnv era
   , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
@@ -464,11 +464,17 @@ dijkstraLedgerTransition = do
           )
       else pure (utxoStateAfterSubLedgers, certStateAfterSubLedgers)
 
-  -- Call UTXOW with DijkstraUtxoEnv, passing the original UTxO and original certState
+  -- Call UTXOW with UtxoEnv, passing the original UTxO, the original certState,
+  -- and the PState updated by all sub-ledgers
   utxoStateFinal <-
     trans @(EraRule "UTXOW" era) $
       TRC
-        ( DijkstraUtxoEnv slot pp (lsCertState ledgerState) originalUtxo
+        ( UtxoEnv
+            slot
+            pp
+            (certStateAfterSubLedgers ^. certPStateL)
+            (lsCertState ledgerState)
+            originalUtxo
         , utxoStateBeforeUtxow
         , stAnnTx
         )
@@ -480,7 +486,7 @@ instance
   , BabbageEraTxBody era
   , Embed (EraRule "UTXO" era) (UTXOW era)
   , State (EraRule "UTXO" era) ~ UTxOState era
-  , Environment (EraRule "UTXO" era) ~ DijkstraUtxoEnv era
+  , Environment (EraRule "UTXO" era) ~ UtxoEnv era
   , Script era ~ AlonzoScript era
   , TxOut era ~ BabbageTxOut era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
@@ -330,3 +330,4 @@ dijkstraUtxoToDijkstraSubUtxoPredFailure = \case
   BabbageNonDisjointRefInputs _ -> error "Impossible: `BabbageNonDisjointRefInputs` for SUBUTXO"
   PtrPresentInCollateralReturn _ -> error "Impossible: `PtrPresentInCollateralReturn` for SUBUTXO"
   WithdrawalsExceedAccountBalance _ -> error "Impossible: `WithdrawalsExceedAccountBalance` for SUBUTXO"
+  ValueNotConservedInLegacyMode _ -> error "Impossible: `ValueNotConservedInLegacyMode` for SUBUTXO"

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -22,7 +22,7 @@
 
 module Cardano.Ledger.Dijkstra.Rules.Utxo (
   UTXO,
-  DijkstraUtxoEnv (..),
+  UtxoEnv (..),
   DijkstraUtxoPredFailure (..),
   conwayToDijkstraUtxoPredFailure,
 ) where
@@ -96,11 +96,12 @@ import GHC.Generics (Generic)
 import Lens.Micro ((^.))
 import Validation (failureUnless)
 
-data DijkstraUtxoEnv era = DijkstraUtxoEnv
-  { dueSlot :: SlotNo
-  , duePParams :: PParams era
-  , dueCertState :: CertState era
-  , dueOriginalUtxo :: UTxO era
+data UtxoEnv era = UtxoEnv
+  { ueSlot :: SlotNo
+  , uePParams :: PParams era
+  , uePState :: PState era
+  , ueOriginalCertState :: CertState era
+  , ueOriginalUtxo :: UTxO era
   }
 
 -- | Predicate failure for the Dijkstra Era
@@ -340,7 +341,7 @@ dijkstraUtxoTransition ::
   , InjectRuleFailure "UTXO" Alonzo.AlonzoUtxoPredFailure era
   , InjectRuleFailure "UTXO" Babbage.BabbageUtxoPredFailure era
   , InjectRuleFailure "UTXO" DijkstraUtxoPredFailure era
-  , Environment (EraRule "UTXO" era) ~ DijkstraUtxoEnv era
+  , Environment (EraRule "UTXO" era) ~ UtxoEnv era
   , State (EraRule "UTXO" era) ~ UTxOState era
   , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   , BaseM (EraRule "UTXO" era) ~ ShelleyBase
@@ -354,12 +355,12 @@ dijkstraUtxoTransition ::
   ) =>
   TransitionRule (EraRule "UTXO" era)
 dijkstraUtxoTransition = do
-  TRC (DijkstraUtxoEnv slot pp certState originalUtxo, utxos, stAnnTx) <-
+  TRC (UtxoEnv slot pp _pState originalCertState originalUtxo, utxos, stAnnTx) <-
     judgmentContext
   let tx = stAnnTx ^. txStAnnTxG
   -- this is the original Accounts, before any transactions were applied
-  let accounts = certState ^. certDStateL . accountsL
-  let originalPState = certState ^. certPStateL
+  let accounts = originalCertState ^. certDStateL . accountsL
+  let originalPState = originalCertState ^. certPStateL
 
   let txBody = tx ^. bodyTxL
 
@@ -428,7 +429,7 @@ dijkstraUtxoTransition = do
   () <- trans @(EraRule "UTXOS" era) $ TRC ((), (), stAnnTx)
   Babbage.updateUTxOState
     pp
-    certState
+    originalCertState
     tx
     (Conway.updateTreasuryDonation tx utxos)
 
@@ -450,7 +451,7 @@ instance
   , InjectRuleFailure "UTXO" Babbage.BabbageUtxoPredFailure era
   , InjectRuleFailure "UTXO" Conway.ConwayUtxoPredFailure era
   , InjectRuleFailure "UTXO" DijkstraUtxoPredFailure era
-  , Environment (EraRule "UTXO" era) ~ DijkstraUtxoEnv era
+  , Environment (EraRule "UTXO" era) ~ UtxoEnv era
   , State (EraRule "UTXO" era) ~ UTxOState era
   , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   , BaseM (EraRule "UTXO" era) ~ ShelleyBase
@@ -468,7 +469,7 @@ instance
   where
   type State (UTXO era) = UTxOState era
   type Signal (UTXO era) = StAnnTx TopTx era
-  type Environment (UTXO era) = DijkstraUtxoEnv era
+  type Environment (UTXO era) = UtxoEnv era
   type BaseM (UTXO era) = ShelleyBase
   type PredicateFailure (UTXO era) = DijkstraUtxoPredFailure era
   type Event (UTXO era) = Alonzo.AlonzoUtxoEvent era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -64,7 +64,11 @@ import Cardano.Ledger.Credential (StakeReference (..))
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra, UTXO)
 import Cardano.Ledger.Dijkstra.Rules.Utxos ()
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody (..))
-import Cardano.Ledger.Dijkstra.UTxO (dijkstraConsumed)
+import Cardano.Ledger.Dijkstra.UTxO (
+  DijkstraEraUTxO,
+  dijkstraConsumed,
+  plutusLegacyModeStAnnTxG,
+ )
 import Cardano.Ledger.Plutus (OrdExUnits)
 import Cardano.Ledger.Rules.ValidationMode (Test, failOnJustStatic, runTest, runTestOnSignal)
 import Cardano.Ledger.Shelley.LedgerState (UTxOState (..))
@@ -86,6 +90,7 @@ import Control.State.Transition.Extended (
   trans,
   validate,
  )
+import Data.Bifunctor
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map.NonEmpty (NonEmptyMap)
 import qualified Data.Map.Strict as Map
@@ -93,7 +98,7 @@ import qualified Data.OMap.Strict as OMap
 import Data.Set.NonEmpty (NonEmptySet)
 import Data.Word (Word16, Word32)
 import GHC.Generics (Generic)
-import Lens.Micro ((^.))
+import Lens.Micro ((&), (.~), (^.))
 import Validation (failureUnless)
 
 data UtxoEnv era = UtxoEnv
@@ -165,6 +170,9 @@ data DijkstraUtxoPredFailure era
   | PtrPresentInCollateralReturn (TxOut era)
   | -- | Total withdrawals per account that exceed the original account balance
     WithdrawalsExceedAccountBalance (NonEmptyMap AccountAddress (Mismatch RelLTEQ Coin))
+  | -- | Legacy-mode top-level transaction does not self-balance
+    ValueNotConservedInLegacyMode
+      (Mismatch RelEQ (Value era))
   deriving (Generic)
 
 type instance EraRuleFailure "UTXO" DijkstraEra = DijkstraUtxoPredFailure DijkstraEra
@@ -317,21 +325,20 @@ validateValueNotConservedUTxO ::
   UTxO era ->
   PState era ->
   TxBody TopTx era ->
-  Test (Shelley.ShelleyUtxoPredFailure era)
+  Test (Mismatch RelEQ (Value era))
 validateValueNotConservedUTxO pp utxo pState txBody =
   failureUnless (consumedValue == producedValue) $
-    Shelley.ValueNotConservedUTxO
-      Mismatch
-        { mismatchSupplied = consumedValue
-        , mismatchExpected = producedValue
-        }
+    Mismatch
+      { mismatchSupplied = consumedValue
+      , mismatchExpected = producedValue
+      }
   where
     consumedValue = dijkstraConsumed pp utxo txBody
     producedValue = produced pp pState txBody
 
 dijkstraUtxoTransition ::
   forall era.
-  ( EraUTxO era
+  ( DijkstraEraUTxO era
   , EraCertState era
   , DijkstraEraTxBody era
   , AlonzoEraTx era
@@ -355,7 +362,7 @@ dijkstraUtxoTransition ::
   ) =>
   TransitionRule (EraRule "UTXO" era)
 dijkstraUtxoTransition = do
-  TRC (UtxoEnv slot pp _pState originalCertState originalUtxo, utxos, stAnnTx) <-
+  TRC (UtxoEnv slot pp postSubsPState originalCertState originalUtxo, utxos, stAnnTx) <-
     judgmentContext
   let tx = stAnnTx ^. txStAnnTxG
   -- this is the original Accounts, before any transactions were applied
@@ -393,7 +400,27 @@ dijkstraUtxoTransition = do
   runTest $ validateBatchWithdrawals accounts tx
 
   {- consumed pp utxo₀ txb = produced pp certState txb -}
-  runTest $ validateValueNotConservedUTxO pp originalUtxo originalPState txBody
+  runTest $
+    first (fmap Shelley.ValueNotConservedUTxO) $
+      validateValueNotConservedUTxO
+        pp
+        originalUtxo
+        originalPState
+        txBody
+
+  {- legacyMode ≡ true → consumedLegacy ≡ producedLegacy -}
+  -- The `PState` has to be the one with all the sub-transactions already applied,
+  -- because if a sub-transaction registered a pool, then the top-transaction
+  -- must not add to the `produced` value if it registers the same pool,
+  -- since it will count as a re-registration.
+  when (stAnnTx ^. plutusLegacyModeStAnnTxG) $
+    runTest $
+      first (fmap ValueNotConservedInLegacyMode) $
+        validateValueNotConservedUTxO
+          pp
+          originalUtxo
+          postSubsPState
+          (txBody & subTransactionsTxBodyL .~ mempty)
 
   {- ∀ txout ∈ allOuts txb, getValue txout ≥ inject (serSize txout * coinsPerUTxOByte pp) -}
   let allSizedOutputs = txBody ^. allSizedOutputsTxBodyF
@@ -440,7 +467,7 @@ dijkstraUtxoTransition = do
 instance
   forall era.
   ( EraTx era
-  , EraUTxO era
+  , DijkstraEraUTxO era
   , EraStake era
   , DijkstraEraTxBody era
   , AlonzoEraTx era
@@ -526,7 +553,8 @@ instance
       BabbageOutputTooSmallUTxO x -> Sum BabbageOutputTooSmallUTxO 20 !> To x
       BabbageNonDisjointRefInputs x -> Sum BabbageNonDisjointRefInputs 21 !> To x
       PtrPresentInCollateralReturn x -> Sum PtrPresentInCollateralReturn 22 !> To x
-      WithdrawalsExceedAccountBalance mm -> Sum WithdrawalsExceedAccountBalance 24 !> To mm
+      WithdrawalsExceedAccountBalance mm -> Sum WithdrawalsExceedAccountBalance 23 !> To mm
+      ValueNotConservedInLegacyMode mm -> Sum ValueNotConservedInLegacyMode 24 !> To mm
 
 instance
   ( Era era
@@ -560,7 +588,8 @@ instance
     20 -> SumD BabbageOutputTooSmallUTxO <! From
     21 -> SumD BabbageNonDisjointRefInputs <! From
     22 -> SumD PtrPresentInCollateralReturn <! From
-    24 -> SumD WithdrawalsExceedAccountBalance <! From
+    23 -> SumD WithdrawalsExceedAccountBalance <! From
+    24 -> SumD ValueNotConservedInLegacyMode <! From
     n -> Invalid n
 
 -- =====================================================

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
@@ -58,7 +58,7 @@ import Cardano.Ledger.Conway.Core
 import qualified Cardano.Ledger.Conway.Rules as Conway
 import Cardano.Ledger.Credential (Credential, credScriptHash)
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra, UTXO, UTXOW)
-import Cardano.Ledger.Dijkstra.Rules.Utxo (DijkstraUtxoEnv (..), DijkstraUtxoPredFailure)
+import Cardano.Ledger.Dijkstra.Rules.Utxo (DijkstraUtxoPredFailure, UtxoEnv (..))
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody (..))
 import Cardano.Ledger.Dijkstra.UTxO (DijkstraEraUTxO (..))
 import Cardano.Ledger.Keys (VKey)
@@ -227,13 +227,13 @@ dijkstraUtxowTransition ::
   , InjectRuleFailure "UTXOW" DijkstraUtxowPredFailure era
   , -- Allow UTXOW to call UTXO
     Embed (EraRule "UTXO" era) (UTXOW era)
-  , Environment (EraRule "UTXO" era) ~ DijkstraUtxoEnv era
+  , Environment (EraRule "UTXO" era) ~ UtxoEnv era
   , State (EraRule "UTXO" era) ~ UTxOState era
   , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   ) =>
   TransitionRule (EraRule "UTXOW" era)
 dijkstraUtxowTransition = do
-  TRC (DijkstraUtxoEnv slot pp certState originalUtxo, u, stAnnTx) <- judgmentContext
+  TRC (UtxoEnv slot pp pState originalCertState originalUtxo, u, stAnnTx) <- judgmentContext
   let tx = stAnnTx ^. txStAnnTxG
       scriptsProvided = scriptsProvidedStAnnTx stAnnTx
 
@@ -290,7 +290,7 @@ dijkstraUtxowTransition = do
   runTestOnSignal $ Shelley.validateVerifiedWits tx
 
   {- witsVKeyNeeded utxo tx genDelegs ⊆ witsKeyHashes -}
-  runTest $ Shelley.validateNeededWitnesses witsKeyHashes certState originalUtxo txBody
+  runTest $ Shelley.validateNeededWitnesses witsKeyHashes originalCertState originalUtxo txBody
 
   -- check metadata hash
   {- ((adh = ◇) ∧ (ad= ◇)) ∨ (adh = hashAD ad) -}
@@ -318,7 +318,7 @@ dijkstraUtxowTransition = do
 
   -- Pass through to UTXO sub-rule, carrying the original UTxO
   trans @(EraRule "UTXO" era) $
-    TRC (DijkstraUtxoEnv slot pp certState originalUtxo, u, stAnnTx)
+    TRC (UtxoEnv slot pp pState originalCertState originalUtxo, u, stAnnTx)
 
 instance
   forall era.
@@ -335,7 +335,7 @@ instance
   , InjectRuleFailure "UTXOW" DijkstraUtxowPredFailure era
   , -- Allow UTXOW to call UTXO
     Embed (EraRule "UTXO" era) (UTXOW era)
-  , Environment (EraRule "UTXO" era) ~ DijkstraUtxoEnv era
+  , Environment (EraRule "UTXO" era) ~ UtxoEnv era
   , State (EraRule "UTXO" era) ~ UTxOState era
   , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   , Eq (PredicateFailure (EraRule "UTXOS" era))
@@ -345,7 +345,7 @@ instance
   where
   type State (UTXOW era) = UTxOState era
   type Signal (UTXOW era) = StAnnTx TopTx era
-  type Environment (UTXOW era) = DijkstraUtxoEnv era
+  type Environment (UTXOW era) = UtxoEnv era
   type BaseM (UTXOW era) = ShelleyBase
   type PredicateFailure (UTXOW era) = DijkstraUtxowPredFailure era
   type Event (UTXOW era) = Alonzo.AlonzoUtxowEvent era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
@@ -16,6 +16,7 @@ module Cardano.Ledger.Dijkstra.UTxO (
   getDijkstraScriptsProvided,
   scriptsProvidedDijkstraStAnnTx,
   batchNonDistinctRefScriptsSize,
+  localProducedValue,
 ) where
 
 import Cardano.Ledger.Alonzo.Plutus.Context (CollectError)
@@ -112,25 +113,36 @@ dijkstraProducedValue ::
   TxBody TopTx era ->
   MaryValue
 dijkstraProducedValue pp isRegPoolId topTxBody =
-  producedPerTxBodyWithoutCerts topTxBody
-    <> foldMap' (producedPerTxBodyWithoutCerts . (^. bodyTxL)) subTxs
+  localProducedValue pp topTxBody
+    <> foldMap' (localProducedValue pp . (^. bodyTxL)) subTxs
     <> inject (topTxBody ^. feeTxBodyL)
     <> inject (getTotalDepositsTxCerts pp isRegPoolId batchTxCerts)
   where
     -- add all values that are produced by both top and sub-transactions
     -- Certs are excluded, since they need to be processed separately
     -- while maintaining the state through all of the certs of a transactions.
-    producedPerTxBodyWithoutCerts :: TxBody l era -> MaryValue
-    producedPerTxBodyWithoutCerts txBody =
-      sumAllValue (txBody ^. outputsTxBodyL)
-        <> inject (txBody ^. treasuryDonationTxBodyL)
-        <> inject (conwayProposalsDeposits pp txBody)
-        <> burnedMultiAssets txBody
-        <> inject (fold (unDirectDeposits (txBody ^. directDepositsTxBodyL)))
     batchTxCerts =
       foldMap' (^. bodyTxL . certsTxBodyL) subTxs
         <> (topTxBody ^. certsTxBodyL)
     subTxs = topTxBody ^. subTransactionsTxBodyL
+
+-- | Produced value that is local to a single transaction body, that is, the part
+-- that can be summed independently for each body in a batch.
+-- Excludes fees and certificate deposits, which are accounted for once per
+-- batch.
+localProducedValue ::
+  ( DijkstraEraTxBody era
+  , Value era ~ MaryValue
+  ) =>
+  PParams era ->
+  TxBody l era ->
+  MaryValue
+localProducedValue pp txBody =
+  sumAllValue (txBody ^. outputsTxBodyL)
+    <> inject (txBody ^. treasuryDonationTxBodyL)
+    <> inject (conwayProposalsDeposits pp txBody)
+    <> burnedMultiAssets txBody
+    <> inject (fold (unDirectDeposits (txBody ^. directDepositsTxBodyL)))
 
 instance EraUTxO DijkstraEra where
   type ScriptsNeeded DijkstraEra = AlonzoScriptsNeeded DijkstraEra

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Era.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Era.hs
@@ -21,6 +21,7 @@ import Cardano.Ledger.Dijkstra.Scripts (DijkstraEraScript)
 import Cardano.Ledger.Dijkstra.State
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody)
 import Cardano.Ledger.Dijkstra.TxInfo (DijkstraContextError)
+import Cardano.Ledger.Dijkstra.UTxO (DijkstraEraUTxO)
 import Cardano.Ledger.Plutus (Language (..))
 import Data.Coerce
 import Data.Maybe (fromJust)
@@ -85,6 +86,7 @@ class
   , DijkstraEraPParams era
   , DijkstraEraTxBody era
   , DijkstraEraScript era
+  , DijkstraEraUTxO era
   , Inject (DijkstraContextError era) (ContextError era)
   ) =>
   DijkstraEraTest era

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
@@ -64,164 +64,174 @@ spec = describe "UTXO" $ do
 
   describe "value produced by a transaction" $ do
     it "counts each new pool deposit at most once across the batch" $ do
-      poolKh <- freshKeyHash
-      tx <- registerPoolTxWithSubTxs [poolKh] [[poolKh], [poolKh]]
       pp <- getsPParams id
-      pState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certPStateL
-      -- just the pool deposits are in `produced` because the transaction is not fixed up
-      produced pp pState (tx ^. bodyTxL) `shouldBe` inject (pp ^. ppPoolDepositL)
-      submitTx_ tx
+      let genTx = do
+            poolKh <- freshKeyHash
+            tx <- registerPoolTxWithSubTxs [poolKh] [[poolKh], [poolKh]]
+            -- just the pool deposits are in `produced` because the transaction is not fixed up
+            expectProduced tx $ inject (pp ^. ppPoolDepositL)
+            pure tx
+      submitTx_ =<< genTx
+      submitTx_ =<< switchTxToLegacyMode =<< genTx
 
     it "counts distinct pool deposits in top and sub separately" $ do
-      poolA <- freshKeyHash
-      poolB <- freshKeyHash
-      tx <- registerPoolTxWithSubTxs [poolB, poolA, poolB] [[poolA, poolA, poolB], [poolA, poolB]]
-
-      pp <- getsPParams id
-      pState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certPStateL
-      produced pp pState (tx ^. bodyTxL) `shouldBe` inject ((2 :: Int) <×> (pp ^. ppPoolDepositL))
-      submitTx_ tx
+      let genTx = do
+            pp <- getsPParams id
+            poolA <- freshKeyHash
+            poolB <- freshKeyHash
+            tx <- registerPoolTxWithSubTxs [poolB, poolA, poolB] [[poolA, poolA, poolB], [poolA, poolB]]
+            expectProduced tx $ inject ((2 :: Int) <×> (pp ^. ppPoolDepositL))
+            pure tx
+      submitTx_ =<< genTx
+      submitTx_ =<< switchTxToLegacyMode =<< genTx
 
     it "includes sub-tx cert deposits when top has no certs" $ do
-      poolKh <- freshKeyHash
-      tx <- registerPoolTxWithSubTxs [] [[poolKh]]
-
       pp <- getsPParams id
-      pState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certPStateL
-      produced pp pState (tx ^. bodyTxL) `shouldBe` inject (pp ^. ppPoolDepositL)
-      submitTx_ tx
+      let genTx = do
+            poolKh <- freshKeyHash
+            tx <- registerPoolTxWithSubTxs [] [[poolKh]]
+            expectProduced tx $ inject (pp ^. ppPoolDepositL)
+            pure tx
+      submitTx_ =<< genTx
+      submitTx_ =<< switchTxToLegacyMode =<< genTx
 
     it "does not count re-registrations of an already-registered pool across the batch" $ do
-      poolKh <- freshKeyHash
-      registerPool poolKh
-      tx <- registerPoolTxWithSubTxs [poolKh] [[poolKh]]
-      pp <- getsPParams id
-      pState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certPStateL
-      produced pp pState (tx ^. bodyTxL) `shouldBe` mempty
-      submitTx_ tx
+      let genTx = do
+            poolKh <- freshKeyHash
+            registerPool poolKh
+            tx <- registerPoolTxWithSubTxs [poolKh] [[poolKh]]
+            expectProduced tx mempty
+            pure tx
+      submitTx_ =<< genTx
+      submitTx_ =<< switchTxToLegacyMode =<< genTx
 
     it "dedupes across multiple subtransactions registering the same fresh pool" $ do
-      poolKh <- freshKeyHash
-      tx <- registerPoolTxWithSubTxs [] [[poolKh], [poolKh]]
       pp <- getsPParams id
-      pState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certPStateL
-      produced pp pState (tx ^. bodyTxL) `shouldBe` inject (pp ^. ppPoolDepositL)
-      submitTx_ tx
+      let genTx = do
+            poolKh <- freshKeyHash
+            tx <- registerPoolTxWithSubTxs [] [[poolKh], [poolKh]]
+            expectProduced tx $ inject (pp ^. ppPoolDepositL)
+            pure tx
+      submitTx_ =<< genTx
+      submitTx_ =<< switchTxToLegacyMode =<< genTx
 
     it "sums outputs, fee, treasury donations and deposits across the batch" $ do
       pp <- getsPParams id
-      let poolDeposit = pp ^. ppPoolDepositL
-          dRepDeposit = pp ^. ppDRepDepositL
+      let genTx = do
+            let poolDeposit = pp ^. ppPoolDepositL
+                dRepDeposit = pp ^. ppDRepDepositL
 
-      let freshPoolCert = do
-            poolKh <- freshKeyHash
-            pps <- freshPoolParams poolKh =<< registerAccountAddress
-            pure $ RegPoolTxCert @era pps
-      topPoolCert <- freshPoolCert
-      subPoolCert <- freshPoolCert
+            let freshPoolCert = do
+                  poolKh <- freshKeyHash
+                  pps <- freshPoolParams poolKh =<< registerAccountAddress
+                  pure $ RegPoolTxCert @era pps
+            topPoolCert <- freshPoolCert
+            subPoolCert <- freshPoolCert
 
-      let freshDRepCert = do
-            kh <- freshKeyHash
-            pure $ RegDRepTxCert @era (KeyHashObj kh) dRepDeposit SNothing
-      topDRepCert <- freshDRepCert
-      subDRepCert <- freshDRepCert
+            let freshDRepCert = do
+                  kh <- freshKeyHash
+                  pure $ RegDRepTxCert @era (KeyHashObj kh) dRepDeposit SNothing
+            topDRepCert <- freshDRepCert
+            subDRepCert <- freshDRepCert
 
-      topDDAccount <- registerAccountAddress
-      subDDAccount <- registerAccountAddress
-      topDDAmount <- (Coin 1 <>) <$> arbitrary
-      subDDAmount <- (Coin 1 <>) <$> arbitrary
+            subDDAccount <- registerAccountAddress
+            subDDAmount <- (Coin 1 <>) <$> arbitrary
 
-      topOut <- freshTxOut
-      subOut <- freshTxOut
-      topTreasury <- arbitrary
-      subTreasury <- arbitrary
-      -- we are setting the fee manually in order to verify the `produced` value before the fixup.
-      topFee <- (Coin 1_000_000 <>) <$> arbitrary
+            topOut <- freshTxOut
+            subOut <- freshTxOut
+            topTreasury <- arbitrary
+            subTreasury <- arbitrary
+            -- we are setting the fee manually in order to verify the `produced` value before the fixup.
+            topFee <- (Coin 1_000_000 <>) <$> arbitrary
 
-      let subTx :: Tx SubTx era
-          subTx =
-            mkBasicTx $
-              mkBasicTxBody
-                & outputsTxBodyL .~ [subOut]
-                & certsTxBodyL
-                  .~ [subPoolCert, subDRepCert]
-                & treasuryDonationTxBodyL .~ subTreasury
-                & directDepositsTxBodyL .~ DirectDeposits [(subDDAccount, subDDAmount)]
-          topTx :: Tx TopTx era
-          topTx =
-            mkBasicTx $
-              mkBasicTxBody
-                & outputsTxBodyL .~ [topOut]
-                & feeTxBodyL .~ topFee
-                & certsTxBodyL
-                  .~ [topPoolCert, topDRepCert]
-                & treasuryDonationTxBodyL .~ topTreasury
-                & directDepositsTxBodyL .~ DirectDeposits [(topDDAccount, topDDAmount)]
-                & subTransactionsTxBodyL .~ [subTx]
-          expectedCoin =
-            (topOut ^. coinTxOutL)
-              <> (subOut ^. coinTxOutL)
-              <> topFee
-              <> topTreasury
-              <> subTreasury
-              <> ((2 :: Int) <×> poolDeposit)
-              <> ((2 :: Int) <×> dRepDeposit)
-              <> topDDAmount
-              <> subDDAmount
-          expected = MaryValue expectedCoin mempty
-      pState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certPStateL
-      produced pp pState (topTx ^. bodyTxL) `shouldBe` expected
-      checkDepositCalculation
-        (topTx ^. bodyTxL)
-        (((2 :: Int) <×> poolDeposit) <> ((2 :: Int) <×> dRepDeposit))
-        (poolDeposit <> dRepDeposit)
-      submitTx_ topTx
+            let subTx :: Tx SubTx era
+                subTx =
+                  mkBasicTx $
+                    mkBasicTxBody
+                      & outputsTxBodyL .~ [subOut]
+                      & certsTxBodyL
+                        .~ [subPoolCert, subDRepCert]
+                      & treasuryDonationTxBodyL .~ subTreasury
+                      & directDepositsTxBodyL .~ DirectDeposits [(subDDAccount, subDDAmount)]
+                topTx :: Tx TopTx era
+                topTx =
+                  mkBasicTx $
+                    mkBasicTxBody
+                      & outputsTxBodyL .~ [topOut]
+                      & feeTxBodyL .~ topFee
+                      & certsTxBodyL
+                        .~ [topPoolCert, topDRepCert]
+                      & treasuryDonationTxBodyL .~ topTreasury
+                      & subTransactionsTxBodyL .~ [subTx]
+                -- we're not adding direct deposits at the top level
+                -- in order to be able to submit this transaction when switched to legacy mode
+                -- (which doesn't support direct deposits)
+                expectedCoin =
+                  (topOut ^. coinTxOutL)
+                    <> (subOut ^. coinTxOutL)
+                    <> topFee
+                    <> topTreasury
+                    <> subTreasury
+                    <> ((2 :: Int) <×> poolDeposit)
+                    <> ((2 :: Int) <×> dRepDeposit)
+                    <> subDDAmount
+            expectProduced topTx $ inject expectedCoin
+            checkDepositCalculation
+              (topTx ^. bodyTxL)
+              (((2 :: Int) <×> poolDeposit) <> ((2 :: Int) <×> dRepDeposit))
+              (poolDeposit <> dRepDeposit)
+            pure topTx
+
+      submitTx_ =<< genTx
+      submitTx_ =<< switchTxToLegacyMode =<< genTx
 
     disableInConformanceIt "sums assets burned by the top and the sub transaction" $ do
-      -- Mint upfront the tokens that the batch is going to burn: one output for the top
-      -- transaction to spend and one for the sub transaction.
-      policyId <- PolicyID <$> (impAddNativeScript . RequireSignature =<< freshKeyHash)
-      assetName <- arbitrary @AssetName
-      topBurnAmount <- getPositive <$> arbitrary
-      subBurnAmount <- getPositive <$> arbitrary
-      tokenAddr <- freshKeyAddr_
-      let tokens n = multiAssetFromList [(policyId, assetName, n)]
-      mintTx <-
-        submitTx $
-          mkBasicTx $
-            mkBasicTxBody
-              & mintTxBodyL .~ tokens (topBurnAmount + subBurnAmount)
-              & outputsTxBodyL
-                .~ [ mkBasicTxOut tokenAddr (MaryValue mempty (tokens topBurnAmount))
-                   , mkBasicTxOut tokenAddr (MaryValue mempty (tokens subBurnAmount))
-                   ]
-      topOut <- freshTxOut
-      subOut <- freshTxOut
-      topFee <- (Coin 1_000_000 <>) <$> arbitrary
-      let subTx :: Tx SubTx era
-          subTx =
-            mkBasicTx $
-              mkBasicTxBody
-                & inputsTxBodyL .~ [txInAt (1 :: Int) mintTx]
-                & outputsTxBodyL .~ [subOut]
-                & mintTxBodyL .~ tokens (negate subBurnAmount)
-          topTx :: Tx TopTx era
-          topTx =
-            mkBasicTx $
-              mkBasicTxBody
-                & inputsTxBodyL .~ [txInAt (0 :: Int) mintTx]
-                & outputsTxBodyL .~ [topOut]
-                & feeTxBodyL .~ topFee
-                & mintTxBodyL .~ tokens (negate topBurnAmount)
-                & subTransactionsTxBodyL .~ [subTx]
-          expected =
-            MaryValue
-              ((topOut ^. coinTxOutL) <> (subOut ^. coinTxOutL) <> topFee)
-              (tokens (topBurnAmount + subBurnAmount))
-      pp <- getsPParams id
-      pState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certPStateL
-      produced pp pState (topTx ^. bodyTxL) `shouldBe` expected
-      submitTx_ topTx
+      let genTx = do
+            -- Mint upfront the tokens that the batch is going to burn: one output for the top
+            -- transaction to spend and one for the sub transaction.
+            policyId <- PolicyID <$> (impAddNativeScript . RequireSignature =<< freshKeyHash)
+            assetName <- arbitrary @AssetName
+            topBurnAmount <- getPositive <$> arbitrary
+            subBurnAmount <- getPositive <$> arbitrary
+            tokenAddr <- freshKeyAddr_
+            let tokens n = multiAssetFromList [(policyId, assetName, n)]
+            mintTx <-
+              submitTx $
+                mkBasicTx $
+                  mkBasicTxBody
+                    & mintTxBodyL .~ tokens (topBurnAmount + subBurnAmount)
+                    & outputsTxBodyL
+                      .~ [ mkBasicTxOut tokenAddr (MaryValue mempty (tokens topBurnAmount))
+                         , mkBasicTxOut tokenAddr (MaryValue mempty (tokens subBurnAmount))
+                         ]
+            topOut <- freshTxOut
+            subOut <- freshTxOut
+            topFee <- (Coin 1_000_000 <>) <$> arbitrary
+            let subTx :: Tx SubTx era
+                subTx =
+                  mkBasicTx $
+                    mkBasicTxBody
+                      & inputsTxBodyL .~ [txInAt (1 :: Int) mintTx]
+                      & outputsTxBodyL .~ [subOut]
+                      & mintTxBodyL .~ tokens (negate subBurnAmount)
+                topTx :: Tx TopTx era
+                topTx =
+                  mkBasicTx $
+                    mkBasicTxBody
+                      & inputsTxBodyL .~ [txInAt (0 :: Int) mintTx]
+                      & outputsTxBodyL .~ [topOut]
+                      & feeTxBodyL .~ topFee
+                      & mintTxBodyL .~ tokens (negate topBurnAmount)
+                      & subTransactionsTxBodyL .~ [subTx]
+                expected =
+                  MaryValue
+                    ((topOut ^. coinTxOutL) <> (subOut ^. coinTxOutL) <> topFee)
+                    (tokens (topBurnAmount + subBurnAmount))
+            expectProduced topTx expected
+            pure topTx
+      submitTx_ =<< genTx
+      submitTx_ =<< switchTxToLegacyMode =<< genTx
+
   describe "Value preservation" $ do
     let mkSubTx :: BatchAmounts -> ImpTestM era (Tx SubTx era)
         mkSubTx BatchAmounts {..} = do
@@ -395,6 +405,11 @@ spec = describe "UTXO" $ do
           )
           khPools
       pure $ mkBasicTx mkBasicTxBody & bodyTxL . certsTxBodyL .~ StrictSeq.fromList certs
+    expectProduced :: Tx TopTx era -> Value era -> ImpTestM era ()
+    expectProduced tx expected = do
+      pp <- getsPParams id
+      pState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certPStateL
+      produced pp pState (tx ^. bodyTxL) `shouldBe` expected
 
     -- Check that `certsTotalDepositsTxBody` (used to set deposits in `UTxOState` and `AdaPots` calculations)
     -- returns the batch deposits, while `getTotalDepositsTxBody` returns the top-level deposits

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
@@ -357,6 +357,26 @@ spec = describe "UTXO" $ do
                   , mismatchExpected = inject (bbBatchProduced balances)
                   }
           ]
+
+    describe "fixup function for balancing subtransactions" $ do
+      it "top-only balanced - normal mode" $ do
+        amounts <- genTopOnlyBalancedAmounts
+        topTx <- mkTopTx amounts
+        balanced <- balanceSubTransactions topTx
+        withFixup noBalanceFixup $ submitTx_ balanced
+
+      it "top-only balanced - legacy mode" $ do
+        amounts <- genTopOnlyBalancedAmounts
+        topTx <- mkTopTx amounts
+        topTxLegacy <- mkTopTxLegacyMode amounts topTx
+        balanced <- balanceSubTransactions topTxLegacy
+        withFixup noBalanceFixup $ submitTx_ balanced
+
+      it "balanced on both levels keeps it balanced" $ do
+        amounts <- genFullyBalancedAmounts
+        topTx <- mkTopTx amounts
+        balanced <- balanceSubTransactions topTx
+        withFixup noBalanceFixup $ submitTx_ balanced
   where
     registerPoolTxWithSubTxs ::
       [KeyHash StakePool] -> -- top's pool certs

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -22,20 +23,24 @@ import Cardano.Ledger.Mary.Value (
   PolicyID (..),
   multiAssetFromList,
  )
+import Cardano.Ledger.Plutus
 import qualified Cardano.Ledger.Shelley.AdaPots as AdaPots
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.Scripts (pattern RequireSignature)
 import Cardano.Ledger.Shelley.UTxO (produced)
 import Cardano.Ledger.Tools (ensureMinCoinTxOut)
+import Cardano.Ledger.TxIn
 import Cardano.Ledger.Val
 import qualified Data.Map.Strict as Map
 import qualified Data.OMap.Strict as OMap
 import qualified Data.Sequence.Strict as StrictSeq
+import qualified Data.Set as Set
 import Data.Typeable (Typeable)
-import Lens.Micro ((&), (.~), (^.))
+import Lens.Micro
 import Test.Cardano.Ledger.Core.Utils (txInAt)
 import Test.Cardano.Ledger.Dijkstra.ImpTest
 import Test.Cardano.Ledger.Imp.Common
+import Test.Cardano.Ledger.Plutus.Examples (alwaysSucceedsWithDatum)
 
 spec ::
   forall era.
@@ -217,6 +222,141 @@ spec = describe "UTXO" $ do
       pState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certPStateL
       produced pp pState (topTx ^. bodyTxL) `shouldBe` expected
       submitTx_ topTx
+  describe "Value preservation" $ do
+    let mkSubTx :: BatchAmounts -> ImpTestM era (Tx SubTx era)
+        mkSubTx BatchAmounts {..} = do
+          txIn <- txInWithFunds baSubTxIn
+          txOut <- mkTxOut baSubTxOut
+          account <- registerAccountAddress
+          pure $
+            mkBasicTx $
+              mkBasicTxBody
+                & inputsTxBodyL .~ [txIn]
+                & outputsTxBodyL .~ [txOut]
+                & directDepositsTxBodyL .~ DirectDeposits [(account, baSubDirectDeposit)]
+
+    let mkTopTx :: BatchAmounts -> ImpTestM era (Tx TopTx era)
+        mkTopTx amounts@BatchAmounts {..} = do
+          txIn <- txInWithFunds baTopTxIn
+          txOut <- mkTxOut baTopTxOut
+          account <- registerAccountAddress
+          fundAccountBalance account baTopWithdrawal
+          subTx <- mkSubTx amounts
+          pure $
+            mkBasicTx $
+              mkBasicTxBody
+                & inputsTxBodyL .~ [txIn]
+                & outputsTxBodyL .~ [txOut]
+                & feeTxBodyL .~ baFee
+                & withdrawalsTxBodyL .~ Withdrawals [(account, baTopWithdrawal)]
+                & subTransactionsTxBodyL .~ OMap.singleton subTx
+
+    let mkTopTxLegacyMode :: BatchAmounts -> Tx TopTx era -> ImpTestM era (Tx TopTx era)
+        mkTopTxLegacyMode BatchAmounts {..} tx = do
+          scriptTxIn <- produceScriptAt (hashPlutusScript $ alwaysSucceedsWithDatum SPlutusV3) baScriptTxIn
+          pure $
+            tx
+              & bodyTxL . inputsTxBodyL <>~ Set.singleton scriptTxIn
+              & bodyTxL . feeTxBodyL <>~ baScriptTxIn
+
+    it "tx balanced across the batch and at the top level - normal mode" $ do
+      amounts <- genFullyBalancedAmounts
+      topTx <- mkTopTx amounts
+      withFixup noBalanceFixup $ submitTx_ topTx
+
+    it "tx balanced across the batch and at the top level - legacy mode" $ do
+      amounts <- genFullyBalancedAmounts
+      topTx <- mkTopTx amounts
+      topTxLegacy <- mkTopTxLegacyMode amounts topTx
+      withFixup noBalanceFixup $ submitTx_ topTxLegacy
+
+    it "tx balanced across the batch and unbalanced at the top level - normal mode" $ do
+      amounts <- genBatchOnlyBalancedAmounts
+      topTx <- mkTopTx amounts
+      withFixup noBalanceFixup $ submitTx_ topTx
+
+    it "tx balanced across the batch and unbalanced at the top level - legacy mode" $ do
+      amounts <- genBatchOnlyBalancedAmounts
+      topTx <- mkTopTx amounts
+      topTxLegacy <- mkTopTxLegacyMode amounts topTx
+      let balances = batchBalances True amounts
+      withFixup noBalanceFixup $
+        submitFailingTx
+          topTxLegacy
+          [ injectFailure $
+              ValueNotConservedInLegacyMode
+                Mismatch
+                  { mismatchSupplied = inject (bbTopConsumed balances)
+                  , mismatchExpected = inject (bbTopProduced balances)
+                  }
+          ]
+
+    it "tx balanced at the top level and unbalanced across the batch - normal mode" $ do
+      amounts <- genTopOnlyBalancedAmounts
+      topTx <- mkTopTx amounts
+      let balances = batchBalances False amounts
+      withFixup noBalanceFixup $
+        submitFailingTx
+          topTx
+          [ injectFailure $
+              ValueNotConservedUTxO
+                Mismatch
+                  { mismatchSupplied = inject (bbBatchConsumed balances)
+                  , mismatchExpected = inject (bbBatchProduced balances)
+                  }
+          ]
+    it "tx balanced at the top level and unbalanced across the batch - legacy mode" $ do
+      amounts <- genTopOnlyBalancedAmounts
+      topTx <- mkTopTx amounts
+      topTxLegacy <- mkTopTxLegacyMode amounts topTx
+      let balances = batchBalances True amounts
+      withFixup noBalanceFixup $
+        submitFailingTx
+          topTxLegacy
+          [ injectFailure $
+              ValueNotConservedUTxO
+                Mismatch
+                  { mismatchSupplied = inject (bbBatchConsumed balances)
+                  , mismatchExpected = inject (bbBatchProduced balances)
+                  }
+          ]
+
+    it "tx unbalanced across the batch and at the top level - normal mode" $ do
+      amounts <- genFullyUnbalancedAmounts
+      topTx <- mkTopTx amounts
+      let balances = batchBalances False amounts
+      withFixup noBalanceFixup $
+        submitFailingTx
+          topTx
+          [ injectFailure $
+              ValueNotConservedUTxO
+                Mismatch
+                  { mismatchSupplied = inject (bbBatchConsumed balances)
+                  , mismatchExpected = inject (bbBatchProduced balances)
+                  }
+          ]
+
+    it "tx unbalanced across the batch and at the top level - legacy mode" $ do
+      amounts <- genFullyUnbalancedAmounts
+      topTx <- mkTopTx amounts
+      topTxLegacy <- mkTopTxLegacyMode amounts topTx
+      let balances = batchBalances True amounts
+      withFixup noBalanceFixup $
+        submitFailingTx
+          topTxLegacy
+          [ injectFailure $
+              ValueNotConservedInLegacyMode
+                Mismatch
+                  { mismatchSupplied = inject (bbTopConsumed balances)
+                  , mismatchExpected = inject (bbTopProduced balances)
+                  }
+          , injectFailure $
+              ValueNotConservedUTxO
+                Mismatch
+                  { mismatchSupplied = inject (bbBatchConsumed balances)
+                  , mismatchExpected = inject (bbBatchProduced balances)
+                  }
+          ]
   where
     registerPoolTxWithSubTxs ::
       [KeyHash StakePool] -> -- top's pool certs
@@ -250,3 +390,175 @@ spec = describe "UTXO" $ do
       addr <- freshKeyAddr_
       amount <- arbitrary @Coin
       pure $ ensureMinCoinTxOut pp (mkBasicTxOut addr (inject amount))
+    fundAccountBalance :: AccountAddress -> Coin -> ImpTestM era ()
+    fundAccountBalance account amount = do
+      submitTx_ $
+        mkBasicTx $
+          mkBasicTxBody
+            & directDepositsTxBodyL .~ DirectDeposits [(account, amount)]
+    txInWithFunds :: Coin -> ImpTestM era TxIn
+    txInWithFunds amount = freshKeyAddr_ >>= \a -> sendCoinTo a amount
+    mkTxOut :: Coin -> ImpTestM era (TxOut era)
+    mkTxOut amount = freshKeyAddr_ >>= \a -> pure $ mkBasicTxOut a (inject amount)
+    produceScriptAt :: ScriptHash -> Coin -> ImpTestM era TxIn
+    produceScriptAt scriptHash amount = do
+      let addr = mkAddr scriptHash StakeRefNull
+      let tx =
+            mkBasicTx mkBasicTxBody
+              & bodyTxL . outputsTxBodyL .~ [mkBasicTxOut addr (inject amount)]
+      txInAt 0 <$> submitTx tx
+
+noBalanceFixup ::
+  ( HasCallStack
+  , DijkstraEraImp era
+  ) =>
+  Tx TopTx era ->
+  ImpTestM era (Tx TopTx era)
+noBalanceFixup =
+  fixupSubTransactions
+    >=> addNativeScriptTxWits
+    >=> fixupAuxDataHash
+    >=> addCollateralInput
+    >=> fixupScriptWits
+    >=> fixupOutputDatums
+    >=> fixupDatums
+    >=> fixupRedeemerIndices
+    >=> fixupTxOuts
+    >=> fixupCollateralReturn
+    >=> fixupRedeemers
+    >=> fixupPPHash
+    >=> updateAddrTxWits
+
+-- A template for creating a transaction with exactly one subtransaction,
+-- with values for different fields that contribute to consumed and produced.
+data BatchAmounts = BatchAmounts
+  { baSubTxIn :: Coin
+  , baSubTxOut :: Coin
+  , baSubDirectDeposit :: Coin
+  , baTopTxIn :: Coin
+  , baTopWithdrawal :: Coin
+  , baTopTxOut :: Coin
+  , baFee :: Coin
+  , baScriptTxIn :: Coin
+  }
+
+genBatchOnlyBalancedAmounts :: ImpTestM era BatchAmounts
+genBatchOnlyBalancedAmounts = do
+  -- we are restricted in the lower bound by min utxo size
+  -- and in the upper bound by the hardcoded collateral in `makeCollateralInput`
+  m <- Coin <$> choose (1_000_000, 2_000_000)
+  pure $ mkAmounts m
+  where
+    mkAmounts m =
+      -- These values create an unbalanced sub-transaction, with:
+      --      consumed = subTxIn   = 1
+      --      produced = subTxOut + subDirectDeposit  =  2 + 3
+      -- and an unbalanced top transaction, with:
+      --      consumed = topTxIn + topWithdrawal = 8 + 5
+      --      produced = topTxOut + fee    = 6 + 3
+      -- Legacy variant adds scriptTxIn on both sides (input + fee)
+      -- On the batch level, the transaction is balancing out.
+      let amounts =
+            BatchAmounts
+              { baSubTxIn = (1 :: Int) <×> m
+              , baSubTxOut = (2 :: Int) <×> m
+              , baSubDirectDeposit = (3 :: Int) <×> m
+              , baTopTxIn = (8 :: Int) <×> m
+              , baTopWithdrawal = (5 :: Int) <×> m
+              , baTopTxOut = (6 :: Int) <×> m
+              , baFee = (3 :: Int) <×> m
+              , baScriptTxIn = (4 :: Int) <×> m
+              }
+       in assertBatchBalanced amounts
+
+-- Amounts for a transaction that balances out both at batch level, and at top level
+genFullyBalancedAmounts :: ImpTestM era BatchAmounts
+genFullyBalancedAmounts = do
+  batchBalanced@BatchAmounts {..} <- genBatchOnlyBalancedAmounts
+  let BatchBalances {..} = batchBalances False batchBalanced
+      mismatch = bbTopConsumed <-> bbTopProduced
+      fullyBalanced =
+        batchBalanced
+          { -- because the batch is balanced, we can fix both top and sub balances with the same `mismatch`
+            baTopTxOut = baTopTxOut <> mismatch
+          , baSubTxIn = baSubTxIn <> mismatch
+          }
+  pure $
+    fullyBalanced
+      & assertBatchBalanced
+      & assertTopBalanced
+      & assertSubBalanced
+
+-- Amounts for a transaction that doesn't balance out - neither at top or batch level
+genFullyUnbalancedAmounts :: ImpTestM era BatchAmounts
+genFullyUnbalancedAmounts = do
+  balanced@BatchAmounts {..} <- genFullyBalancedAmounts
+  extra <- Coin . getPositive <$> arbitrary
+  pure $ balanced {baTopTxIn = baTopTxIn <> extra}
+
+genTopOnlyBalancedAmounts :: ImpTestM era BatchAmounts
+genTopOnlyBalancedAmounts = do
+  balanced@BatchAmounts {..} <- genFullyBalancedAmounts
+  extra <- Coin . getPositive <$> arbitrary
+  pure $ balanced {baSubTxIn = baSubTxIn <> extra}
+
+data BatchBalances = BatchBalances
+  { bbSubConsumed :: Coin
+  , bbSubProduced :: Coin
+  , bbTopConsumed :: Coin
+  , bbTopProduced :: Coin
+  , bbBatchConsumed :: Coin
+  , bbBatchProduced :: Coin
+  }
+
+assertBatchBalanced :: HasCallStack => BatchAmounts -> BatchAmounts
+assertBatchBalanced ba
+  | bbBatchConsumed bb == bbBatchProduced bb = ba
+  | otherwise =
+      error $
+        "Impossible: batch amounts are not balanced: consumed = "
+          <> show (bbBatchConsumed bb)
+          <> ", produced = "
+          <> show (bbBatchProduced bb)
+  where
+    bb = batchBalances False ba
+
+assertTopBalanced :: HasCallStack => BatchAmounts -> BatchAmounts
+assertTopBalanced ba
+  | bbTopConsumed bb == bbTopProduced bb = ba
+  | otherwise =
+      error $
+        "Impossible: top transaction amounts are not balanced: consumed = "
+          <> show (bbTopConsumed bb)
+          <> ", produced = "
+          <> show (bbTopProduced bb)
+  where
+    bb = batchBalances False ba
+
+assertSubBalanced :: HasCallStack => BatchAmounts -> BatchAmounts
+assertSubBalanced ba
+  | bbSubConsumed bb == bbSubProduced bb = ba
+  | otherwise =
+      error $
+        "Impossible: sub-transaction amounts are not balanced: consumed = "
+          <> show (bbSubConsumed bb)
+          <> ", produced = "
+          <> show (bbSubProduced bb)
+  where
+    bb = batchBalances False ba
+
+batchBalances :: Bool -> BatchAmounts -> BatchBalances
+batchBalances isLegacy BatchAmounts {..} =
+  let script = if isLegacy then baScriptTxIn else mempty
+      subConsumed = baSubTxIn
+      subProduced = baSubTxOut <> baSubDirectDeposit
+      topConsumed = baTopTxIn <> baTopWithdrawal <> script
+      topProduced = baTopTxOut <> baFee <> script
+   in BatchBalances
+        { bbSubConsumed = subConsumed
+        , bbSubProduced = subProduced
+        , bbTopConsumed = topConsumed
+        , bbTopProduced = topProduced
+        , bbBatchConsumed = subConsumed <> topConsumed
+        , bbBatchProduced = subProduced <> topProduced
+        }

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
@@ -44,7 +44,7 @@ import Cardano.Ledger.Dijkstra.Scripts (
   pattern RequireGuard,
  )
 import Cardano.Ledger.Dijkstra.UTxO
-import Cardano.Ledger.Plutus (SLanguage (..))
+import Cardano.Ledger.Plutus
 import Cardano.Ledger.Shelley.API (mkStAnnTx)
 import Cardano.Ledger.Shelley.LedgerState
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
@@ -204,20 +204,12 @@ dijkstraGenUnRegTxCert stakingCredential = do
   pure $ UnRegDepositTxCert stakingCredential deposit
 
 switchTxToLegacyMode ::
-  forall era.
   DijkstraEraImp era =>
   Tx TopTx era ->
   ImpTestM era (Tx TopTx era)
 switchTxToLegacyMode tx = do
-  let plutus = alwaysSucceedsWithDatum SPlutusV3
-  Just plutusScript <- pure $ mkPlutusScript @era plutus
-  let eraScript = fromPlutusScript plutusScript
-      scriptHash = hashScript eraScript
-  txIn <- produceScript scriptHash
-  pure $
-    tx
-      & bodyTxL . inputsTxBodyL <>~ [txIn]
-      & witsTxL . scriptTxWitsL %~ Map.insert scriptHash eraScript
+  txIn <- produceScript . hashPlutusScript $ alwaysSucceedsWithDatum SPlutusV3
+  pure $ tx & bodyTxL . inputsTxBodyL <>~ [txIn]
 
 dijkstraFixupTx ::
   ( HasCallStack
@@ -226,8 +218,9 @@ dijkstraFixupTx ::
   Tx TopTx era ->
   ImpTestM era (Tx TopTx era)
 dijkstraFixupTx tx = do
-  isLegacy <- detectLegacyMode tx
-  fixedUp <- fixupSubTransactions tx
+  -- add top-level Plutus script witnesses so legacy detection sees them
+  fixedUp <- fixupScriptWits =<< fixupSubTransactions tx
+  isLegacy <- detectLegacyMode fixedUp
   balancedInLegacy <- if isLegacy then balanceSubTransactions fixedUp else pure fixedUp
   babbageFixupTx balancedInLegacy
 

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
@@ -294,7 +294,8 @@ mkBalancerSubTx consumed produced = do
         changeCoin = minChangeCoin <> surplus
         changeOut = mkBasicTxOut addr (inject changeCoin)
       newTxIn <- withFixup fixupTx $ sendCoinTo addr inputCoin
-      pure . Just $
-        mkBasicTx mkBasicTxBody
-          & bodyTxL . inputsTxBodyL .~ [newTxIn]
-          & bodyTxL . outputsTxBodyL .~ [changeOut]
+      let subTx =
+            mkBasicTx mkBasicTxBody
+              & bodyTxL . inputsTxBodyL .~ [newTxIn]
+              & bodyTxL . outputsTxBodyL .~ [changeOut]
+      Just <$> updateAddrTxWits subTx

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}
@@ -16,6 +19,7 @@ module Test.Cardano.Ledger.Dijkstra.ImpTest (
   DijkstraEraImp,
   impDijkstraSatisfyNativeScript,
   fixupSubTransactions,
+  balanceSubTransactions,
 ) where
 
 import Cardano.Ledger.Allegra.Scripts (
@@ -37,6 +41,10 @@ import Cardano.Ledger.Dijkstra.Scripts (
   evalDijkstraNativeScript,
   pattern RequireGuard,
  )
+import Cardano.Ledger.Dijkstra.UTxO (
+  dijkstraConsumed,
+  localProducedValue,
+ )
 import Cardano.Ledger.Plutus (SLanguage (..))
 import Cardano.Ledger.Shelley.LedgerState
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
@@ -47,6 +55,9 @@ import Cardano.Ledger.Shelley.Scripts (
   pattern RequireSignature,
  )
 import Cardano.Ledger.State
+import Cardano.Ledger.Tools (ensureMinCoinTxOut)
+import Cardano.Ledger.Val
+import Data.Foldable
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
 import qualified Data.OMap.Strict as OMap
@@ -226,3 +237,51 @@ fixupSubTransactions tx = impAnn "fixupSubTransactions" $ do
           -- to make sure it isn't affected by any higher-level fixup modifications
           newTxIn <- withFixup fixupTx $ sendCoinTo addr (Coin 1_000_000)
           pure $ subTx & bodyTxL . inputsTxBodyL .~ Set.singleton newTxIn
+
+balanceSubTransactions ::
+  DijkstraEraImp era =>
+  Tx TopTx era ->
+  ImpTestM era (Tx TopTx era)
+balanceSubTransactions topTx = do
+  pp <- getsNES $ nesEsL . curPParamsEpochStateL
+  pools <- Map.keysSet <$> getsNES (nesEsL . esLStateL . lsCertStateL . certPStateL . psStakePoolsL)
+  utxo <- getUTxO
+  let
+    subTransactions = topTx ^. bodyTxL . subTransactionsTxBodyL
+    subsCerts = foldMap' (^. bodyTxL . certsTxBodyL) subTransactions
+    subsConsumed = coin $ foldMap' (dijkstraConsumed pp utxo . (^. bodyTxL)) subTransactions
+    subsProduced =
+      foldMap' (coin . localProducedValue pp . (^. bodyTxL)) subTransactions
+        <> getTotalDepositsTxCerts pp (`Set.member` pools) subsCerts
+  balancer <- mkBalancerSubTx subsConsumed subsProduced
+  case balancer of
+    Nothing -> pure topTx
+    Just b -> pure $ topTx & bodyTxL . subTransactionsTxBodyL %~ (OMap.|> b)
+
+mkBalancerSubTx ::
+  DijkstraEraImp era =>
+  -- | Cumulated consumed value by all sub-transactions
+  Coin ->
+  -- | Cumulated produced value by all sub-transactions
+  Coin ->
+  ImpTestM era (Maybe (Tx SubTx era))
+mkBalancerSubTx consumed produced = do
+  pp <- getsNES $ nesEsL . curPParamsEpochStateL
+  case consumed `compare` produced of
+    EQ -> pure Nothing
+    ord -> do
+      addr <- freshKeyAddr_
+      let
+        (surplus, shortfall) = case ord of
+          GT -> (consumed <-> produced, mempty)
+          LT -> (mempty, produced <-> consumed)
+        -- a buffer to make both the input UTxO and the change output satisfy minCoin. It's added on both sides, so it cancels out.
+        minChangeCoin = ensureMinCoinTxOut pp (mkBasicTxOut addr mempty) ^. coinTxOutL
+        inputCoin = minChangeCoin <> shortfall
+        changeCoin = minChangeCoin <> surplus
+        changeOut = mkBasicTxOut addr (inject changeCoin)
+      newTxIn <- withFixup fixupTx $ sendCoinTo addr inputCoin
+      pure . Just $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . inputsTxBodyL .~ [newTxIn]
+          & bodyTxL . outputsTxBodyL .~ [changeOut]

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
@@ -15,6 +15,7 @@ module Test.Cardano.Ledger.Dijkstra.ImpTest (
   module Test.Cardano.Ledger.Conway.ImpTest,
   DijkstraEraImp,
   impDijkstraSatisfyNativeScript,
+  fixupSubTransactions,
 ) where
 
 import Cardano.Ledger.Allegra.Scripts (

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -20,6 +21,7 @@ module Test.Cardano.Ledger.Dijkstra.ImpTest (
   impDijkstraSatisfyNativeScript,
   fixupSubTransactions,
   balanceSubTransactions,
+  switchTxToLegacyMode,
 ) where
 
 import Cardano.Ledger.Allegra.Scripts (
@@ -66,6 +68,7 @@ import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Dijkstra.Era
 import Test.Cardano.Ledger.Dijkstra.Examples (exampleDijkstraGenesis)
 import Test.Cardano.Ledger.Imp.Common
+import Test.Cardano.Ledger.Plutus.Examples (alwaysSucceedsWithDatum)
 
 instance ShelleyEraImp DijkstraEra where
   initGenesis = pure exampleDijkstraGenesis
@@ -199,6 +202,22 @@ dijkstraGenUnRegTxCert stakingCredential = do
     Nothing -> getsNES $ nesEsL . curPParamsEpochStateL . ppKeyDepositL
     Just accountState -> pure (fromCompact (accountState ^. depositAccountStateL))
   pure $ UnRegDepositTxCert stakingCredential deposit
+
+switchTxToLegacyMode ::
+  forall era.
+  DijkstraEraImp era =>
+  Tx TopTx era ->
+  ImpTestM era (Tx TopTx era)
+switchTxToLegacyMode tx = do
+  let plutus = alwaysSucceedsWithDatum SPlutusV3
+  Just plutusScript <- pure $ mkPlutusScript @era plutus
+  let eraScript = fromPlutusScript plutusScript
+      scriptHash = hashScript eraScript
+  txIn <- produceScript scriptHash
+  pure $
+    tx
+      & bodyTxL . inputsTxBodyL <>~ [txIn]
+      & witsTxL . scriptTxWitsL %~ Map.insert scriptHash eraScript
 
 dijkstraFixupTx ::
   ( HasCallStack

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
@@ -41,11 +41,9 @@ import Cardano.Ledger.Dijkstra.Scripts (
   evalDijkstraNativeScript,
   pattern RequireGuard,
  )
-import Cardano.Ledger.Dijkstra.UTxO (
-  dijkstraConsumed,
-  localProducedValue,
- )
+import Cardano.Ledger.Dijkstra.UTxO
 import Cardano.Ledger.Plutus (SLanguage (..))
+import Cardano.Ledger.Shelley.API (mkStAnnTx)
 import Cardano.Ledger.Shelley.LedgerState
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Cardano.Ledger.Shelley.Scripts (
@@ -57,6 +55,7 @@ import Cardano.Ledger.Shelley.Scripts (
 import Cardano.Ledger.State
 import Cardano.Ledger.Tools (ensureMinCoinTxOut)
 import Cardano.Ledger.Val
+import Control.Monad.State (gets)
 import Data.Foldable
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
@@ -207,8 +206,22 @@ dijkstraFixupTx ::
   ) =>
   Tx TopTx era ->
   ImpTestM era (Tx TopTx era)
-dijkstraFixupTx =
-  fixupSubTransactions >=> babbageFixupTx
+dijkstraFixupTx tx = do
+  isLegacy <- detectLegacyMode tx
+  fixedUp <- fixupSubTransactions tx
+  balancedInLegacy <- if isLegacy then balanceSubTransactions fixedUp else pure fixedUp
+  babbageFixupTx balancedInLegacy
+
+detectLegacyMode ::
+  DijkstraEraImp era =>
+  Tx TopTx era ->
+  ImpTestM era Bool
+detectLegacyMode tx = do
+  Globals {systemStart, epochInfo} <- gets (^. impGlobalsL)
+  pp <- getsNES $ nesEsL . curPParamsEpochStateL
+  utxo <- getUTxO
+  let stAnnTx = mkStAnnTx epochInfo systemStart pp utxo mempty tx
+  pure $ stAnnTx ^. plutusLegacyModeStAnnTxG
 
 fixupSubTransactions ::
   ( HasCallStack


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

In legacy mode, the top-level transaction has to be balanced.  
This PR introduces this check in Utxo rule. 
We check that it balances with the subtransactions set to empty  -  and pass the PState that has been threaded through (so AFTER the application of subtransactions)  - so that if a subtransaction registers a pool and the top level one re-registers it,  the latter doesn't have to pay deposit. 

I updated the Imp test-framework  to fixup the transaction in legacy mode  - that is: to make a transaction submittable in legacy mode by balancing out the list of subtransactions.  
Then the regular fixup balances the whole batch (as is the case at the moment in master). As a result, with this PR, we can build arbitrary transactions with subtransactions and they will balance out in both normal and legacy mode. 

I added  tests that check the value conservation without the fixup, and tests that check the fixup itself.

The conformance tests pass only with the newer version of the formal ledger spec, which this PR depends on (https://github.com/IntersectMBO/cardano-ledger/pull/6022)

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
