### PR TITLE
Redo PlutusPurpose translation

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.17.0.0
 
+* Switch `toPlutusScriptPurpose` to accept `LedgerTxInfo` instead of `ProtVer`
 * Add `ltiScriptsUsed` and `ltiScriptHashesUsed` to `LedgerTxInfo`
 * Add `toScriptHashByPurpose` helper
 * Remove no longer necessary argument from `scriptsWithContextFromLedgerTxInfoWithResult` and `scriptsWithContextFromLedgerTxInfo`, since it is now available as `ltiScriptsUsed`

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -10,7 +10,6 @@
 * Remove `AlonzoEraUTxO` constraint from `mkPlutusWithContext`
 * Change `toPlutusArgs` and `toPlutusV1Args` to accept `LedgerTxInfo era` and `ScriptHash` arguments instead of `ProtVer` and `Maybe (Data era)`
 * Change the `PlutusV4` instances of the `PlutusTxCert`, `PlutusScriptPurpose`, `PlutusTxInfo` and `PlutusTxInInfo` type families to point to `PlutusLedgerApi.V4` types instead of `PlutusLedgerApi.V3`
-* Add `transRedeemerPointerV1`
 * Add `EncCBOR`, `ToCBOR` for `Block`
 * Add `DecCBOR` instances for `Annotator Block`
 

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.17.0.0
 
+* Add `ltiScriptsUsed` to `LedgerTxInfo`
+* Remove no longer necessary argument from `scriptsWithContextFromLedgerTxInfoWithResult` and `scriptsWithContextFromLedgerTxInfo`, since it is now available as `ltiScriptsUsed`
 * Add `FromJSON` instance for `AlonzoTxOut era`
 * Remove `AlonzoEraUTxO` constraint from `mkPlutusWithContext`
 * Change `toPlutusArgs` and `toPlutusV1Args` to accept `LedgerTxInfo era` and `ScriptHash` arguments instead of `ProtVer` and `Maybe (Data era)`
@@ -12,6 +14,7 @@
 
 ### `testlib`
 
+* Add `mkTestLedgerTxInfo` helper
 * Add `Serialise` instance for `PV4.POSIXTimeRange`
 * Add `Serialise` instances for `PlutusLedgerApi.V4` script context types
 * Change `TxInfoPV4` constructor of `VersionedTxInfo` to contain `PV4.TxInfo` instead of `PV3.TxInfo`

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.17.0.0
 
-* Add `ltiScriptsUsed` to `LedgerTxInfo`
+* Add `ltiScriptsUsed` and `ltiScriptHashesUsed` to `LedgerTxInfo`
+* Add `toScriptHashByPurpose` helper
 * Remove no longer necessary argument from `scriptsWithContextFromLedgerTxInfoWithResult` and `scriptsWithContextFromLedgerTxInfo`, since it is now available as `ltiScriptsUsed`
 * Add `FromJSON` instance for `AlonzoTxOut era`
 * Remove `AlonzoEraUTxO` constraint from `mkPlutusWithContext`

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -4,12 +4,8 @@
 
 * Add `FromJSON` instance for `AlonzoTxOut era`
 * Remove `AlonzoEraUTxO` constraint from `mkPlutusWithContext`
-* Add `toPlutusRedeemerPointer` and `toPlutusTxOut` methods to `EraPlutusTxInfo`
-* Add `PlutusPurposeScriptHashArg`, `PlutusRedeemerPointer` and `PlutusTxOut` type families
-* Change `toPlutusScriptPurpose` to accept a `PlutusPurposeScriptHashArg l` argument
 * Change `toPlutusArgs` and `toPlutusV1Args` to accept `LedgerTxInfo era` and `ScriptHash` arguments instead of `ProtVer` and `Maybe (Data era)`
 * Change the `PlutusV4` instances of the `PlutusTxCert`, `PlutusScriptPurpose`, `PlutusTxInfo` and `PlutusTxInInfo` type families to point to `PlutusLedgerApi.V4` types instead of `PlutusLedgerApi.V3`
-* Change `toLegacyPlutusArgs` and `transPlutusPurpose` to accept a `PlutusPurposeScriptHashArg l` argument
 * Add `transRedeemerPointerV1`
 * Add `EncCBOR`, `ToCBOR` for `Block`
 * Add `DecCBOR` instances for `Annotator Block`

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -146,6 +146,7 @@ mkAlonzoStAnnTx ei sysStart pp utxo stAnnTxCache tx =
         , ltiSystemStart = sysStart
         , ltiUTxO = utxo
         , ltiTx = tx
+        , ltiScriptsUsed = plutusScriptsUsed
         , ltiMemoizedSubTransactions = mempty
         }
    in
@@ -157,5 +158,5 @@ mkAlonzoStAnnTx ei sysStart pp utxo stAnnTxCache tx =
       , asatPlutusLanguagesUsed =
           Set.fromList [plutusLanguage spr | (_, SupportedPlutusRunnable spr) <- plutusScriptsUsed]
       , asatPlutusScriptsWithContext =
-          scriptsWithContextFromLedgerTxInfo ledgerTxInfo (pp ^. ppCostModelsL) plutusScriptsUsed
+          scriptsWithContextFromLedgerTxInfo ledgerTxInfo (pp ^. ppCostModelsL)
       }

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -35,6 +35,7 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
   EraPlutusContext,
   LedgerTxInfo (..),
   SupportedPlutusRunnable (..),
+  toScriptHashByPurpose,
  )
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (
   scriptsWithContextFromLedgerTxInfo,
@@ -147,6 +148,7 @@ mkAlonzoStAnnTx ei sysStart pp utxo stAnnTxCache tx =
         , ltiUTxO = utxo
         , ltiTx = tx
         , ltiScriptsUsed = plutusScriptsUsed
+        , ltiScriptHashesUsed = toScriptHashByPurpose plutusScriptsUsed
         , ltiMemoizedSubTransactions = mempty
         }
    in

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
@@ -49,7 +49,6 @@ module Cardano.Ledger.Alonzo.Plutus.Context (
   PlutusTxInInfo,
   PlutusPurposeScriptHashArg,
   PlutusRedeemerPointer,
-  PlutusTxOut,
 ) where
 
 import Cardano.Ledger.Alonzo.Era (AlonzoEra)
@@ -77,7 +76,6 @@ import Cardano.Ledger.Plutus (
   PlutusRunnable (..),
   PlutusScriptContext,
   SLanguage (..),
-  TxOutSource,
   asSLanguage,
   plutusLanguage,
  )
@@ -163,12 +161,6 @@ class
     Map (PlutusPurpose AsIx era) ScriptHash ->
     (PlutusPurpose AsIx era, (Data era, ExUnits)) ->
     Either (ContextError era) (PlutusRedeemerPointer l)
-
-  toPlutusTxOut ::
-    proxy l ->
-    TxOutSource ->
-    TxOut era ->
-    Either (ContextError era) (PlutusTxOut l)
 
 -- | This is the helper type that captures translation of `Tx` to `PlutusTxInfo`.
 --
@@ -294,14 +286,6 @@ type family PlutusRedeemerPointer (l :: Language) where
   PlutusRedeemerPointer 'PlutusV2 = (PlutusScriptPurpose 'PlutusV2, PV2.Redeemer)
   PlutusRedeemerPointer 'PlutusV3 = (PlutusScriptPurpose 'PlutusV3, PV3.Redeemer)
   PlutusRedeemerPointer 'PlutusV4 = (PlutusScriptPurpose 'PlutusV4, PV4.Redeemer)
-
-type family PlutusTxOut (l :: Language) where
-  -- This special case is here because Alonzo does not have a ContextError
-  -- for the case where it encounters a Byron address in a TxIn
-  PlutusTxOut 'PlutusV1 = Maybe PV1.TxOut
-  PlutusTxOut 'PlutusV2 = PV2.TxOut
-  PlutusTxOut 'PlutusV3 = PV3.TxOut
-  PlutusTxOut 'PlutusV4 = PV4.TxOut
 
 -- | This is just like `mkPlutusScript`, except it is guaranteed to be total through the enforcement
 -- of support by the type system and `EraPlutusTxInfo` type class instances for supported plutus

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
@@ -102,6 +102,7 @@ data LedgerTxInfo era where
     , ltiSystemStart :: !SystemStart
     , ltiUTxO :: !(UTxO era)
     , ltiTx :: !(Tx level era)
+    , ltiScriptsUsed :: [(PlutusPurpose AsIxItem era, SupportedPlutusRunnable era)]
     , ltiMemoizedSubTransactions :: Map TxId (TxInfoResult era)
     -- ^ This is a tricky field that is only used starting with Dijkstra era and only by top level
     -- transactions. It is always safe to leave it as `mempty` upon construction, even for Dijkstra

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
@@ -48,17 +48,14 @@ module Cardano.Ledger.Alonzo.Plutus.Context (
   PlutusScriptContext,
   PlutusTxInInfo,
   PlutusPurposeScriptHashArg,
-  PlutusRedeemerPointer,
 ) where
 
 import Cardano.Ledger.Alonzo.Era (AlonzoEra)
 import Cardano.Ledger.Alonzo.Scripts (
   AlonzoEraScript (eraMaxLanguage, mkPlutusScript),
   AsItem (..),
-  AsIx,
   AsIxItem (..),
   AsPurpose,
-  ExUnits,
   PlutusPurpose,
   PlutusScript (..),
  )
@@ -153,14 +150,6 @@ class
     UTxO era ->
     TxIn ->
     Either (ContextError era) (PlutusTxInInfo era l)
-
-  toPlutusRedeemerPointer ::
-    proxy l ->
-    ProtVer ->
-    TxBody t era ->
-    Map (PlutusPurpose AsIx era) ScriptHash ->
-    (PlutusPurpose AsIx era, (Data era, ExUnits)) ->
-    Either (ContextError era) (PlutusRedeemerPointer l)
 
 -- | This is the helper type that captures translation of `Tx` to `PlutusTxInfo`.
 --
@@ -280,12 +269,6 @@ type family PlutusPurposeScriptHashArg (l :: Language) where
   PlutusPurposeScriptHashArg 'PlutusV2 = ()
   PlutusPurposeScriptHashArg 'PlutusV3 = ()
   PlutusPurposeScriptHashArg 'PlutusV4 = ScriptHash
-
-type family PlutusRedeemerPointer (l :: Language) where
-  PlutusRedeemerPointer 'PlutusV1 = ()
-  PlutusRedeemerPointer 'PlutusV2 = (PlutusScriptPurpose 'PlutusV2, PV2.Redeemer)
-  PlutusRedeemerPointer 'PlutusV3 = (PlutusScriptPurpose 'PlutusV3, PV3.Redeemer)
-  PlutusRedeemerPointer 'PlutusV4 = (PlutusScriptPurpose 'PlutusV4, PV4.Redeemer)
 
 -- | This is just like `mkPlutusScript`, except it is guaranteed to be total through the enforcement
 -- of support by the type system and `EraPlutusTxInfo` type class instances for supported plutus

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
@@ -143,7 +143,7 @@ class
 
   toPlutusScriptPurpose ::
     proxy l ->
-    ProtVer ->
+    LedgerTxInfo era ->
     PlutusPurpose AsIxItem era ->
     Either (ContextError era) (PlutusScriptPurpose l)
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
@@ -28,6 +28,7 @@
 module Cardano.Ledger.Alonzo.Plutus.Context (
   CollectError (..),
   LedgerTxInfo (..),
+  toScriptHashByPurpose,
   EraPlutusTxInfo (..),
   PlutusTxInfoResult (..),
   mkPlutusTxInfoFromResult,
@@ -53,10 +54,13 @@ import Cardano.Ledger.Alonzo.Era (AlonzoEra)
 import Cardano.Ledger.Alonzo.Scripts (
   AlonzoEraScript (eraMaxLanguage, mkPlutusScript),
   AsItem (..),
+  AsIx,
   AsIxItem (..),
   AsPurpose,
   PlutusPurpose,
   PlutusScript (..),
+  hoistPlutusPurpose,
+  toAsIx,
  )
 import Cardano.Ledger.BaseTypes (ProtVer (..), Version, kindObjectValue)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
@@ -86,6 +90,7 @@ import Data.Aeson (ToJSON (..), (.=), pattern String)
 import Data.Kind (Type)
 import Data.List.NonEmpty (NonEmpty, nonEmpty)
 import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import GHC.Generics
 import GHC.Stack
@@ -103,11 +108,23 @@ data LedgerTxInfo era where
     , ltiUTxO :: !(UTxO era)
     , ltiTx :: !(Tx level era)
     , ltiScriptsUsed :: [(PlutusPurpose AsIxItem era, SupportedPlutusRunnable era)]
+    , ltiScriptHashesUsed :: Map.Map (PlutusPurpose AsIx era) ScriptHash
+    -- ^ Map that will be used for looking up `ScriptHash`. Currently unused until Dijkstra era, hence is lazy.
     , ltiMemoizedSubTransactions :: Map TxId (TxInfoResult era)
     -- ^ This is a tricky field that is only used starting with Dijkstra era and only by top level
     -- transactions. It is always safe to leave it as `mempty` upon construction, even for Dijkstra
     } ->
     LedgerTxInfo era
+
+toScriptHashByPurpose ::
+  Ord (PlutusPurpose AsIx era) =>
+  [(PlutusPurpose AsIxItem era, SupportedPlutusRunnable era)] ->
+  Map (PlutusPurpose AsIx era) ScriptHash
+toScriptHashByPurpose scriptsUsed =
+  Map.fromList
+    [ (hoistPlutusPurpose toAsIx sp, plutusRunnableScriptHash sr)
+    | (sp, SupportedPlutusRunnable sr) <- scriptsUsed
+    ]
 
 class
   ( PlutusLanguage l

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
@@ -47,7 +47,6 @@ module Cardano.Ledger.Alonzo.Plutus.Context (
   PlutusScriptPurpose,
   PlutusScriptContext,
   PlutusTxInInfo,
-  PlutusPurposeScriptHashArg,
 ) where
 
 import Cardano.Ledger.Alonzo.Era (AlonzoEra)
@@ -127,7 +126,6 @@ class
   toPlutusScriptPurpose ::
     proxy l ->
     ProtVer ->
-    PlutusPurposeScriptHashArg l ->
     PlutusPurpose AsIxItem era ->
     Either (ContextError era) (PlutusScriptPurpose l)
 
@@ -139,7 +137,6 @@ class
   toPlutusArgs ::
     proxy l ->
     LedgerTxInfo era ->
-    ScriptHash ->
     PlutusTxInfo l ->
     PlutusPurpose AsIxItem era ->
     Data era ->
@@ -263,12 +260,6 @@ type family PlutusTxInInfo era (l :: Language) where
   PlutusTxInInfo _ 'PlutusV2 = PV2.TxInInfo
   PlutusTxInInfo _ 'PlutusV3 = PV3.TxInInfo
   PlutusTxInInfo _ 'PlutusV4 = PV4.TxInInfo
-
-type family PlutusPurposeScriptHashArg (l :: Language) where
-  PlutusPurposeScriptHashArg 'PlutusV1 = ()
-  PlutusPurposeScriptHashArg 'PlutusV2 = ()
-  PlutusPurposeScriptHashArg 'PlutusV3 = ()
-  PlutusPurposeScriptHashArg 'PlutusV4 = ScriptHash
 
 -- | This is just like `mkPlutusScript`, except it is guaranteed to be total through the enforcement
 -- of support by the type system and `EraPlutusTxInfo` type class instances for supported plutus

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Evaluate.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Evaluate.hs
@@ -95,7 +95,7 @@ collectPlutusScriptsWithContext ::
   UTxO era ->
   Either (NonEmpty (CollectError era)) [PlutusWithContext]
 collectPlutusScriptsWithContext epochInfo systemStart pp tx utxo =
-  scriptsWithContextFromLedgerTxInfo ledgerTxInfo (pp ^. ppCostModelsL) neededPlutusScripts
+  scriptsWithContextFromLedgerTxInfo ledgerTxInfo (pp ^. ppCostModelsL)
   where
     -- We need to pass major protocol version to the script for script evaluation
     protVer = pp ^. ppProtocolVersionL
@@ -106,6 +106,7 @@ collectPlutusScriptsWithContext epochInfo systemStart pp tx utxo =
         , ltiSystemStart = systemStart
         , ltiUTxO = utxo
         , ltiTx = tx
+        , ltiScriptsUsed = neededPlutusScripts
         , ltiMemoizedSubTransactions = mempty
         }
     (_, neededPlutusScripts) =
@@ -123,7 +124,6 @@ scriptsWithContextFromLedgerTxInfo ::
   ) =>
   LedgerTxInfo era ->
   CostModels ->
-  [(PlutusPurpose AsIxItem era, SupportedPlutusRunnable era)] ->
   Either (NonEmpty (CollectError era)) [PlutusWithContext]
 scriptsWithContextFromLedgerTxInfo lti =
   scriptsWithContextFromLedgerTxInfoWithResult lti (mkTxInfoResult lti)
@@ -136,12 +136,11 @@ scriptsWithContextFromLedgerTxInfoWithResult ::
   LedgerTxInfo era ->
   TxInfoResult era ->
   CostModels ->
-  [(PlutusPurpose AsIxItem era, SupportedPlutusRunnable era)] ->
   Either (NonEmpty (CollectError era)) [PlutusWithContext]
-scriptsWithContextFromLedgerTxInfoWithResult lti txInfoResult costModels plutusScriptsUsed =
+scriptsWithContextFromLedgerTxInfoWithResult lti txInfoResult costModels =
   merge
     apply
-    (map getScriptWithRedeemer plutusScriptsUsed)
+    (map getScriptWithRedeemer (ltiScriptsUsed lti))
     (Right [])
   where
     redeemers =
@@ -343,6 +342,7 @@ evalTxExUnitsWithLogs pp tx utxo epochInfo systemStart = Map.mapWithKey findAndC
         , ltiSystemStart = systemStart
         , ltiUTxO = utxo
         , ltiTx = tx
+        , ltiScriptsUsed = plutusScriptsUsed
         , ltiMemoizedSubTransactions = mempty
         }
     txInfoResult = mkTxInfoResult ledgerTxInfo
@@ -352,8 +352,9 @@ evalTxExUnitsWithLogs pp tx utxo epochInfo systemStart = Map.mapWithKey findAndC
     rdmrs = wits ^. rdmrsTxWitsL . unRedeemersL
     protVer = pp ^. ppProtocolVersionL
     costModels = costModelsValid $ pp ^. ppCostModelsL
-    ScriptsProvided scriptsProvided = getScriptsProvided utxo tx
-    AlonzoScriptsNeeded scriptsNeeded = getScriptsNeeded utxo txBody
+    provided@(ScriptsProvided scriptsProvided) = getScriptsProvided utxo tx
+    needed@(AlonzoScriptsNeeded scriptsNeeded) = getScriptsNeeded utxo txBody
+    (_, plutusScriptsUsed) = resolveNeededPlutusScriptsWithPurpose protVer provided needed mempty
     findAndCount pointer (redeemerData, exUnits) = do
       (plutusPurpose, plutusScriptHash) <-
         note (RedeemerPointsToUnknownScriptHash pointer) $

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Evaluate.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Evaluate.hs
@@ -39,6 +39,7 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
   EraPlutusContext (..),
   LedgerTxInfo (..),
   SupportedPlutusRunnable (..),
