### PR TITLE
shelley: force the initial-funds injection result

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Transition.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Transition.hs
@@ -658,7 +658,8 @@ registerInitialFunds hasFS tc newEpochState = do
   (newUtxoEntries, totalCoins) <-
     foldInjectionData hasFS source addInitialFund (Map.empty, mempty)
 
-  pure $ applyFunds newUtxoEntries totalCoins
+  -- Forced: left lazy, this thunk retains both inputs of `mergeUtxoNoOverlap`.
+  pure $! applyFunds newUtxoEntries totalCoins
   where
     epochState = nesEs newEpochState
     accountState = esChainAccountState epochState


### PR DESCRIPTION
`registerInitialFunds` returned `pure $ applyFunds newUtxoEntries totalCoins`,
    leaving the whole merge unevaluated. The resulting thunk closes over both
    arguments of `mergeUtxoNoOverlap`: the map of funds just accumulated by the
    injection fold, and the UTxO already present in the incoming `NewEpochState`.
    Whichever of the two is populated is a complete UTxO map.

 That thunk is reachable for the lifetime of the process, because it is carried
    by the initial `ExtLedgerState` that `protocolInfo` produces. The node therefore
    holds the UTxO twice: once merged and wrapped in `CardanoTxOut` inside the
    ledger tables, and once unwrapped as unevaluated thunk payload.

 Measured on a benchmark genesis with 11.3M initial funds, at a fixed point in
    startup (`ChainDB.OpenEvent.OpenedDB` plus 60s, idle GC enabled), against
    cardano-node 11.0.1 on the same profile and dataset:

      live heap                4349 MiB -> 6207 MiB   (+1858 MiB)
      TxIn closures          11,300,003 -> 21,252,208 (1.88x)
      TxOutCompact'          10,000,003 -> 18,652,208 (1.87x)
      ConwayTxOut            11,300,003 -> 11,300,002 (unchanged)

 `ConwayTxOut` staying flat is what identifies the second copy as a raw ledger
    UTxO map rather than a duplicated set of ledger tables: table values are wrapped,
    and there is still exactly one set of wrappers.

 Heap retainer paths (ghc-debug, with info-table maps) name the chain: a
    `ShelleyLedgerState` held via an unevaluated `NewEpochState` thunk at the
    consensus injection call site, which holds a partial application of `applyFunds`
    of type `Map TxIn (TxOut era) -> Coin -> m (NewEpochState era)`, originating at
    this line.

 Note this forces to WHNF only. It is sufficient here because it drops the
    references to the two pre-merge maps; a deeper force would traverse the merged
    UTxO and defeat the purpose.