### PR TITLE
Add `POOL` rule for Dijkstra

### DIFF
--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.4.0.0
 
+* Add `POOL` rule type and add `poolTransition` to `Cardano.Ledger.Dijkstra.Rules.Pool`
 * Add `AlonzoEraTransition` instance for `DijkstraEra`
 * Re-export `GuardingPurpose` from `Cardano.Ledger.Dijkstra.Core` for consistency with prior eras.
 * Adapt to `plutus-ledger-api` v1.38: remove `txInfoFee` from PV4 `TxInfo`, convert `txInfoValidRange` via `transPOSIXTimeRange`, use `Credential` instead of `AccountId` for withdrawals and direct deposits

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -130,6 +130,7 @@ library
     microlens,
     nothunks,
     plutus-ledger-api,
+    primitive,
     small-steps >=1.2,
     text,
     transformers,

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Era.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Era.hs
@@ -19,6 +19,7 @@ module Cardano.Ledger.Dijkstra.Era (
   GOVCERT,
   LEDGER,
   MEMPOOL,
+  POOL,
   SUBCERT,
   SUBCERTS,
   SUBENTITIES,
@@ -285,6 +286,10 @@ type DijkstraMEMPOOL = MEMPOOL
 
 type instance EraRule "MEMPOOL" DijkstraEra = MEMPOOL DijkstraEra
 
+data POOL era
+
+type instance EraRule "POOL" DijkstraEra = POOL DijkstraEra
+
 type instance EraRule "HARDFORK" DijkstraEra = Conway.HARDFORK DijkstraEra
 
 -- Rules inherited from Shelley
@@ -298,5 +303,3 @@ type instance EraRule "RUPD" DijkstraEra = Shelley.RUPD DijkstraEra
 type instance EraRule "SNAP" DijkstraEra = Shelley.SNAP DijkstraEra
 
 type instance EraRule "TICK" DijkstraEra = Shelley.TICK DijkstraEra
-
-type instance EraRule "POOL" DijkstraEra = Shelley.POOL DijkstraEra

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules.hs
@@ -11,6 +11,7 @@ module Cardano.Ledger.Dijkstra.Rules (
   module Cardano.Ledger.Dijkstra.Rules.GovCert,
   module Cardano.Ledger.Dijkstra.Rules.Ledger,
   module Cardano.Ledger.Dijkstra.Rules.Mempool,
+  module Cardano.Ledger.Dijkstra.Rules.Pool,
   module Cardano.Ledger.Dijkstra.Rules.SubCert,
   module Cardano.Ledger.Dijkstra.Rules.SubCerts,
   module Cardano.Ledger.Dijkstra.Rules.SubDeleg,
@@ -41,7 +42,7 @@ import Cardano.Ledger.Dijkstra.Rules.GovCert
 import Cardano.Ledger.Dijkstra.Rules.Ledger
 import Cardano.Ledger.Dijkstra.Rules.Ledgers ()
 import Cardano.Ledger.Dijkstra.Rules.Mempool
-import Cardano.Ledger.Dijkstra.Rules.Pool ()
+import Cardano.Ledger.Dijkstra.Rules.Pool
 import Cardano.Ledger.Dijkstra.Rules.SubCert
 import Cardano.Ledger.Dijkstra.Rules.SubCerts
 import Cardano.Ledger.Dijkstra.Rules.SubDeleg

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Cert.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Cert.hs
@@ -20,6 +20,7 @@ import Cardano.Ledger.Conway.TxCert
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Era
 import Cardano.Ledger.Dijkstra.Rules.GovCert (DijkstraGovCertPredFailure)
+import Cardano.Ledger.Dijkstra.Rules.Pool ()
 import Cardano.Ledger.Dijkstra.State
 import Cardano.Ledger.Dijkstra.TxCert
 import qualified Cardano.Ledger.Shelley.Rules as Shelley

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Certs.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Certs.hs
@@ -12,6 +12,7 @@ import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Era
 import Cardano.Ledger.Dijkstra.Rules.Cert ()
 import Cardano.Ledger.Dijkstra.Rules.GovCert (DijkstraGovCertPredFailure)
+import Cardano.Ledger.Dijkstra.Rules.Pool ()
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Control.State.Transition.Extended
 import GHC.Base (absurd)
@@ -58,11 +59,11 @@ instance
   wrapEvent = absurd
 
 instance
-  ( STS (Shelley.POOL era)
+  ( STS (POOL era)
   , PredicateFailure (EraRule "POOL" era) ~ Shelley.ShelleyPoolPredFailure era
   , Event (EraRule "POOL" era) ~ Shelley.PoolEvent era
   ) =>
-  Embed (Shelley.POOL era) (CERT era)
+  Embed (POOL era) (CERT era)
   where
   wrapFailed = Conway.PoolFailure
   wrapEvent = Conway.PoolEvent

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Pool.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Pool.hs
@@ -1,18 +1,207 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Cardano.Ledger.Dijkstra.Rules.Pool () where
+module Cardano.Ledger.Dijkstra.Rules.Pool (
+  POOL,
+  poolTransition,
+) where
 
+import Cardano.Crypto.Hash.Class (hashSize)
+import Cardano.Ledger.BaseTypes (
+  Globals (..),
+  Mismatch (..),
+  ProtVer,
+  ShelleyBase,
+  addEpochInterval,
+  knownNonZeroBounded,
+  natVersion,
+  networkId,
+  pvMajor,
+ )
 import Cardano.Ledger.Dijkstra.Core
-import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
-import qualified Cardano.Ledger.Shelley.Rules as Shelley
+import Cardano.Ledger.Dijkstra.Era (DijkstraEra, POOL)
+import Cardano.Ledger.Shelley.Rules (
+  PoolEnv (..),
+  PoolEvent (..),
+  ShelleyPoolPredFailure (..),
+ )
+import qualified Cardano.Ledger.Shelley.SoftForks as SoftForks
+import Cardano.Ledger.State
+import Control.Monad (forM_, when)
+import Control.Monad.Trans.Reader (asks)
+import Control.State.Transition (
+  STS (..),
+  TRC (..),
+  TransitionRule,
+  judgmentContext,
+  liftSTS,
+  tellEvent,
+  (?!),
+ )
+import qualified Data.Map as Map
+import Data.Primitive.ByteArray (sizeofByteArray)
+import Lens.Micro
 
-type instance EraRuleFailure "POOL" DijkstraEra = Shelley.ShelleyPoolPredFailure DijkstraEra
+-- Private copies of the protocol-version gates from the hidden
+-- `Cardano.Ledger.Shelley.Era` module, kept so that this rule remains a verbatim
+-- copy of the Shelley POOL rule. Both are always `True` in this era.
+hardforkAlonzoValidatePoolAccountAddressNetID :: ProtVer -> Bool
+hardforkAlonzoValidatePoolAccountAddressNetID pv = pvMajor pv > natVersion @4
 
-type instance EraRuleEvent "POOL" DijkstraEra = Shelley.PoolEvent DijkstraEra
+hardforkConwayDisallowDuplicatedVRFKeys :: ProtVer -> Bool
+hardforkConwayDisallowDuplicatedVRFKeys pv = pvMajor pv > natVersion @10
 
-instance InjectRuleFailure "POOL" Shelley.ShelleyPoolPredFailure DijkstraEra
+type instance EraRuleFailure "POOL" DijkstraEra = ShelleyPoolPredFailure DijkstraEra
 
-instance InjectRuleEvent "POOL" Shelley.PoolEvent DijkstraEra
+type instance EraRuleEvent "POOL" DijkstraEra = PoolEvent DijkstraEra
+
+instance InjectRuleFailure "POOL" ShelleyPoolPredFailure DijkstraEra
+
+instance InjectRuleEvent "POOL" PoolEvent DijkstraEra
+
+instance
+  ( EraPParams era
+  , EraRule "POOL" era ~ POOL era
+  , InjectRuleFailure "POOL" ShelleyPoolPredFailure era
+  , InjectRuleEvent "POOL" PoolEvent era
+  ) =>
+  STS (POOL era)
+  where
+  type State (POOL era) = PState era
+
+  type Signal (POOL era) = PoolCert era
+
+  type Environment (POOL era) = PoolEnv era
+
+  type BaseM (POOL era) = ShelleyBase
+  type PredicateFailure (POOL era) = ShelleyPoolPredFailure era
+  type Event (POOL era) = PoolEvent era
+
+  transitionRules = [poolTransition]
+
+poolTransition ::
+  forall rule era.
+  ( EraPParams era
+  , Signal (EraRule rule era) ~ PoolCert era
+  , Environment (EraRule rule era) ~ PoolEnv era
+  , State (EraRule rule era) ~ PState era
+  , STS (EraRule rule era)
+  , BaseM (EraRule rule era) ~ ShelleyBase
+  , InjectRuleFailure rule ShelleyPoolPredFailure era
+  , InjectRuleEvent rule PoolEvent era
+  ) =>
+  TransitionRule (EraRule rule era)
+poolTransition = do
+  TRC
+    ( PoolEnv cEpoch pp
+      , ps@PState {psStakePools, psFutureStakePoolParams, psVRFKeyHashes}
+      , poolCert
+      ) <-
+    judgmentContext
+  case poolCert of
+    RegPool stakePoolParams@StakePoolParams {sppId, sppVrf, sppAccountAddress, sppMetadata, sppCost} -> do
+      let pv = pp ^. ppProtocolVersionL
+      when (hardforkAlonzoValidatePoolAccountAddressNetID pv) $ do
+        actualNetID <- liftSTS $ asks networkId
+        let suppliedNetID = aaNetworkId sppAccountAddress
+        actualNetID
+          == suppliedNetID
+            ?! injectFailure
+              ( WrongNetworkPOOL
+                  Mismatch
+                    { mismatchSupplied = suppliedNetID
+                    , mismatchExpected = actualNetID
+                    }
+                  sppId
+              )
+
+      when (SoftForks.restrictPoolMetadataHash pv) $
+        forM_ sppMetadata $ \pmd ->
+          let s = sizeofByteArray $ pmHash pmd
+           in s
+                <= fromIntegral (hashSize ([] @HASH))
+                  ?! injectFailure (PoolMedataHashTooBig sppId s)
+
+      let minPoolCost = pp ^. ppMinPoolCostL
+      sppCost
+        >= minPoolCost
+          ?! injectFailure
+            ( StakePoolCostTooLowPOOL
+                Mismatch
+                  { mismatchSupplied = sppCost
+                  , mismatchExpected = minPoolCost
+                  }
+            )
+      case Map.lookup sppId psStakePools of
+        -- register new, Pool-Reg
+        Nothing -> do
+          when (hardforkConwayDisallowDuplicatedVRFKeys pv) $ do
+            Map.notMember sppVrf psVRFKeyHashes
+              ?! injectFailure (VRFKeyHashAlreadyRegistered sppId sppVrf)
+          let updateVRFKeyHash
+                | hardforkConwayDisallowDuplicatedVRFKeys pv = Map.insert sppVrf (knownNonZeroBounded @1)
+                | otherwise = id
+          tellEvent $ injectEvent $ RegisterPool sppId
+          pure $
+            ps
+              & psStakePoolsL
+                %~ Map.insert sppId (mkStakePoolState (pp ^. ppPoolDepositCompactL) mempty stakePoolParams)
+              & psVRFKeyHashesL %~ updateVRFKeyHash
+        -- re-register Pool
+        Just stakePoolState -> do
+          when (hardforkConwayDisallowDuplicatedVRFKeys pv) $ do
+            sppVrf == stakePoolState ^. spsVrfL
+              || Map.notMember sppVrf psVRFKeyHashes
+                ?! injectFailure (VRFKeyHashAlreadyRegistered sppId sppVrf)
+          let updateFutureVRFKeyHash
+                | hardforkConwayDisallowDuplicatedVRFKeys pv =
+                    -- If a pool re-registers with a fresh VRF, we have to record it in the map,
+                    -- but also remove the previous VRFHashKey potentially stored in previous re-registration within the same epoch,
+                    -- which we retrieve from futureStakePools.
+                    case Map.lookup sppId psFutureStakePoolParams of
+                      Nothing -> Map.insert sppVrf (knownNonZeroBounded @1)
+                      Just futureStakePoolParams
+                        | futureStakePoolParams ^. sppVrfL /= sppVrf ->
+                            Map.insert sppVrf (knownNonZeroBounded @1)
+                              . Map.delete (futureStakePoolParams ^. sppVrfL)
+                        | otherwise -> id
+                | otherwise = id
+          tellEvent $ injectEvent $ ReregisterPool sppId
+          -- This `sppId` is already registered, so we want to reregister it.
+          -- That means adding it to the futureStakePoolParams or overriding it  with the new 'poolParams'.
+          -- We must also unretire it, if it has been scheduled for retirement.
+          -- The deposit does not change.
+          pure $
+            ps
+              & psFutureStakePoolParamsL
+                %~ Map.insert sppId stakePoolParams
+              & psRetiringL %~ Map.delete sppId
+              & psVRFKeyHashesL %~ updateFutureVRFKeyHash
+    RetirePool sppId e -> do
+      Map.member sppId psStakePools ?! injectFailure (StakePoolNotRegisteredOnKeyPOOL sppId)
+      let maxEpoch = pp ^. ppEMaxL
+          limitEpoch = addEpochInterval cEpoch maxEpoch
+      (cEpoch < e && e <= limitEpoch)
+        ?! injectFailure
+          ( StakePoolRetirementWrongEpochPOOL
+              Mismatch -- RelGT - The supplied value should be greater than the current epoch
+                { mismatchSupplied = e
+                , mismatchExpected = cEpoch
+                }
+              Mismatch -- RelLTEQ - The supplied value should be less then or equal to ppEMax after the current epoch
+                { mismatchSupplied = e
+                , mismatchExpected = limitEpoch
+                }
+          )
+      -- We just schedule it for retirement. When it is retired we refund the deposit (see POOLREAP)
+      pure $ ps & psRetiringL %~ Map.insert sppId e

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubPool.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubPool.hs
@@ -32,6 +32,7 @@ import Cardano.Ledger.Dijkstra.Era (
   DijkstraEra,
   SUBPOOL,
  )
+import Cardano.Ledger.Dijkstra.Rules.Pool (poolTransition)
 import Cardano.Ledger.Dijkstra.State
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Control.DeepSeq (NFData)
@@ -84,4 +85,4 @@ instance
   type PredicateFailure (SUBPOOL era) = DijkstraSubPoolPredFailure era
   type Event (SUBPOOL era) = DijkstraSubPoolEvent era
 
-  transitionRules = [Shelley.poolTransition]
+  transitionRules = [poolTransition]


### PR DESCRIPTION
# Description
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->
Adds the exact copy of the Shelley `POOL` rule to Dijkstra as a placeholder, since we will need to rewrite the `POOL` rule for Dijkstra. The reason why we want to merge this as is, is that so others can start working on different parts of the rewrite in parallel. 
 
Initial step for #6003
# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
