### PR TITLE
Backport of fixes for node 11.1.1 - take 2

### DIFF
--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Version history for `cardano-ledger-shelley`
 
+## 1.19.0.1
+
+* Force the initial-funds injection result in `Cardano.Ledger.Shelley.Transition`
+  to prevent holding onto the thunk for the lifetime of the process.
+
 ## 1.19.0.0
 
 * Restrict `shelleyCertsTotalDepositsTxBody` to `TxBody TopTx era` type

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-shelley
-version: 1.19.0.0
+version: 1.19.0.1
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Transition.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Transition.hs
@@ -658,7 +658,8 @@ registerInitialFunds hasFS tc newEpochState = do
   (newUtxoEntries, totalCoins) <-
     foldInjectionData hasFS source addInitialFund (Map.empty, mempty)
 
-  pure $ applyFunds newUtxoEntries totalCoins
+  -- Forced: left lazy, this thunk retains both inputs of `mergeUtxoNoOverlap`.
+  pure $! applyFunds newUtxoEntries totalCoins
   where
     epochState = nesEs newEpochState
     accountState = esChainAccountState epochState


### PR DESCRIPTION
# Description

we backport https://github.com/IntersectMBO/cardano-ledger/pull/6017 for releasing into cardano-ledger-shelley-1.19.0.1

there was an earlier attempt in #6025 but that was based on the wrong commit `aaeb6b26ba1ab95e65a051b6d3d616ebe663a811`, which is where the tag for `cardano-ledger-shelley-1.19.0.0` is at, but it's 25 commits older than what was actually released to CHaP, which is `f649f9751074d2ab3de033fc3912f29c9862c1f5`; that is now the parent commit for this patch.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
