### PR TITLE
Make OutputVRF decoder more resilient

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 * Add `DecCBOR` instance for `Block`
 
+### `cddl`
+
+* Add `HuddleRule "vrf_cert"` instance
+
 ## 1.10.0.0
 
 * Add `Ord` instances for `AllegraUtxoPredFailure`, `Timelock`, `TimelockRaw`

--- a/eras/allegra/impl/cddl/lib/Cardano/Ledger/Allegra/HuddleSpec.hs
+++ b/eras/allegra/impl/cddl/lib/Cardano/Ledger/Allegra/HuddleSpec.hs
@@ -186,6 +186,9 @@ instance HuddleRule "update" AllegraEra where
 instance HuddleRule "genesis_hash" AllegraEra where
   huddleRuleNamed = genesisHashRule
 
+instance HuddleRule "vrf_cert" AllegraEra where
+  huddleRuleNamed pname _ = pname =.= arr [a VBytes, a (VBytes `sized` (80 :: Word64))]
+
 instance HuddleGroup "operational_cert" AllegraEra where
   huddleGroupNamed = shelleyOperationalCertGroup
 

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -19,6 +19,10 @@
 * Change `TxInfoPV4` constructor of `VersionedTxInfo` to contain `PV4.TxInfo` instead of `PV3.TxInfo`
 * Add `DecCBOR` instance for `Block`
 
+### `cddl`
+
+* Add `HuddleRule "vrf_cert"` instance
+
 ## 1.16.0.0
 
 * Add `Ord` constraints to `AlonzoEraScript` and `EraPlutusContext` classes

--- a/eras/alonzo/impl/cddl/lib/Cardano/Ledger/Alonzo/HuddleSpec.hs
+++ b/eras/alonzo/impl/cddl/lib/Cardano/Ledger/Alonzo/HuddleSpec.hs
@@ -316,6 +316,9 @@ instance HuddleRule "block" AlonzoEra where
           , "invalid_transactions" ==> arr [0 <+ a (huddleRule @"transaction_index" p)] //- "new"
           ]
 
+instance HuddleRule "vrf_cert" AlonzoEra where
+  huddleRuleNamed pname _ = pname =.= arr [a VBytes, a (VBytes `sized` (80 :: Word64))]
+
 instance HuddleRule "header" AlonzoEra where
   huddleRuleNamed pname p =
     pname

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -13,6 +13,10 @@
 * Expose `fixupCollateralReturn`
 * Add `DecCBOR` instance for `Block`
 
+### `cddl`
+
+* Add `HuddleRule "vrf_cert"` instance
+
 ## 1.14.0.0
 
 * Add `Ord` instances for `BabbageContextError`, `BabbageTxOut`, `BabbageUtxoPredFailure`, `BabbageUtxowPredFailure`

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -94,7 +94,7 @@ library
     cardano-ledger-allegra ^>=1.10,
     cardano-ledger-alonzo ^>=1.17,
     cardano-ledger-binary >=1.9,
-    cardano-ledger-core:{cardano-ledger-core, internal} >=1.22,
+    cardano-ledger-core:{cardano-ledger-core, internal} ^>=1.22,
     cardano-ledger-mary ^>=1.11,
     cardano-ledger-shelley ^>=1.20,
     cardano-strict-containers,

--- a/eras/babbage/impl/cddl/lib/Cardano/Ledger/Babbage/HuddleSpec.hs
+++ b/eras/babbage/impl/cddl/lib/Cardano/Ledger/Babbage/HuddleSpec.hs
@@ -139,7 +139,8 @@ babbageScript pname p =
 
 babbageHeaderBodyRule ::
   forall era.
-  ( HuddleRule "operational_cert" era
+  ( HuddleRule "vrf_cert" era
+  , HuddleRule "operational_cert" era
   , HuddleRule "protocol_version" era
   ) =>
   Proxy "header_body" ->
@@ -318,6 +319,9 @@ instance HuddleRule "block" BabbageEra where
                 ]
           , "invalid_transactions" ==> arr [0 <+ a (huddleRule @"transaction_index" p)]
           ]
+
+instance HuddleRule "vrf_cert" BabbageEra where
+  huddleRuleNamed pname _ = pname =.= arr [a VBytes, a (VBytes `sized` (80 :: Word64))]
 
 instance HuddleRule "header" BabbageEra where
   huddleRuleNamed pname p =

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 * Add `DecCBOR` instance for `Block`
 
+### `cddl`
+
+* Add `HuddleRule "vrf_cert"` instance
+
 ## 1.23.0.0
 
 * Add `Ord` instances for `ConwayBbodyPredFailure`, `ConwayCertPredFailure`,

--- a/eras/conway/impl/cddl/lib/Cardano/Ledger/Conway/HuddleSpec.hs
+++ b/eras/conway/impl/cddl/lib/Cardano/Ledger/Conway/HuddleSpec.hs
@@ -1352,6 +1352,9 @@ instance HuddleRule "proposed_protocol_parameter_updates" ConwayEra where
 instance HuddleRule "update" ConwayEra where
   huddleRuleNamed = updateRule
 
