### PR TITLE
Update formal-ledger-specification

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
   subdir: hs
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `*-artifacts` BEFORE MERGE!
-  tag: acb729666717e3d1791ade785658bfc70de38e92
+  tag: d7e19b24d5f37c34859087b284c75de4ebf48c8d
 
 source-repository-package
   type: git

--- a/flake.lock
+++ b/flake.lock
@@ -222,11 +222,11 @@
     "formal-ledger-specifications": {
       "flake": false,
       "locked": {
-        "lastModified": 1785425266,
-        "narHash": "sha256-mmvDtwb+sUO6AVL67Jpxhr40LtzICapq1/NITFlytdQ=",
+        "lastModified": 1786392170,
+        "narHash": "sha256-4VSi+UVYMXXZWxcIEUMDt+NN47TYDNrl4MWVuUkYHm0=",
         "owner": "IntersectMBO",
         "repo": "formal-ledger-specifications",
-        "rev": "acb729666717e3d1791ade785658bfc70de38e92",
+        "rev": "d7e19b24d5f37c34859087b284c75de4ebf48c8d",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
@@ -13,7 +13,6 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.GovCert () where
 
 import Cardano.Ledger.Conway (ConwayEra)
 import Control.State.Transition.Extended (TRC (..))
-import Data.Bifunctor (Bifunctor (..))
 import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert (ConwayCertExecContext (..))
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
@@ -37,6 +36,6 @@ instance ExecSpecRule "GOVCERT" ConwayEra where
     agdaSig <- withCtxSpecTransM () $ toSpecRep sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
-  runAgdaRule (SpecTRC env (Agda.MkCertState dState pState vState) sig) =
-    second (Agda.MkCertState dState pState) . unComputationResult $
-      Agda.govCertStep env vState sig
+  runAgdaRule (SpecTRC env st sig) =
+    unComputationResult $
+      Agda.govCertStep env st sig


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->


This should correct the `produced` value in legacy mode to not add the pool re-registration at the top-level  of pools registered in subtransactions  (implemented in ledger in a coming PR) 

# Checklist


- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
