### PR TITLE
Add `EMax /= 0` as well formed check to Dijkstra era

### DIFF
--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/PParams.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/PParams.hs
@@ -642,6 +642,7 @@ instance ConwayEraPParams DijkstraEra where
       , isValid ((/= CompactCoin 0) . unCoinPerByte) ppuCoinsPerUTxOByteL
       , ppu /= emptyPParamsUpdate
       , isValid (/= 0) ppuNOptL
+      , isValid (/= EpochInterval 0) ppuEMaxL
       ]
     where
       isValid ::


### PR DESCRIPTION
# Description

This is a very simple PR that prevents `ppEMax` to be set to zero through governance.
The reason why this value makes no sense is because when set to zero, it would prevent any pool from ever being retired (`cEpoch < e && e <= limitEpoch` would always be `False`):
https://github.com/IntersectMBO/cardano-ledger/blob/abcf0a87b6ad060fde9c50b9e23ee176b4d56f1d/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs#L307-L312

Once in Dijkstra we will remove this check and change the actual type of the parameter to be `NonZero EpochInterval`: https://github.com/IntersectMBO/cardano-ledger/issues/5323

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