+instance HuddleRule "vrf_cert" ConwayEra where
+  huddleRuleNamed pname _ = pname =.= arr [a VBytes, a (VBytes `sized` (80 :: Word64))]
+
 instance HuddleRule "header_body" ConwayEra where
   huddleRuleNamed = babbageHeaderBodyRule
 

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -39,11 +39,12 @@
   - Add `ppMinPoolMarginL` and `ppuMinPoolMarginL`
   - Override `ppMinPoolMarginG` in `EraPParams` instance
 
-### cddl
+### `cddl`
 
+* Add `HuddleRule "vrf_cert"` instance
 * Add `max_pledge_leverage` rule and its entry in `protocol_param_update`
 
-### testlib
+### `testlib`
 
 * Add `switchTxToLegacyMode` helper
 * Add `balanceSubTransactions`
@@ -212,7 +213,7 @@
   - Remove `WdrlNotDelegatedToDRep` constructor from `EntitiesPredFailure`
   - Remove `SubWdrlNotDelegatedToDRep` constructor from `SubEntitiesPredFailure`
 
-### cddl
+### `cddl`
 
 * Add `eb_announcement` rule and extend `header_body` with `block_body_contains_leios_cert` and `eb_announcement` for the Leios block header
 * Remove re-exported `genByteString`, `distinct`, `genHash28`, `majorProtocolVersionRule`, `ipRule` and `ipValidator`
@@ -223,7 +224,7 @@
 * Add optional `bls_key` field to `pool_params`
 * Add `bls_key` rule with `bls_pubkey` (96 bytes) and `bls_possession_proof` (48 bytes)
 
-### testlib
+### `testlib`
 
 * Add `exampleBlsKey` to `Test.Cardano.Ledger.Dijkstra.Examples`
 * Add `genSmallDijkstraBlockBody`
@@ -365,7 +366,7 @@
 * Move `cddl-files` to `cddl/data`.
 * Add full `HuddleSpec`.
 
-### testlib
+### `testlib`
 
 * Add `Test.Cardano.Ledger.Dijkstra.Imp.LedgerSpec`
 * Add `Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec`

--- a/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+++ b/eras/dijkstra/impl/cddl/data/dijkstra.cddl
@@ -74,7 +74,7 @@ vkey = bytes .size 32
 
 vrf_vkey = bytes .size 32
 