+  toScriptHashByPurpose,
  )
 import Cardano.Ledger.Alonzo.Plutus.TxInfo (mkPlutusWithContext)
 import Cardano.Ledger.Alonzo.Scripts (lookupPlutusScript, plutusScriptLanguage, toAsItem, toAsIx)
@@ -106,10 +107,11 @@ collectPlutusScriptsWithContext epochInfo systemStart pp tx utxo =
         , ltiSystemStart = systemStart
         , ltiUTxO = utxo
         , ltiTx = tx
-        , ltiScriptsUsed = neededPlutusScripts
+        , ltiScriptsUsed = plutusScriptsUsed
+        , ltiScriptHashesUsed = toScriptHashByPurpose plutusScriptsUsed
         , ltiMemoizedSubTransactions = mempty
         }
-    (_, neededPlutusScripts) =
+    (_, plutusScriptsUsed) =
       resolveNeededPlutusScriptsWithPurpose
         protVer
         (getScriptsProvided utxo tx)
@@ -343,6 +345,7 @@ evalTxExUnitsWithLogs pp tx utxo epochInfo systemStart = Map.mapWithKey findAndC
         , ltiUTxO = utxo
         , ltiTx = tx
         , ltiScriptsUsed = plutusScriptsUsed
+        , ltiScriptHashesUsed = toScriptHashByPurpose plutusScriptsUsed
         , ltiMemoizedSubTransactions = mempty
         }
     txInfoResult = mkTxInfoResult ledgerTxInfo

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
@@ -171,8 +171,6 @@ instance EraPlutusTxInfo 'PlutusV1 AlonzoEra where
 
   toPlutusRedeemerPointer = transRedeemerPointerV1
 
