### PR TITLE
SUBUTXOW predicate failures

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### `testlib`
 
+* Export `makeCollateralInput` and `txWithMaxRedeemers`
 * Add `Inject (AlonzoContextError era) (ContextError era)` superclass constraint to the `AlonzoEraTest` type class
 * Add `mkTestLedgerTxInfo` helper
 * Add `Serialise` instance for `PV4.POSIXTimeRange`

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxosSpec.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxosSpec.hs
@@ -125,7 +125,7 @@ spec = describe "UTXOS" $ do
                   Map.preserveMissing -- Don't touch purposes not being updated
                   (Map.zipWithMatched $ \_ -> set _2) -- Replace the units, keep the datum
             txIn <- produceScript alwaysSucceedsWithDatumHash
-            withPostFixup (overrideExUnits >=> fixupPPHash >=> resetAddrTxWits) $
+            withPostFixup (overrideExUnits >=> fixupPPHash >=> rederiveAddrTxWits) $
               submitTx_ $
                 mkBasicTx mkBasicTxBody & bodyTxL . inputsTxBodyL .~ [txIn]
 

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxosSpec.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxosSpec.hs
@@ -124,10 +124,8 @@ spec = describe "UTXOS" $ do
                   Map.dropMissing -- Ignore purposes not already in the redeemers
                   Map.preserveMissing -- Don't touch purposes not being updated
                   (Map.zipWithMatched $ \_ -> set _2) -- Replace the units, keep the datum
-              redoAddrWits = updateAddrTxWits . (witsTxL . addrTxWitsL .~ mempty)
-
             txIn <- produceScript alwaysSucceedsWithDatumHash
-            withPostFixup (overrideExUnits >=> fixupPPHash >=> redoAddrWits) $
+            withPostFixup (overrideExUnits >=> fixupPPHash >=> resetAddrTxWits) $
               submitTx_ $
                 mkBasicTx mkBasicTxBody & bodyTxL . inputsTxBodyL .~ [txIn]
 

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Invalid.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Invalid.hs
@@ -62,8 +62,7 @@ spec = describe "Invalid transactions" $ do
       tx
       [injectFailure $ Shelley.ScriptWitnessNotValidatingUTXOW $ NES.singleton scriptHash]
 
-  let resetAddrWits tx = updateAddrTxWits $ tx & witsTxL . addrTxWitsL .~ []
-      fixupResetAddrWits = fixupPPHash >=> resetAddrWits
+  let fixupResetAddrWits = fixupPPHash >=> resetAddrTxWits
 
   forM_ (eraLanguages @era) $ \lang ->
     withSLanguage lang $ \slang ->
@@ -112,7 +111,7 @@ spec = describe "Invalid transactions" $ do
               txIn <- produceScript redeemerSameAsDatumHash
               goodHashTx <- fixupTx $ mkBasicTx mkBasicTxBody & bodyTxL . inputsTxBodyL .~ [txIn]
               badHashTx <-
-                resetAddrWits $ goodHashTx & bodyTxL . scriptIntegrityHashTxBodyL .~ badHash
+                resetAddrTxWits $ goodHashTx & bodyTxL . scriptIntegrityHashTxBodyL .~ badHash
               let goodHash = goodHashTx ^. bodyTxL . scriptIntegrityHashTxBodyL
               withNoFixup $
                 submitFailingTx
@@ -162,7 +161,7 @@ spec = describe "Invalid transactions" $ do
                   . (witsTxL . datsTxWitsL .~ mempty)
                   . (witsTxL . rdmrsTxWitsL .~ mempty)
               resetScriptHash = pure . (bodyTxL . scriptIntegrityHashTxBodyL .~ SNothing)
-          withPostFixup (dropScriptWitnesses >=> resetScriptHash >=> resetAddrWits) $
+          withPostFixup (dropScriptWitnesses >=> resetScriptHash >=> resetAddrTxWits) $
             submitFailingTx tx [injectFailure $ Shelley.MissingScriptWitnessesUTXOW $ NES.singleton scriptHash]
 
         it "Redeemer with incorrect purpose" $ do
@@ -176,7 +175,7 @@ spec = describe "Invalid transactions" $ do
               isSpender = isJust . toSpendingPurpose @era @AsIx
               removeSpenders = Map.filterWithKey (const . not . isSpender)
               dropSpendingRedeemers = pure . (witsTxL . rdmrsTxWitsL . unRedeemersL %~ removeSpenders)