-vrf_cert = [bytes, bytes .size 80]
+vrf_cert = [bytes .size 64, bytes .size 80]
 
 operational_cert =
   [ hot_vkey        : kes_vkey

--- a/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
+++ b/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
@@ -1005,7 +1005,8 @@ instance HuddleRule "update" DijkstraEra where
 
 leiosHeaderBodyRule ::
   forall era.
-  ( HuddleRule "operational_cert" era
+  ( HuddleRule "vrf_cert" era
+  , HuddleRule "operational_cert" era
   , HuddleRule "protocol_version" era
   , HuddleRule "eb_announcement" era
   ) =>
@@ -1028,6 +1029,9 @@ leiosHeaderBodyRule pname p =
       , "block_body_contains_leios_cert" ==> VBool
       , "eb_announcement" ==> (huddleRule @"eb_announcement" p / VNil)
       ]
+
+instance HuddleRule "vrf_cert" DijkstraEra where
+  huddleRuleNamed pname _ = pname =.= arr [a (VBytes `sized` (64 :: Word64)), a (VBytes `sized` (80 :: Word64))]
 
 instance HuddleRule "header_body" DijkstraEra where
   huddleRuleNamed = leiosHeaderBodyRule

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 * Add `DecCBOR` instance for `Block`
 
+### `cddl`
+
+* Add `HuddleRule "vrf_cert"` instance
+
 ## 1.11.0.0
 
 * Add `Ord` instances for `MaryValue`, `CompactForm MaryValue`

--- a/eras/mary/impl/cddl/lib/Cardano/Ledger/Mary/HuddleSpec.hs
+++ b/eras/mary/impl/cddl/lib/Cardano/Ledger/Mary/HuddleSpec.hs
@@ -79,6 +79,9 @@ instance HuddleRule "block" MaryEra where
 instance HuddleRule "transaction" MaryEra where
   huddleRuleNamed = transactionRule
 
+instance HuddleRule "vrf_cert" MaryEra where
+  huddleRuleNamed pname _ = pname =.= arr [a VBytes, a (VBytes `sized` (80 :: Word64))]
+
 instance HuddleRule "header" MaryEra where
   huddleRuleNamed = headerRule
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -15,6 +15,10 @@
 * Add `DecCBOR` instance for `Block`
 * Add `registerPoolWithParams`, which registers a stake pool with adjusted parameters
 
+### `cddl`
+
+* Add `HuddleRule "vrf_cert"` instance
+
 ## 1.19.0.1
 
 * Force the initial-funds injection result in `Cardano.Ledger.Shelley.Transition`

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -124,7 +124,6 @@ library
     cardano-data ^>=1.3.2,
     cardano-ledger-binary ^>=1.10,
     cardano-ledger-byron,
-    cardano-ledger-core,
     cardano-ledger-core:{cardano-ledger-core, internal} ^>=1.22,
     cardano-slotting,
     cardano-strict-containers >=0.1.5,

--- a/eras/shelley/impl/cddl/lib/Cardano/Ledger/Shelley/HuddleSpec.hs
+++ b/eras/shelley/impl/cddl/lib/Cardano/Ledger/Shelley/HuddleSpec.hs
@@ -119,7 +119,9 @@ protocolParamUpdateRule pname p =
 
 shelleyHeaderBodyRule ::
   forall era.
-  HuddleGroup "operational_cert" era =>
+  ( HuddleRule "vrf_cert" era
+  , HuddleGroup "operational_cert" era
+  ) =>
   Proxy "header_body" ->
   Proxy era ->
   Rule
@@ -491,6 +493,9 @@ instance HuddleRule "proposed_protocol_parameter_updates" ShelleyEra where
 
 instance HuddleRule "update" ShelleyEra where
   huddleRuleNamed = updateRule
+
+instance HuddleRule "vrf_cert" ShelleyEra where
+  huddleRuleNamed pname _ = pname =.= arr [a VBytes, a (VBytes `sized` (80 :: Word64))]
 
 instance HuddleGroup "operational_cert" ShelleyEra where
   huddleGroupNamed = shelleyOperationalCertGroup

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs
@@ -615,7 +615,16 @@ instance DecCBOR (CertVRF Praos.PraosVRF) where
   {-# INLINE decCBOR #-}
 
 instance Typeable v => DecCBOR (OutputVRF v) where
-  decCBOR = OutputVRF <$> decCBOR
+  decCBOR = do
+    bs <- decCBOR
+    whenDecoderVersionAtLeast (natVersion @12) $ do
+      let
+        len = BS.length bs
+        vrfOutputLen = sizeOutputVRF (Proxy :: Proxy v)
+      when (len /= vrfOutputLen) $
+        fail $
+          "OutputVRF is expected to be " <> show vrfOutputLen <> " bytes, but received " <> show len
+    pure $ OutputVRF bs
   {-# INLINE decCBOR #-}
 
 instance (VRFAlgorithm v, Typeable a) => DecCBOR (CertifiedVRF v a) where

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs
@@ -43,6 +43,7 @@ import Cardano.Crypto.VRF.Class (
   SignKeyVRF,
   VRFAlgorithm,
   VerKeyVRF,
+  sizeOutputVRF,
  )
 import Cardano.Crypto.VRF.Mock (MockVRF)
 import qualified Cardano.Crypto.VRF.Praos as Praos
@@ -614,17 +615,17 @@ instance DecCBOR (CertVRF Praos.PraosVRF) where
   decCBOR = decodeFixedSized
   {-# INLINE decCBOR #-}
 
-instance Typeable v => DecCBOR (OutputVRF v) where
+instance VRFAlgorithm v => DecCBOR (OutputVRF v) where
   decCBOR = do
-    bs <- decCBOR
+    ba <- decCBOR
     whenDecoderVersionAtLeast (natVersion @12) $ do
       let
-        len = BS.length bs
+        len = fromIntegral @Int @Word $ Prim.sizeofByteArray ba
         vrfOutputLen = sizeOutputVRF (Proxy :: Proxy v)
       when (len /= vrfOutputLen) $
         fail $
           "OutputVRF is expected to be " <> show vrfOutputLen <> " bytes, but received " <> show len
-    pure $ OutputVRF bs
+    pure $ OutputVRF ba
   {-# INLINE decCBOR #-}
 
 instance (VRFAlgorithm v, Typeable a) => DecCBOR (CertifiedVRF v a) where

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -42,6 +42,10 @@
 
 * Add `Arbitrary` and `ToExpr` instances for `MaxPledgeLeverage`
 
+### `cddl`
+
+* Remove `HuddleRule "vrf_cert"` instance
+
 ## 1.21.0.0
 
 * Add `Ord` constraint to `Val` class

--- a/libs/cardano-ledger-core/cddl/Cardano/Ledger/Core/HuddleSpec.hs
+++ b/libs/cardano-ledger-core/cddl/Cardano/Ledger/Core/HuddleSpec.hs
@@ -133,9 +133,6 @@ instance Era era => HuddleRule "vkey" era where
 instance Era era => HuddleRule "vrf_vkey" era where
   huddleRuleNamed pname _ = pname =.= VBytes `H.sized` (32 :: Word64)
 
-instance Era era => HuddleRule "vrf_cert" era where
-  huddleRuleNamed pname _ = pname =.= arr [a VBytes, a (VBytes `H.sized` (80 :: Word64))]
-
 instance Era era => HuddleRule "kes_vkey" era where
   huddleRuleNamed pname _ = pname =.= VBytes `H.sized` (32 :: Word64)
 


### PR DESCRIPTION
# Description

Currently size of the VRF Output is restricted with the rules. It is much better to restrict this statically known size at the decoder level, which is known to be 64 bytes: https://github.com/IntersectMBO/cardano-base/blob/8d2c5361c932537e04577c77e6180deb221b3dc9/cardano-crypto-praos/cbits/vrf03/crypto_vrf_ietfdraft03.h#L32-L34

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