-  toPlutusTxOut _ _ = pure . transTxOut
-
 transRedeemerPointerV1 ::
   proxy 'PlutusV1 ->
   ProtVer ->

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
@@ -41,7 +41,6 @@ module Cardano.Ledger.Alonzo.Plutus.TxInfo (
   transTxBodyWithdrawals,
   transTxBodyReqSignerHashes,
   transTxWitsDatums,
-  transRedeemerPointerV1,
 
   -- * LegacyPlutusArgs helpers
   toPlutusV1Args,
@@ -168,17 +167,6 @@ instance EraPlutusTxInfo 'PlutusV1 AlonzoEra where
   toPlutusTxInInfo _ utxo txIn = do
     txOut <- transLookupTxOut utxo txIn
     pure $ PV1.TxInInfo (transTxIn txIn) <$> transTxOut txOut
-
-  toPlutusRedeemerPointer = transRedeemerPointerV1
-
-transRedeemerPointerV1 ::
-  proxy 'PlutusV1 ->
-  ProtVer ->
-  TxBody t era ->
-  Map.Map (PlutusPurpose AsIx era) ScriptHash ->
-  (PlutusPurpose AsIx era, (Data era, ExUnits)) ->
-  Either (ContextError era) (PlutusRedeemerPointer 'PlutusV1)
-transRedeemerPointerV1 _ _ _ _ _ = Right ()
 
 toPlutusV1Args ::
   ( AlonzoEraUTxO era

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
@@ -118,7 +118,6 @@ mkPlutusWithContext script plutusPurpose lti@LedgerTxInfo {ltiProtVer} txInfoRes
         toPlutusArgs
           slang
           lti
-          (plutusRunnableScriptHash plutusRunnable)
           txInfo
           plutusPurpose
           redeemerData
@@ -174,17 +173,15 @@ toPlutusV1Args ::
   ) =>
   proxy 'PlutusV1 ->
   LedgerTxInfo era ->
-  ScriptHash ->
   PV1.TxInfo ->
   PlutusPurpose AsIxItem era ->
   Data era ->
   Either (ContextError era) (PlutusArgs 'PlutusV1)
-toPlutusV1Args proxy LedgerTxInfo {..} _ txInfo plutusPurpose redeemerData =
+toPlutusV1Args proxy LedgerTxInfo {..} txInfo plutusPurpose redeemerData =
   PlutusV1Args
     <$> toLegacyPlutusArgs
       proxy
       ltiProtVer
-      ()
       (PV1.ScriptContext txInfo)
       plutusPurpose
       maybeSpendingDatum
@@ -197,14 +194,13 @@ toLegacyPlutusArgs ::
   EraPlutusTxInfo l era =>
   proxy l ->
   ProtVer ->
-  PlutusPurposeScriptHashArg l ->
   (PlutusScriptPurpose l -> PlutusScriptContext l) ->
   PlutusPurpose AsIxItem era ->
   Maybe (Data era) ->
   Data era ->
   Either (ContextError era) (LegacyPlutusArgs l)
-toLegacyPlutusArgs proxy pv sh mkScriptContext scriptPurpose maybeSpendingData redeemerData = do
-  scriptContext <- mkScriptContext <$> toPlutusScriptPurpose proxy pv sh scriptPurpose
+toLegacyPlutusArgs proxy pv mkScriptContext scriptPurpose maybeSpendingData redeemerData = do
+  scriptContext <- mkScriptContext <$> toPlutusScriptPurpose proxy pv scriptPurpose
   let redeemer = getPlutusData redeemerData
   pure $ case maybeSpendingData of
     Nothing -> LegacyPlutusArgs2 redeemer scriptContext
@@ -399,10 +395,9 @@ transPlutusPurpose ::
   (EraPlutusTxInfo l era, PlutusTxCert l ~ PV1.DCert) =>
   proxy l ->
   ProtVer ->
-  PlutusPurposeScriptHashArg l ->
   AlonzoPlutusPurpose AsIxItem era ->
   Either (ContextError era) PV1.ScriptPurpose
-transPlutusPurpose proxy pv _ = \case
+transPlutusPurpose proxy pv = \case
   AlonzoSpending (AsIxItem _ txIn) -> pure $ PV1.Spending (transTxIn txIn)
   AlonzoMinting (AsIxItem _ policyId) -> pure $ PV1.Minting (transPolicyID policyId)
   AlonzoCertifying (AsIxItem _ txCert) -> PV1.Certifying <$> toPlutusTxCert proxy pv txCert

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
@@ -133,7 +133,7 @@ mkPlutusWithContext script plutusPurpose lti@LedgerTxInfo {ltiProtVer} txInfoRes
 instance EraPlutusTxInfo 'PlutusV1 AlonzoEra where
   toPlutusTxCert _ _ = pure . transTxCert
 
-  toPlutusScriptPurpose = transPlutusPurpose
+  toPlutusScriptPurpose proxy lti = transPlutusPurpose proxy (ltiProtVer lti)
 
   toPlutusTxInfo proxy LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} =
     PlutusTxInfoResult $ withTopTxLevelOnly ltiTx $ \tx -> do
@@ -177,11 +177,11 @@ toPlutusV1Args ::
   PlutusPurpose AsIxItem era ->
   Data era ->
   Either (ContextError era) (PlutusArgs 'PlutusV1)
-toPlutusV1Args proxy LedgerTxInfo {..} txInfo plutusPurpose redeemerData =
+toPlutusV1Args proxy lti@LedgerTxInfo {..} txInfo plutusPurpose redeemerData =
   PlutusV1Args
     <$> toLegacyPlutusArgs
       proxy
-      ltiProtVer
+      lti
       (PV1.ScriptContext txInfo)
       plutusPurpose
       maybeSpendingDatum
@@ -193,14 +193,14 @@ toPlutusV1Args proxy LedgerTxInfo {..} txInfo plutusPurpose redeemerData =
 toLegacyPlutusArgs ::
   EraPlutusTxInfo l era =>
   proxy l ->
-  ProtVer ->
+  LedgerTxInfo era ->
   (PlutusScriptPurpose l -> PlutusScriptContext l) ->
   PlutusPurpose AsIxItem era ->
   Maybe (Data era) ->
   Data era ->
   Either (ContextError era) (LegacyPlutusArgs l)
-toLegacyPlutusArgs proxy pv mkScriptContext scriptPurpose maybeSpendingData redeemerData = do
-  scriptContext <- mkScriptContext <$> toPlutusScriptPurpose proxy pv scriptPurpose
+toLegacyPlutusArgs proxy lti mkScriptContext scriptPurpose maybeSpendingData redeemerData = do
+  scriptContext <- mkScriptContext <$> toPlutusScriptPurpose proxy lti scriptPurpose
   let redeemer = getPlutusData redeemerData
   pure $ case maybeSpendingData of
     Nothing -> LegacyPlutusArgs2 redeemer scriptContext

--- a/eras/alonzo/impl/test/Test/Cardano/Ledger/Alonzo/Imp/TxInfoSpec.hs
+++ b/eras/alonzo/impl/test/Test/Cardano/Ledger/Alonzo/Imp/TxInfoSpec.hs
@@ -7,7 +7,6 @@ import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Plutus.Context (
   EraPlutusTxInfo (..),
-  LedgerTxInfo (..),
   PlutusTxInfoResult (..),
  )
 import Cardano.Ledger.BaseTypes
@@ -17,6 +16,7 @@ import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
 import Lens.Micro ((&), (.~))
 import Lens.Micro.Mtl (use)
+import Test.Cardano.Ledger.Alonzo.Era (mkTestLedgerTxInfo)
 import Test.Cardano.Ledger.Alonzo.ImpTest
 import Test.Cardano.Ledger.Imp.Common
 
@@ -41,15 +41,7 @@ spec = withImpInit @(LedgerSpec AlonzoEra) $ describe "TxInfo" $ do
             & bodyTxL
               . outputsTxBodyL
               .~ SSeq.singleton byronTxOut
-        lti =
-          LedgerTxInfo
-            { ltiProtVer = pv
-            , ltiEpochInfo = epochInfo
-            , ltiSystemStart = systemStart
-            , ltiUTxO = utxo
-            , ltiTx = tx
-            , ltiMemoizedSubTransactions = mempty
-            }
+        lti = mkTestLedgerTxInfo pv epochInfo systemStart utxo tx
       void $ expectRight $ unPlutusTxInfoResult $ toPlutusTxInfo SPlutusV1 lti
     it "toPlutusTxInfo does not fail when Byron scripts are present in TxIns" $ do
       pv <- getProtVer
@@ -69,13 +61,5 @@ spec = withImpInit @(LedgerSpec AlonzoEra) $ describe "TxInfo" $ do
             & bodyTxL
               . outputsTxBodyL
               .~ SSeq.singleton shelleyTxOut
-        lti =
-          LedgerTxInfo
-            { ltiProtVer = pv
-            , ltiEpochInfo = epochInfo
-            , ltiSystemStart = systemStart
-            , ltiUTxO = utxo
-            , ltiTx = tx
-            , ltiMemoizedSubTransactions = mempty
-            }
+        lti = mkTestLedgerTxInfo pv epochInfo systemStart utxo tx
       void $ expectRight $ unPlutusTxInfoResult $ toPlutusTxInfo SPlutusV1 lti

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Era.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Era.hs
@@ -8,14 +8,21 @@
 module Test.Cardano.Ledger.Alonzo.Era (
   module Test.Cardano.Ledger.Mary.Era,
   AlonzoEraTest,
+  mkTestLedgerTxInfo,
 ) where
 
 import Cardano.Ledger.Alonzo
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Plutus.Context
 import Cardano.Ledger.Alonzo.UTxO
+import Cardano.Ledger.BaseTypes (ProtVer)
 import Cardano.Ledger.Plutus (Language (..))
+import Cardano.Ledger.State
+import Cardano.Slotting.EpochInfo (EpochInfo)
+import Cardano.Slotting.Time (SystemStart)
+import Data.Text (Text)
 import Data.TreeDiff
+import Lens.Micro
 import Paths_cardano_ledger_alonzo (getDataFileName)
 import Test.Cardano.Ledger.Alonzo.Arbitrary ()
 import Test.Cardano.Ledger.Alonzo.Binary.Annotator ()
@@ -81,3 +88,29 @@ instance AllegraEraTest AlonzoEra
 instance MaryEraTest AlonzoEra
 
 instance AlonzoEraTest AlonzoEra
+
+-- | This is a construction of `LedgerTxInfo` without any memoization.
+mkTestLedgerTxInfo ::
+  (EraUTxO era, EraPlutusContext era, ScriptsNeeded era ~ AlonzoScriptsNeeded era) =>
+  ProtVer ->
+  EpochInfo (Either Text) ->
+  SystemStart ->
+  UTxO era ->
+  Tx level era ->
+  LedgerTxInfo era
+mkTestLedgerTxInfo protVer epochInfo systemStart utxo tx =
+  let
+    scriptsProvided = getScriptsProvided utxo tx
+    scriptsNeeded = getScriptsNeeded utxo (tx ^. bodyTxL)
+    (_, plutusScriptsUsed) =
+      resolveNeededPlutusScriptsWithPurpose protVer scriptsProvided scriptsNeeded mempty
+   in
+    LedgerTxInfo
+      { ltiProtVer = protVer
+      , ltiEpochInfo = epochInfo
+      , ltiSystemStart = systemStart
+      , ltiUTxO = utxo
+      , ltiTx = tx
+      , ltiScriptsUsed = plutusScriptsUsed
+      , ltiMemoizedSubTransactions = mempty
+      }

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Era.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Era.hs
@@ -112,5 +112,6 @@ mkTestLedgerTxInfo protVer epochInfo systemStart utxo tx =
       , ltiUTxO = utxo
       , ltiTx = tx
       , ltiScriptsUsed = plutusScriptsUsed
+      , ltiScriptHashesUsed = toScriptHashByPurpose plutusScriptsUsed
       , ltiMemoizedSubTransactions = mempty
       }

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxosSpec.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxosSpec.hs
@@ -13,7 +13,7 @@ module Test.Cardano.Ledger.Alonzo.Imp.UtxosSpec (spec) where
 
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Core
-import Cardano.Ledger.Alonzo.Plutus.Context (LedgerTxInfo (..), toPlutusTxInfoForPurpose)
+import Cardano.Ledger.Alonzo.Plutus.Context (toPlutusTxInfoForPurpose)
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (
   CollectError (NoCostModel),
   TransactionScriptFailure (RedeemerPointsToUnknownScriptHash),
@@ -52,6 +52,7 @@ import Lens.Micro (set, to, (%~), (&), (.~), (<>~), (^.), _2)
 import Lens.Micro.Mtl (use)
 import qualified PlutusLedgerApi.Common as P
 import qualified PlutusLedgerApi.V1 as PV1
+import Test.Cardano.Ledger.Alonzo.Era (mkTestLedgerTxInfo)
 import Test.Cardano.Ledger.Alonzo.ImpTest
 import Test.Cardano.Ledger.Imp.Common
 import Test.Cardano.Ledger.Plutus.Examples (
@@ -80,15 +81,7 @@ spec = describe "UTXOS" $ do
           expectedUpperBound = (startPOSIX + fromIntegral (currentSlot + txValidity)) * 1000
           tx :: Tx TopTx era
           tx = mkBasicTx mkBasicTxBody & bodyTxL . vldtTxBodyL .~ interval
-          lti =
-            LedgerTxInfo
-              { ltiProtVer = protVer
-              , ltiEpochInfo = ei
-              , ltiSystemStart = ss
-              , ltiUTxO = utxo
-              , ltiTx = tx
-              , ltiMemoizedSubTransactions = mempty
-              }
+          lti = mkTestLedgerTxInfo protVer ei ss utxo tx
       case toPlutusTxInfoForPurpose SPlutusV1 lti (SpendingPurpose AsPurpose) of
         Left e -> assertFailure $ "No translation error was expected, but got: " <> show e
         Right txInfo ->

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Translation/Golden.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Translation/Golden.hs
@@ -8,15 +8,13 @@ module Test.Cardano.Ledger.Alonzo.Translation.Golden (
   assertTranslationResultsMatchGolden,
 ) where
 
-import Cardano.Ledger.Alonzo.Plutus.Context (
-  LedgerTxInfo (..),
-  SupportedLanguage (..),
- )
+import Cardano.Ledger.Alonzo.Plutus.Context (SupportedLanguage (..))
 import Cardano.Ledger.Binary
 import Cardano.Ledger.Core
 import Control.Exception (throwIO)
 import qualified Data.ByteString.Lazy as BSL
 import Test.Cardano.Ledger.Alonzo.Binary.Annotator ()
+import Test.Cardano.Ledger.Alonzo.Era (mkTestLedgerTxInfo)
 import Test.Cardano.Ledger.Alonzo.Translation.TranslatableGen (
   TranslatableGen (..),
   epochInfo,
@@ -71,15 +69,7 @@ assertTranslationComparison (TranslationInstance protVer supportedLanguage utxo 
       let actual = mkPlutusTxInfo slang lti plutusPurpose
       assertEqual errorMessage expected $ toVersionedTxInfo slang actual
   where
-    lti =
-      LedgerTxInfo
-        { ltiProtVer = protVer
-        , ltiEpochInfo = epochInfo
-        , ltiSystemStart = systemStart
-        , ltiUTxO = utxo
-        , ltiTx = tx
-        , ltiMemoizedSubTransactions = mempty
-        }
+    lti = mkTestLedgerTxInfo protVer epochInfo systemStart utxo tx
     errorMessage =
       unlines
         [ "Unexpected TxInfo with arguments: "

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Translation/TranslatableGen.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Translation/TranslatableGen.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 
 module Test.Cardano.Ledger.Alonzo.Translation.TranslatableGen (
@@ -26,10 +27,11 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
  )
 import Cardano.Ledger.Alonzo.Scripts (AsIx, PlutusPurpose, hoistPlutusPurpose, toAsPurpose)
 import Cardano.Ledger.Alonzo.TxWits (Redeemers)
+import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded)
 import Cardano.Ledger.BaseTypes (ProtVer (ProtVer))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Plutus.Language (SLanguage (..))
-import Cardano.Ledger.State (UTxO (..))
+import Cardano.Ledger.State (EraUTxO (..), UTxO (..))
 import Cardano.Slotting.EpochInfo (EpochInfo, fixedEpochInfo)
 import Cardano.Slotting.Slot (EpochSize (..))
 import Cardano.Slotting.Time (SystemStart (..), mkSlotLength)
@@ -38,6 +40,7 @@ import qualified Data.Set as Set
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Lens.Micro ((^.))
 import Test.Cardano.Ledger.Alonzo.Arbitrary ()
+import Test.Cardano.Ledger.Alonzo.Era (mkTestLedgerTxInfo)
 import Test.Cardano.Ledger.Alonzo.Translation.TranslationInstance (
   TranslationInstance (..),
   VersionedTxInfo (..),
@@ -45,7 +48,12 @@ import Test.Cardano.Ledger.Alonzo.Translation.TranslationInstance (
 import Test.Cardano.Ledger.Common
 
 class
-  (EraTx era, EraPlutusContext era, Arbitrary (Script era), Arbitrary (PlutusPurpose AsIx era)) =>
+  ( EraUTxO era
+  , EraPlutusContext era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , Arbitrary (Script era)
+  , Arbitrary (PlutusPurpose AsIx era)
+  ) =>
   TranslatableGen era
   where
   tgRedeemers :: Gen (Redeemers era)
@@ -86,15 +94,7 @@ genTranslationInstance = do
   supportedLanguage :: SupportedLanguage era <- arbitrary
   tx <- tgTx supportedLanguage
   utxo <- tgUtxo supportedLanguage tx
-  let lti =
-        LedgerTxInfo
-          { ltiProtVer = protVer
-          , ltiEpochInfo = epochInfo
-          , ltiSystemStart = systemStart
-          , ltiUTxO = utxo
-          , ltiTx = tx
-          , ltiMemoizedSubTransactions = mempty
-          }
+  let lti = mkTestLedgerTxInfo protVer epochInfo systemStart utxo tx
   plutusPurpose <- arbitrary
   pure $ case supportedLanguage of
     SupportedLanguage slang ->

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## 1.15.0.0
 
 * Add `FromJSON` instance for `BabbageTxOut era`
-* Change `transTxRedeemers` to accept a `UTxO era` argument
-* Change `toPlutusV2Args` to accept `LedgerTxInfo era` and `ScriptHash` arguments instead of `ProtVer` and `Maybe (Data era)`
+* Change `toPlutusV2Args` to accept `LedgerTxInfo era` argument instead of `ProtVer` and `Maybe (Data era)`
 * Rename `transRedeemerPtr` to `transRedeemerPointerV2V3`
 * Add `EncCBOR`, `ToCBOR` for `Block`
 * Add `DecCBOR` instances for `Annotator Block`

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
@@ -34,7 +34,6 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
   EraPlutusTxInfo (..),
   LedgerTxInfo (..),
   PlutusPurposeScriptHashArg,
-  PlutusRedeemerPointer,
   PlutusScriptPurpose,
   PlutusTxInfoResult (..),
   SupportedLanguage (..),
@@ -46,10 +45,10 @@ import Cardano.Ledger.Alonzo.Plutus.TxInfo (
   toLegacyPlutusArgs,
  )
 import qualified Cardano.Ledger.Alonzo.Plutus.TxInfo as Alonzo
-import Cardano.Ledger.Alonzo.Scripts (toAsItem, toAsIx)
+import Cardano.Ledger.Alonzo.Scripts (toAsItem)
 import Cardano.Ledger.Alonzo.Tx (Data)
 import Cardano.Ledger.Alonzo.TxWits (unRedeemersL)
-import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded (..), getSpendingDatum)
+import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, getSpendingDatum)
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Era (BabbageEra)
 import Cardano.Ledger.Babbage.Scripts (PlutusScript (..))
@@ -88,13 +87,12 @@ import Cardano.Ledger.Plutus.TxInfo (
   transTxIn,
   txOutSourceToText,
  )
-import Cardano.Ledger.State (EraUTxO (..), UTxO (..))
+import Cardano.Ledger.State (UTxO (..))
 import Cardano.Ledger.TxIn (TxIn (..), txInToText)
 import Control.Arrow (left)
 import Control.DeepSeq (NFData)
 import Control.Monad (unless, when, zipWithM)
 import Data.Aeson (ToJSON (..), (.=), pattern String)
-import Data.Bifunctor (Bifunctor (..))
 import Data.Foldable as F (Foldable (..))
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -205,10 +203,9 @@ transRedeemerPointerV2V3 ::
   proxy l ->
   ProtVer ->
   TxBody t era ->
-  Map.Map (PlutusPurpose AsIx era) ScriptHash ->
   (PlutusPurpose AsIx era, (Data era, ExUnits)) ->
   Either (ContextError era) (PlutusScriptPurpose l, PV2.Redeemer)
-transRedeemerPointerV2V3 proxy pv txBody _ (ptr, (d, _)) =
+transRedeemerPointerV2V3 proxy pv txBody (ptr, (d, _)) =
   case redeemerPointerInverse txBody ptr of
     SNothing -> Left $ inject $ RedeemerPointerPointsToNothing ptr
     SJust sp -> do
@@ -219,24 +216,21 @@ transRedeemerPointerV2V3 proxy pv txBody _ (ptr, (d, _)) =
 -- to a `PV2.Redeemer`
 transTxRedeemers ::
   ( EraPlutusTxInfo l era
-  , EraUTxO era
+  , AlonzoEraTxBody era
+  , EraTx era
   , AlonzoEraTxWits era
-  , PlutusRedeemerPointer l ~ (PlutusScriptPurpose l, PV2.Redeemer)
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , Inject (BabbageContextError era) (ContextError era)
+  , PlutusPurposeScriptHashArg l ~ ()
   ) =>
   proxy l ->
   ProtVer ->
   Tx t era ->
-  UTxO era ->
   Either (ContextError era) (PV2.Map (PlutusScriptPurpose l) PV2.Redeemer)
-transTxRedeemers proxy pv tx utxo =
+transTxRedeemers proxy pv tx =
   PV2.unsafeFromList
     <$> mapM
-      (toPlutusRedeemerPointer proxy pv (tx ^. bodyTxL) scriptHashes)
+      (transRedeemerPointerV2V3 proxy pv (tx ^. bodyTxL))
       (Map.toList $ tx ^. witsTxL . rdmrsTxWitsL . unRedeemersL)
-  where
-    AlonzoScriptsNeeded scriptsNeeded = getScriptsNeeded utxo $ tx ^. bodyTxL
-    scriptHashes = Map.fromList $ first (hoistPlutusPurpose toAsIx) <$> scriptsNeeded
 
 instance EraPlutusContext BabbageEra where
   type ContextError BabbageEra = BabbageContextError BabbageEra
@@ -375,8 +369,6 @@ instance EraPlutusTxInfo 'PlutusV1 BabbageEra where
 
   toPlutusTxInInfo _ = transTxInInfoV1
 
-  toPlutusRedeemerPointer = Alonzo.transRedeemerPointerV1
-
 instance EraPlutusTxInfo 'PlutusV2 BabbageEra where
   toPlutusTxCert _ _ = pure . Alonzo.transTxCert
 
@@ -395,7 +387,7 @@ instance EraPlutusTxInfo 'PlutusV2 BabbageEra where
           [minBound ..]
           (F.toList (txBody ^. outputsTxBodyL))
       txCerts <- Alonzo.transTxBodyCerts proxy ltiProtVer txBody
-      plutusRedeemers <- transTxRedeemers proxy ltiProtVer tx ltiUTxO
+      plutusRedeemers <- transTxRedeemers proxy ltiProtVer tx
       -- It is important for memoization for `txInfo` to be a let binding
       let
         txInfo =
@@ -418,8 +410,6 @@ instance EraPlutusTxInfo 'PlutusV2 BabbageEra where
   toPlutusArgs = toPlutusV2Args
 
   toPlutusTxInInfo _ = transTxInInfoV2
-
-  toPlutusRedeemerPointer = transRedeemerPointerV2V3
 
 toPlutusV2Args ::
   ( AlonzoEraUTxO era

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
@@ -33,7 +33,6 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
   EraPlutusContext (..),
   EraPlutusTxInfo (..),
   LedgerTxInfo (..),
-  PlutusPurposeScriptHashArg,
   PlutusScriptPurpose,
   PlutusTxInfoResult (..),
   SupportedLanguage (..),
@@ -198,7 +197,6 @@ transRedeemerPointerV2V3 ::
   ( EraPlutusTxInfo l era
   , AlonzoEraTxBody era
   , Inject (BabbageContextError era) (ContextError era)
-  , PlutusPurposeScriptHashArg l ~ ()
   ) =>
   proxy l ->
   ProtVer ->
@@ -209,7 +207,7 @@ transRedeemerPointerV2V3 proxy pv txBody (ptr, (d, _)) =
   case redeemerPointerInverse txBody ptr of
     SNothing -> Left $ inject $ RedeemerPointerPointsToNothing ptr
     SJust sp -> do
-      plutusScriptPurpose <- toPlutusScriptPurpose proxy pv () sp
+      plutusScriptPurpose <- toPlutusScriptPurpose proxy pv sp
       Right (plutusScriptPurpose, transRedeemer d)
 
 -- | Translate all `Redeemers` from within a `Tx` into a Map from a `PlutusScriptPurpose`
@@ -220,7 +218,6 @@ transTxRedeemers ::
   , EraTx era
   , AlonzoEraTxWits era
   , Inject (BabbageContextError era) (ContextError era)
-  , PlutusPurposeScriptHashArg l ~ ()
   ) =>
   proxy l ->
   ProtVer ->
@@ -417,17 +414,15 @@ toPlutusV2Args ::
   ) =>
   proxy 'PlutusV2 ->
   LedgerTxInfo era ->
-  ScriptHash ->
   PV2.TxInfo ->
   PlutusPurpose AsIxItem era ->
   Data era ->
   Either (ContextError era) (PlutusArgs 'PlutusV2)
-toPlutusV2Args proxy LedgerTxInfo {..} _ txInfo scriptPurpose redeemerData =
+toPlutusV2Args proxy LedgerTxInfo {..} txInfo scriptPurpose redeemerData =
   PlutusV2Args
     <$> toLegacyPlutusArgs
       proxy
       ltiProtVer
-      ()
       (PV2.ScriptContext txInfo)
       scriptPurpose
       maybeSpendingDatum

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
@@ -377,8 +377,6 @@ instance EraPlutusTxInfo 'PlutusV1 BabbageEra where
 
   toPlutusRedeemerPointer = Alonzo.transRedeemerPointerV1
 
-  toPlutusTxOut _ src txOut = Just <$> transTxOutV1 src txOut
-
 instance EraPlutusTxInfo 'PlutusV2 BabbageEra where
   toPlutusTxCert _ _ = pure . Alonzo.transTxCert
 
@@ -422,8 +420,6 @@ instance EraPlutusTxInfo 'PlutusV2 BabbageEra where
   toPlutusTxInInfo _ = transTxInInfoV2
 
   toPlutusRedeemerPointer = transRedeemerPointerV2V3
-
-  toPlutusTxOut _ = transTxOutV2
 
 toPlutusV2Args ::
   ( AlonzoEraUTxO era

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
@@ -54,7 +54,6 @@ import Cardano.Ledger.Babbage.Scripts (PlutusScript (..))
 import Cardano.Ledger.Babbage.UTxO ()
 import Cardano.Ledger.BaseTypes (
   Inject (..),
-  ProtVer,
   StrictMaybe (..),
   isSJust,
   kindObjectValue,
@@ -193,21 +192,21 @@ transRedeemer :: Data era -> PV2.Redeemer
 transRedeemer = PV2.Redeemer . PV2.dataToBuiltinData . getPlutusData
 
 transRedeemerPointerV2V3 ::
-  forall proxy l era t.
-  ( EraPlutusTxInfo l era
+  forall proxy l era.
+  ( EraTx era
   , AlonzoEraTxBody era
+  , EraPlutusTxInfo l era
   , Inject (BabbageContextError era) (ContextError era)
   ) =>
   proxy l ->
-  ProtVer ->
-  TxBody t era ->
+  LedgerTxInfo era ->
   (PlutusPurpose AsIx era, (Data era, ExUnits)) ->
   Either (ContextError era) (PlutusScriptPurpose l, PV2.Redeemer)
-transRedeemerPointerV2V3 proxy pv txBody (ptr, (d, _)) =
-  case redeemerPointerInverse txBody ptr of
+transRedeemerPointerV2V3 proxy lti@LedgerTxInfo {ltiTx} (ptr, (d, _)) =
+  case redeemerPointerInverse (ltiTx ^. bodyTxL) ptr of
     SNothing -> Left $ inject $ RedeemerPointerPointsToNothing ptr
     SJust sp -> do
-      plutusScriptPurpose <- toPlutusScriptPurpose proxy pv sp
+      plutusScriptPurpose <- toPlutusScriptPurpose proxy lti sp
       Right (plutusScriptPurpose, transRedeemer d)
 
 -- | Translate all `Redeemers` from within a `Tx` into a Map from a `PlutusScriptPurpose`
@@ -220,14 +219,13 @@ transTxRedeemers ::
   , Inject (BabbageContextError era) (ContextError era)
   ) =>
   proxy l ->
-  ProtVer ->
-  Tx t era ->
+  LedgerTxInfo era ->
   Either (ContextError era) (PV2.Map (PlutusScriptPurpose l) PV2.Redeemer)
-transTxRedeemers proxy pv tx =
+transTxRedeemers proxy lti@LedgerTxInfo {ltiTx} =
   PV2.unsafeFromList
     <$> mapM
-      (transRedeemerPointerV2V3 proxy pv (tx ^. bodyTxL))
-      (Map.toList $ tx ^. witsTxL . rdmrsTxWitsL . unRedeemersL)
+      (transRedeemerPointerV2V3 proxy lti)
+      (Map.toList $ ltiTx ^. witsTxL . rdmrsTxWitsL . unRedeemersL)
 
 instance EraPlutusContext BabbageEra where
   type ContextError BabbageEra = BabbageContextError BabbageEra
@@ -327,7 +325,7 @@ instance ToJSON (PlutusPurpose AsIx era) => ToJSON (BabbageContextError era) whe
 instance EraPlutusTxInfo 'PlutusV1 BabbageEra where
   toPlutusTxCert _ _ = pure . Alonzo.transTxCert
 
-  toPlutusScriptPurpose = Alonzo.transPlutusPurpose
+  toPlutusScriptPurpose proxy lti = Alonzo.transPlutusPurpose proxy (ltiProtVer lti)
 
   toPlutusTxInfo proxy LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} =
     PlutusTxInfoResult $ withTopTxLevelOnly ltiTx $ \tx -> do
@@ -369,9 +367,9 @@ instance EraPlutusTxInfo 'PlutusV1 BabbageEra where
 instance EraPlutusTxInfo 'PlutusV2 BabbageEra where
   toPlutusTxCert _ _ = pure . Alonzo.transTxCert
 
-  toPlutusScriptPurpose = Alonzo.transPlutusPurpose
+  toPlutusScriptPurpose proxy lti = Alonzo.transPlutusPurpose proxy (ltiProtVer lti)
 
-  toPlutusTxInfo proxy LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} =
+  toPlutusTxInfo proxy lti@LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} =
     PlutusTxInfoResult $ withTopTxLevelOnly ltiTx $ \tx -> do
       let txBody = tx ^. bodyTxL
       timeRange <-
@@ -384,7 +382,7 @@ instance EraPlutusTxInfo 'PlutusV2 BabbageEra where
           [minBound ..]
           (F.toList (txBody ^. outputsTxBodyL))
       txCerts <- Alonzo.transTxBodyCerts proxy ltiProtVer txBody
-      plutusRedeemers <- transTxRedeemers proxy ltiProtVer tx
+      plutusRedeemers <- transTxRedeemers proxy lti
       -- It is important for memoization for `txInfo` to be a let binding
       let
         txInfo =
@@ -418,11 +416,11 @@ toPlutusV2Args ::
   PlutusPurpose AsIxItem era ->
   Data era ->
   Either (ContextError era) (PlutusArgs 'PlutusV2)
-toPlutusV2Args proxy LedgerTxInfo {..} txInfo scriptPurpose redeemerData =
+toPlutusV2Args proxy lti@LedgerTxInfo {..} txInfo scriptPurpose redeemerData =
   PlutusV2Args
     <$> toLegacyPlutusArgs
       proxy
-      ltiProtVer
+      lti
       (PV2.ScriptContext txInfo)
       scriptPurpose
       maybeSpendingDatum

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/TxInfoSpec.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/TxInfoSpec.hs
@@ -13,13 +13,13 @@ module Test.Cardano.Ledger.Babbage.TxInfoSpec (txInfoSpec, spec) where
 import Cardano.Ledger.Alonzo.Plutus.Context (
   ContextError,
   EraPlutusTxInfo (..),
-  LedgerTxInfo (..),
   PlutusTxInInfo,
   PlutusTxInfo,
   toPlutusTxInfoForPurpose,
  )
 import Cardano.Ledger.Alonzo.Plutus.TxInfo (AlonzoContextError (..), TxOutSource (..))
 import Cardano.Ledger.Alonzo.Scripts (AsPurpose (..))
+import Cardano.Ledger.Alonzo.UTxO
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.TxInfo (
   BabbageContextError (..),
@@ -37,7 +37,7 @@ import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
 import Cardano.Ledger.Mary.Value (MaryValue)
 import Cardano.Ledger.Plutus.Data (Data (..), Datum (..), dataToBinaryData)
 import Cardano.Ledger.Plutus.Language (Language (..), SLanguage (..))
-import Cardano.Ledger.State (UTxO (..))
+import Cardano.Ledger.State (EraUTxO (..), UTxO (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..), mkTxInPartial)
 import Cardano.Slotting.EpochInfo (EpochInfo, fixedEpochInfo)
 import Cardano.Slotting.Slot (EpochSize (..))
@@ -53,6 +53,7 @@ import qualified PlutusLedgerApi.V2 as PV2
 import qualified PlutusLedgerApi.V3 as PV3
 import qualified PlutusLedgerApi.V4 as PV4
 import Test.Cardano.Ledger.Alonzo.Arbitrary (alwaysSucceeds)
+import Test.Cardano.Ledger.Alonzo.Era (mkTestLedgerTxInfo)
 import Test.Cardano.Ledger.Binary.Random (mkDummyHash)
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..), mkCredential, mkKeyPair)
@@ -191,60 +192,50 @@ expectOneOutput o slang txInfo =
 
 successfulTranslation ::
   forall era l.
-  ( BabbageEraTxOut era
+  ( EraUTxO era
+  , BabbageEraTxOut era
   , EraPlutusTxInfo l era
   , EraPlutusTxInfo 'PlutusV2 era
   , Value era ~ MaryValue
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>
   SLanguage l ->
   Tx TopTx era ->
   (SLanguage l -> PlutusTxInfo l -> Expectation) ->
   Expectation
 successfulTranslation slang tx f =
-  let lti =
-        LedgerTxInfo
-          { ltiProtVer = ProtVer (eraProtVerLow @era) 0
-          , ltiEpochInfo = ei
-          , ltiSystemStart = ss
-          , ltiUTxO = exampleUTxO
-          , ltiTx = tx
-          , ltiMemoizedSubTransactions = mempty
-          }
+  let lti = mkTestLedgerTxInfo (ProtVer (eraProtVerLow @era) 0) ei ss exampleUTxO tx
    in case toPlutusTxInfoForPurpose slang lti (SpendingPurpose AsPurpose) of
         Right txInfo -> f slang txInfo
         Left e -> assertFailure $ "No translation error was expected, but got: " <> show e
 
 expectTranslationError ::
   forall era l.
-  ( BabbageEraTxOut era
+  ( EraUTxO era
+  , BabbageEraTxOut era
   , EraPlutusTxInfo l era
   , EraPlutusTxInfo 'PlutusV2 era
   , Value era ~ MaryValue
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>
   SLanguage l ->
   Tx TopTx era ->
   ContextError era ->
   Expectation
 expectTranslationError slang tx expected =
-  let lti =
-        LedgerTxInfo
-          { ltiProtVer = ProtVer (eraProtVerLow @era) 0
-          , ltiEpochInfo = ei
-          , ltiSystemStart = ss
-          , ltiUTxO = exampleUTxO
-          , ltiTx = tx
-          , ltiMemoizedSubTransactions = mempty
-          }
+  let lti = mkTestLedgerTxInfo (ProtVer (eraProtVerLow @era) 0) ei ss exampleUTxO tx
    in case toPlutusTxInfoForPurpose slang lti (SpendingPurpose AsPurpose) of
         Right txInfo ->
           assertFailure $ "This translation was expected to fail, but it succeeded: " <> show txInfo
         Left e -> e `shouldBe` expected
 
 expectV1TranslationError ::
-  ( BabbageEraTxOut era
+  ( EraUTxO era
+  , BabbageEraTxOut era
   , EraPlutusTxInfo 'PlutusV1 era
   , EraPlutusTxInfo 'PlutusV2 era
   , Value era ~ MaryValue
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>
   Tx TopTx era ->
   ContextError era ->
@@ -286,9 +277,10 @@ translatedOutputEx2 =
 
 txInfoSpecV1 ::
   forall era.
-  ( EraTx era
+  ( EraUTxO era
   , BabbageEraTxBody era
   , Value era ~ MaryValue
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , EraPlutusTxInfo 'PlutusV1 era
   , EraPlutusTxInfo 'PlutusV2 era
   , Inject (BabbageContextError era) (ContextError era)
@@ -319,11 +311,12 @@ txInfoSpecV1 =
 
 txInfoSpec ::
   forall era l.
-  ( EraTx era
+  ( EraUTxO era
   , EraPlutusTxInfo l era
   , EraPlutusTxInfo 'PlutusV2 era
   , BabbageEraTxBody era
   , Value era ~ MaryValue
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , Inject (BabbageContextError era) (ContextError era)
   , Show (PlutusTxInInfo era l)
   , Eq (PlutusTxInInfo era l)
@@ -376,9 +369,10 @@ txInfoSpec lang =
 
 spec ::
   forall era.
-  ( EraTx era
+  ( EraUTxO era
   , BabbageEraTxBody era
   , Value era ~ MaryValue
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , Inject (BabbageContextError era) (ContextError era)
   , EraPlutusTxInfo 'PlutusV1 era
   , EraPlutusTxInfo 'PlutusV2 era

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/TxInfoSpec.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/TxInfoSpec.hs
@@ -16,7 +16,6 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
   LedgerTxInfo (..),
   PlutusTxInInfo,
   PlutusTxInfo,
-  PlutusTxOut,
   toPlutusTxInfoForPurpose,
  )
 import Cardano.Ledger.Alonzo.Plutus.TxInfo (AlonzoContextError (..), TxOutSource (..))
@@ -24,6 +23,7 @@ import Cardano.Ledger.Alonzo.Scripts (AsPurpose (..))
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.TxInfo (
   BabbageContextError (..),
+  transTxOutV2,
  )
 import Cardano.Ledger.BaseTypes (
   Inject (..),
@@ -36,13 +36,12 @@ import Cardano.Ledger.Credential (StakeReference (..))
 import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
 import Cardano.Ledger.Mary.Value (MaryValue)
 import Cardano.Ledger.Plutus.Data (Data (..), Datum (..), dataToBinaryData)
-import Cardano.Ledger.Plutus.Language (Language (..), SLanguage (..), plutusLanguage)
+import Cardano.Ledger.Plutus.Language (Language (..), SLanguage (..))
 import Cardano.Ledger.State (UTxO (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..), mkTxInPartial)
 import Cardano.Slotting.EpochInfo (EpochInfo, fixedEpochInfo)
 import Cardano.Slotting.Slot (EpochSize (..))
 import Cardano.Slotting.Time (SystemStart (..), mkSlotLength)
-import Data.Data (Proxy (..))
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
@@ -99,10 +98,10 @@ inlineDatumOutput =
   mkBasicTxOut shelleyAddr (inject $ Coin 3)
     & datumTxOutL .~ datumEx
 
-refScriptOutput :: forall l era. (BabbageEraTxOut era, EraPlutusTxInfo l era) => TxOut era
+refScriptOutput :: (BabbageEraTxOut era, EraPlutusTxInfo 'PlutusV2 era) => TxOut era
 refScriptOutput =
   mkBasicTxOut shelleyAddr (inject $ Coin 3)
-    & referenceScriptTxOutL .~ SJust (alwaysSucceeds @l 3)
+    & referenceScriptTxOutL .~ (SJust $ alwaysSucceeds @'PlutusV2 3)
 
 -- This input is only a "Shelley input" in the sense
 -- that we attach it to a Shelley output in the UTxO created below.
@@ -116,9 +115,8 @@ inputWithRefScript :: TxIn
 inputWithRefScript = mkTxInPartial genesisId 4
 
 exampleUTxO ::
-  forall l era.
   ( BabbageEraTxOut era
-  , EraPlutusTxInfo l era
+  , EraPlutusTxInfo 'PlutusV2 era
   , Value era ~ MaryValue
   ) =>
   UTxO era
@@ -128,7 +126,7 @@ exampleUTxO =
       [ (byronInput, byronOutput)
       , (shelleyInput, shelleyOutput)
       , (inputWithInlineDatum, inlineDatumOutput)
-      , (inputWithRefScript, refScriptOutput @l)
+      , (inputWithRefScript, refScriptOutput)
       ]
 
 txb ::
@@ -159,10 +157,9 @@ txRefInput refInput = mkBasicTx (txb shelleyInput (Just refInput) shelleyOutput)
 hasReferenceInput :: SLanguage l -> PlutusTxInfo l -> Expectation
 hasReferenceInput slang txInfo =
   case slang of
-    SPlutusV1 -> expectationFailure "PlutusV1 does not have reference inputs"
+    -- This test would fail in PlutusV3 onwards because of ReferenceInputsNotDisjointFromInputs
     SPlutusV2 -> PV2.txInfoReferenceInputs txInfo `shouldNotBe` mempty
-    SPlutusV3 -> PV3.txInfoReferenceInputs txInfo `shouldNotBe` mempty
-    SPlutusV4 -> PV4.txInfoReferenceInputs txInfo `shouldNotBe` mempty
+    _ -> expectationFailure $ show slang <> " is not supported for this test"
 
 plutusTxInInfoInputs ::
   forall era l. HasCallStack => SLanguage l -> PlutusTxInfo l -> [PlutusTxInInfo era l]
@@ -185,18 +182,18 @@ expectOneInput ::
   Expectation
 expectOneInput l i txInfo = plutusTxInInfoInputs @era l txInfo `shouldBe` [i]
 
-expectOneOutput :: PlutusTxOut l -> SLanguage l -> PlutusTxInfo l -> Expectation
+expectOneOutput :: PV2.TxOut -> SLanguage l -> PlutusTxInfo l -> Expectation
 expectOneOutput o slang txInfo =
   case slang of
-    SPlutusV1 -> expectationFailure "PlutusV1 not supported"
     SPlutusV2 -> PV2.txInfoOutputs txInfo `shouldBe` [o]
     SPlutusV3 -> PV3.txInfoOutputs txInfo `shouldBe` [o]
-    SPlutusV4 -> PV4.txInfoOutputs txInfo `shouldBe` [o]
+    _ -> expectationFailure $ show slang <> " is not supported"
 
 successfulTranslation ::
   forall era l.
   ( BabbageEraTxOut era
   , EraPlutusTxInfo l era
+  , EraPlutusTxInfo 'PlutusV2 era
   , Value era ~ MaryValue
   ) =>
   SLanguage l ->
@@ -209,7 +206,7 @@ successfulTranslation slang tx f =
           { ltiProtVer = ProtVer (eraProtVerLow @era) 0
           , ltiEpochInfo = ei
           , ltiSystemStart = ss
-          , ltiUTxO = exampleUTxO @l
+          , ltiUTxO = exampleUTxO
           , ltiTx = tx
           , ltiMemoizedSubTransactions = mempty
           }
@@ -221,6 +218,7 @@ expectTranslationError ::
   forall era l.
   ( BabbageEraTxOut era
   , EraPlutusTxInfo l era
+  , EraPlutusTxInfo 'PlutusV2 era
   , Value era ~ MaryValue
   ) =>
   SLanguage l ->
@@ -233,7 +231,7 @@ expectTranslationError slang tx expected =
           { ltiProtVer = ProtVer (eraProtVerLow @era) 0
           , ltiEpochInfo = ei
           , ltiSystemStart = ss
-          , ltiUTxO = exampleUTxO @l
+          , ltiUTxO = exampleUTxO
           , ltiTx = tx
           , ltiMemoizedSubTransactions = mempty
           }
@@ -241,6 +239,17 @@ expectTranslationError slang tx expected =
         Right txInfo ->
           assertFailure $ "This translation was expected to fail, but it succeeded: " <> show txInfo
         Left e -> e `shouldBe` expected
+
+expectV1TranslationError ::
+  ( BabbageEraTxOut era
+  , EraPlutusTxInfo 'PlutusV1 era
+  , EraPlutusTxInfo 'PlutusV2 era
+  , Value era ~ MaryValue
+  ) =>
+  Tx TopTx era ->
+  ContextError era ->
+  Expectation
+expectV1TranslationError = expectTranslationError SPlutusV1
 
 errorTranslate ::
   forall era b.
@@ -252,26 +261,28 @@ errorTranslate exampleName =
   either (\err -> error $ exampleName ++ " failed: " ++ show err) id
 
 translatedOutputEx1 ::
-  forall era l.
+  forall era.
   ( BabbageEraTxOut era
+  , Show (ContextError era)
   , Value era ~ MaryValue
-  , EraPlutusTxInfo l era
+  , Inject (BabbageContextError era) (ContextError era)
   ) =>
-  PlutusTxOut l
+  PV2.TxOut
 translatedOutputEx1 =
   errorTranslate @era "translatedOutputEx1" $
-    toPlutusTxOut (Proxy @l) (TxOutFromOutput minBound) inlineDatumOutput
+    transTxOutV2 @era (TxOutFromOutput minBound) inlineDatumOutput
 
 translatedOutputEx2 ::
-  forall l era.
+  forall era.
   ( BabbageEraTxOut era
   , EraPlutusTxInfo 'PlutusV2 era
-  , EraPlutusTxInfo l era
+  , Value era ~ MaryValue
+  , Inject (BabbageContextError era) (ContextError era)
   ) =>
-  PlutusTxOut l
+  PV2.TxOut
 translatedOutputEx2 =
   errorTranslate @era "translatedOutputEx2" $
-    toPlutusTxOut (Proxy @l) (TxOutFromOutput minBound) (refScriptOutput @l)
+    transTxOutV2 @era (TxOutFromOutput minBound) refScriptOutput
 
 txInfoSpecV1 ::
   forall era.
@@ -279,34 +290,30 @@ txInfoSpecV1 ::
   , BabbageEraTxBody era
   , Value era ~ MaryValue
   , EraPlutusTxInfo 'PlutusV1 era
+  , EraPlutusTxInfo 'PlutusV2 era
   , Inject (BabbageContextError era) (ContextError era)
   ) =>
   Spec
 txInfoSpecV1 =
   describe "Plutus V1" $ do
     it "translation error on byron txout" $
-      expectTranslationError @era
-        SPlutusV1
+      expectV1TranslationError @era
         (txBare shelleyInput byronOutput)
         (inject $ ByronTxOutInContext @era (TxOutFromOutput minBound))
     it "translation error on byron txin" $
-      expectTranslationError @era
-        SPlutusV1
+      expectV1TranslationError @era
         (txBare byronInput shelleyOutput)
         (inject $ ByronTxOutInContext @era (TxOutFromInput byronInput))
     it "translation error on unknown txin (logic error)" $
-      expectTranslationError @era
-        SPlutusV1
+      expectV1TranslationError @era
         (txBare unknownInput shelleyOutput)
         (inject $ AlonzoContextError $ TranslationLogicMissingInput @era unknownInput)
     it "translation error on inline datum in input" $
-      expectTranslationError @era
-        SPlutusV1
+      expectV1TranslationError @era
         (txBare inputWithInlineDatum shelleyOutput)
         (inject $ InlineDatumsNotSupported @era (TxOutFromInput inputWithInlineDatum))
     it "translation error on inline datum in output" $
-      expectTranslationError @era
-        SPlutusV1
+      expectV1TranslationError @era
         (txBare shelleyInput inlineDatumOutput)
         (inject $ InlineDatumsNotSupported @era (TxOutFromOutput minBound))
 
@@ -340,39 +347,32 @@ txInfoSpec lang =
         lang
         (txBare unknownInput shelleyOutput)
         (inject $ AlonzoContextError $ TranslationLogicMissingInput @era unknownInput)
-    -- This test will fail in PlutusV3 because of ReferenceInputsNotDisjointFromInputs
-    when (plutusLanguage lang == PlutusV2) $
-      it "use reference input starting in Babbage" $
-        successfulTranslation @era
-          lang
-          (txRefInput shelleyInput)
-          hasReferenceInput
     it "use inline datum in input" $
       successfulTranslation @era
         lang
         (txBare inputWithInlineDatum shelleyOutput)
         ( \l txInfo -> do
-            txInInfo <- expectRight $ toPlutusTxInInfo l (exampleUTxO @l @era) inputWithInlineDatum
+            txInInfo <- expectRight $ toPlutusTxInInfo @_ @era l exampleUTxO inputWithInlineDatum
             expectOneInput @era l txInInfo txInfo
         )
     it "use inline datum in output" $
       successfulTranslation @era
         lang
         (txBare shelleyInput inlineDatumOutput)
-        (expectOneOutput (translatedOutputEx1 @era @l))
+        (expectOneOutput (translatedOutputEx1 @era))
     it "use reference script in input" $
       successfulTranslation @era
         lang
         (txBare inputWithRefScript shelleyOutput)
         ( \l txInfo -> do
-            txInInfo <- expectRight $ toPlutusTxInInfo @_ @era l (exampleUTxO @l) inputWithRefScript
+            txInInfo <- expectRight $ toPlutusTxInInfo @_ @era l exampleUTxO inputWithRefScript
             expectOneInput @era l txInInfo txInfo
         )
     it "use reference script in output" $
       successfulTranslation @era
         lang
-        (txBare shelleyInput $ refScriptOutput @l)
-        (expectOneOutput (translatedOutputEx2 @l @era))
+        (txBare shelleyInput refScriptOutput)
+        (expectOneOutput (translatedOutputEx2 @era))
 
 spec ::
   forall era.
@@ -388,6 +388,12 @@ spec =
   describe "txInfo translation" $ do
     txInfoSpecV1 @era
     txInfoSpec @era SPlutusV2
+    it "use reference input starting in Babbage" $
+      -- This test will fail in PlutusV3 because of ReferenceInputsNotDisjointFromInputs
+      successfulTranslation @era
+        SPlutusV2
+        (txRefInput shelleyInput)
+        hasReferenceInput
 
 genesisId :: TxId
 genesisId = TxId (unsafeMakeSafeHash (mkDummyHash (0 :: Int)))

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -8,8 +8,7 @@
 * Remove `certsTx` field from `CertsEnv`
 * Export `applyEnactedWithdrawals`, `returnProposalDeposits`, `updateCommitteeState` and `updateNumDormantEpochs`
 * Replace `StakeKeyRegisteredDELEG` constructor with `DelegAccountAlreadyRegistered` in `ConwayDelegPredFailure`, which wraps the new `AccountAlreadyRegistered` type instead of `Credential Staking`
-* Change `toPlutusV3Args` to accept `LedgerTxInfo era` and `ScriptHash` arguments instead of `ProtVer` and `Maybe (Data era)`
-* Change `transPlutusPurposeV3` and `transPlutusPurposeV1V2` to accept an extra `()` argument for `PlutusPurposeScriptHashArg`
+* Change `toPlutusV3Args` to accept `LedgerTxInfo era` argument instead of `ProtVer` and `Maybe (Data era)`
 * Export `transVoter`
 * Add `EncCBOR`, `ToCBOR` for `Block`
 * Add `DecCBOR` instances for `Annotator Block`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
@@ -51,7 +51,6 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
   EraPlutusContext (..),
   EraPlutusTxInfo (..),
   LedgerTxInfo (..),
-  PlutusPurposeScriptHashArg,
   PlutusTxCert,
   PlutusTxInfoResult (..),
   SupportedLanguage (..),
@@ -649,10 +648,9 @@ transPlutusPurposeV3 ::
   ) =>
   proxy 'PlutusV3 ->
   ProtVer ->
-  () ->
   PlutusPurpose AsIxItem era ->
   Either (ContextError era) PV3.ScriptPurpose
-transPlutusPurposeV3 proxy pv _ = \case
+transPlutusPurposeV3 proxy pv = \case
   SpendingPurpose (AsIxItem _ txIn) -> pure $ PV3.Spending (transTxIn txIn)
   MintingPurpose (AsIxItem _ policyId) -> pure $ PV3.Minting (Alonzo.transPolicyID policyId)
   CertifyingPurpose (AsIxItem ix txCert) ->
@@ -743,20 +741,18 @@ transProposal proxy ProposalProcedure {pProcDeposit, pProcReturnAddr, pProcGovAc
 transPlutusPurposeV1V2 ::
   forall l era proxy.
   ( PlutusTxCert l ~ PV2.DCert
-  , PlutusPurposeScriptHashArg l ~ ()
   , EraPlutusTxInfo l era
   , Inject (ConwayContextError era) (ContextError era)
   ) =>
   proxy l ->
   ProtVer ->
-  () ->
   PlutusPurpose AsIxItem era ->
   Either (ContextError era) PV2.ScriptPurpose
-transPlutusPurposeV1V2 proxy pv sh = \case
-  SpendingPurpose asIxItem -> Alonzo.transPlutusPurpose proxy pv sh $ AlonzoSpending asIxItem
-  MintingPurpose asIxItem -> Alonzo.transPlutusPurpose proxy pv sh $ AlonzoMinting asIxItem
-  CertifyingPurpose asIxItem -> Alonzo.transPlutusPurpose proxy pv sh $ AlonzoCertifying asIxItem
-  WithdrawingPurpose asIxItem -> Alonzo.transPlutusPurpose proxy pv sh $ AlonzoWithdrawing asIxItem
+transPlutusPurposeV1V2 proxy pv = \case
+  SpendingPurpose asIxItem -> Alonzo.transPlutusPurpose proxy pv $ AlonzoSpending asIxItem
+  MintingPurpose asIxItem -> Alonzo.transPlutusPurpose proxy pv $ AlonzoMinting asIxItem
+  CertifyingPurpose asIxItem -> Alonzo.transPlutusPurpose proxy pv $ AlonzoCertifying asIxItem
+  WithdrawingPurpose asIxItem -> Alonzo.transPlutusPurpose proxy pv $ AlonzoWithdrawing asIxItem
   purpose -> Left $ inject $ PlutusPurposeNotSupported @era $ hoistPlutusPurpose toAsItem purpose
 
 transProtVer :: ProtVer -> PV3.ProtocolVersion
@@ -769,13 +765,12 @@ toPlutusV3Args ::
   ) =>
   proxy 'PlutusV3 ->
   LedgerTxInfo era ->
-  ScriptHash ->
   PV3.TxInfo ->
   PlutusPurpose AsIxItem era ->
   Data era ->
   Either (ContextError era) (PlutusArgs 'PlutusV3)
-toPlutusV3Args proxy LedgerTxInfo {..} _ txInfo plutusPurpose redeemerData = do
-  scriptPurpose <- toPlutusScriptPurpose proxy ltiProtVer () plutusPurpose
+toPlutusV3Args proxy LedgerTxInfo {..} txInfo plutusPurpose redeemerData = do
+  scriptPurpose <- toPlutusScriptPurpose proxy ltiProtVer plutusPurpose
   let
     maybeSpendingData =
       getSpendingDatum ltiUTxO ltiTx $ hoistPlutusPurpose toAsItem plutusPurpose

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
@@ -416,7 +416,7 @@ transTxCertV1V2 = \case
 instance EraPlutusTxInfo 'PlutusV1 ConwayEra where
   toPlutusTxCert _ _ = transTxCertV1V2
 
-  toPlutusScriptPurpose = transPlutusPurposeV1V2
+  toPlutusScriptPurpose proxy lti = transPlutusPurposeV1V2 proxy (ltiProtVer lti)
 
   toPlutusTxInfo proxy LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} =
     PlutusTxInfoResult $ withTopTxLevelOnly ltiTx $ \tx -> do
@@ -456,9 +456,9 @@ instance EraPlutusTxInfo 'PlutusV1 ConwayEra where
 instance EraPlutusTxInfo 'PlutusV2 ConwayEra where
   toPlutusTxCert _ _ = transTxCertV1V2
 
-  toPlutusScriptPurpose = transPlutusPurposeV1V2
+  toPlutusScriptPurpose proxy lti = transPlutusPurposeV1V2 proxy (ltiProtVer lti)
 
-  toPlutusTxInfo proxy LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} =
+  toPlutusTxInfo proxy lti@LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} =
     PlutusTxInfoResult $ withTopTxLevelOnly ltiTx $ \tx -> do
       let txBody = tx ^. bodyTxL
       guardConwayFeaturesForPlutusV1V2 tx
@@ -472,7 +472,7 @@ instance EraPlutusTxInfo 'PlutusV2 ConwayEra where
           [minBound ..]
           (F.toList (txBody ^. outputsTxBodyL))
       txCerts <- Alonzo.transTxBodyCerts proxy ltiProtVer txBody
-      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer tx
+      plutusRedeemers <- Babbage.transTxRedeemers proxy lti
       -- It is important for memoization for `txInfo` to be a let binding
       let
         txInfo =
@@ -499,9 +499,9 @@ instance EraPlutusTxInfo 'PlutusV2 ConwayEra where
 instance EraPlutusTxInfo 'PlutusV3 ConwayEra where
   toPlutusTxCert _ pv = pure . transTxCert pv
 
-  toPlutusScriptPurpose = transPlutusPurposeV3
+  toPlutusScriptPurpose proxy lti = transPlutusPurposeV3 proxy (ltiProtVer lti)
 
-  toPlutusTxInfo proxy LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} =
+  toPlutusTxInfo proxy lti@LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} =
     PlutusTxInfoResult $ withTopTxLevelOnly ltiTx $ \tx -> do
       let
         txBody = tx ^. bodyTxL
@@ -518,7 +518,7 @@ instance EraPlutusTxInfo 'PlutusV3 ConwayEra where
           [minBound ..]
           (F.toList (txBody ^. outputsTxBodyL))
       txCerts <- Alonzo.transTxBodyCerts proxy ltiProtVer txBody
-      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer tx
+      plutusRedeemers <- Babbage.transTxRedeemers proxy lti
       -- It is important for memoization for `txInfo` to be a let binding
       let txInfo =
             PV3.TxInfo
@@ -769,8 +769,8 @@ toPlutusV3Args ::
   PlutusPurpose AsIxItem era ->
   Data era ->
   Either (ContextError era) (PlutusArgs 'PlutusV3)
-toPlutusV3Args proxy LedgerTxInfo {..} txInfo plutusPurpose redeemerData = do
-  scriptPurpose <- toPlutusScriptPurpose proxy ltiProtVer plutusPurpose
+toPlutusV3Args proxy lti@LedgerTxInfo {..} txInfo plutusPurpose redeemerData = do
+  scriptPurpose <- toPlutusScriptPurpose proxy lti plutusPurpose
   let
     maybeSpendingData =
       getSpendingDatum ltiUTxO ltiTx $ hoistPlutusPurpose toAsItem plutusPurpose

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
@@ -456,8 +456,6 @@ instance EraPlutusTxInfo 'PlutusV1 ConwayEra where
 
   toPlutusRedeemerPointer = Alonzo.transRedeemerPointerV1
 
-  toPlutusTxOut _ src txOut = Just <$> transTxOutV1 src txOut
-
 instance EraPlutusTxInfo 'PlutusV2 ConwayEra where
   toPlutusTxCert _ _ = transTxCertV1V2
 
@@ -502,8 +500,6 @@ instance EraPlutusTxInfo 'PlutusV2 ConwayEra where
   toPlutusTxInInfo _ = Babbage.transTxInInfoV2
 
   toPlutusRedeemerPointer = Babbage.transRedeemerPointerV2V3
-
-  toPlutusTxOut _ = transTxOutV2
 
 instance EraPlutusTxInfo 'PlutusV3 ConwayEra where
   toPlutusTxCert _ pv = pure . transTxCert pv
@@ -560,8 +556,6 @@ instance EraPlutusTxInfo 'PlutusV3 ConwayEra where
   toPlutusTxInInfo _ = transTxInInfoV3
 
   toPlutusRedeemerPointer = Babbage.transRedeemerPointerV2V3
-
-  toPlutusTxOut _ = transTxOutV2
 
 transTxId :: TxId -> PV3.TxId
 transTxId txId = PV3.TxId (transSafeHash (unTxId txId))

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
@@ -454,8 +454,6 @@ instance EraPlutusTxInfo 'PlutusV1 ConwayEra where
 
   toPlutusTxInInfo _ = transTxInInfoV1
 
-  toPlutusRedeemerPointer = Alonzo.transRedeemerPointerV1
-
 instance EraPlutusTxInfo 'PlutusV2 ConwayEra where
   toPlutusTxCert _ _ = transTxCertV1V2
 
@@ -475,7 +473,7 @@ instance EraPlutusTxInfo 'PlutusV2 ConwayEra where
           [minBound ..]
           (F.toList (txBody ^. outputsTxBodyL))
       txCerts <- Alonzo.transTxBodyCerts proxy ltiProtVer txBody
-      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer tx ltiUTxO
+      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer tx
       -- It is important for memoization for `txInfo` to be a let binding
       let
         txInfo =
@@ -499,8 +497,6 @@ instance EraPlutusTxInfo 'PlutusV2 ConwayEra where
 
   toPlutusTxInInfo _ = Babbage.transTxInInfoV2
 
-  toPlutusRedeemerPointer = Babbage.transRedeemerPointerV2V3
-
 instance EraPlutusTxInfo 'PlutusV3 ConwayEra where
   toPlutusTxCert _ pv = pure . transTxCert pv
 
@@ -523,7 +519,7 @@ instance EraPlutusTxInfo 'PlutusV3 ConwayEra where
           [minBound ..]
           (F.toList (txBody ^. outputsTxBodyL))
       txCerts <- Alonzo.transTxBodyCerts proxy ltiProtVer txBody
-      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer tx ltiUTxO
+      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer tx
       -- It is important for memoization for `txInfo` to be a let binding
       let txInfo =
             PV3.TxInfo
@@ -554,8 +550,6 @@ instance EraPlutusTxInfo 'PlutusV3 ConwayEra where
   toPlutusArgs = toPlutusV3Args
 
   toPlutusTxInInfo _ = transTxInInfoV3
-
-  toPlutusRedeemerPointer = Babbage.transRedeemerPointerV2V3
 
 transTxId :: TxId -> PV3.TxId
 transTxId txId = PV3.TxId (transSafeHash (unTxId txId))

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -36,7 +36,6 @@
 * Change `PointerPresentInOutput` constructor of `DijkstraContextError` to contain a `NonEmptySet TxOutSource` instead of `NonEmpty (TxOut era)`
 * Add `udppPlutusV4CostModel` field to `UpgradeDijkstraPParams`
 * Add `HKDSemialign` constraint to `upgradeDijkstraPParams`
-* Add `transRedeemerPointerV4`
 * Add `EncCBOR`, `ToCBOR` for `Block`
 * Add `DecCBOR` instances for `Annotator Block`
 * Remove `EncCBORGroup` instance for `DijkstraBlockBody`

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.4.0.0
 
+* Re-export `GuardingPurpose` from `Cardano.Ledger.Dijkstra.Core` for consistency with prior eras.
 * Adapt to `plutus-ledger-api` v1.38: remove `txInfoFee` from PV4 `TxInfo`, convert `txInfoValidRange` via `transPOSIXTimeRange`, use `Credential` instead of `AccountId` for withdrawals and direct deposits
 * Add `era` parameter to `PoolCert`s
 * Enforce `accountBalanceIntervals` in `ENTITIES` and `SUBENTITIES`, and `startingAccountBalanceIntervals` in `ENTITIES`:

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -183,6 +183,7 @@ library testlib
     ghc-options:
       -Wno-pattern-namespace-specifier
   build-depends:
+    FailT,
     base,
     bytestring,
     cardano-base,

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
@@ -22,6 +22,7 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
   EraPlutusContext (mkTxInfoResult),
   LedgerTxInfo (..),
   SupportedPlutusRunnable (..),
+  toScriptHashByPurpose,
  )
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (
   scriptsWithContextFromLedgerTxInfo,
@@ -138,6 +139,7 @@ mkDijkstraStAnnTopTx ei sysStart pp utxo stAnnTxCache tx =
         , ltiUTxO = utxo
         , ltiTx = tx
         , ltiScriptsUsed = plutusScriptsUsed
+        , ltiScriptHashesUsed = toScriptHashByPurpose plutusScriptsUsed
         , ltiMemoizedSubTransactions =
             Map.fromList
               [ (txIdTx dsastTx, dsastTxInfoResult)
@@ -187,6 +189,7 @@ mkDijkstraStAnnSubTx ei sysStart pp utxo scriptsProvided plutusScriptsCache tx =
         , ltiUTxO = utxo
         , ltiTx = tx
         , ltiScriptsUsed = plutusScriptsUsed
+        , ltiScriptHashesUsed = toScriptHashByPurpose plutusScriptsUsed
         , ltiMemoizedSubTransactions = mempty
         }
     txInfoResult = mkTxInfoResult ledgerTxInfo

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
@@ -137,6 +137,7 @@ mkDijkstraStAnnTopTx ei sysStart pp utxo stAnnTxCache tx =
         , ltiSystemStart = sysStart
         , ltiUTxO = utxo
         , ltiTx = tx
+        , ltiScriptsUsed = plutusScriptsUsed
         , ltiMemoizedSubTransactions =
             Map.fromList
               [ (txIdTx dsastTx, dsastTxInfoResult)
@@ -154,7 +155,7 @@ mkDijkstraStAnnTopTx ei sysStart pp utxo stAnnTxCache tx =
       , dsattPlutusRunnableCache = newStAnnTxCache
       , dsattPlutusLanguagesUsed = languagesUsed
       , dsattPlutusScriptsWithContext =
-          scriptsWithContextFromLedgerTxInfo ledgerTxInfo (pp ^. ppCostModelsL) plutusScriptsUsed
+          scriptsWithContextFromLedgerTxInfo ledgerTxInfo (pp ^. ppCostModelsL)
       , dsattSubTransactions = stAnnSubTxs
       }
 
@@ -185,6 +186,7 @@ mkDijkstraStAnnSubTx ei sysStart pp utxo scriptsProvided plutusScriptsCache tx =
         , ltiSystemStart = sysStart
         , ltiUTxO = utxo
         , ltiTx = tx
+        , ltiScriptsUsed = plutusScriptsUsed
         , ltiMemoizedSubTransactions = mempty
         }
     txInfoResult = mkTxInfoResult ledgerTxInfo
@@ -203,5 +205,4 @@ mkDijkstraStAnnSubTx ei sysStart pp utxo scriptsProvided plutusScriptsCache tx =
             ledgerTxInfo
             txInfoResult
             (pp ^. ppCostModelsL)
-            plutusScriptsUsed
       }

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Core.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Core.hs
@@ -1,11 +1,15 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Cardano.Ledger.Dijkstra.Core (
   DijkstraEraTxBody (..),
   DijkstraBlockBody (..),
   module Cardano.Ledger.Conway.Core,
   DirectDeposits (..),
+  pattern GuardingPurpose,
 ) where
 
 import Cardano.Ledger.Address (DirectDeposits (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Dijkstra.BlockBody (DijkstraBlockBody (..))
+import Cardano.Ledger.Dijkstra.Scripts (pattern GuardingPurpose)
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody (..))

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
@@ -43,7 +43,7 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
  )
 import Cardano.Ledger.Alonzo.Plutus.TxInfo (transPolicyID, transValue)
 import qualified Cardano.Ledger.Alonzo.Plutus.TxInfo as Alonzo
-import Cardano.Ledger.Alonzo.Scripts (toAsItem)
+import Cardano.Ledger.Alonzo.Scripts (toAsItem, toAsIx)
 import Cardano.Ledger.Alonzo.TxWits (unRedeemersL)
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO (..))
 import qualified Cardano.Ledger.Babbage.TxInfo as Babbage
@@ -83,7 +83,7 @@ import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Scripts (
   AccountBalanceInterval (..),
   AccountBalanceIntervals (..),
-  DijkstraPlutusPurpose (..),
+  DijkstraEraScript,
   PlutusScript (..),
  )
 import Cardano.Ledger.Dijkstra.TxCert (DijkstraTxCert)
@@ -109,6 +109,7 @@ import Cardano.Ledger.Plutus (
   transEpochNo,
   transKeyHash,
   transSafeHash,
+  transScriptHash,
  )
 import Cardano.Ledger.Plutus.Data (Data)
 import Cardano.Ledger.Plutus.ToPlutusData (ToPlutusData (..))
@@ -735,9 +736,6 @@ transTxRedeemersV4 proxy lti@LedgerTxInfo {ltiTx} =
       (transRedeemerPointerV4 proxy lti)
       (Map.toList $ ltiTx ^. witsTxL . rdmrsTxWitsL . unRedeemersL)
 
-transAccountId :: AccountId -> PV4.AccountId
-transAccountId (AccountId cred) = PV4.AccountId $ transCred cred
-
 transTxBodyWithdrawals ::
   DijkstraEraTxBody era => TxBody l era -> PV4.Map PV4.Credential PV4.Lovelace
 transTxBodyWithdrawals txb = transMap transAccountAddressToCredential transCoinToLovelace withdrawals
@@ -842,6 +840,7 @@ scriptPurposeToScriptInfo sp datum topInfo = case sp of
 toPlutusV4Args ::
   ( AlonzoEraUTxO era
   , EraPlutusTxInfo PlutusV4 era
+  , Inject (DijkstraContextError era) (ContextError era)
   ) =>
   proxy 'PlutusV4 ->
   LedgerTxInfo era ->
@@ -855,7 +854,11 @@ toPlutusV4Args proxy lti@LedgerTxInfo {..} txInfo plutusPurpose redeemerData = d
     maybeSpendingData = getSpendingDatum ltiUTxO ltiTx $ hoistPlutusPurpose toAsItem plutusPurpose
     -- TODO TopTxInfo should be set if this is a top-level transaction
     scriptInfo = scriptPurposeToScriptInfo scriptPurpose (transDatum <$> maybeSpendingData) Nothing
-    sh = error "Unimplemented: ScriptHash for ScriptContext"
+    ixPurpose = hoistPlutusPurpose toAsIx plutusPurpose
+  sh <-
+    case Map.lookup ixPurpose ltiScriptHashesUsed of
+      Nothing -> Left $ inject $ ScriptHashNotFoundForPurpose ixPurpose
+      Just scriptHash -> Right $ transScriptHash scriptHash
   pure $
     PlutusV4Args $
       PV4.ScriptContext
@@ -869,23 +872,34 @@ transTxId :: TxId -> PV4.TxId
 transTxId (TxId h) = PV4.TxId $ transSafeHash h
 
 transPlutusPurposeV4 ::
-  ConwayEraPlutusTxInfo PlutusV4 era =>
+  forall era proxy.
+  ( DijkstraEraScript era
+  , ConwayEraPlutusTxInfo PlutusV4 era
+  , Inject (ConwayContextError era) (ContextError era)
+  , Inject (DijkstraContextError era) (ContextError era)
+  ) =>
   proxy 'PlutusV4 ->
   LedgerTxInfo era ->
-  DijkstraPlutusPurpose AsIxItem era ->
+  PlutusPurpose AsIxItem era ->
   Either (ContextError era) (PlutusScriptPurpose PlutusV4)
-transPlutusPurposeV4 proxy lti = \case
-  DijkstraSpending (AsIxItem _ (TxIn txId (TxIx ix))) ->
-    pure . PV4.Spending sh $ PV4.TxOutRef (transTxId txId) (toInteger ix)
-  DijkstraMinting (AsIxItem _ pId) -> pure . PV4.Minting sh $ transPolicyID pId
-  DijkstraCertifying (AsIxItem ix cert) ->
-    PV4.Certifying sh (toInteger ix) <$> toPlutusTxCert proxy pv cert
-  DijkstraWithdrawing (AsIxItem _ (AccountAddress _ (AccountId c))) ->
-    pure $ PV4.Withdrawing sh (transCred c)
-  DijkstraVoting (AsIxItem _ voter) -> pure $ PV4.Voting sh (transVoter voter)
-  DijkstraProposing (AsIxItem ix proc) ->
-    pure $ PV4.Proposing sh (toInteger ix) (transProposal proxy proc)
-  DijkstraGuarding (AsIxItem ix _) -> pure $ PV4.Guarding sh (toInteger ix)
-  where
+transPlutusPurposeV4 proxy lti plutusPurpose = do
+  let
     pv = ltiProtVer lti
-    sh = error "Unimplemented: ScriptHash for purpose"
+    ixPurpose = hoistPlutusPurpose toAsIx plutusPurpose
+  sh <-
+    case Map.lookup ixPurpose (ltiScriptHashesUsed lti) of
+      Nothing -> Left $ inject $ ScriptHashNotFoundForPurpose @era ixPurpose
+      Just scriptHash -> Right $ transScriptHash scriptHash
+  case plutusPurpose of
+    SpendingPurpose (AsIxItem _ (TxIn txId (TxIx ix))) ->
+      pure . PV4.Spending sh $ PV4.TxOutRef (transTxId txId) (toInteger ix)
+    MintingPurpose (AsIxItem _ pId) -> pure . PV4.Minting sh $ transPolicyID pId
+    CertifyingPurpose (AsIxItem ix cert) ->
+      PV4.Certifying sh (toInteger ix) <$> toPlutusTxCert proxy pv cert
+    WithdrawingPurpose (AsIxItem _ (AccountAddress _ (AccountId c))) ->
+      pure $ PV4.Withdrawing sh (transCred c)
+    VotingPurpose (AsIxItem _ voter) -> pure $ PV4.Voting sh (transVoter voter)
+    ProposingPurpose (AsIxItem ix proc) ->
+      pure $ PV4.Proposing sh (toInteger ix) (transProposal proxy proc)
+    GuardingPurpose (AsIxItem ix _) -> pure $ PV4.Guarding sh (toInteger ix)
+    _ -> Left $ inject $ PlutusPurposeNotSupported @era $ hoistPlutusPurpose toAsItem plutusPurpose

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
@@ -591,7 +591,7 @@ transRedeemerPointerV4 proxy pv txBody scriptHashes (ptr, (d, _)) =
         Nothing -> Left . inject $ ScriptHashNotFoundForPurpose @era ptr
 
 instance EraPlutusTxInfo 'PlutusV4 DijkstraEra where
-  toPlutusTxCert proxy pv cert = pure $ transTxCertV4 proxy pv cert
+  toPlutusTxCert proxy _pv cert = pure $ transTxCertV4 proxy cert
 
   toPlutusScriptPurpose = transPlutusPurposeV4
 
@@ -758,8 +758,8 @@ transTxBodyWithdrawals txb = transMap transAccountAddressToCredential transCoinT
 transCredToAccountId :: Credential r -> PV4.AccountId
 transCredToAccountId = PV4.AccountId . transCred
 
-transTxCertV4 :: ConwayEraTxCert era => proxy 'PlutusV4 -> ProtVer -> TxCert era -> PV4.TxCert
-transTxCertV4 _proxy _pv = \case
+transTxCertV4 :: ConwayEraTxCert era => proxy 'PlutusV4 -> TxCert era -> PV4.TxCert
+transTxCertV4 _proxy = \case
   RegPoolTxCert StakePoolParams {sppId, sppVrf} ->
     PV4.TxCertPoolRegister
       (transKeyHash sppId)
@@ -880,9 +880,7 @@ transTxId :: TxId -> PV4.TxId
 transTxId (TxId h) = PV4.TxId $ transSafeHash h
 
 transPlutusPurposeV4 ::
-  ( ConwayEraTxCert era
-  , ConwayEraPlutusTxInfo PlutusV4 era
-  ) =>
+  ConwayEraPlutusTxInfo PlutusV4 era =>
   proxy 'PlutusV4 ->
   ProtVer ->
   DijkstraPlutusPurpose AsIxItem era ->
@@ -892,7 +890,7 @@ transPlutusPurposeV4 proxy pv = \case
     pure . PV4.Spending sh $ PV4.TxOutRef (transTxId txId) (toInteger ix)
   DijkstraMinting (AsIxItem _ pId) -> pure . PV4.Minting sh $ transPolicyID pId
   DijkstraCertifying (AsIxItem ix cert) ->
-    pure $ PV4.Certifying sh (toInteger ix) (transTxCertV4 proxy pv cert)
+    PV4.Certifying sh (toInteger ix) <$> toPlutusTxCert proxy pv cert
   DijkstraWithdrawing (AsIxItem _ (AccountAddress _ (AccountId c))) ->
     pure $ PV4.Withdrawing sh (transCred c)
   DijkstraVoting (AsIxItem _ voter) -> pure $ PV4.Voting sh (transVoter voter)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
@@ -363,8 +363,6 @@ instance EraPlutusTxInfo 'PlutusV1 DijkstraEra where
 
   toPlutusRedeemerPointer = Alonzo.transRedeemerPointerV1
 
-  toPlutusTxOut _ src txOut = Just <$> Conway.transTxOutV1 src txOut
-
 transTxCertV1V2 ::
   ( ConwayEraTxCert era
   , Inject (ConwayContextError era) (ContextError era)
@@ -433,8 +431,6 @@ instance EraPlutusTxInfo 'PlutusV2 DijkstraEra where
 
   toPlutusRedeemerPointer = Babbage.transRedeemerPointerV2V3
 
-  toPlutusTxOut _ = Babbage.transTxOutV2
-
 instance EraPlutusTxInfo 'PlutusV3 DijkstraEra where
   toPlutusTxCert _ _ = pure . transTxCertV3
 
@@ -492,8 +488,6 @@ instance EraPlutusTxInfo 'PlutusV3 DijkstraEra where
   toPlutusTxInInfo _ = transTxInInfoV3
 
   toPlutusRedeemerPointer = Babbage.transRedeemerPointerV2V3
-
-  toPlutusTxOut _ = Babbage.transTxOutV2
 
 guardDijkstraFeaturesForPlutusV1toV3 ::
   forall era.
@@ -681,8 +675,6 @@ instance EraPlutusTxInfo 'PlutusV4 DijkstraEra where
   toPlutusTxInInfo _ = transTxInInfoV4
 
   toPlutusRedeemerPointer = transRedeemerPointerV4
-
-  toPlutusTxOut _ = transTxOutV4
 
 transTxInV4 :: TxIn -> PV4.TxOutRef
 transTxInV4 (TxIn txid txIx) = PV4.TxOutRef (transTxId txid) (toInteger (txIxToInt txIx))

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
@@ -37,7 +37,6 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
   EraPlutusTxInfo (..),
   LedgerTxInfo (..),
   PlutusPurposeScriptHashArg,
-  PlutusRedeemerPointer,
   PlutusScriptPurpose,
   PlutusTxInfoResult (..),
   SupportedLanguage (..),
@@ -46,6 +45,7 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
 import Cardano.Ledger.Alonzo.Plutus.TxInfo (transPolicyID, transValue)
 import qualified Cardano.Ledger.Alonzo.Plutus.TxInfo as Alonzo
 import Cardano.Ledger.Alonzo.Scripts (toAsItem)
+import Cardano.Ledger.Alonzo.TxWits (unRedeemersL)
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO (..))
 import Cardano.Ledger.Babbage.TxInfo (BabbageContextError (..), transRedeemer, transReferenceScript)
 import qualified Cardano.Ledger.Babbage.TxInfo as Babbage
@@ -361,8 +361,6 @@ instance EraPlutusTxInfo 'PlutusV1 DijkstraEra where
 
   toPlutusTxInInfo _ = transTxInInfoV1
 
-  toPlutusRedeemerPointer = Alonzo.transRedeemerPointerV1
-
 transTxCertV1V2 ::
   ( ConwayEraTxCert era
   , Inject (ConwayContextError era) (ContextError era)
@@ -405,7 +403,7 @@ instance EraPlutusTxInfo 'PlutusV2 DijkstraEra where
           [minBound ..]
           (F.toList (txBody ^. outputsTxBodyL))
       txCerts <- Alonzo.transTxBodyCerts proxy ltiProtVer txBody
-      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer tx ltiUTxO
+      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer tx
       -- It is important for memoization for `txInfo` to be a let binding
       let
         txInfo =
@@ -428,8 +426,6 @@ instance EraPlutusTxInfo 'PlutusV2 DijkstraEra where
   toPlutusArgs = Babbage.toPlutusV2Args
 
   toPlutusTxInInfo _ = Babbage.transTxInInfoV2
-
-  toPlutusRedeemerPointer = Babbage.transRedeemerPointerV2V3
 
 instance EraPlutusTxInfo 'PlutusV3 DijkstraEra where
   toPlutusTxCert _ _ = pure . transTxCertV3
@@ -454,7 +450,7 @@ instance EraPlutusTxInfo 'PlutusV3 DijkstraEra where
           [minBound ..]
           (F.toList (txBody ^. outputsTxBodyL))
       txCerts <- Alonzo.transTxBodyCerts proxy ltiProtVer txBody
-      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer tx ltiUTxO
+      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer tx
       -- It is important for memoization for `txInfo` to be a let binding
       let
         txInfo =
@@ -486,8 +482,6 @@ instance EraPlutusTxInfo 'PlutusV3 DijkstraEra where
   toPlutusArgs = Conway.toPlutusV3Args
 
   toPlutusTxInInfo _ = transTxInInfoV3
-
-  toPlutusRedeemerPointer = Babbage.transRedeemerPointerV2V3
 
 guardDijkstraFeaturesForPlutusV1toV3 ::
   forall era.
@@ -583,7 +577,6 @@ transRedeemerPointerV4 ::
   , Inject (BabbageContextError era) (ContextError era)
   , EraPlutusTxInfo l era
   , PlutusPurposeScriptHashArg l ~ ScriptHash
-  , PlutusRedeemerPointer l ~ (PlutusScriptPurpose l, PV4.Redeemer)
   , Inject (DijkstraContextError era) (ContextError era)
   ) =>
   proxy l ->
@@ -591,7 +584,7 @@ transRedeemerPointerV4 ::
   TxBody t era ->
   Map.Map (PlutusPurpose AsIx era) ScriptHash ->
   (PlutusPurpose AsIx era, (Data era, ExUnits)) ->
-  Either (ContextError era) (PlutusRedeemerPointer l)
+  Either (ContextError era) (PlutusScriptPurpose l, PV4.Redeemer)
 transRedeemerPointerV4 proxy pv txBody scriptHashes (ptr, (d, _)) =
   case redeemerPointerInverse txBody ptr of
     SNothing -> Left . inject $ RedeemerPointerPointsToNothing ptr
@@ -641,7 +634,8 @@ instance EraPlutusTxInfo 'PlutusV4 DijkstraEra where
             (Right mempty)
             ([minBound ..] `zip` F.toList (txBody ^. outputsTxBodyL))
       txCerts <- Alonzo.transTxBodyCerts proxy ltiProtVer txBody
-      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer ltiTx ltiUTxO
+      let scriptHashes = mempty -- TODO: Pipe in resolved ScriptHashes
+      plutusRedeemers <- transTxRedeemersV4 proxy ltiProtVer ltiTx scriptHashes
       let
         txInfo =
           PV4.TxInfo
@@ -673,8 +667,6 @@ instance EraPlutusTxInfo 'PlutusV4 DijkstraEra where
   toPlutusArgs = toPlutusV4Args
 
   toPlutusTxInInfo _ = transTxInInfoV4
-
-  toPlutusRedeemerPointer = transRedeemerPointerV4
 
 transTxInV4 :: TxIn -> PV4.TxOutRef
 transTxInV4 (TxIn txid txIx) = PV4.TxOutRef (transTxId txid) (toInteger (txIxToInt txIx))
@@ -735,6 +727,31 @@ transTxOutV4 txOutSource txOut = do
       , txOutValue = val
       , txOutAddress = addr
       }
+
+-- | Translate all `Redeemers` from within a `Tx` into a Map from a `PlutusScriptPurpose`
+-- to a `PV2.Redeemer`
+transTxRedeemersV4 ::
+  ( EraPlutusTxInfo l era
+  , AlonzoEraTxBody era
+  , EraTx era
+  , AlonzoEraTxWits era
+  , Inject (BabbageContextError era) (ContextError era)
+  , Inject (DijkstraContextError era) (ContextError era)
+  , PlutusPurposeScriptHashArg l ~ ScriptHash
+  ) =>
+  proxy l ->
+  ProtVer ->
+  Tx t era ->
+  Map.Map (PlutusPurpose AsIx era) ScriptHash ->
+  Either (ContextError era) (PV2.Map (PlutusScriptPurpose l) PV2.Redeemer)
+transTxRedeemersV4 proxy pv tx scriptHashes =
+  PV2.unsafeFromList
+    <$> mapM
+      (transRedeemerPointerV4 proxy pv (tx ^. bodyTxL) scriptHashes)
+      (Map.toList $ tx ^. witsTxL . rdmrsTxWitsL . unRedeemersL)
+
+transAccountId :: AccountId -> PV4.AccountId
+transAccountId (AccountId cred) = PV4.AccountId $ transCred cred
 
 transTxBodyWithdrawals ::
   DijkstraEraTxBody era => TxBody l era -> PV4.Map PV4.Credential PV4.Lovelace

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
@@ -566,7 +566,7 @@ instance ConwayEraPlutusTxInfo 'PlutusV4 DijkstraEra where
   toPlutusChangedParameters _ x = PV3.ChangedParameters (PV3.dataToBuiltinData (toPlutusData x))
 
 instance EraPlutusTxInfo 'PlutusV4 DijkstraEra where
-  toPlutusTxCert proxy _pv cert = pure $ transTxCertV4 proxy cert
+  toPlutusTxCert _proxy _pv = pure . transTxCertV4
 
   toPlutusScriptPurpose = transPlutusPurposeV4
 
@@ -708,8 +708,8 @@ transTxBodyWithdrawals txb = transMap transAccountAddressToCredential transCoinT
 transCredToAccountId :: Credential r -> PV4.AccountId
 transCredToAccountId = PV4.AccountId . transCred
 
-transTxCertV4 :: ConwayEraTxCert era => proxy 'PlutusV4 -> TxCert era -> PV4.TxCert
-transTxCertV4 _proxy = \case
+transTxCertV4 :: ConwayEraTxCert era => TxCert era -> PV4.TxCert
+transTxCertV4 = \case
   RegPoolTxCert StakePoolParams {sppId, sppVrf} ->
     PV4.TxCertPoolRegister
       (transKeyHash sppId)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
@@ -36,7 +36,6 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
   EraPlutusContext (..),
   EraPlutusTxInfo (..),
   LedgerTxInfo (..),
-  PlutusPurposeScriptHashArg,
   PlutusScriptPurpose,
   PlutusTxInfoResult (..),
   SupportedLanguage (..),
@@ -112,7 +111,6 @@ import Cardano.Ledger.Plutus (
   transEpochNo,
   transKeyHash,
   transSafeHash,
-  transScriptHash,
  )
 import Cardano.Ledger.Plutus.Data (Data)
 import Cardano.Ledger.Plutus.ToPlutusData (ToPlutusData (..))
@@ -576,7 +574,6 @@ transRedeemerPointerV4 ::
   ( AlonzoEraTxBody era
   , Inject (BabbageContextError era) (ContextError era)
   , EraPlutusTxInfo l era
-  , PlutusPurposeScriptHashArg l ~ ScriptHash
   , Inject (DijkstraContextError era) (ContextError era)
   ) =>
   proxy l ->
@@ -590,7 +587,7 @@ transRedeemerPointerV4 proxy pv txBody scriptHashes (ptr, (d, _)) =
     SNothing -> Left . inject $ RedeemerPointerPointsToNothing ptr
     SJust sp -> do
       case Map.lookup ptr scriptHashes of
-        Just sh -> (,transRedeemer d) <$> toPlutusScriptPurpose proxy pv sh sp
+        Just _sh -> (,transRedeemer d) <$> toPlutusScriptPurpose proxy pv sp
         Nothing -> Left . inject $ ScriptHashNotFoundForPurpose @era ptr
 
 instance EraPlutusTxInfo 'PlutusV4 DijkstraEra where
@@ -737,7 +734,6 @@ transTxRedeemersV4 ::
   , AlonzoEraTxWits era
   , Inject (BabbageContextError era) (ContextError era)
   , Inject (DijkstraContextError era) (ContextError era)
-  , PlutusPurposeScriptHashArg l ~ ScriptHash
   ) =>
   proxy l ->
   ProtVer ->
@@ -860,24 +856,24 @@ toPlutusV4Args ::
   ) =>
   proxy 'PlutusV4 ->
   LedgerTxInfo era ->
-  ScriptHash ->
   PV4.TxInfo ->
   PlutusPurpose AsIxItem era ->
   Data era ->
   Either (ContextError era) (PlutusArgs 'PlutusV4)
-toPlutusV4Args proxy LedgerTxInfo {..} sh txInfo plutusPurpose redeemerData = do
-  scriptPurpose <- toPlutusScriptPurpose proxy ltiProtVer sh plutusPurpose
+toPlutusV4Args proxy LedgerTxInfo {..} txInfo plutusPurpose redeemerData = do
+  scriptPurpose <- toPlutusScriptPurpose proxy ltiProtVer plutusPurpose
   let
     maybeSpendingData = getSpendingDatum ltiUTxO ltiTx $ hoistPlutusPurpose toAsItem plutusPurpose
     -- TODO TopTxInfo should be set if this is a top-level transaction
     scriptInfo = scriptPurposeToScriptInfo scriptPurpose (transDatum <$> maybeSpendingData) Nothing
+    sh = error "Unimplemented: ScriptHash for ScriptContext"
   pure $
     PlutusV4Args $
       PV4.ScriptContext
         { PV4.scriptContextTxInfo = txInfo
         , PV4.scriptContextRedeemer = Babbage.transRedeemer redeemerData
         , PV4.scriptContextScriptInfo = scriptInfo
-        , PV4.scriptContextScriptHash = transScriptHash sh
+        , PV4.scriptContextScriptHash = sh
         }
 
 transTxId :: TxId -> PV4.TxId
@@ -889,10 +885,9 @@ transPlutusPurposeV4 ::
   ) =>
   proxy 'PlutusV4 ->
   ProtVer ->
-  ScriptHash ->
   DijkstraPlutusPurpose AsIxItem era ->
   Either (ContextError era) (PlutusScriptPurpose PlutusV4)
-transPlutusPurposeV4 proxy pv (transScriptHash -> sh) = \case
+transPlutusPurposeV4 proxy pv = \case
   DijkstraSpending (AsIxItem _ (TxIn txId (TxIx ix))) ->
     pure . PV4.Spending sh $ PV4.TxOutRef (transTxId txId) (toInteger ix)
   DijkstraMinting (AsIxItem _ pId) -> pure . PV4.Minting sh $ transPolicyID pId
@@ -904,3 +899,5 @@ transPlutusPurposeV4 proxy pv (transScriptHash -> sh) = \case
   DijkstraProposing (AsIxItem ix proc) ->
     pure $ PV4.Proposing sh (toInteger ix) (transProposal proxy proc)
   DijkstraGuarding (AsIxItem ix _) -> pure $ PV4.Guarding sh (toInteger ix)
+  where
+    sh = error "Unimplemented: ScriptHash for purpose"

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
@@ -46,13 +46,11 @@ import qualified Cardano.Ledger.Alonzo.Plutus.TxInfo as Alonzo
 import Cardano.Ledger.Alonzo.Scripts (toAsItem)
 import Cardano.Ledger.Alonzo.TxWits (unRedeemersL)
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO (..))
-import Cardano.Ledger.Babbage.TxInfo (BabbageContextError (..), transRedeemer, transReferenceScript)
 import qualified Cardano.Ledger.Babbage.TxInfo as Babbage
 import Cardano.Ledger.BaseTypes (
   Exclusive (..),
   Inclusive (..),
   Inject (..),
-  ProtVer (..),
   StrictMaybe (..),
   TxIx (TxIx),
   kindObjectValue,
@@ -322,7 +320,7 @@ instance EraPlutusContext DijkstraEra where
 instance EraPlutusTxInfo 'PlutusV1 DijkstraEra where
   toPlutusTxCert _ _ = transTxCertV1V2
 
-  toPlutusScriptPurpose = Conway.transPlutusPurposeV1V2
+  toPlutusScriptPurpose proxy lti = Conway.transPlutusPurposeV1V2 proxy (ltiProtVer lti)
 
   toPlutusTxInfo proxy LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} =
     flip (withBothTxLevels ltiTx) transFailUnsupportedScriptInSubTx $ \tx -> PlutusTxInfoResult $ do
@@ -384,9 +382,9 @@ transTxCertV1V2 = \case
 instance EraPlutusTxInfo 'PlutusV2 DijkstraEra where
   toPlutusTxCert _ _ = transTxCertV1V2
 
-  toPlutusScriptPurpose = Conway.transPlutusPurposeV1V2
+  toPlutusScriptPurpose proxy lti = Conway.transPlutusPurposeV1V2 proxy (ltiProtVer lti)
 
-  toPlutusTxInfo proxy LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} =
+  toPlutusTxInfo proxy lti@LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} =
     flip (withBothTxLevels ltiTx) transFailUnsupportedScriptInSubTx $ \tx -> PlutusTxInfoResult $ do
       let txBody = tx ^. bodyTxL
       Conway.guardConwayFeaturesForPlutusV1V2 tx
@@ -401,7 +399,7 @@ instance EraPlutusTxInfo 'PlutusV2 DijkstraEra where
           [minBound ..]
           (F.toList (txBody ^. outputsTxBodyL))
       txCerts <- Alonzo.transTxBodyCerts proxy ltiProtVer txBody
-      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer tx
+      plutusRedeemers <- Babbage.transTxRedeemers proxy lti
       -- It is important for memoization for `txInfo` to be a let binding
       let
         txInfo =
@@ -428,9 +426,9 @@ instance EraPlutusTxInfo 'PlutusV2 DijkstraEra where
 instance EraPlutusTxInfo 'PlutusV3 DijkstraEra where
   toPlutusTxCert _ _ = pure . transTxCertV3
 
-  toPlutusScriptPurpose = Conway.transPlutusPurposeV3
+  toPlutusScriptPurpose proxy lti = Conway.transPlutusPurposeV3 proxy (ltiProtVer lti)
 
-  toPlutusTxInfo proxy LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} =
+  toPlutusTxInfo proxy lti@LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} =
     flip (withBothTxLevels ltiTx) transFailUnsupportedScriptInSubTx $ \tx -> PlutusTxInfoResult $ do
       let
         txBody = tx ^. bodyTxL
@@ -448,7 +446,7 @@ instance EraPlutusTxInfo 'PlutusV3 DijkstraEra where
           [minBound ..]
           (F.toList (txBody ^. outputsTxBodyL))
       txCerts <- Alonzo.transTxBodyCerts proxy ltiProtVer txBody
-      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer tx
+      plutusRedeemers <- Babbage.transTxRedeemers proxy lti
       -- It is important for memoization for `txInfo` to be a let binding
       let
         txInfo =
@@ -570,32 +568,27 @@ instance ConwayEraPlutusTxInfo 'PlutusV4 DijkstraEra where
   toPlutusChangedParameters _ x = PV3.ChangedParameters (PV3.dataToBuiltinData (toPlutusData x))
 
 transRedeemerPointerV4 ::
-  forall era t l proxy.
-  ( AlonzoEraTxBody era
-  , Inject (BabbageContextError era) (ContextError era)
+  forall era l proxy.
+  ( EraTx era
+  , AlonzoEraTxBody era
   , EraPlutusTxInfo l era
-  , Inject (DijkstraContextError era) (ContextError era)
+  , Inject (Babbage.BabbageContextError era) (ContextError era)
   ) =>
   proxy l ->
-  ProtVer ->
-  TxBody t era ->
-  Map.Map (PlutusPurpose AsIx era) ScriptHash ->
+  LedgerTxInfo era ->
   (PlutusPurpose AsIx era, (Data era, ExUnits)) ->
   Either (ContextError era) (PlutusScriptPurpose l, PV4.Redeemer)
-transRedeemerPointerV4 proxy pv txBody scriptHashes (ptr, (d, _)) =
-  case redeemerPointerInverse txBody ptr of
-    SNothing -> Left . inject $ RedeemerPointerPointsToNothing ptr
-    SJust sp -> do
-      case Map.lookup ptr scriptHashes of
-        Just _sh -> (,transRedeemer d) <$> toPlutusScriptPurpose proxy pv sp
-        Nothing -> Left . inject $ ScriptHashNotFoundForPurpose @era ptr
+transRedeemerPointerV4 proxy lti@LedgerTxInfo {ltiTx} (ptr, (d, _)) =
+  case redeemerPointerInverse (ltiTx ^. bodyTxL) ptr of
+    SNothing -> Left . inject $ Babbage.RedeemerPointerPointsToNothing ptr
+    SJust sp -> (,Babbage.transRedeemer d) <$> toPlutusScriptPurpose proxy lti sp
 
 instance EraPlutusTxInfo 'PlutusV4 DijkstraEra where
   toPlutusTxCert proxy _pv cert = pure $ transTxCertV4 proxy cert
 
   toPlutusScriptPurpose = transPlutusPurposeV4
 
-  toPlutusTxInfo proxy LedgerTxInfo {..} =
+  toPlutusTxInfo proxy lti@LedgerTxInfo {..} =
     PlutusTxInfoResult $ do
       let
         era = Proxy @DijkstraEra
@@ -631,8 +624,7 @@ instance EraPlutusTxInfo 'PlutusV4 DijkstraEra where
             (Right mempty)
             ([minBound ..] `zip` F.toList (txBody ^. outputsTxBodyL))
       txCerts <- Alonzo.transTxBodyCerts proxy ltiProtVer txBody
-      let scriptHashes = mempty -- TODO: Pipe in resolved ScriptHashes
-      plutusRedeemers <- transTxRedeemersV4 proxy ltiProtVer ltiTx scriptHashes
+      plutusRedeemers <- transTxRedeemersV4 proxy lti
       let
         txInfo =
           PV4.TxInfo
@@ -672,14 +664,14 @@ transTxInInfoV4 ::
   forall era.
   ( BabbageEraTxOut era
   , Value era ~ MaryValue
-  , Inject (BabbageContextError era) (ContextError era)
+  , Inject (Babbage.BabbageContextError era) (ContextError era)
   , Inject (DijkstraContextError era) (ContextError era)
   ) =>
   UTxO era ->
   TxIn ->
   Either (ContextError era) PV4.TxInInfo
 transTxInInfoV4 utxo txIn = do
-  txOut <- first (inject . AlonzoContextError @era) $ Alonzo.transLookupTxOut utxo txIn
+  txOut <- first (inject . Babbage.AlonzoContextError @era) $ Alonzo.transLookupTxOut utxo txIn
   plutusTxOut <- transTxOutV4 (TxOutFromInput txIn) txOut
   Right (PV4.TxInInfo (transTxInV4 txIn) plutusTxOut)
 
@@ -687,7 +679,7 @@ transTxOutV4 ::
   forall era.
   ( BabbageEraTxOut era
   , Value era ~ MaryValue
-  , Inject (BabbageContextError era) (ContextError era)
+  , Inject (Babbage.BabbageContextError era) (ContextError era)
   , Inject (DijkstraContextError era) (ContextError era)
   ) =>
   TxOutSource ->
@@ -696,7 +688,7 @@ transTxOutV4 ::
 transTxOutV4 txOutSource txOut = do
   let
     val = transValue $ txOut ^. valueTxOutL
-    referenceScript = transReferenceScript $ txOut ^. referenceScriptTxOutL
+    referenceScript = Babbage.transReferenceScript $ txOut ^. referenceScriptTxOutL
     datum =
       case txOut ^. datumTxOutF of
         NoDatum -> PV2.NoOutputDatum
@@ -716,7 +708,7 @@ transTxOutV4 txOutSource txOut = do
           StakeRefBase sCred -> Right . Just $ transCredToAccountId sCred
           StakeRefNull -> Right Nothing
           StakeRefPtr _ -> Left . inject . PointerPresentInOutput @era $ NES.singleton txOutSource
-      AddrBootstrap _ -> Left . inject $ ByronTxOutInContext @era txOutSource
+      AddrBootstrap _ -> Left . inject $ Babbage.ByronTxOutInContext @era txOutSource
   pure $
     PV4.TxOut
       { txOutReferenceScript = referenceScript
@@ -732,19 +724,16 @@ transTxRedeemersV4 ::
   , AlonzoEraTxBody era
   , EraTx era
   , AlonzoEraTxWits era
-  , Inject (BabbageContextError era) (ContextError era)
-  , Inject (DijkstraContextError era) (ContextError era)
+  , Inject (Babbage.BabbageContextError era) (ContextError era)
   ) =>
   proxy l ->
-  ProtVer ->
-  Tx t era ->
-  Map.Map (PlutusPurpose AsIx era) ScriptHash ->
+  LedgerTxInfo era ->
   Either (ContextError era) (PV2.Map (PlutusScriptPurpose l) PV2.Redeemer)
-transTxRedeemersV4 proxy pv tx scriptHashes =
+transTxRedeemersV4 proxy lti@LedgerTxInfo {ltiTx} =
   PV2.unsafeFromList
     <$> mapM
-      (transRedeemerPointerV4 proxy pv (tx ^. bodyTxL) scriptHashes)
-      (Map.toList $ tx ^. witsTxL . rdmrsTxWitsL . unRedeemersL)
+      (transRedeemerPointerV4 proxy lti)
+      (Map.toList $ ltiTx ^. witsTxL . rdmrsTxWitsL . unRedeemersL)
 
 transAccountId :: AccountId -> PV4.AccountId
 transAccountId (AccountId cred) = PV4.AccountId $ transCred cred
@@ -860,8 +849,8 @@ toPlutusV4Args ::
   PlutusPurpose AsIxItem era ->
   Data era ->
   Either (ContextError era) (PlutusArgs 'PlutusV4)
-toPlutusV4Args proxy LedgerTxInfo {..} txInfo plutusPurpose redeemerData = do
-  scriptPurpose <- toPlutusScriptPurpose proxy ltiProtVer plutusPurpose
+toPlutusV4Args proxy lti@LedgerTxInfo {..} txInfo plutusPurpose redeemerData = do
+  scriptPurpose <- toPlutusScriptPurpose proxy lti plutusPurpose
   let
     maybeSpendingData = getSpendingDatum ltiUTxO ltiTx $ hoistPlutusPurpose toAsItem plutusPurpose
     -- TODO TopTxInfo should be set if this is a top-level transaction
@@ -882,10 +871,10 @@ transTxId (TxId h) = PV4.TxId $ transSafeHash h
 transPlutusPurposeV4 ::
   ConwayEraPlutusTxInfo PlutusV4 era =>
   proxy 'PlutusV4 ->
-  ProtVer ->
+  LedgerTxInfo era ->
   DijkstraPlutusPurpose AsIxItem era ->
   Either (ContextError era) (PlutusScriptPurpose PlutusV4)
-transPlutusPurposeV4 proxy pv = \case
+transPlutusPurposeV4 proxy lti = \case
   DijkstraSpending (AsIxItem _ (TxIn txId (TxIx ix))) ->
     pure . PV4.Spending sh $ PV4.TxOutRef (transTxId txId) (toInteger ix)
   DijkstraMinting (AsIxItem _ pId) -> pure . PV4.Minting sh $ transPolicyID pId
@@ -898,4 +887,5 @@ transPlutusPurposeV4 proxy pv = \case
     pure $ PV4.Proposing sh (toInteger ix) (transProposal proxy proc)
   DijkstraGuarding (AsIxItem ix _) -> pure $ PV4.Guarding sh (toInteger ix)
   where
+    pv = ltiProtVer lti
     sh = error "Unimplemented: ScriptHash for purpose"

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
@@ -27,7 +27,6 @@ module Cardano.Ledger.Dijkstra.TxInfo (
   DijkstraContextError (..),
   guardDijkstraFeaturesForPlutusV1toV3,
   transFailUnsupportedScriptInSubTx,
-  transRedeemerPointerV4,
   transValidityInterval,
 ) where
 
@@ -44,7 +43,6 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
 import Cardano.Ledger.Alonzo.Plutus.TxInfo (transPolicyID, transValue)
 import qualified Cardano.Ledger.Alonzo.Plutus.TxInfo as Alonzo
 import Cardano.Ledger.Alonzo.Scripts (toAsItem, toAsIx)
-import Cardano.Ledger.Alonzo.TxWits (unRedeemersL)
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO (..))
 import qualified Cardano.Ledger.Babbage.TxInfo as Babbage
 import Cardano.Ledger.BaseTypes (
@@ -91,7 +89,6 @@ import Cardano.Ledger.Dijkstra.UTxO ()
 import Cardano.Ledger.Mary.Value (MaryValue)
 import Cardano.Ledger.Plutus (
   Datum (..),
-  ExUnits,
   Language (..),
   PlutusArgs (..),
   PlutusLanguage,
@@ -568,22 +565,6 @@ instance ConwayEraPlutusTxInfo 'PlutusV3 DijkstraEra where
 instance ConwayEraPlutusTxInfo 'PlutusV4 DijkstraEra where
   toPlutusChangedParameters _ x = PV3.ChangedParameters (PV3.dataToBuiltinData (toPlutusData x))
 
-transRedeemerPointerV4 ::
-  forall era l proxy.
-  ( EraTx era
-  , AlonzoEraTxBody era
-  , EraPlutusTxInfo l era
-  , Inject (Babbage.BabbageContextError era) (ContextError era)
-  ) =>
-  proxy l ->
-  LedgerTxInfo era ->
-  (PlutusPurpose AsIx era, (Data era, ExUnits)) ->
-  Either (ContextError era) (PlutusScriptPurpose l, PV4.Redeemer)
-transRedeemerPointerV4 proxy lti@LedgerTxInfo {ltiTx} (ptr, (d, _)) =
-  case redeemerPointerInverse (ltiTx ^. bodyTxL) ptr of
-    SNothing -> Left . inject $ Babbage.RedeemerPointerPointsToNothing ptr
-    SJust sp -> (,Babbage.transRedeemer d) <$> toPlutusScriptPurpose proxy lti sp
-
 instance EraPlutusTxInfo 'PlutusV4 DijkstraEra where
   toPlutusTxCert proxy _pv cert = pure $ transTxCertV4 proxy cert
 
@@ -625,7 +606,7 @@ instance EraPlutusTxInfo 'PlutusV4 DijkstraEra where
             (Right mempty)
             ([minBound ..] `zip` F.toList (txBody ^. outputsTxBodyL))
       txCerts <- Alonzo.transTxBodyCerts proxy ltiProtVer txBody
-      plutusRedeemers <- transTxRedeemersV4 proxy lti
+      plutusRedeemers <- Babbage.transTxRedeemers proxy lti
       let
         txInfo =
           PV4.TxInfo
@@ -717,24 +698,6 @@ transTxOutV4 txOutSource txOut = do
       , txOutValue = val
       , txOutAddress = addr
       }
-
--- | Translate all `Redeemers` from within a `Tx` into a Map from a `PlutusScriptPurpose`
--- to a `PV2.Redeemer`
-transTxRedeemersV4 ::
-  ( EraPlutusTxInfo l era
-  , AlonzoEraTxBody era
-  , EraTx era
-  , AlonzoEraTxWits era
-  , Inject (Babbage.BabbageContextError era) (ContextError era)
-  ) =>
-  proxy l ->
-  LedgerTxInfo era ->
-  Either (ContextError era) (PV2.Map (PlutusScriptPurpose l) PV2.Redeemer)
-transTxRedeemersV4 proxy lti@LedgerTxInfo {ltiTx} =
-  PV2.unsafeFromList
-    <$> mapM
-      (transRedeemerPointerV4 proxy lti)
-      (Map.toList $ ltiTx ^. witsTxL . rdmrsTxWitsL . unRedeemersL)
 
 transTxBodyWithdrawals ::
   DijkstraEraTxBody era => TxBody l era -> PV4.Map PV4.Credential PV4.Lovelace

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
@@ -43,7 +43,7 @@ import Cardano.Ledger.Conway.UTxO (
 import Cardano.Ledger.Credential (Credential, credScriptHash)
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
-import Cardano.Ledger.Dijkstra.Scripts (DijkstraEraScript (..), pattern GuardingPurpose)
+import Cardano.Ledger.Dijkstra.Scripts (DijkstraEraScript (..))
 import Cardano.Ledger.Dijkstra.State
 import Cardano.Ledger.Dijkstra.Tx (DijkstraStAnnTx (..))
 import Cardano.Ledger.Mary.UTxO (burnedMultiAssets, getConsumedMaryValue)

--- a/eras/dijkstra/impl/test/Main.hs
+++ b/eras/dijkstra/impl/test/Main.hs
@@ -54,7 +54,6 @@ main =
     describe "TxInfo" $ do
       BabbageTxInfo.spec @DijkstraEra
       txInfoSpec @DijkstraEra SPlutusV3
-      txInfoSpec @DijkstraEra SPlutusV4
       DijkstraTxInfoSpec.spec @DijkstraEra
     GoldenBinary.spec @DijkstraEra
     PlutusSpec.spec

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TxInfoSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TxInfoSpec.hs
@@ -5,18 +5,19 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Test.Cardano.Ledger.Dijkstra.TxInfoSpec (spec) where
 
 import Cardano.Ledger.Alonzo.Plutus.Context (
   EraPlutusContext (..),
   EraPlutusTxInfo (..),
-  LedgerTxInfo (..),
   PlutusTxInfoResult (..),
   SupportedLanguage (..),
  )
 import Cardano.Ledger.Alonzo.Scripts (AsPurpose (..), toAsPurpose)
 import Cardano.Ledger.Alonzo.TxWits (unRedeemersL)
+import Cardano.Ledger.Alonzo.UTxO
 import Cardano.Ledger.Babbage.TxInfo (BabbageContextError (..))
 import Cardano.Ledger.BaseTypes (
   Globals (..),
@@ -44,6 +45,7 @@ import Cardano.Ledger.Plutus (
   transSafeHash,
   transScriptHash,
  )
+import Cardano.Ledger.State (EraUTxO (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import qualified Cardano.Ledger.Val as Val
 import Data.List.NonEmpty (NonEmpty (..))
@@ -55,6 +57,7 @@ import Data.Proxy (Proxy (..))
 import qualified Data.Set.NonEmpty as NES
 import Lens.Micro ((&), (.~))
 import qualified PlutusLedgerApi.V4 as PV4
+import Test.Cardano.Ledger.Alonzo.Era (mkTestLedgerTxInfo)
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Utils (testGlobals)
 import Test.Cardano.Ledger.Dijkstra.Arbitrary ()
@@ -69,12 +72,17 @@ spec ::
   , Inject (DijkstraContextError era) (ContextError era)
   , Inject (BabbageContextError era) (ContextError era)
   , DijkstraEraTxBody era
-  , EraTx era
+  , EraUTxO era
   , Arbitrary (Value era)
   , AlonzoEraTxWits era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>
   Spec
 spec = describe "TxInfo" $ do
+  let mkLocalLedgerTxInfo utxo tx =
+        let ei = epochInfo testGlobals
+            ss = systemStart testGlobals
+         in mkTestLedgerTxInfo (ProtVer (eraProtVerLow @era) 0) ei ss utxo tx
   describe "PlutusV4" $ do
     prop "Fails translation when Ptr present in outputs" $ do
       paymentCred <- arbitrary
@@ -95,15 +103,7 @@ spec = describe "TxInfo" $ do
             mkBasicTxBody
               & outputsTxBodyL .~ [txOut]
               & inputsTxBodyL .~ [txIn]
-        ledgerTxInfo =
-          LedgerTxInfo
-            { ltiProtVer = ProtVer (eraProtVerLow @era) 0
-            , ltiEpochInfo = epochInfo testGlobals
-            , ltiSystemStart = systemStart testGlobals
-            , ltiUTxO = utxo
-            , ltiTx = tx
-            , ltiMemoizedSubTransactions = mempty
-            }
+        ledgerTxInfo = mkLocalLedgerTxInfo utxo tx
       pure $
         (($ SpendingPurpose AsPurpose) <$> unPlutusTxInfoResult (toPlutusTxInfo SPlutusV4 ledgerTxInfo))
           `shouldBeLeft` inject (PointerPresentInOutput @era (NES.singleton . TxOutFromOutput $ TxIx 0))
@@ -124,15 +124,7 @@ spec = describe "TxInfo" $ do
           , mkBasicTxOut (Addr Testnet pc2 (StakeRefPtr ptr2)) val2
           ]
         tx = mkBasicTx @era @TopTx $ mkBasicTxBody & outputsTxBodyL .~ txOuts
-        ledgerTxInfo =
-          LedgerTxInfo
-            { ltiProtVer = ProtVer (eraProtVerLow @era) 0
-            , ltiEpochInfo = epochInfo testGlobals
-            , ltiSystemStart = systemStart testGlobals
-            , ltiUTxO = mempty
-            , ltiTx = tx
-            , ltiMemoizedSubTransactions = mempty
-            }
+        ledgerTxInfo = mkLocalLedgerTxInfo mempty tx
       pure $
         (($ SpendingPurpose AsPurpose) <$> unPlutusTxInfoResult (toPlutusTxInfo SPlutusV4 ledgerTxInfo))
           `shouldBeLeft` inject
@@ -153,15 +145,7 @@ spec = describe "TxInfo" $ do
           , mkBasicTxOut (AddrBootstrap ba2) val2
           ]
         tx = mkBasicTx @era @TopTx $ mkBasicTxBody & outputsTxBodyL .~ txOuts
-        ledgerTxInfo =
-          LedgerTxInfo
-            { ltiProtVer = ProtVer (eraProtVerLow @era) 0
-            , ltiEpochInfo = epochInfo testGlobals
-            , ltiSystemStart = systemStart testGlobals
-            , ltiUTxO = mempty
-            , ltiTx = tx
-            , ltiMemoizedSubTransactions = mempty
-            }
+        ledgerTxInfo = mkLocalLedgerTxInfo mempty tx
       pure $
         (($ SpendingPurpose AsPurpose) <$> unPlutusTxInfoResult (toPlutusTxInfo SPlutusV4 ledgerTxInfo))
           `shouldBeLeft` inject (ByronTxOutInContext @era (TxOutFromOutput $ TxIx 0))
@@ -181,15 +165,7 @@ spec = describe "TxInfo" $ do
           , mkBasicTxOut (Addr Testnet pc2 (StakeRefPtr ptr2)) val2
           ]
         tx = mkBasicTx @era @TopTx $ mkBasicTxBody & outputsTxBodyL .~ txOuts
-        ledgerTxInfo =
-          LedgerTxInfo
-            { ltiProtVer = ProtVer (eraProtVerLow @era) 0
-            , ltiEpochInfo = epochInfo testGlobals
-            , ltiSystemStart = systemStart testGlobals
-            , ltiUTxO = mempty
-            , ltiTx = tx
-            , ltiMemoizedSubTransactions = mempty
-            }
+        ledgerTxInfo = mkLocalLedgerTxInfo mempty tx
       pure $
         (($ SpendingPurpose AsPurpose) <$> unPlutusTxInfoResult (toPlutusTxInfo SPlutusV4 ledgerTxInfo))
           `shouldBeLeft` inject
@@ -210,15 +186,7 @@ spec = describe "TxInfo" $ do
           , mkBasicTxOut (Addr Testnet pc2 StakeRefNull) val2
           ]
         tx = mkBasicTx @era @TopTx $ mkBasicTxBody & outputsTxBodyL .~ txOuts
-        ledgerTxInfo =
-          LedgerTxInfo
-            { ltiProtVer = ProtVer (eraProtVerLow @era) 0
-            , ltiEpochInfo = epochInfo testGlobals
-            , ltiSystemStart = systemStart testGlobals
-            , ltiUTxO = mempty
-            , ltiTx = tx
-            , ltiMemoizedSubTransactions = mempty
-            }
+        ledgerTxInfo = mkLocalLedgerTxInfo mempty tx
       pure $
         case ($ SpendingPurpose AsPurpose) <$> unPlutusTxInfoResult (toPlutusTxInfo SPlutusV4 ledgerTxInfo) of
           Right (Right txInfo) ->
@@ -227,7 +195,6 @@ spec = describe "TxInfo" $ do
           err -> expectationFailure $ "Failed to translate TxInfo: " <> show err
     describe "toPlutusTxInfo" $ do
       prop "succeeds when purpose points at a script hash" $ do
-        pv <- elements $ eraProtVersions @era
         paymentCred1 <- arbitrary
         stakeRef1 <- oneof [StakeRefBase <$> arbitrary, pure StakeRefNull]
         stakeRef2 <- oneof [StakeRefBase <$> arbitrary, pure StakeRefNull]
@@ -257,16 +224,7 @@ spec = describe "TxInfo" $ do
               )
               & witsTxL . rdmrsTxWitsL . unRedeemersL
                 .~ Map.singleton (SpendingPurpose $ AsIx 0) (redeemer, exUnits)
-          protVer = ProtVer pv 0
-          lti =
-            LedgerTxInfo
-              { ltiUTxO = utxo
-              , ltiTx = tx
-              , ltiSystemStart = systemStart testGlobals
-              , ltiProtVer = protVer
-              , ltiMemoizedSubTransactions = mempty
-              , ltiEpochInfo = epochInfo testGlobals
-              }
+          lti = mkLocalLedgerTxInfo utxo tx
           purpose = SpendingPurpose @era $ AsIxItem 0 txIn
           TxIn (TxId txIdHash) (TxIx txIx) = txIn
           TxId txBodyHash = txIdTx tx
@@ -333,15 +291,7 @@ spec = describe "TxInfo" $ do
       it "UnsupportedScriptInSubTx" $ do
         let
           tx = mkBasicTx @era @SubTx mkBasicTxBody
-          ledgerTxInfo =
-            LedgerTxInfo
-              { ltiProtVer = ProtVer (eraProtVerLow @era) 0
-              , ltiEpochInfo = epochInfo testGlobals
-              , ltiSystemStart = systemStart testGlobals
-              , ltiUTxO = mempty
-              , ltiTx = tx
-              , ltiMemoizedSubTransactions = mempty
-              }
+          ledgerTxInfo = mkLocalLedgerTxInfo mempty tx
           txInfoResult =
             ($ SpendingPurpose AsPurpose)
               <$> unPlutusTxInfoResult (toPlutusTxInfo slang ledgerTxInfo)
@@ -355,15 +305,7 @@ spec = describe "TxInfo" $ do
           tx =
             mkBasicTx @era @TopTx $
               mkBasicTxBody & directDepositsTxBodyL .~ dd
-          ledgerTxInfo =
-            LedgerTxInfo
-              { ltiProtVer = ProtVer (eraProtVerLow @era) 0
-              , ltiEpochInfo = epochInfo testGlobals
-              , ltiSystemStart = systemStart testGlobals
-              , ltiUTxO = mempty
-              , ltiTx = tx
-              , ltiMemoizedSubTransactions = mempty
-              }
+          ledgerTxInfo = mkLocalLedgerTxInfo mempty tx
           txInfoResult =
             ($ SpendingPurpose AsPurpose)
               <$> unPlutusTxInfoResult (toPlutusTxInfo slang ledgerTxInfo)
@@ -375,15 +317,7 @@ spec = describe "TxInfo" $ do
           tx =
             mkBasicTx @era @TopTx $
               mkBasicTxBody & accountBalanceIntervalsTxBodyL .~ abi
-          ledgerTxInfo =
-            LedgerTxInfo
-              { ltiProtVer = ProtVer (eraProtVerLow @era) 0
-              , ltiEpochInfo = epochInfo testGlobals
-              , ltiSystemStart = systemStart testGlobals
-              , ltiUTxO = mempty
-              , ltiTx = tx
-              , ltiMemoizedSubTransactions = mempty
-              }
+          ledgerTxInfo = mkLocalLedgerTxInfo mempty tx
           txInfoResult =
             ($ SpendingPurpose AsPurpose)
               <$> unPlutusTxInfoResult (toPlutusTxInfo slang ledgerTxInfo)
@@ -396,15 +330,7 @@ spec = describe "TxInfo" $ do
           tx =
             mkBasicTx @era @TopTx $
               mkBasicTxBody & guardsTxBodyL .~ guards
-          ledgerTxInfo =
-            LedgerTxInfo
-              { ltiProtVer = ProtVer (eraProtVerLow @era) 0
-              , ltiEpochInfo = epochInfo testGlobals
-              , ltiSystemStart = systemStart testGlobals
-              , ltiUTxO = mempty
-              , ltiTx = tx
-              , ltiMemoizedSubTransactions = mempty
-              }
+          ledgerTxInfo = mkLocalLedgerTxInfo mempty tx
           txInfoResult =
             ($ SpendingPurpose AsPurpose)
               <$> unPlutusTxInfoResult (toPlutusTxInfo slang ledgerTxInfo)
@@ -415,15 +341,7 @@ spec = describe "TxInfo" $ do
           tx =
             mkBasicTx @era @TopTx $
               mkBasicTxBody & requiredTopLevelGuardsL .~ NEM.toMap neRequiredTopLevelGuards
-          ledgerTxInfo =
-            LedgerTxInfo
-              { ltiProtVer = ProtVer (eraProtVerLow @era) 0
-              , ltiEpochInfo = epochInfo testGlobals
-              , ltiSystemStart = systemStart testGlobals
-              , ltiUTxO = mempty
-              , ltiTx = tx
-              , ltiMemoizedSubTransactions = mempty
-              }
+          ledgerTxInfo = mkLocalLedgerTxInfo mempty tx
           txInfoResult =
             ($ SpendingPurpose AsPurpose)
               <$> unPlutusTxInfoResult (toPlutusTxInfo slang ledgerTxInfo)

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TxInfoSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TxInfoSpec.hs
@@ -14,6 +14,7 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
   EraPlutusTxInfo (..),
   PlutusTxInfoResult (..),
   SupportedLanguage (..),
+  toPlutusTxInfoForPurpose,
  )
 import Cardano.Ledger.Alonzo.Scripts (AsPurpose (..), toAsPurpose)
 import Cardano.Ledger.Alonzo.TxWits (unRedeemersL)
@@ -48,6 +49,7 @@ import Cardano.Ledger.Plutus (
 import Cardano.Ledger.State (EraUTxO (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import qualified Cardano.Ledger.Val as Val
+import Control.Monad.Trans.Fail.String (errorFail)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.NonEmpty as NEM
 import qualified Data.Map.Strict as Map
@@ -105,7 +107,7 @@ spec = describe "TxInfo" $ do
               & inputsTxBodyL .~ [txIn]
         ledgerTxInfo = mkLocalLedgerTxInfo utxo tx
       pure $
-        (($ SpendingPurpose AsPurpose) <$> unPlutusTxInfoResult (toPlutusTxInfo SPlutusV4 ledgerTxInfo))
+        toPlutusTxInfoForPurpose SPlutusV4 ledgerTxInfo (SpendingPurpose AsPurpose)
           `shouldBeLeft` inject (PointerPresentInOutput @era (NES.singleton . TxOutFromOutput $ TxIx 0))
     prop "Collects all Ptr sources when multiple outputs have pointers" $ do
       pc0 <- arbitrary
@@ -126,7 +128,7 @@ spec = describe "TxInfo" $ do
         tx = mkBasicTx @era @TopTx $ mkBasicTxBody & outputsTxBodyL .~ txOuts
         ledgerTxInfo = mkLocalLedgerTxInfo mempty tx
       pure $
-        (($ SpendingPurpose AsPurpose) <$> unPlutusTxInfoResult (toPlutusTxInfo SPlutusV4 ledgerTxInfo))
+        toPlutusTxInfoForPurpose SPlutusV4 ledgerTxInfo (SpendingPurpose AsPurpose)
           `shouldBeLeft` inject
             ( PointerPresentInOutput @era . fromJust $
                 NES.fromSet [TxOutFromOutput $ TxIx 0, TxOutFromOutput $ TxIx 2]
@@ -147,7 +149,7 @@ spec = describe "TxInfo" $ do
         tx = mkBasicTx @era @TopTx $ mkBasicTxBody & outputsTxBodyL .~ txOuts
         ledgerTxInfo = mkLocalLedgerTxInfo mempty tx
       pure $
-        (($ SpendingPurpose AsPurpose) <$> unPlutusTxInfoResult (toPlutusTxInfo SPlutusV4 ledgerTxInfo))
+        toPlutusTxInfoForPurpose SPlutusV4 ledgerTxInfo (SpendingPurpose AsPurpose)
           `shouldBeLeft` inject (ByronTxOutInContext @era (TxOutFromOutput $ TxIx 0))
     prop "Reports the first error kind when Ptr and Byron outputs are mixed" $ do
       pc0 <- arbitrary
@@ -167,7 +169,7 @@ spec = describe "TxInfo" $ do
         tx = mkBasicTx @era @TopTx $ mkBasicTxBody & outputsTxBodyL .~ txOuts
         ledgerTxInfo = mkLocalLedgerTxInfo mempty tx
       pure $
-        (($ SpendingPurpose AsPurpose) <$> unPlutusTxInfoResult (toPlutusTxInfo SPlutusV4 ledgerTxInfo))
+        toPlutusTxInfoForPurpose SPlutusV4 ledgerTxInfo (SpendingPurpose AsPurpose)
           `shouldBeLeft` inject
             ( PointerPresentInOutput @era . fromJust $
                 NES.fromSet [TxOutFromOutput $ TxIx 0, TxOutFromOutput $ TxIx 2]
@@ -188,8 +190,8 @@ spec = describe "TxInfo" $ do
         tx = mkBasicTx @era @TopTx $ mkBasicTxBody & outputsTxBodyL .~ txOuts
         ledgerTxInfo = mkLocalLedgerTxInfo mempty tx
       pure $
-        case ($ SpendingPurpose AsPurpose) <$> unPlutusTxInfoResult (toPlutusTxInfo SPlutusV4 ledgerTxInfo) of
-          Right (Right txInfo) ->
+        case toPlutusTxInfoForPurpose SPlutusV4 ledgerTxInfo (SpendingPurpose AsPurpose) of
+          Right txInfo ->
             map PV4.txOutAddress (PV4.txInfoOutputs txInfo)
               `shouldBe` [PV4.Address (transCred pc) Nothing | pc <- [pc0, pc1, pc2]]
           err -> expectationFailure $ "Failed to translate TxInfo: " <> show err
@@ -203,10 +205,11 @@ spec = describe "TxInfo" $ do
         txIn <- arbitrary
         redeemer <- arbitrary
         exUnits <- arbitrary
+        let plutusScript = Plutus.alwaysSucceedsNoDatum SPlutusV4
+            script = errorFail $ mkPlutusScript plutusScript
         let
           proxy = Proxy @PlutusV4
-          script = Plutus.alwaysSucceedsNoDatum SPlutusV4
-          scriptHash = hashPlutusScript script
+          scriptHash = hashPlutusScript plutusScript
           paymentCred2 = ScriptHashObj scriptHash
           txOut = mkBasicTxOut (Addr Testnet paymentCred1 stakeRef1) (Val.inject coin1)
           utxo =
@@ -224,6 +227,7 @@ spec = describe "TxInfo" $ do
               )
               & witsTxL . rdmrsTxWitsL . unRedeemersL
                 .~ Map.singleton (SpendingPurpose $ AsIx 0) (redeemer, exUnits)
+              & witsTxL . scriptTxWitsL .~ Map.singleton scriptHash (fromPlutusScript script)
           lti = mkLocalLedgerTxInfo utxo tx
           purpose = SpendingPurpose @era $ AsIxItem 0 txIn
           TxIn (TxId txIdHash) (TxIx txIx) = txIn
@@ -233,10 +237,10 @@ spec = describe "TxInfo" $ do
           transStakeRef _ = Nothing
           addr1 = PV4.Address (transCred paymentCred1) (transStakeRef stakeRef1)
           addr2 = PV4.Address (transCred paymentCred2) (transStakeRef stakeRef2)
-        pure $ case toPlutusTxInfo proxy lti of
-          PlutusTxInfoResult (Right f) ->
-            f (hoistPlutusPurpose toAsPurpose purpose)
-              `shouldBeRight` PV4.TxInfo
+        pure $ case toPlutusTxInfoForPurpose proxy lti (hoistPlutusPurpose toAsPurpose purpose) of
+          Right txInfo ->
+            txInfo
+              `shouldBe` PV4.TxInfo
                 { PV4.txInfoWithdrawals = PV4.unsafeFromList []
                 , PV4.txInfoVotes = PV4.unsafeFromList []
                 , PV4.txInfoValidRange = PV4.POSIXTimeRange Nothing Nothing
@@ -279,7 +283,7 @@ spec = describe "TxInfo" $ do
                 , PV4.txInfoAccountBalanceIntervals =
                     PV4.AccountBalanceIntervals $ PV4.unsafeFromList []
                 }
-          _ -> expectationFailure "Failed to translate TxInfo"
+          Left failure -> expectationFailure $ "Failed to translate TxInfo: " <> show failure
   describe "PlutusV1-V3" $ do
     let plutusV1toV3 :: [SupportedLanguage era]
         plutusV1toV3 =

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
@@ -44,7 +44,6 @@ import Cardano.Ledger.Plutus (
   Data (..),
   ExUnits (..),
   Language (..),
-  PlutusRunnable (..),
   PlutusWithContext (..),
   decodePlutusRunnable,
   hashData,
@@ -101,7 +100,6 @@ collectTwoPhaseScriptInputsOutputOrdering = do
               toPlutusArgs
                 plutus
                 lti
-                (plutusRunnableScriptHash plutusRunnable)
                 txInfo
                 spendingPurpose1
                 (redeemer @AlonzoEra)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
@@ -58,6 +58,7 @@ import Data.Text (Text)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Lens.Micro
 import qualified PlutusLedgerApi.V1 as PV1
+import Test.Cardano.Ledger.Alonzo.Era (mkTestLedgerTxInfo)
 import Test.Cardano.Ledger.Alonzo.Scripts (alwaysSucceeds)
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.KeyPair (mkWitnessVKey)
@@ -112,15 +113,7 @@ collectTwoPhaseScriptInputsOutputOrdering = do
     plutus = alwaysSucceedsPlutus @'PlutusV1 3
     plutusRunnable = decodePlutusRunnable (pvMajor protVer) plutus
     lti :: LedgerTxInfo AlonzoEra
-    lti =
-      LedgerTxInfo
-        { ltiProtVer = protVer
-        , ltiEpochInfo = testEpochInfo
-        , ltiSystemStart = testSystemStart
-        , ltiUTxO = initUTxO
-        , ltiTx = validatingTx
-        , ltiMemoizedSubTransactions = mempty
-        }
+    lti = mkTestLedgerTxInfo protVer testEpochInfo testSystemStart initUTxO validatingTx
 
 -- ============================== DATA ===============================
 


### PR DESCRIPTION
# Description

This PR undoes the solution for passing the script hash to ScriptPurpose upon ScriptContext translation introduced in #5983 and reimplements in a much cleaner and more efficient manner

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
