### PR TITLE
Make the `branch-history` CI job more robust

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -508,12 +508,18 @@ jobs:
   branch-history:
     name: Check branch history
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     if: ${{ github.base_ref != '' && github.ref != '' }}  # Only true for PRs
     steps:
     - uses: actions/checkout@v7
     - name: Ensure the branch doesn't contain any merges
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
-        PR_TARGET=${{ github.base_ref }}
+        PR_NUMBER=${{ github.event.pull_request.number }}
+        PR_TARGET=$(gh pr view "$PR_NUMBER" --json baseRefName -q .baseRefName)
         PR_MERGE=${{ github.ref }}
         PR_HEAD=${PR_MERGE%/merge}/head
         git fetch origin -n --refmap= +$PR_TARGET:pr-target +$PR_HEAD:pr-head


### PR DESCRIPTION
# Description

This handles a rerun of the failed workflow after the target branch has changed in the PR.

`github.base_ref` is populated from the webhook payload of the event that first triggered the run. It's not queried live from the PR at execution time, so if you rerun a failed job, GitHub reuses the value from the original stored event payload for the run.

Instead of using `github.base_ref`, we now use the `gh` command to query the target branch, which will always return the current value.

The `gh` command is preinstalled on GitHub shared runners, but it requires the `GH_TOKEN` env var to be set.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
