### PR TITLE
Enable Shelley Imp tests for Pool in conformance (Dijkstra)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
   subdir: hs
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `*-artifacts` BEFORE MERGE!
-  tag: d7e19b24d5f37c34859087b284c75de4ebf48c8d
+  tag: acbbd74a02987678ad83d9285976328d6a6e146d
 
 source-repository-package
   type: git

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/PoolSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/PoolSpec.hs
@@ -64,7 +64,9 @@ spec = describe "POOL" $ do
         else
           submitFailingTx tx [injectFailure $ WrongNetworkPOOL (Mismatch Mainnet Testnet) kh]
 
-    it "register a pool with too big metadata" $ do
+    -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/1293
+    -- TODO: Re-enable after issue is resolved, by removing this override
+    disableInConformanceIt "register a pool with too big metadata" $ do
       pv <- getsPParams ppProtocolVersionL
       let maxMetadataSize = hashSize (Proxy :: Proxy HASH)
       tooBigSize <- choose (maxMetadataSize + 1, maxMetadataSize + 50)

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/PoolSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/PoolSpec.hs
@@ -47,6 +47,16 @@ spec = describe "POOL" $ do
         tx
         [injectFailure $ StakePoolCostTooLowPOOL $ Mismatch tooLowCost minPoolCost]
 
+    it "re-register a pool with too low cost" $ do
+      (kh, vrf) <- registerNewPool
+      pps <- poolParams kh vrf
+      minPoolCost <- getsPParams ppMinPoolCostL
+      tooLowCost <- Coin <$> choose (0, unCoin minPoolCost)
+      let tx = registerPoolTx (pps & sppCostL .~ tooLowCost)
+      submitFailingTx
+        tx
+        [injectFailure $ StakePoolCostTooLowPOOL $ Mismatch tooLowCost minPoolCost]
+
     it "register a pool with a staking address having the wrong network id" $ do
       pv <- getsPParams ppProtocolVersionL
       accountCredential <- KeyHashObj <$> freshKeyHash

--- a/flake.lock
+++ b/flake.lock
@@ -222,11 +222,11 @@
     "formal-ledger-specifications": {
       "flake": false,
       "locked": {
-        "lastModified": 1786392170,
-        "narHash": "sha256-4VSi+UVYMXXZWxcIEUMDt+NN47TYDNrl4MWVuUkYHm0=",
+        "lastModified": 1787585825,
+        "narHash": "sha256-teN+Y9DW7OZgen1CM8PkTt3F8IKP22NvyBBEcDXSGzc=",
         "owner": "IntersectMBO",
         "repo": "formal-ledger-specifications",
-        "rev": "d7e19b24d5f37c34859087b284c75de4ebf48c8d",
+        "rev": "acbbd74a02987678ad83d9285976328d6a6e146d",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
@@ -50,6 +50,8 @@ import Cardano.Ledger.Conway.Core (
   PParamsHKD,
   PParamsUpdate (..),
   ScriptHash (..),
+  VRFVerKeyHash,
+  fromVRFVerKeyHash,
  )
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
@@ -187,6 +189,11 @@ instance SpecTranslate era (WitVKey k) where
   type SpecRep era (WitVKey k) = (SpecRep era (VKey k), Integer)
 
   toSpecRep (WitVKey vk sk) = toSpecRepTuple (vk, sk)
+
+instance SpecTranslate era (VRFVerKeyHash r) where
+  type SpecRep era (VRFVerKeyHash r) = Integer
+
+  toSpecRep = toSpecRep . fromVRFVerKeyHash
 
 instance SpecTranslate era CommitteeAuthorization where
   type

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Dijkstra/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Dijkstra/Base.hs
@@ -24,7 +24,6 @@ module Test.Cardano.Ledger.Conformance.SpecTranslate.Dijkstra.Base (
 
 import Cardano.Ledger.Address (
   DirectDeposits (..),
-  accountAddressCredentialL,
  )
 import Cardano.Ledger.Allegra.Scripts (
   pattern RequireTimeExpire,
@@ -285,6 +284,7 @@ instance SpecTranslate DijkstraEra (DijkstraPParams Identity DijkstraEra) where
       ppMaxHeaderSize = toInteger $ unTHKD dppMaxBHSize
     ppKeyDeposit <- toSpecRep dppKeyDeposit
     ppPoolDeposit <- toSpecRep dppPoolDeposit
+    ppMinPoolCost <- toSpecRep dppMinPoolCost
     ppEmax <- toSpecRep dppEMax
     ppNopt <- toSpecRep (toInteger $ unTHKD dppNOpt)
     let
@@ -377,7 +377,8 @@ instance SpecTranslate DijkstraEra StakePoolParams where
       <*> toSpecRep sppCost
       <*> toSpecRep sppMargin
       <*> toSpecRep sppPledge
-      <*> toSpecRep (sppAccountAddress ^. accountAddressCredentialL)
+      <*> toSpecRep sppAccountAddress
+      <*> toSpecRep sppVrf
 
 instance SpecTranslate DijkstraEra DRep where
   type SpecRep DijkstraEra DRep = Agda.VDeleg
@@ -501,6 +502,7 @@ instance SpecTranslate DijkstraEra (DijkstraPParams StrictMaybe DijkstraEra) whe
       ppuMaxHeaderSize = fmap toInteger . strictMaybeToMaybe . unTHKD $ dppMaxBHSize
     ppuKeyDeposit <- toSpecRep dppKeyDeposit
     ppuPoolDeposit <- toSpecRep dppPoolDeposit
+    ppuMinPoolCost <- toSpecRep dppMinPoolCost
     ppuEmax <- toSpecRep dppEMax
     ppuNopt <- toSpecRep (fmap toInteger . strictMaybeToMaybe $ unTHKD dppNOpt)
     let

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Dijkstra/Epoch.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Dijkstra/Epoch.hs
@@ -83,7 +83,8 @@ instance SpecTranslate DijkstraEra StakePoolSnapShot where
       <*> toSpecRep spssCost
       <*> toSpecRep spssMargin
       <*> toSpecRep spssPledge
-      <*> toSpecRep (unAccountId spssAccountId)
+      <*> (Agda.RewardAddress <$> pure 0 <*> toSpecRep (unAccountId spssAccountId))
+      <*> toSpecRep spssVrf
 
 instance SpecTranslate DijkstraEra Stake where
   type SpecRep DijkstraEra Stake = Agda.HSMap Agda.Credential Agda.Coin

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Dijkstra.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Dijkstra.hs
@@ -75,7 +75,7 @@ spec = do
             ConwayLEDGER.spec
             LEDGER.spec
 
-            xdescribe "disabled" ShelleyPOOL.spec
+            ShelleyPOOL.spec
             POOL.spec
 
             ConwayRATIFY.spec


### PR DESCRIPTION
# Description

- Update formal-ledger-specifications
- Add test covering re-registering a pool with too low cost
- Enable Pool Imp tests in conformance for Dijkstra

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