-          withPostFixup (dropSpendingRedeemers >=> fixupPPHash >=> resetAddrWits) $
+          withPostFixup (dropSpendingRedeemers >=> fixupPPHash >=> resetAddrTxWits) $
             submitFailingTx
               tx
               [ injectFailure $

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Invalid.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Invalid.hs
@@ -62,7 +62,7 @@ spec = describe "Invalid transactions" $ do
       tx
       [injectFailure $ Shelley.ScriptWitnessNotValidatingUTXOW $ NES.singleton scriptHash]
 
-  let fixupResetAddrWits = fixupPPHash >=> resetAddrTxWits
+  let fixupResetAddrWits = fixupPPHash >=> rederiveAddrTxWits
 
   forM_ (eraLanguages @era) $ \lang ->
     withSLanguage lang $ \slang ->
@@ -111,7 +111,7 @@ spec = describe "Invalid transactions" $ do
               txIn <- produceScript redeemerSameAsDatumHash
               goodHashTx <- fixupTx $ mkBasicTx mkBasicTxBody & bodyTxL . inputsTxBodyL .~ [txIn]
               badHashTx <-
-                resetAddrTxWits $ goodHashTx & bodyTxL . scriptIntegrityHashTxBodyL .~ badHash
+                rederiveAddrTxWits $ goodHashTx & bodyTxL . scriptIntegrityHashTxBodyL .~ badHash
               let goodHash = goodHashTx ^. bodyTxL . scriptIntegrityHashTxBodyL
               withNoFixup $
                 submitFailingTx
@@ -161,7 +161,7 @@ spec = describe "Invalid transactions" $ do
                   . (witsTxL . datsTxWitsL .~ mempty)
                   . (witsTxL . rdmrsTxWitsL .~ mempty)
               resetScriptHash = pure . (bodyTxL . scriptIntegrityHashTxBodyL .~ SNothing)
-          withPostFixup (dropScriptWitnesses >=> resetScriptHash >=> resetAddrTxWits) $
+          withPostFixup (dropScriptWitnesses >=> resetScriptHash >=> rederiveAddrTxWits) $
             submitFailingTx tx [injectFailure $ Shelley.MissingScriptWitnessesUTXOW $ NES.singleton scriptHash]
 
         it "Redeemer with incorrect purpose" $ do
@@ -175,7 +175,7 @@ spec = describe "Invalid transactions" $ do
               isSpender = isJust . toSpendingPurpose @era @AsIx
               removeSpenders = Map.filterWithKey (const . not . isSpender)
               dropSpendingRedeemers = pure . (witsTxL . rdmrsTxWitsL . unRedeemersL %~ removeSpenders)
-          withPostFixup (dropSpendingRedeemers >=> fixupPPHash >=> resetAddrTxWits) $
+          withPostFixup (dropSpendingRedeemers >=> fixupPPHash >=> rederiveAddrTxWits) $
             submitFailingTx
               tx
               [ injectFailure $

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -22,6 +22,8 @@ module Test.Cardano.Ledger.Alonzo.ImpTest (
   impLookupPlutusScript,
   malformedPlutus,
   addCollateralInput,
+  makeCollateralInput,
+  txWithMaxRedeemers,
   impGetPlutusContexts,
   alonzoFixupTx,
   plutusTestScripts,

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -98,7 +98,6 @@
 * Add `InjectRuleFailure "LEDGER" DijkstraSubUtxowPredFailure era` as a superclass of `DijkstraEraImp`
 * Add `mkTopTxWithSubTxs` and `withPostFixupSubTxs`
 * Add `Test.Cardano.Ledger.Dijkstra.Imp.SubUtxowSpec`
-* Run the Plutus fixup steps and add collateral for sub-transactions in `dijkstraFixupTx`
 * Add `switchTxToLegacyMode` helper
 * Add `balanceSubTransactions`
 * Expose `fixupSubTransactions`

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -95,6 +95,10 @@
 
 ### `testlib`
 
+* Add `InjectRuleFailure "LEDGER" DijkstraSubUtxowPredFailure era` as a superclass of `DijkstraEraImp`
+* Add `submitFailingSubTx` and `withPostFixupSubTxs`
+* Add `Test.Cardano.Ledger.Dijkstra.Imp.SubUtxowSpec`
+* Run the Plutus fixup steps and add collateral for sub-transactions in `dijkstraFixupTx`
 * Add `switchTxToLegacyMode` helper
 * Add `balanceSubTransactions`
 * Expose `fixupSubTransactions`

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -96,7 +96,7 @@
 ### `testlib`
 
 * Add `InjectRuleFailure "LEDGER" DijkstraSubUtxowPredFailure era` as a superclass of `DijkstraEraImp`
-* Add `submitFailingSubTx` and `withPostFixupSubTxs`
+* Add `mkTopTxWithSubTxs` and `withPostFixupSubTxs`
 * Add `Test.Cardano.Ledger.Dijkstra.Imp.SubUtxowSpec`
 * Run the Plutus fixup steps and add collateral for sub-transactions in `dijkstraFixupTx`
 * Add `switchTxToLegacyMode` helper

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -96,7 +96,7 @@
 ### `testlib`
 
 * Add `InjectRuleFailure "LEDGER" DijkstraSubUtxowPredFailure era` as a superclass of `DijkstraEraImp`
-* Add `mkTopTxWithSubTxs` and `withPostFixupSubTxs`
+* Add `mkTopTxWithSubTxs`, `traverseSubTxs` and `withPostFixupSubTxs`
 * Add `Test.Cardano.Ledger.Dijkstra.Imp.SubUtxowSpec`
 * Add `switchTxToLegacyMode` helper
 * Add `balanceSubTransactions`

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -157,6 +157,7 @@ library testlib
     Test.Cardano.Ledger.Dijkstra.Imp.LedgerSpec
     Test.Cardano.Ledger.Dijkstra.Imp.PoolSpec
     Test.Cardano.Ledger.Dijkstra.Imp.SnapSpec
+    Test.Cardano.Ledger.Dijkstra.Imp.SubUtxowSpec
     Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec
     Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec
     Test.Cardano.Ledger.Dijkstra.ImpTest

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
@@ -15,6 +15,7 @@ import qualified Test.Cardano.Ledger.Dijkstra.Imp.EntitiesSpec as ENTITIES
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.LedgerSpec as LEDGER
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.PoolSpec as POOL
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.SnapSpec as SNAP
+import qualified Test.Cardano.Ledger.Dijkstra.Imp.SubUtxowSpec as SUBUTXOW
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec as UTXO
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec as UTXOW
 import Test.Cardano.Ledger.Dijkstra.ImpTest
@@ -38,3 +39,4 @@ spec era = do
     SNAP.spec
     UTXOW.spec
     UTXO.spec
+    SUBUTXOW.spec

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/SubUtxowSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/SubUtxowSpec.hs
@@ -1,0 +1,594 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Dijkstra.Imp.SubUtxowSpec (spec) where
+
+import Cardano.Ledger.Address (bootstrapKeyHash)
+import Cardano.Ledger.Allegra.Scripts (AllegraEraScript (..))
+import Cardano.Ledger.Alonzo.Scripts (eraLanguages)
+import Cardano.Ledger.Alonzo.TxWits (unRedeemersL, unTxDatsL)
+import Cardano.Ledger.BaseTypes (Mismatch (..), SlotNo (..), StrictMaybe (..))
+import Cardano.Ledger.Conway.Governance (
+  GovAction (..),
+  GovActionId,
+  Vote (..),
+  Voter (..),
+  VotingProcedure (..),
+  VotingProcedures (..),
+ )
+import Cardano.Ledger.Core
+import Cardano.Ledger.Credential (Credential (..), StakeReference (..), credKeyHashWitness)
+import Cardano.Ledger.Dijkstra.Core
+import Cardano.Ledger.Dijkstra.Rules (DijkstraSubUtxowPredFailure (..))
+import Cardano.Ledger.Keys (asWitness, witVKeyHash)
+import Cardano.Ledger.Plutus (
+  Data (..),
+  ExUnits (..),
+  Language (..),
+  SLanguage (..),
+  hashData,
+  hashPlutusScript,
+  plutusBinary,
+  withSLanguage,
+ )
+import Cardano.Ledger.Plutus.Language (asSLanguage)
+import Cardano.Ledger.Shelley.Scripts (pattern RequireAllOf)
+import Cardano.Ledger.State (StakePoolParams (..))
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as Map
+import qualified Data.OMap.Strict as OMap
+import Data.Sequence.Strict (StrictSeq ((:<|)))
+import qualified Data.Set as Set
+import qualified Data.Set.NonEmpty as NES
+import Lens.Micro ((%~), (&), (.~), (^.))
+import qualified PlutusLedgerApi.Common as P
+import Test.Cardano.Ledger.Core.KeyPair (mkWitnessesVKey)
+import Test.Cardano.Ledger.Core.Utils (txInAt)
+import Test.Cardano.Ledger.Dijkstra.ImpTest
+import Test.Cardano.Ledger.Imp.Common
+import Test.Cardano.Ledger.Plutus.Examples (alwaysSucceedsNoDatum, redeemerSameAsDatum)
+
+spec :: forall era. DijkstraEraImp era => SpecWith (ImpInit (LedgerSpec era))
+spec = describe "SUBUTXOW" $ do
+  -- TODO: `SubUtxoFailure`, which embeds the SUBUTXO rule's failures,
+  -- has no test here, and the SUBUTXO rule has no spec of its own, so
+  -- nothing exercises the embedding.
+  it "SubInvalidWitnessesUTXOW" $ do
+    keyHash <- freshKeyHash @Payment
+    keyPair <- getKeyPair $ asWitness keyHash
+    txIn <- sendCoinTo (mkAddr keyHash StakeRefNull) mempty
+    staleBodyHash <- arbitrary
+    let subTx :: Tx SubTx era
+        subTx = mkBasicTx $ mkBasicTxBody & inputsTxBodyL .~ [txIn]
+        plantStaleWitness =
+          pure . (witsTxL . addrTxWitsL .~ mkWitnessesVKey staleBodyHash [keyPair])
+    withPostFixupSubTxs plantStaleWitness $
+      submitFailingSubTx
+        subTx
+        [injectFailure . SubInvalidWitnessesUTXOW @era $ pure (vKey keyPair)]
+
+  describe "SubMissingVKeyWitnessesUTXOW" $
+    forM_ (missingVKeyWitnessSources @era) $ \(sourceName, mkSubTx) ->
+      it sourceName $ do
+        (subTx, keyHash) <- mkSubTx
+        let dropWitness =
+              pure
+                . (witsTxL . addrTxWitsL %~ Set.filter ((/= keyHash) . witVKeyHash))
+                . (witsTxL . bootAddrTxWitsL .~ mempty)
+        withPostFixupSubTxs dropWitness $
+          submitFailingSubTx
+            subTx
+            [injectFailure . SubMissingVKeyWitnessesUTXOW @era $ NES.singleton keyHash]
+
+  describe "SubScriptWitnessNotValidatingUTXOW" $
+    forM_ (failingNativeScriptPurposes @era) $ \(purposeName, mkSubTx) ->
+      it purposeName $ do
+        (subTx, scriptHash) <- mkSubTx
+        submitFailingSubTx
+          subTx
+          [injectFailure . SubScriptWitnessNotValidatingUTXOW @era $ NES.singleton scriptHash]
+
+  it "SubMissingTxMetadata" $ do
+    auxData <- arbitrary @(TxAuxData era)
+    let auxDataHash = hashTxAuxData auxData
+        subTx :: Tx SubTx era
+        subTx = mkBasicTx $ mkBasicTxBody & auxDataHashTxBodyL .~ SJust auxDataHash
+    submitFailingSubTx subTx [injectFailure $ SubMissingTxMetadata @era auxDataHash]
+
+  it "SubConflictingMetadataHash" $ do
+    auxData <- arbitrary @(TxAuxData era)
+    wrongAuxDataHash <- arbitrary @TxAuxDataHash
+    let subTx :: Tx SubTx era
+        subTx =
+          mkBasicTx mkBasicTxBody
+            & bodyTxL . auxDataHashTxBodyL .~ SJust wrongAuxDataHash
+            & auxDataTxL .~ SJust auxData
+    submitFailingSubTx
+      subTx
+      [ injectFailure . SubConflictingMetadataHash @era $
+          Mismatch
+            { mismatchSupplied = wrongAuxDataHash
+            , mismatchExpected = hashTxAuxData auxData
+            }
+      ]
+
+  it "SubMissingTxBodyMetadataHash" $ do
+    auxData <- arbitrary @(TxAuxData era)
+    let subTx :: Tx SubTx era
+        subTx = mkBasicTx mkBasicTxBody & auxDataTxL .~ SJust auxData
+        dropAuxDataHash =
+          resetAddrTxWits . (bodyTxL . auxDataHashTxBodyL .~ SNothing)
+    withPostFixupSubTxs dropAuxDataHash $
+      submitFailingSubTx
+        subTx
+        [injectFailure . SubMissingTxBodyMetadataHash @era $ hashTxAuxData auxData]
+
+  describe "SubExtraRedeemers" $ do
+    it "for a native script, which takes no redeemer" $ do
+      scriptHash <- impAddNativeScript $ RequireAllOf []
+      txIn <- produceScript scriptHash
+      collateralInput <- makeCollateralInput
+      redeemerData <- arbitrary
+      let extraPurpose = mkSpendingPurpose $ AsIx 0
+          subTx :: Tx SubTx era
+          subTx = mkBasicTx $ mkBasicTxBody & inputsTxBodyL .~ [txIn]
+          topTx =
+            mkBasicTx mkBasicTxBody
+              & bodyTxL . collateralInputsTxBodyL .~ [collateralInput]
+              & bodyTxL . subTransactionsTxBodyL .~ OMap.singleton subTx
+          addExtraRedeemer =
+            (fixupPPHash >=> resetAddrTxWits)
+              . ( witsTxL . rdmrsTxWitsL . unRedeemersL
+                    %~ Map.insert extraPurpose (redeemerData, ExUnits 0 0)
+                )
+      withPostFixupSubTxs addExtraRedeemer $
+        submitFailingTx topTx [injectFailure $ SubExtraRedeemers @era [extraPurpose]]
+
+    it "at an index that points at no item" $ do
+      keyHash <- freshKeyHash @Payment
+      txIn <- sendCoinTo (mkAddr keyHash StakeRefNull) mempty
+      collateralInput <- makeCollateralInput
+      redeemerData <- arbitrary
+      let extraPurpose = mkSpendingPurpose $ AsIx 99
+          subTx :: Tx SubTx era
+          subTx = mkBasicTx $ mkBasicTxBody & inputsTxBodyL .~ [txIn]
+          topTx =
+            mkBasicTx mkBasicTxBody
+              & bodyTxL . collateralInputsTxBodyL .~ [collateralInput]
+              & bodyTxL . subTransactionsTxBodyL .~ OMap.singleton subTx
+          addExtraRedeemer =
+            (fixupPPHash >=> resetAddrTxWits)
+              . ( witsTxL . rdmrsTxWitsL . unRedeemersL
+                    %~ Map.insert extraPurpose (redeemerData, ExUnits 0 0)
+                )
+      withPostFixupSubTxs addExtraRedeemer $
+        submitFailingTx topTx [injectFailure $ SubExtraRedeemers @era [extraPurpose]]
+
+  -- `SubPPViewHashesDontMatch` is the other failure
+  -- `checkScriptIntegrityHash` can raise. It is unreachable in
+  -- Dijkstra: it is selected only below protocol version 11, and
+  -- Dijkstra is pinned to 12.
+  describe "SubScriptIntegrityHashMismatch" $
+    it "when no script requires an integrity hash" $ do
+      badHash <- arbitrary
+      let subTx :: Tx SubTx era
+          subTx = mkBasicTx mkBasicTxBody
+          supplyIntegrityHash =
+            resetAddrTxWits . (bodyTxL . scriptIntegrityHashTxBodyL .~ SJust badHash)
+      withPostFixupSubTxs supplyIntegrityHash $
+        submitFailingSubTx
+          subTx
+          [ injectFailure $
+              SubScriptIntegrityHashMismatch @era
+                Mismatch {mismatchSupplied = SJust badHash, mismatchExpected = SNothing}
+                SNothing
+          ]
+
+  describe "SubMalformedGuardDatums" $
+    forM_ (malformedGuardDatumCases @era) $ \(caseName, mkGuard) ->
+      it caseName $ do
+        (guardCred, requiredGuards) <- mkGuard
+        let subTx :: Tx SubTx era
+            subTx = mkBasicTx $ mkBasicTxBody & requiredTopLevelGuardsL .~ requiredGuards
+            topTx =
+              mkBasicTx mkBasicTxBody
+                & bodyTxL . guardsTxBodyL .~ [guardCred]
+                & bodyTxL . subTransactionsTxBodyL .~ OMap.singleton subTx
+        submitFailingTx
+          topTx
+          [injectFailure . SubMalformedGuardDatums @era $ NES.singleton guardCred]
+
+  -- The filter mirrors the rule: `getInputDataHashesTxBody` records
+  -- an input as unspendable only when its spending script is below
+  -- PlutusV3, since CIP-0069 made spending datums optional from V3 on.
+  describe "SubUnspendableUTxONoDatumHash, for languages that require a spending datum" $
+    forM_ (filter (< PlutusV3) (eraLanguages @era)) $ \lang ->
+      withSLanguage lang $ \slang ->
+        it (show lang) $ do
+          let scriptHash = hashPlutusScript $ redeemerSameAsDatum slang
+          txIn <- impAnn "Produce a script output with no datum hash" $ do
+            let addr = mkAddr scriptHash StakeRefNull
+                tx =
+                  mkBasicTx mkBasicTxBody
+                    & bodyTxL . outputsTxBodyL .~ [mkBasicTxOut addr mempty]
+                resetTxOutDataHash =
+                  bodyTxL . outputsTxBodyL
+                    %~ ( \case
+                           h :<| r -> (h & dataHashTxOutL .~ SNothing) :<| r
+                           _ -> error "Expected non-empty outputs"
+                       )
+            txInAt 0
+              <$> withPostFixup (resetAddrTxWits . resetTxOutDataHash) (submitTx tx)
+          submitFailingSubTx
+            (mkBasicTx $ mkBasicTxBody & inputsTxBodyL .~ [txIn])
+            [injectFailure . SubUnspendableUTxONoDatumHash @era $ NES.singleton txIn]
+
+  forM_ (eraLanguages @era) $ \lang ->
+    withSLanguage lang $ \slang ->
+      describe (show lang) $ do
+        let redeemerSameAsDatumHash = hashPlutusScript $ redeemerSameAsDatum slang
+            fixupResetAddrWits = fixupPPHash >=> resetAddrTxWits
+            scriptSpendingSubTx txIn = mkBasicTx $ mkBasicTxBody & inputsTxBodyL .~ [txIn]
+
+        it "SubMissingRequiredDatums" $ do
+          txIn <- produceScript redeemerSameAsDatumHash
+          let missingDatum = hashData @era (Data (P.I 3))
+          withPostFixupSubTxs (fixupResetAddrWits . (witsTxL . datsTxWitsL .~ mempty)) $
+            submitFailingSubTx
+              (scriptSpendingSubTx txIn)
+              [injectFailure $ SubMissingRequiredDatums @era (NES.singleton missingDatum) []]
+
+        it "SubNotAllowedSupplementalDatums" $ do
+          txIn <- produceScript redeemerSameAsDatumHash
+          let extraDatum = Data (P.I 30)
+              extraDatumHash = hashData @era extraDatum
+              addExtraDatum =
+                fixupResetAddrWits
+                  . ( witsTxL . datsTxWitsL . unTxDatsL
+                        %~ Map.insert extraDatumHash extraDatum
+                    )
+          withPostFixupSubTxs addExtraDatum $
+            submitFailingSubTx
+              (scriptSpendingSubTx txIn)
+              [ injectFailure $
+                  SubNotAllowedSupplementalDatums @era (NES.singleton extraDatumHash) []
+              ]
+
+        it "SubMissingRedeemers" $ do
+          txIn <- produceScript redeemerSameAsDatumHash
+          let missingRedeemer = mkSpendingPurpose $ AsItem txIn
+          withPostFixupSubTxs (fixupResetAddrWits . (witsTxL . rdmrsTxWitsL .~ mempty)) $
+            submitFailingSubTx
+              (scriptSpendingSubTx txIn)
+              [ injectFailure $
+                  SubMissingRedeemers @era [(missingRedeemer, redeemerSameAsDatumHash)]
+              ]
+
+        it "SubExtraRedeemers" $ do
+          txIn <- produceScript redeemerSameAsDatumHash
+          redeemerData <- arbitrary
+          let extraPurpose = mkMintingPurpose $ AsIx 2
+              addExtraRedeemer =
+                fixupResetAddrWits
+                  . ( witsTxL . rdmrsTxWitsL . unRedeemersL
+                        %~ Map.insert extraPurpose (redeemerData, ExUnits 0 0)
+                    )
+          withPostFixupSubTxs addExtraRedeemer $
+            submitFailingSubTx
+              (scriptSpendingSubTx txIn)
+              [injectFailure $ SubExtraRedeemers @era [extraPurpose]]
+
+        describe "SubScriptIntegrityHashMismatch" $ do
+          let testHashMismatch badHash = do
+                txIn <- produceScript redeemerSameAsDatumHash
+                let topTx =
+                      mkBasicTx mkBasicTxBody
+                        & bodyTxL . subTransactionsTxBodyL
+                          .~ OMap.singleton (scriptSpendingSubTx txIn)
+                fixedUpTx <- fixupTx topTx
+                let fixedUpSubTxs = OMap.elems $ fixedUpTx ^. bodyTxL . subTransactionsTxBodyL
+                fixedUpSubTx <- case fixedUpSubTxs of
+                  [subTx] -> pure subTx
+                  _ -> assertFailure "Expected exactly one sub-transaction"
+                let goodHash = fixedUpSubTx ^. bodyTxL . scriptIntegrityHashTxBodyL
+                expectedIntegrity <- impComputeScriptIntegrity fixedUpSubTx
+                badSubTx <-
+                  resetAddrTxWits $
+                    fixedUpSubTx & bodyTxL . scriptIntegrityHashTxBodyL .~ badHash
+                badTopTx <-
+                  resetAddrTxWits $
+                    fixedUpTx & bodyTxL . subTransactionsTxBodyL .~ OMap.singleton badSubTx
+                withNoFixup $
+                  submitFailingTx
+                    badTopTx
+                    [ injectFailure $
+                        SubScriptIntegrityHashMismatch @era
+                          Mismatch {mismatchSupplied = badHash, mismatchExpected = goodHash}
+                          (originalBytes <$> expectedIntegrity)
+                    ]
+          it "the supplied hash is wrong" $ testHashMismatch . SJust =<< arbitrary
+          it "the supplied hash is missing" $ testHashMismatch SNothing
+
+        disableInConformanceIt "SubMalformedScriptWitnesses" $ do
+          let scriptHash = hashPlutusScript $ asSLanguage slang malformedPlutus
+          txIn <- produceScript scriptHash
+          submitFailingSubTx
+            (scriptSpendingSubTx txIn)
+            [injectFailure . SubMalformedScriptWitnesses @era $ NES.singleton scriptHash]
+
+        disableInConformanceIt "SubMalformedReferenceScripts" $ do
+          script <- fromPlutusScript <$> mkPlutusScript (asSLanguage slang malformedPlutus)
+          addr <- freshKeyAddr_
+          let subTx :: Tx SubTx era
+              subTx =
+                mkBasicTx $
+                  mkBasicTxBody
+                    & outputsTxBodyL
+                      .~ [mkBasicTxOut addr mempty & referenceScriptTxOutL .~ SJust script]
+          submitFailingSubTx
+            subTx
+            [ injectFailure . SubMalformedReferenceScripts @era . NES.singleton $
+                hashScript script
+            ]
+
+        it "SubInvalidMetadata" $ do
+          let auxData :: TxAuxData era
+              auxData =
+                mkBasicTxAuxData
+                  & plutusScriptsTxAuxDataL
+                    .~ Map.singleton lang (pure . plutusBinary $ asSLanguage slang malformedPlutus)
+              subTx :: Tx SubTx era
+              subTx = mkBasicTx mkBasicTxBody & auxDataTxL .~ SJust auxData
+          submitFailingSubTx subTx [injectFailure $ SubInvalidMetadata @era]
+
+-- | Every distinct reason a sub-transaction requires a key witness,
+-- paired with a sub-transaction that requires it and the key hash whose
+-- witness is to be withheld.
+missingVKeyWitnessSources ::
+  forall era.
+  DijkstraEraImp era =>
+  [(String, ImpTestM era (Tx SubTx era, KeyHash Witness))]
+missingVKeyWitnessSources =
+  [
+    ( "spending a key hash locked input"
+    , do
+        keyHash <- freshKeyHash @Payment
+        txIn <- sendCoinTo (mkAddr keyHash StakeRefNull) mempty
+        pure (mkBasicTx $ mkBasicTxBody & inputsTxBodyL .~ [txIn], asWitness keyHash)
+    )
+  ,
+    ( "unregistering a staking credential"
+    , do
+        keyHash <- freshKeyHash
+        void . registerStakeCredential $ KeyHashObj keyHash
+        deposit <- getsPParams ppKeyDepositL
+        pure
+          ( mkBasicTx $
+              mkBasicTxBody
+                & certsTxBodyL .~ [UnRegDepositTxCert (KeyHashObj keyHash) deposit]
+          , asWitness keyHash
+          )
+    )
+  ,
+    ( "withdrawing from an account"
+    , do
+        keyHash <- freshKeyHash
+        accountAddress <- registerStakeCredential $ KeyHashObj keyHash
+        pure
+          ( mkBasicTx $
+              mkBasicTxBody & withdrawalsTxBodyL .~ Withdrawals [(accountAddress, mempty)]
+          , asWitness keyHash
+          )
+    )
+  ,
+    ( "requiring a key hash guard"
+    , do
+        keyHash <- freshKeyHash
+        pure
+          ( mkBasicTx $ mkBasicTxBody & guardsTxBodyL .~ [KeyHashObj keyHash]
+          , asWitness keyHash
+          )
+    )
+  ,
+    ( "spending a bootstrap address input"
+    , do
+        bootAddr <- freshBootstapAddress
+        txIn <- sendCoinTo (AddrBootstrap bootAddr) mempty
+        pure
+          ( mkBasicTx $ mkBasicTxBody & inputsTxBodyL .~ [txIn]
+          , asWitness $ bootstrapKeyHash bootAddr
+          )
+    )
+  ,
+    ( "registering a stake pool with an owner"
+    , do
+        poolKeyHash <- freshKeyHash
+        ownerKeyHash <- freshKeyHash
+        accountAddress <- registerStakeCredential . KeyHashObj =<< freshKeyHash
+        poolParams <- freshPoolParams poolKeyHash accountAddress
+        pure
+          ( mkBasicTx $
+              mkBasicTxBody
+                & certsTxBodyL
+                  .~ [RegPoolTxCert poolParams {sppOwners = Set.singleton ownerKeyHash}]
+          , asWitness ownerKeyHash
+          )
+    )
+  ,
+    ( "voting as a DRep"
+    , do
+        (drepCredential, _, _) <- setupSingleDRep 1_000_000
+        govActionId <- submitGovAction InfoAction
+        keyHash <- expectJust $ credKeyHashWitness drepCredential
+        pure (voteSubTx (DRepVoter drepCredential) govActionId, keyHash)
+    )
+  ,
+    ( "voting as a committee member"
+    , do
+        hotCredential <- NE.head <$> registerInitialCommittee
+        govActionId <- submitGovAction InfoAction
+        keyHash <- expectJust $ credKeyHashWitness hotCredential
+        pure (voteSubTx (CommitteeVoter hotCredential) govActionId, keyHash)
+    )
+  ,
+    ( "voting as a stake pool"
+    , do
+        poolKeyHash <- freshKeyHash
+        registerPool poolKeyHash
+        govActionId <- submitGovAction InfoAction
+        pure (voteSubTx (StakePoolVoter poolKeyHash) govActionId, asWitness poolKeyHash)
+    )
+  ]
+
+-- | A sub-transaction that casts a single yes vote.
+voteSubTx :: DijkstraEraImp era => Voter -> GovActionId -> Tx SubTx era
+voteSubTx voter govActionId =
+  mkBasicTx $
+    mkBasicTxBody
+      & votingProceduresTxBodyL
+        .~ VotingProcedures
+          ( Map.singleton voter . Map.singleton govActionId $
+              VotingProcedure {vProcVote = VoteYes, vProcAnchor = SNothing}
+          )
+
+-- | Every script purpose at which a sub-transaction can require a
+-- native script, paired with a sub-transaction that needs a failing
+-- script for that purpose and the hash of that script.
+failingNativeScriptPurposes ::
+  forall era.
+  DijkstraEraImp era =>
+  [(String, ImpTestM era (Tx SubTx era, ScriptHash))]
+failingNativeScriptPurposes =
+  [
+    ( "spending"
+    , do
+        scriptHash <- unsatisfiableTimeLock
+        txIn <- produceScript scriptHash
+        pure (mkBasicTx $ mkBasicTxBody & inputsTxBodyL .~ [txIn], scriptHash)
+    )
+  ,
+    ( "certifying"
+    , do
+        scriptHash <- unsatisfiableTimeLock
+        deposit <- getsPParams ppKeyDepositL
+        pure
+          ( mkBasicTx $
+              mkBasicTxBody
+                & certsTxBodyL .~ [RegDepositTxCert (ScriptHashObj scriptHash) deposit]
+          , scriptHash
+          )
+    )
+  ,
+    ( "guarding"
+    , do
+        scriptHash <- unsatisfiableTimeLock
+        pure
+          ( mkBasicTx $ mkBasicTxBody & guardsTxBodyL .~ [ScriptHashObj scriptHash]
+          , scriptHash
+          )
+    )
+  ,
+    ( "minting"
+    , do
+        scriptHash <- unsatisfiableTimeLock
+        subTx <- mkTokenMintingTx scriptHash
+        pure (subTx, scriptHash)
+    )
+  ,
+    ( "withdrawing"
+    , do
+        (scriptHash, accountAddress) <- registerLowerBoundTimeLockAccount
+        pure
+          ( mkBasicTx $
+              mkBasicTxBody & withdrawalsTxBodyL .~ Withdrawals [(accountAddress, mempty)]
+          , scriptHash
+          )
+    )
+  ,
+    ( "voting"
+    , do
+        scriptHash <- registerLowerBoundTimeLockDRep
+        govActionId <- submitGovAction InfoAction
+        pure (voteSubTx (DRepVoter (ScriptHashObj scriptHash)) govActionId, scriptHash)
+    )
+  ]
+
+-- | A time lock that no sub-transaction can satisfy.
+unsatisfiableTimeLock :: DijkstraEraImp era => ImpTestM era ScriptHash
+unsatisfiableTimeLock = impAddNativeScript $ mkTimeStart (SlotNo maxBound)
+
+-- | A time lock that is satisfied only by a transaction that declares a
+-- lower bound on its validity interval. Registering the credential that
+-- it locks therefore succeeds, while a sub-transaction, which declares
+-- no lower bound, fails to satisfy it.
+lowerBoundTimeLock :: DijkstraEraImp era => ImpTestM era ScriptHash
+lowerBoundTimeLock = impAddNativeScript $ mkTimeStart lowerBoundSlot
+
+lowerBoundSlot :: SlotNo
+lowerBoundSlot = SlotNo 1
+
+registerLowerBoundTimeLockAccount ::
+  DijkstraEraImp era => ImpTestM era (ScriptHash, AccountAddress)
+registerLowerBoundTimeLockAccount = do
+  scriptHash <- lowerBoundTimeLock
+  deposit <- getsPParams ppKeyDepositL
+  submitTx_ $
+    mkBasicTx mkBasicTxBody
+      & bodyTxL . certsTxBodyL .~ [RegDepositTxCert (ScriptHashObj scriptHash) deposit]
+      & bodyTxL . vldtTxBodyL .~ ValidityInterval (SJust lowerBoundSlot) SNothing
+  accountAddress <- getAccountAddressFor $ ScriptHashObj scriptHash
+  pure (scriptHash, accountAddress)
+
+registerLowerBoundTimeLockDRep :: DijkstraEraImp era => ImpTestM era ScriptHash
+registerLowerBoundTimeLockDRep = do
+  scriptHash <- lowerBoundTimeLock
+  deposit <- getsPParams ppDRepDepositL
+  submitTx_ $
+    mkBasicTx mkBasicTxBody
+      & bodyTxL . certsTxBodyL .~ [RegDRepTxCert (ScriptHashObj scriptHash) deposit SNothing]
+      & bodyTxL . vldtTxBodyL .~ ValidityInterval (SJust lowerBoundSlot) SNothing
+  pure scriptHash
+
+-- | The ways a guard credential can carry the wrong datum presence,
+-- paired with the guard credential and the @requiredTopLevelGuards@
+-- entry that makes it malformed.
+malformedGuardDatumCases ::
+  forall era.
+  DijkstraEraImp era =>
+  [ ( String
+    , ImpTestM era (Credential Guard, Map.Map (Credential Guard) (StrictMaybe (Data era)))
+    )
+  ]
+malformedGuardDatumCases =
+  [
+    ( "a key hash guard carrying a datum"
+    , do
+        guardCred <- KeyHashObj <$> freshKeyHash
+        datum <- arbitrary @(Data era)
+        pure (guardCred, Map.singleton guardCred (SJust datum))
+    )
+  ,
+    ( "a native script guard carrying a datum"
+    , do
+        guardCred <- ScriptHashObj <$> impAddNativeScript (RequireAllOf [])
+        datum <- arbitrary @(Data era)
+        pure (guardCred, Map.singleton guardCred (SJust datum))
+    )
+  ,
+    ( "a Plutus script guard without a datum"
+    , do
+        -- TODO: Plutus guards require PlutusV4, which `eraLanguages`
+        -- does not reach while `eraMaxLanguage` is PlutusV3, so this
+        -- row names the language directly instead of iterating.
+        plutusScript <- mkPlutusScript $ alwaysSucceedsNoDatum SPlutusV4
+        let guardScript = fromPlutusScript plutusScript :: Script era
+            guardCred = ScriptHashObj $ hashScript guardScript
+        pure (guardCred, Map.singleton guardCred SNothing)
+    )
+  ]

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/SubUtxowSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/SubUtxowSpec.hs
@@ -69,8 +69,8 @@ spec = describe "SUBUTXOW" $ do
         plantStaleWitness =
           pure . (witsTxL . addrTxWitsL .~ mkWitnessesVKey staleBodyHash [keyPair])
     withPostFixupSubTxs plantStaleWitness $
-      submitFailingSubTx
-        subTx
+      submitFailingTx
+        (mkTopTxWithSubTxs [subTx])
         [injectFailure . SubInvalidWitnessesUTXOW @era $ pure (vKey keyPair)]
 
   describe "SubMissingVKeyWitnessesUTXOW" $
@@ -82,16 +82,16 @@ spec = describe "SUBUTXOW" $ do
                 . (witsTxL . addrTxWitsL %~ Set.filter ((/= keyHash) . witVKeyHash))
                 . (witsTxL . bootAddrTxWitsL .~ mempty)
         withPostFixupSubTxs dropWitness $
-          submitFailingSubTx
-            subTx
+          submitFailingTx
+            (mkTopTxWithSubTxs [subTx])
             [injectFailure . SubMissingVKeyWitnessesUTXOW @era $ NES.singleton keyHash]
 
   describe "SubScriptWitnessNotValidatingUTXOW" $
     forM_ (failingNativeScriptPurposes @era) $ \(purposeName, mkSubTx) ->
       it purposeName $ do
         (subTx, scriptHash) <- mkSubTx
-        submitFailingSubTx
-          subTx
+        submitFailingTx
+          (mkTopTxWithSubTxs [subTx])
           [injectFailure . SubScriptWitnessNotValidatingUTXOW @era $ NES.singleton scriptHash]
 
   it "SubMissingTxMetadata" $ do
@@ -99,7 +99,9 @@ spec = describe "SUBUTXOW" $ do
     let auxDataHash = hashTxAuxData auxData
         subTx :: Tx SubTx era
         subTx = mkBasicTx $ mkBasicTxBody & auxDataHashTxBodyL .~ SJust auxDataHash
-    submitFailingSubTx subTx [injectFailure $ SubMissingTxMetadata @era auxDataHash]
+    submitFailingTx
+      (mkTopTxWithSubTxs [subTx])
+      [injectFailure $ SubMissingTxMetadata @era auxDataHash]
 
   it "SubConflictingMetadataHash" $ do
     auxData <- arbitrary @(TxAuxData era)
@@ -109,8 +111,8 @@ spec = describe "SUBUTXOW" $ do
           mkBasicTx mkBasicTxBody
             & bodyTxL . auxDataHashTxBodyL .~ SJust wrongAuxDataHash
             & auxDataTxL .~ SJust auxData
-    submitFailingSubTx
-      subTx
+    submitFailingTx
+      (mkTopTxWithSubTxs [subTx])
       [ injectFailure . SubConflictingMetadataHash @era $
           Mismatch
             { mismatchSupplied = wrongAuxDataHash
@@ -125,8 +127,8 @@ spec = describe "SUBUTXOW" $ do
         dropAuxDataHash =
           rederiveAddrTxWits . (bodyTxL . auxDataHashTxBodyL .~ SNothing)
     withPostFixupSubTxs dropAuxDataHash $
-      submitFailingSubTx
-        subTx
+      submitFailingTx
+        (mkTopTxWithSubTxs [subTx])
         [injectFailure . SubMissingTxBodyMetadataHash @era $ hashTxAuxData auxData]
 
   describe "SubExtraRedeemers" $ do
@@ -139,9 +141,8 @@ spec = describe "SUBUTXOW" $ do
           subTx :: Tx SubTx era
           subTx = mkBasicTx $ mkBasicTxBody & inputsTxBodyL .~ [txIn]
           topTx =
-            mkBasicTx mkBasicTxBody
+            mkTopTxWithSubTxs [subTx]
               & bodyTxL . collateralInputsTxBodyL .~ [collateralInput]
-              & bodyTxL . subTransactionsTxBodyL .~ OMap.singleton subTx
           addExtraRedeemer =
             (fixupPPHash >=> rederiveAddrTxWits)
               . ( witsTxL . rdmrsTxWitsL . unRedeemersL
@@ -159,9 +160,8 @@ spec = describe "SUBUTXOW" $ do
           subTx :: Tx SubTx era
           subTx = mkBasicTx $ mkBasicTxBody & inputsTxBodyL .~ [txIn]
           topTx =
-            mkBasicTx mkBasicTxBody
+            mkTopTxWithSubTxs [subTx]
               & bodyTxL . collateralInputsTxBodyL .~ [collateralInput]
-              & bodyTxL . subTransactionsTxBodyL .~ OMap.singleton subTx
           addExtraRedeemer =
             (fixupPPHash >=> rederiveAddrTxWits)
               . ( witsTxL . rdmrsTxWitsL . unRedeemersL
@@ -182,8 +182,8 @@ spec = describe "SUBUTXOW" $ do
           supplyIntegrityHash =
             rederiveAddrTxWits . (bodyTxL . scriptIntegrityHashTxBodyL .~ SJust badHash)
       withPostFixupSubTxs supplyIntegrityHash $
-        submitFailingSubTx
-          subTx
+        submitFailingTx
+          (mkTopTxWithSubTxs [subTx])
           [ injectFailure $
               SubScriptIntegrityHashMismatch @era
                 Mismatch {mismatchSupplied = SJust badHash, mismatchExpected = SNothing}
@@ -197,9 +197,8 @@ spec = describe "SUBUTXOW" $ do
         let subTx :: Tx SubTx era
             subTx = mkBasicTx $ mkBasicTxBody & requiredTopLevelGuardsL .~ requiredGuards
             topTx =
-              mkBasicTx mkBasicTxBody
+              mkTopTxWithSubTxs [subTx]
                 & bodyTxL . guardsTxBodyL .~ [guardCred]
-                & bodyTxL . subTransactionsTxBodyL .~ OMap.singleton subTx
         submitFailingTx
           topTx
           [injectFailure . SubMalformedGuardDatums @era $ NES.singleton guardCred]
@@ -225,8 +224,8 @@ spec = describe "SUBUTXOW" $ do
                        )
             txInAt 0
               <$> withPostFixup (rederiveAddrTxWits . resetTxOutDataHash) (submitTx tx)
-          submitFailingSubTx
-            (mkBasicTx $ mkBasicTxBody & inputsTxBodyL .~ [txIn])
+          submitFailingTx
+            (mkTopTxWithSubTxs [mkBasicTx $ mkBasicTxBody & inputsTxBodyL .~ [txIn]])
             [injectFailure . SubUnspendableUTxONoDatumHash @era $ NES.singleton txIn]
 
   forM_ (eraLanguages @era) $ \lang ->
@@ -240,8 +239,8 @@ spec = describe "SUBUTXOW" $ do
           txIn <- produceScript redeemerSameAsDatumHash
           let missingDatum = hashData @era (Data (P.I 3))
           withPostFixupSubTxs (fixupResetAddrWits . (witsTxL . datsTxWitsL .~ mempty)) $
-            submitFailingSubTx
-              (scriptSpendingSubTx txIn)
+            submitFailingTx
+              (mkTopTxWithSubTxs [scriptSpendingSubTx txIn])
               [injectFailure $ SubMissingRequiredDatums @era (NES.singleton missingDatum) []]
 
         it "SubNotAllowedSupplementalDatums" $ do
@@ -254,8 +253,8 @@ spec = describe "SUBUTXOW" $ do
                         %~ Map.insert extraDatumHash extraDatum
                     )
           withPostFixupSubTxs addExtraDatum $
-            submitFailingSubTx
-              (scriptSpendingSubTx txIn)
+            submitFailingTx
+              (mkTopTxWithSubTxs [scriptSpendingSubTx txIn])
               [ injectFailure $
                   SubNotAllowedSupplementalDatums @era (NES.singleton extraDatumHash) []
               ]
@@ -264,8 +263,8 @@ spec = describe "SUBUTXOW" $ do
           txIn <- produceScript redeemerSameAsDatumHash
           let missingRedeemer = mkSpendingPurpose $ AsItem txIn
           withPostFixupSubTxs (fixupResetAddrWits . (witsTxL . rdmrsTxWitsL .~ mempty)) $
-            submitFailingSubTx
-              (scriptSpendingSubTx txIn)
+            submitFailingTx
+              (mkTopTxWithSubTxs [scriptSpendingSubTx txIn])
               [ injectFailure $
                   SubMissingRedeemers @era [(missingRedeemer, redeemerSameAsDatumHash)]
               ]
@@ -280,17 +279,14 @@ spec = describe "SUBUTXOW" $ do
                         %~ Map.insert extraPurpose (redeemerData, ExUnits 0 0)
                     )
           withPostFixupSubTxs addExtraRedeemer $
-            submitFailingSubTx
-              (scriptSpendingSubTx txIn)
+            submitFailingTx
+              (mkTopTxWithSubTxs [scriptSpendingSubTx txIn])
               [injectFailure $ SubExtraRedeemers @era [extraPurpose]]
 
         describe "SubScriptIntegrityHashMismatch" $ do
           let testHashMismatch badHash = do
                 txIn <- produceScript redeemerSameAsDatumHash
-                let topTx =
-                      mkBasicTx mkBasicTxBody
-                        & bodyTxL . subTransactionsTxBodyL
-                          .~ OMap.singleton (scriptSpendingSubTx txIn)
+                let topTx = mkTopTxWithSubTxs [scriptSpendingSubTx txIn]
                 fixedUpTx <- fixupTx topTx
                 let fixedUpSubTxs = OMap.elems $ fixedUpTx ^. bodyTxL . subTransactionsTxBodyL
                 fixedUpSubTx <- case fixedUpSubTxs of
@@ -318,8 +314,8 @@ spec = describe "SUBUTXOW" $ do
         disableInConformanceIt "SubMalformedScriptWitnesses" $ do
           let scriptHash = hashPlutusScript $ asSLanguage slang malformedPlutus
           txIn <- produceScript scriptHash
-          submitFailingSubTx
-            (scriptSpendingSubTx txIn)
+          submitFailingTx
+            (mkTopTxWithSubTxs [scriptSpendingSubTx txIn])
             [injectFailure . SubMalformedScriptWitnesses @era $ NES.singleton scriptHash]
 
         disableInConformanceIt "SubMalformedReferenceScripts" $ do
@@ -331,8 +327,8 @@ spec = describe "SUBUTXOW" $ do
                   mkBasicTxBody
                     & outputsTxBodyL
                       .~ [mkBasicTxOut addr mempty & referenceScriptTxOutL .~ SJust script]
-          submitFailingSubTx
-            subTx
+          submitFailingTx
+            (mkTopTxWithSubTxs [subTx])
             [ injectFailure . SubMalformedReferenceScripts @era . NES.singleton $
                 hashScript script
             ]
@@ -345,7 +341,9 @@ spec = describe "SUBUTXOW" $ do
                     .~ Map.singleton lang (pure . plutusBinary $ asSLanguage slang malformedPlutus)
               subTx :: Tx SubTx era
               subTx = mkBasicTx mkBasicTxBody & auxDataTxL .~ SJust auxData
-          submitFailingSubTx subTx [injectFailure $ SubInvalidMetadata @era]
+          submitFailingTx
+            (mkTopTxWithSubTxs [subTx])
+            [injectFailure $ SubInvalidMetadata @era]
 
 -- | Every distinct reason a sub-transaction requires a key witness,
 -- paired with a sub-transaction that requires it and the key hash whose

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/SubUtxowSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/SubUtxowSpec.hs
@@ -269,7 +269,7 @@ spec = describe "SUBUTXOW" $ do
                   SubMissingRedeemers @era [(missingRedeemer, redeemerSameAsDatumHash)]
               ]
 
-        it "SubExtraRedeemers" $ do
+        it "SubExtraRedeemers, alongside a needed redeemer" $ do
           txIn <- produceScript redeemerSameAsDatumHash
           redeemerData <- arbitrary
           let extraPurpose = mkMintingPurpose $ AsIx 2

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/SubUtxowSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/SubUtxowSpec.hs
@@ -73,26 +73,62 @@ spec = describe "SUBUTXOW" $ do
         (mkTopTxWithSubTxs [subTx])
         [injectFailure . SubInvalidWitnessesUTXOW @era $ pure (vKey keyPair)]
 
-  describe "SubMissingVKeyWitnessesUTXOW" $
+  describe "SubMissingVKeyWitnessesUTXOW" $ do
+    let withheldWitnessFails mkSubTx = do
+          (subTx, keyHash) <- mkSubTx
+          let dropWitness =
+                pure
+                  . (witsTxL . addrTxWitsL %~ Set.filter ((/= keyHash) . witVKeyHash))
+                  . (witsTxL . bootAddrTxWitsL .~ mempty)
+          withPostFixupSubTxs dropWitness $
+            submitFailingTx
+              (mkTopTxWithSubTxs [subTx])
+              [injectFailure . SubMissingVKeyWitnessesUTXOW @era $ NES.singleton keyHash]
+
     forM_ (missingVKeyWitnessSources @era) $ \(sourceName, mkSubTx) ->
-      it sourceName $ do
-        (subTx, keyHash) <- mkSubTx
-        let dropWitness =
-              pure
-                . (witsTxL . addrTxWitsL %~ Set.filter ((/= keyHash) . witVKeyHash))
-                . (witsTxL . bootAddrTxWitsL .~ mempty)
-        withPostFixupSubTxs dropWitness $
+      it sourceName $ withheldWitnessFails mkSubTx
+
+    -- The conformance translation has no representation for bootstrap addresses.
+    disableInConformanceIt "spending a bootstrap address input" $
+      withheldWitnessFails $ do
+        bootAddr <- freshBootstapAddress
+        txIn <- sendCoinTo (AddrBootstrap bootAddr) mempty
+        pure
+          ( mkBasicTx $ mkBasicTxBody & inputsTxBodyL .~ [txIn]
+          , asWitness $ bootstrapKeyHash bootAddr
+          )
+
+    -- The spec accepts a pool registration whose owner witness is missing.
+    disableInConformanceIt "registering a stake pool with an owner" $
+      withheldWitnessFails $ do
+        poolKeyHash <- freshKeyHash
+        ownerKeyHash <- freshKeyHash
+        accountAddress <- registerStakeCredential . KeyHashObj =<< freshKeyHash
+        poolParams <- freshPoolParams poolKeyHash accountAddress
+        pure
+          ( mkBasicTx $
+              mkBasicTxBody
+                & certsTxBodyL
+                  .~ [RegPoolTxCert poolParams {sppOwners = Set.singleton ownerKeyHash}]
+          , asWitness ownerKeyHash
+          )
+
+  describe "SubScriptWitnessNotValidatingUTXOW" $ do
+    let failingScriptFails mkSubTx = do
+          (subTx, scriptHash) <- mkSubTx
           submitFailingTx
             (mkTopTxWithSubTxs [subTx])
-            [injectFailure . SubMissingVKeyWitnessesUTXOW @era $ NES.singleton keyHash]
+            [injectFailure . SubScriptWitnessNotValidatingUTXOW @era $ NES.singleton scriptHash]
 
-  describe "SubScriptWitnessNotValidatingUTXOW" $
     forM_ (failingNativeScriptPurposes @era) $ \(purposeName, mkSubTx) ->
-      it purposeName $ do
-        (subTx, scriptHash) <- mkSubTx
-        submitFailingTx
-          (mkTopTxWithSubTxs [subTx])
-          [injectFailure . SubScriptWitnessNotValidatingUTXOW @era $ NES.singleton scriptHash]
+      it purposeName $ failingScriptFails mkSubTx
+
+    -- The spec attributes a failing minting script to UTXOW, not SUBUTXOW.
+    disableInConformanceIt "minting" $
+      failingScriptFails $ do
+        scriptHash <- unsatisfiableTimeLock
+        subTx <- mkTokenMintingTx scriptHash
+        pure (subTx, scriptHash)
 
   it "SubMissingTxMetadata" $ do
     auxData <- arbitrary @(TxAuxData era)
@@ -311,7 +347,7 @@ spec = describe "SUBUTXOW" $ do
           it "the supplied hash is wrong" $ testHashMismatch . SJust =<< arbitrary
           it "the supplied hash is missing" $ testHashMismatch SNothing
 
-        disableInConformanceIt "SubMalformedScriptWitnesses" $ do
+        it "SubMalformedScriptWitnesses" $ do
           let scriptHash = hashPlutusScript $ asSLanguage slang malformedPlutus
           txIn <- produceScript scriptHash
           submitFailingTx
@@ -333,7 +369,7 @@ spec = describe "SUBUTXOW" $ do
                 hashScript script
             ]
 
-        it "SubInvalidMetadata" $ do
+        disableInConformanceIt "SubInvalidMetadata" $ do
           let auxData :: TxAuxData era
               auxData =
                 mkBasicTxAuxData
@@ -391,31 +427,6 @@ missingVKeyWitnessSources =
         pure
           ( mkBasicTx $ mkBasicTxBody & guardsTxBodyL .~ [KeyHashObj keyHash]
           , asWitness keyHash
-          )
-    )
-  ,
-    ( "spending a bootstrap address input"
-    , do
-        bootAddr <- freshBootstapAddress
-        txIn <- sendCoinTo (AddrBootstrap bootAddr) mempty
-        pure
-          ( mkBasicTx $ mkBasicTxBody & inputsTxBodyL .~ [txIn]
-          , asWitness $ bootstrapKeyHash bootAddr
-          )
-    )
-  ,
-    ( "registering a stake pool with an owner"
-    , do
-        poolKeyHash <- freshKeyHash
-        ownerKeyHash <- freshKeyHash
-        accountAddress <- registerStakeCredential . KeyHashObj =<< freshKeyHash
-        poolParams <- freshPoolParams poolKeyHash accountAddress
-        pure
-          ( mkBasicTx $
-              mkBasicTxBody
-                & certsTxBodyL
-                  .~ [RegPoolTxCert poolParams {sppOwners = Set.singleton ownerKeyHash}]
-          , asWitness ownerKeyHash
           )
     )
   ,
@@ -490,13 +501,6 @@ failingNativeScriptPurposes =
           ( mkBasicTx $ mkBasicTxBody & guardsTxBodyL .~ [ScriptHashObj scriptHash]
           , scriptHash
           )
-    )
-  ,
-    ( "minting"
-    , do
-        scriptHash <- unsatisfiableTimeLock
-        subTx <- mkTokenMintingTx scriptHash
-        pure (subTx, scriptHash)
     )
   ,
     ( "withdrawing"

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/SubUtxowSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/SubUtxowSpec.hs
@@ -123,7 +123,7 @@ spec = describe "SUBUTXOW" $ do
     let subTx :: Tx SubTx era
         subTx = mkBasicTx mkBasicTxBody & auxDataTxL .~ SJust auxData
         dropAuxDataHash =
-          resetAddrTxWits . (bodyTxL . auxDataHashTxBodyL .~ SNothing)
+          rederiveAddrTxWits . (bodyTxL . auxDataHashTxBodyL .~ SNothing)
     withPostFixupSubTxs dropAuxDataHash $
       submitFailingSubTx
         subTx
@@ -143,7 +143,7 @@ spec = describe "SUBUTXOW" $ do
               & bodyTxL . collateralInputsTxBodyL .~ [collateralInput]
               & bodyTxL . subTransactionsTxBodyL .~ OMap.singleton subTx
           addExtraRedeemer =
-            (fixupPPHash >=> resetAddrTxWits)
+            (fixupPPHash >=> rederiveAddrTxWits)
               . ( witsTxL . rdmrsTxWitsL . unRedeemersL
                     %~ Map.insert extraPurpose (redeemerData, ExUnits 0 0)
                 )
@@ -163,7 +163,7 @@ spec = describe "SUBUTXOW" $ do
               & bodyTxL . collateralInputsTxBodyL .~ [collateralInput]
               & bodyTxL . subTransactionsTxBodyL .~ OMap.singleton subTx
           addExtraRedeemer =
-            (fixupPPHash >=> resetAddrTxWits)
+            (fixupPPHash >=> rederiveAddrTxWits)
               . ( witsTxL . rdmrsTxWitsL . unRedeemersL
                     %~ Map.insert extraPurpose (redeemerData, ExUnits 0 0)
                 )
@@ -180,7 +180,7 @@ spec = describe "SUBUTXOW" $ do
       let subTx :: Tx SubTx era
           subTx = mkBasicTx mkBasicTxBody
           supplyIntegrityHash =
-            resetAddrTxWits . (bodyTxL . scriptIntegrityHashTxBodyL .~ SJust badHash)
+            rederiveAddrTxWits . (bodyTxL . scriptIntegrityHashTxBodyL .~ SJust badHash)
       withPostFixupSubTxs supplyIntegrityHash $
         submitFailingSubTx
           subTx
@@ -224,7 +224,7 @@ spec = describe "SUBUTXOW" $ do
                            _ -> error "Expected non-empty outputs"
                        )
             txInAt 0
-              <$> withPostFixup (resetAddrTxWits . resetTxOutDataHash) (submitTx tx)
+              <$> withPostFixup (rederiveAddrTxWits . resetTxOutDataHash) (submitTx tx)
           submitFailingSubTx
             (mkBasicTx $ mkBasicTxBody & inputsTxBodyL .~ [txIn])
             [injectFailure . SubUnspendableUTxONoDatumHash @era $ NES.singleton txIn]
@@ -233,7 +233,7 @@ spec = describe "SUBUTXOW" $ do
     withSLanguage lang $ \slang ->
       describe (show lang) $ do
         let redeemerSameAsDatumHash = hashPlutusScript $ redeemerSameAsDatum slang
-            fixupResetAddrWits = fixupPPHash >=> resetAddrTxWits
+            fixupResetAddrWits = fixupPPHash >=> rederiveAddrTxWits
             scriptSpendingSubTx txIn = mkBasicTx $ mkBasicTxBody & inputsTxBodyL .~ [txIn]
 
         it "SubMissingRequiredDatums" $ do
@@ -299,10 +299,10 @@ spec = describe "SUBUTXOW" $ do
                 let goodHash = fixedUpSubTx ^. bodyTxL . scriptIntegrityHashTxBodyL
                 expectedIntegrity <- impComputeScriptIntegrity fixedUpSubTx
                 badSubTx <-
-                  resetAddrTxWits $
+                  rederiveAddrTxWits $
                     fixedUpSubTx & bodyTxL . scriptIntegrityHashTxBodyL .~ badHash
                 badTopTx <-
-                  resetAddrTxWits $
+                  rederiveAddrTxWits $
                     fixedUpTx & bodyTxL . subTransactionsTxBodyL .~ OMap.singleton badSubTx
                 withNoFixup $
                   submitFailingTx

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
@@ -22,6 +22,8 @@ module Test.Cardano.Ledger.Dijkstra.ImpTest (
   fixupSubTransactions,
   balanceSubTransactions,
   switchTxToLegacyMode,
+  submitFailingSubTx,
+  withPostFixupSubTxs,
 ) where
 
 import Cardano.Ledger.Allegra.Scripts (
@@ -116,6 +118,7 @@ class
   , InjectRuleFailure "MEMPOOL" DijkstraMempoolPredFailure era
   , InjectRuleFailure "MEMPOOL" DijkstraUtxoPredFailure era
   , InjectRuleFailure "LEDGER" DijkstraSubUtxoPredFailure era
+  , InjectRuleFailure "LEDGER" DijkstraSubUtxowPredFailure era
   , Inject (NonEmpty (Conway.PredicateFailure (EraRule "MEMPOOL" era))) (ApplyTxError era)
   ) =>
   DijkstraEraImp era
@@ -147,6 +150,51 @@ instance InjectRuleFailure "LEDGER" DijkstraSubUtxoPredFailure DijkstraEra where
       . SubLedgerFailure
       . SubUtxowFailure
       . SubUtxoFailure
+
+instance InjectRuleFailure "LEDGER" DijkstraSubUtxowPredFailure DijkstraEra where
+  injectFailure =
+    injectFailure @"LEDGER" @DijkstraSubLedgersPredFailure
+      . SubLedgerFailure
+      . SubUtxowFailure
+
+-- | Submit a sub-transaction, nested in an otherwise empty top level
+-- transaction, that is expected to be rejected with exactly the given
+-- predicate failures.
+submitFailingSubTx ::
+  ( HasCallStack
+  , DijkstraEraImp era
+  ) =>
+  Tx SubTx era ->
+  NonEmpty (PredicateFailure (EraRule "LEDGER" era)) ->
+  ImpTestM era ()
+submitFailingSubTx subTx =
+  submitFailingTx $
+    mkBasicTx mkBasicTxBody & bodyTxL . subTransactionsTxBodyL .~ OMap.singleton subTx
+
+-- | Apply a modification to every sub-transaction, after the given
+-- fixup `f` has run, in order to provoke a failure that `f` otherwise
+-- repairs.
+--
+-- The top level transaction is signed again afterwards, since
+-- sub-transactions are part of its body and modifying one invalidates
+-- its witnesses.
+--
+-- Sub-transactions are keyed by transaction id, so a modification that
+-- makes two of them equal would silently drop one. Report this as a
+-- test failure.
+withPostFixupSubTxs ::
+  ( HasCallStack
+  , DijkstraEraImp era
+  ) =>
+  (Tx SubTx era -> ImpTestM era (Tx SubTx era)) ->
+  ImpTestM era a ->
+  ImpTestM era a
+withPostFixupSubTxs f = withPostFixup $ \tx -> do
+  subTxs <- traverse f . OMap.elems $ tx ^. bodyTxL . subTransactionsTxBodyL
+  let modifiedSubTxs = OMap.fromFoldable subTxs
+  unless (OMap.size modifiedSubTxs == length subTxs) $
+    assertFailure "Modifying the sub-transactions resulted in collision of transaction id"
+  resetAddrTxWits $ tx & bodyTxL . subTransactionsTxBodyL .~ modifiedSubTxs
 
 impDijkstraSatisfyNativeScript ::
   ( DijkstraEraImp era
@@ -219,7 +267,7 @@ dijkstraFixupTx ::
   ImpTestM era (Tx TopTx era)
 dijkstraFixupTx tx = do
   -- add top-level Plutus script witnesses so legacy detection sees them
-  fixedUp <- fixupScriptWits =<< fixupSubTransactions tx
+  fixedUp <- fixupScriptWits =<< addSubTxCollateralInput =<< fixupSubTransactions tx
   isLegacy <- detectLegacyMode fixedUp
   balancedInLegacy <- if isLegacy then balanceSubTransactions fixedUp else pure fixedUp
   babbageFixupTx balancedInLegacy
@@ -234,6 +282,28 @@ detectLegacyMode tx = do
   utxo <- getUTxO
   let stAnnTx = mkStAnnTx epochInfo systemStart pp utxo mempty tx
   pure $ stAnnTx ^. plutusLegacyModeStAnnTxG
+
+-- | Add a collateral input when a sub-transaction needs a Plutus
+-- script.
+--
+-- `addCollateralInput` only inspects the top level transaction, so it
+-- does not account for scripts that are needed by a sub-transaction,
+-- even though collateral is validated for the whole batch of
+-- transactions.
+addSubTxCollateralInput ::
+  DijkstraEraImp era =>
+  Tx TopTx era ->
+  ImpTestM era (Tx TopTx era)
+addSubTxCollateralInput tx
+  | not (null (tx ^. bodyTxL . collateralInputsTxBodyL)) = pure tx
+  | otherwise = do
+      subTxContexts <-
+        traverse impGetPlutusContexts . OMap.elems $ tx ^. bodyTxL . subTransactionsTxBodyL
+      if all null subTxContexts
+        then pure tx
+        else impAnn "addSubTxCollateralInput" $ do
+          collateralInput <- makeCollateralInput
+          pure $ tx & bodyTxL . collateralInputsTxBodyL %~ Set.insert collateralInput
 
 fixupSubTransactions ::
   ( HasCallStack
@@ -252,7 +322,12 @@ fixupSubTransactions tx = impAnn "fixupSubTransactions" $ do
       addSubTxIn
         >=> addNativeScriptTxWits
         >=> fixupAuxDataHash
+        >=> fixupScriptWits
+        >=> fixupOutputDatums
+        >=> fixupDatums
         >=> fixupTxOuts
+        >=> txWithMaxRedeemers
+        >=> fixupPPHash
         >=> updateAddrTxWits
     addSubTxIn subTx
       | not (Set.null (subTx ^. bodyTxL . inputsTxBodyL)) = pure subTx

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
@@ -22,7 +22,7 @@ module Test.Cardano.Ledger.Dijkstra.ImpTest (
   fixupSubTransactions,
   balanceSubTransactions,
   switchTxToLegacyMode,
-  submitFailingSubTx,
+  mkTopTxWithSubTxs,
   withPostFixupSubTxs,
 ) where
 
@@ -157,19 +157,11 @@ instance InjectRuleFailure "LEDGER" DijkstraSubUtxowPredFailure DijkstraEra wher
       . SubLedgerFailure
       . SubUtxowFailure
 
--- | Submit a sub-transaction, nested in an otherwise empty top level
--- transaction, that is expected to be rejected with exactly the given
--- predicate failures.
-submitFailingSubTx ::
-  ( HasCallStack
-  , DijkstraEraImp era
-  ) =>
-  Tx SubTx era ->
-  NonEmpty (PredicateFailure (EraRule "LEDGER" era)) ->
-  ImpTestM era ()
-submitFailingSubTx subTx =
-  submitFailingTx $
-    mkBasicTx mkBasicTxBody & bodyTxL . subTransactionsTxBodyL .~ OMap.singleton subTx
+-- | A top level transaction that nests the given sub-transactions and
+-- is otherwise empty.
+mkTopTxWithSubTxs :: DijkstraEraImp era => [Tx SubTx era] -> Tx TopTx era
+mkTopTxWithSubTxs subTxs =
+  mkBasicTx mkBasicTxBody & bodyTxL . subTransactionsTxBodyL .~ OMap.fromFoldable subTxs
 
 -- | Apply a modification to every sub-transaction, after the given
 -- fixup `f` has run, in order to provoke a failure that `f` otherwise

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
@@ -194,7 +194,7 @@ withPostFixupSubTxs f = withPostFixup $ \tx -> do
   let modifiedSubTxs = OMap.fromFoldable subTxs
   unless (OMap.size modifiedSubTxs == length subTxs) $
     assertFailure "Modifying the sub-transactions resulted in collision of transaction id"
-  resetAddrTxWits $ tx & bodyTxL . subTransactionsTxBodyL .~ modifiedSubTxs
+  rederiveAddrTxWits $ tx & bodyTxL . subTransactionsTxBodyL .~ modifiedSubTxs
 
 impDijkstraSatisfyNativeScript ::
   ( DijkstraEraImp era

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
@@ -23,6 +23,7 @@ module Test.Cardano.Ledger.Dijkstra.ImpTest (
   balanceSubTransactions,
   switchTxToLegacyMode,
   mkTopTxWithSubTxs,
+  traverseSubTxs,
   withPostFixupSubTxs,
 ) where
 
@@ -144,24 +145,45 @@ instance InjectRuleFailure "DELEG" Shelley.ShelleyDelegPredFailure DijkstraEra w
   injectFailure (Shelley.StakeKeyNonZeroAccountBalanceDELEG c) = Conway.StakeKeyHasNonZeroAccountBalanceDELEG c
   injectFailure _ = error "Cannot inject ShelleyDelegPredFailure into DijkstraEra"
 
-instance InjectRuleFailure "LEDGER" DijkstraSubUtxoPredFailure DijkstraEra where
-  injectFailure =
-    injectFailure @"LEDGER" @DijkstraSubLedgersPredFailure
-      . SubLedgerFailure
-      . SubUtxowFailure
-      . SubUtxoFailure
-
 instance InjectRuleFailure "LEDGER" DijkstraSubUtxowPredFailure DijkstraEra where
-  injectFailure =
-    injectFailure @"LEDGER" @DijkstraSubLedgersPredFailure
-      . SubLedgerFailure
-      . SubUtxowFailure
+  injectFailure = DijkstraSubLedgersFailure . injectFailure @"SUBLEDGERS"
+
+instance InjectRuleFailure "SUBLEDGERS" DijkstraSubUtxowPredFailure DijkstraEra where
+  injectFailure = SubLedgerFailure . injectFailure @"SUBLEDGER"
+
+instance InjectRuleFailure "LEDGER" DijkstraSubUtxoPredFailure DijkstraEra where
+  injectFailure = DijkstraSubLedgersFailure . injectFailure @"SUBLEDGERS"
+
+instance InjectRuleFailure "SUBLEDGERS" DijkstraSubUtxoPredFailure DijkstraEra where
+  injectFailure = SubLedgerFailure . injectFailure @"SUBLEDGER"
+
+instance InjectRuleFailure "SUBLEDGER" DijkstraSubUtxoPredFailure DijkstraEra where
+  injectFailure = SubUtxowFailure . injectFailure @"SUBUTXOW"
 
 -- | A top level transaction that nests the given sub-transactions and
 -- is otherwise empty.
 mkTopTxWithSubTxs :: DijkstraEraImp era => [Tx SubTx era] -> Tx TopTx era
 mkTopTxWithSubTxs subTxs =
   mkBasicTx mkBasicTxBody & bodyTxL . subTransactionsTxBodyL .~ OMap.fromFoldable subTxs
+
+-- | Apply an effectful modification to every sub-transaction of a top
+-- level transaction.
+--
+-- Sub-transactions are keyed by their transaction id, so a modification
+-- that makes two of them equal keeps only the first.
+traverseSubTxs ::
+  ( Applicative m
+  , EraTx era
+  , DijkstraEraTxBody era
+  ) =>
+  (Tx SubTx era -> m (Tx SubTx era)) ->
+  Tx TopTx era ->
+  m (Tx TopTx era)
+traverseSubTxs f tx =
+  replaceSubTxs <$> traverse f (OMap.elems (tx ^. bodyTxL . subTransactionsTxBodyL))
+  where
+    replaceSubTxs subTxs =
+      tx & bodyTxL . subTransactionsTxBodyL .~ OMap.fromFoldable subTxs
 
 -- | Apply a modification to every sub-transaction, after the given
 -- fixup `f` has run, in order to provoke a failure that `f` otherwise
@@ -170,10 +192,6 @@ mkTopTxWithSubTxs subTxs =
 -- The top level transaction is signed again afterwards, since
 -- sub-transactions are part of its body and modifying one invalidates
 -- its witnesses.
---
--- Sub-transactions are keyed by transaction id, so a modification that
--- makes two of them equal would silently drop one. Report this as a
--- test failure.
 withPostFixupSubTxs ::
   ( HasCallStack
   , DijkstraEraImp era
@@ -181,12 +199,7 @@ withPostFixupSubTxs ::
   (Tx SubTx era -> ImpTestM era (Tx SubTx era)) ->
   ImpTestM era a ->
   ImpTestM era a
-withPostFixupSubTxs f = withPostFixup $ \tx -> do
-  subTxs <- traverse f . OMap.elems $ tx ^. bodyTxL . subTransactionsTxBodyL
-  let modifiedSubTxs = OMap.fromFoldable subTxs
-  unless (OMap.size modifiedSubTxs == length subTxs) $
-    assertFailure "Modifying the sub-transactions resulted in collision of transaction id"
-  rederiveAddrTxWits $ tx & bodyTxL . subTransactionsTxBodyL .~ modifiedSubTxs
+withPostFixupSubTxs f = withPostFixup $ traverseSubTxs f >=> rederiveAddrTxWits
 
 impDijkstraSatisfyNativeScript ::
   ( DijkstraEraImp era

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
@@ -259,7 +259,7 @@ dijkstraFixupTx ::
   ImpTestM era (Tx TopTx era)
 dijkstraFixupTx tx = do
   -- add top-level Plutus script witnesses so legacy detection sees them
-  fixedUp <- fixupScriptWits =<< addSubTxCollateralInput =<< fixupSubTransactions tx
+  fixedUp <- fixupScriptWits =<< addCollateralInputForSubTxs =<< fixupSubTransactions tx
   isLegacy <- detectLegacyMode fixedUp
   balancedInLegacy <- if isLegacy then balanceSubTransactions fixedUp else pure fixedUp
   babbageFixupTx balancedInLegacy
@@ -275,25 +275,27 @@ detectLegacyMode tx = do
   let stAnnTx = mkStAnnTx epochInfo systemStart pp utxo mempty tx
   pure $ stAnnTx ^. plutusLegacyModeStAnnTxG
 
--- | Add a collateral input when a sub-transaction needs a Plutus
--- script.
+-- | Add a collateral input to the top-level transaction when a
+-- sub-transaction needs a Plutus script.
 --
--- `addCollateralInput` only inspects the top level transaction, so it
--- does not account for scripts that are needed by a sub-transaction,
--- even though collateral is validated for the whole batch of
--- transactions.
-addSubTxCollateralInput ::
+-- Collateral is validated across the whole batch but the inherited
+-- `addCollateralInput` step only inspects the top-level transaction's
+-- own script needs. This step covers the sub-transactions. Both skip
+-- when a collateral input is already present, so at most one collateral
+-- input is added for the whole batch, and neither step overrides
+-- collateral that a test set itself.
+addCollateralInputForSubTxs ::
   DijkstraEraImp era =>
   Tx TopTx era ->
   ImpTestM era (Tx TopTx era)
-addSubTxCollateralInput tx
+addCollateralInputForSubTxs tx
   | not (null (tx ^. bodyTxL . collateralInputsTxBodyL)) = pure tx
   | otherwise = do
       subTxContexts <-
         traverse impGetPlutusContexts . OMap.elems $ tx ^. bodyTxL . subTransactionsTxBodyL
       if all null subTxContexts
         then pure tx
-        else impAnn "addSubTxCollateralInput" $ do
+        else impAnn "addCollateralInputForSubTxs" $ do
           collateralInput <- makeCollateralInput
           pure $ tx & bodyTxL . collateralInputsTxBodyL %~ Set.insert collateralInput
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### `testlib`
 
+* Add `resetAddrTxWits`, which re-derives key witnesses for a modified transaction body
 * Add `era` parameter to `PoolCert`s and `StakePoolParams`
 * Add `submitFailingSubsetTx{,M}`
 * Make `fixupTxOuts` parametric on level

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### `testlib`
 
-* Add `resetAddrTxWits`, which re-derives key witnesses for a modified transaction body
+* Add `rederiveAddrTxWits`, which re-derives key witnesses for a modified transaction body
 * Add `era` parameter to `PoolCert`s and `StakePoolParams`
 * Add `submitFailingSubsetTx{,M}`
 * Make `fixupTxOuts` parametric on level

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -120,6 +120,7 @@ module Test.Cardano.Ledger.Shelley.ImpTest (
   expectTreasury,
   disableTreasuryExpansion,
   updateAddrTxWits,
+  resetAddrTxWits,
   addNativeScriptTxWits,
   addRootTxIn,
   fixupTxOuts,
@@ -1097,7 +1098,14 @@ addNativeScriptTxWits tx = impAnn "addNativeScriptTxWits" $ do
     tx
       & witsTxL . scriptTxWitsL <>~ fmap fromNativeScript scriptsToAdd
 
--- | Adds @TxWits@ that will satisfy all of the required key witnesses
+-- | Add the @TxWits@ that are needed to satisfy the required key
+-- witnesses and are not already present.
+--
+-- Witnesses that are already present are retained, and this acts as a
+-- fixup step: a test can supply a witness of its own and it will be
+-- retained. But a witness signed over a transaction body that has since
+-- changed is left in place, since its key hash is already covered. If
+-- we want to reset all use `resetAddrTxWits`.
 updateAddrTxWits ::
   ( HasCallStack
   , ShelleyEraImp era
@@ -1134,6 +1142,20 @@ updateAddrTxWits tx = impAnn "updateAddrTxWits" $ do
     tx
       & witsTxL . addrTxWitsL <>~ extraAddrVKeyWits <> extraNativeScriptVKeyWits
       & witsTxL . bootAddrTxWitsL <>~ Set.fromList extraBootAddrWits
+
+-- | Discard Shelley-based address witnesses and derive them afresh for
+-- the current transaction body. Leave bootstrap witnesses untouched.
+--
+-- Required when transaction body is modified after witnesses have been
+-- added, because `updateAddrTxWits` leaves witnesses signed over the
+-- previous body in place.
+resetAddrTxWits ::
+  ( HasCallStack
+  , ShelleyEraImp era
+  ) =>
+  Tx l era ->
+  ImpTestM era (Tx l era)
+resetAddrTxWits = updateAddrTxWits . (witsTxL . addrTxWitsL .~ mempty)
 
 -- | This fixup step ensures that there are enough funds in the transaction.
 addRootTxIn ::

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -120,7 +120,7 @@ module Test.Cardano.Ledger.Shelley.ImpTest (
   expectTreasury,
   disableTreasuryExpansion,
   updateAddrTxWits,
-  resetAddrTxWits,
+  rederiveAddrTxWits,
   addNativeScriptTxWits,
   addRootTxIn,
   fixupTxOuts,
@@ -1105,7 +1105,7 @@ addNativeScriptTxWits tx = impAnn "addNativeScriptTxWits" $ do
 -- fixup step: a test can supply a witness of its own and it will be
 -- retained. But a witness signed over a transaction body that has since
 -- changed is left in place, since its key hash is already covered. If
--- we want to reset all use `resetAddrTxWits`.
+-- we want to reset all use `rederiveAddrTxWits`.
 updateAddrTxWits ::
   ( HasCallStack
   , ShelleyEraImp era
@@ -1149,13 +1149,13 @@ updateAddrTxWits tx = impAnn "updateAddrTxWits" $ do
 -- Required when transaction body is modified after witnesses have been
 -- added, because `updateAddrTxWits` leaves witnesses signed over the
 -- previous body in place.
-resetAddrTxWits ::
+rederiveAddrTxWits ::
   ( HasCallStack
   , ShelleyEraImp era
   ) =>
   Tx l era ->
   ImpTestM era (Tx l era)
-resetAddrTxWits = updateAddrTxWits . (witsTxL . addrTxWitsL .~ mempty)
+rederiveAddrTxWits = updateAddrTxWits . (witsTxL . addrTxWitsL .~ mempty)
 
 -- | This fixup step ensures that there are enough funds in the transaction.
 addRootTxIn ::

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Dijkstra.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Dijkstra.hs
@@ -32,6 +32,7 @@ import Test.Cardano.Ledger.Dijkstra.Imp.CertSpec qualified as CERT
 import Test.Cardano.Ledger.Dijkstra.Imp.EntitiesSpec qualified as ENTITIES
 import Test.Cardano.Ledger.Dijkstra.Imp.LedgerSpec qualified as LEDGER
 import Test.Cardano.Ledger.Dijkstra.Imp.PoolSpec qualified as POOL
+import Test.Cardano.Ledger.Dijkstra.Imp.SubUtxowSpec qualified as SUBUTXOW
 import Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec qualified as UTXO
 import Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec qualified as UTXOW
 import Test.Cardano.Ledger.Dijkstra.ImpTest
@@ -94,6 +95,7 @@ spec = do
             BabbageUTXOW.spec
             ConwayUTXOW.spec
             UTXOW.spec
+            SUBUTXOW.spec
 
             AlonzoUTXOS.spec
             BabbageUTXOS.spec


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
