### PR TITLE
Remove `hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule` and `WithdrawalsNotInRewardsCERTS`

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.24.0.0
 
+* Remove `hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule`
+* Remove `WithdrawalsNotInRewardsCERTS` from `ConwayCertsPredFailure`
+* Remove `certsTx` field from `CertsEnv`
 * Export `applyEnactedWithdrawals`, `returnProposalDeposits`, `updateCommitteeState` and `updateNumDormantEpochs`
 * Replace `StakeKeyRegisteredDELEG` constructor with `DelegAccountAlreadyRegistered` in `ConwayDelegPredFailure`, which wraps the new `AccountAlreadyRegistered` type instead of `Credential Staking`
 * Change `toPlutusV3Args` to accept `LedgerTxInfo era` and `ScriptHash` arguments instead of `ProtVer` and `Maybe (Data era)`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -15,7 +15,6 @@ module Cardano.Ledger.Conway (
   hardforkConwayBootstrapPhase,
   hardforkConwayDisallowUnelectedCommitteeFromVoting,
   hardforkConwayDELEGIncorrectDepositsAndRefunds,
-  hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule,
   Tx (..),
   ApplyTxError (..),
 ) where
@@ -31,7 +30,6 @@ import Cardano.Ledger.Conway.Era (
   hardforkConwayBootstrapPhase,
   hardforkConwayDELEGIncorrectDepositsAndRefunds,
   hardforkConwayDisallowUnelectedCommitteeFromVoting,
-  hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule,
  )
 import Cardano.Ledger.Conway.Forecast ()
 import Cardano.Ledger.Conway.Governance (RunConwayRatify (..))

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
@@ -29,7 +29,6 @@ module Cardano.Ledger.Conway.Era (
   hardforkConwayBootstrapPhase,
   hardforkConwayDisallowUnelectedCommitteeFromVoting,
   hardforkConwayDELEGIncorrectDepositsAndRefunds,
-  hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule,
 
   -- * Deprecated
   ConwayBBODY,
@@ -265,20 +264,3 @@ hardforkConwayDisallowUnelectedCommitteeFromVoting pv = pvMajor pv > natVersion 
 -- | Starting with protocol version 11, we report incorrect deposit and refunds better
 hardforkConwayDELEGIncorrectDepositsAndRefunds :: ProtVer -> Bool
 hardforkConwayDELEGIncorrectDepositsAndRefunds pv = pvMajor pv > natVersion @10
-
--- | Starting with protocol version 11, we move a predicate check and updates
--- related to DRep dormancy and expiry from CERTS to LEDGER since that is a
--- more suitable place for them.
---
--- 1. updates to drep expiry for all voting dreps
--- 2. drep dormancy tracking updates
--- 3. withdrawals draining - (split into two)
---
--- NOTE: In addition, we split the predicate check for withdrawals into two to
--- make it better: both invalid withdrawals (submitted in the wrong network or
--- with missing account addresss) and incomplete withdrawals were being reported
--- with WithdrawalsNotInRewardsCERTS but now ConwayWithdrawalsMissingAccounts and
--- ConwayIncompleteWithdrawals are the new predicate failures we use to report
--- the two separate cases in LEDGER
-hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule :: ProtVer -> Bool
-hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule pv = pvMajor pv > natVersion @10

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
@@ -35,8 +35,6 @@ module Cardano.Ledger.Conway.Rules.Certs (
 import Cardano.Ledger.BaseTypes (
   EpochInterval,
   EpochNo (EpochNo),
-  Globals (..),
-  Mismatch (..),
   ShelleyBase,
   StrictMaybe,
   binOpEpochNo,
@@ -55,7 +53,6 @@ import Cardano.Ledger.Conway.Era (
   CERT,
   CERTS,
   ConwayEra,
-  hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule,
  )
 import Cardano.Ledger.Conway.Governance (
   Committee,
@@ -72,15 +69,12 @@ import Cardano.Ledger.Conway.State
 import Cardano.Ledger.DRep (drepExpiryL)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Control.DeepSeq (NFData)
-import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition.Extended (
   Embed (..),
   STS (..),
   TRC (..),
   TransitionRule,
-  failOnJust,
   judgmentContext,
-  liftSTS,
   trans,
  )
 import qualified Data.Map.Strict as Map
@@ -90,8 +84,7 @@ import GHC.Generics (Generic)
 import Lens.Micro
 
 data CertsEnv era = CertsEnv
-  { certsTx :: Tx TopTx era
-  , certsPParams :: PParams era
+  { certsPParams :: PParams era
   , certsCurrentEpoch :: EpochNo
   -- ^ Lazy on purpose, because not all certificates need to know the current EpochNo
   , certsCurrentCommittee :: StrictMaybe (Committee era)
@@ -100,11 +93,10 @@ data CertsEnv era = CertsEnv
   deriving (Generic)
 
 instance EraTx era => EncCBOR (CertsEnv era) where
-  encCBOR x@(CertsEnv _ _ _ _ _) =
+  encCBOR x@(CertsEnv {}) =
     let CertsEnv {..} = x
      in encode $
           Rec CertsEnv
-            !> To certsTx
             !> To certsPParams
             !> To certsCurrentEpoch
             !> To certsCurrentCommittee
@@ -116,10 +108,8 @@ deriving instance (EraPParams era, Show (Tx TopTx era)) => Show (CertsEnv era)
 
 instance (EraPParams era, NFData (Tx TopTx era)) => NFData (CertsEnv era)
 
-data ConwayCertsPredFailure era
-  = -- | Withdrawals that are missing or do not withdraw the entire amount (pv < 11)
-    WithdrawalsNotInRewardsCERTS Withdrawals
-  | -- | CERT rule subtransition Failures
+newtype ConwayCertsPredFailure era
+  = -- | CERT rule subtransition Failures
     CertFailure (PredicateFailure (EraRule "CERT" era))
   deriving (Generic)
 
@@ -172,7 +162,6 @@ instance
   where
   encCBOR =
     encode . \case
-      WithdrawalsNotInRewardsCERTS rs -> Sum (WithdrawalsNotInRewardsCERTS @era) 0 !> To rs
       CertFailure x -> Sum (CertFailure @era) 1 !> To x
 
 instance
@@ -182,7 +171,6 @@ instance
   DecCBOR (ConwayCertsPredFailure era)
   where
   decCBOR = decode $ Summands "ConwayGovPredFailure" $ \case
-    0 -> SumD WithdrawalsNotInRewardsCERTS <! From
     1 -> SumD CertFailure <! From
     k -> Invalid k
 
@@ -223,31 +211,13 @@ conwayCertsTransition ::
   TransitionRule (CERTS era)
 conwayCertsTransition = do
   TRC
-    ( env@(CertsEnv tx pp currentEpoch committee committeeProposals)
+    ( env@(CertsEnv pp currentEpoch committee committeeProposals)
       , certState
       , certificates
       ) <-
     judgmentContext
   case certificates of
-    Empty ->
-      if hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule $ pp ^. ppProtocolVersionL
-        then pure certState
-        else do
-          network <- liftSTS $ asks networkId
-          let accounts = certState ^. certDStateL . accountsL
-              withdrawals = tx ^. bodyTxL . withdrawalsTxBodyL
-          failOnJust
-            (withdrawalsThatDoNotDrainAccounts withdrawals network accounts)
-            ( \(invalid, incomplete) ->
-                WithdrawalsNotInRewardsCERTS $
-                  Withdrawals $
-                    unWithdrawals invalid <> fmap mismatchSupplied incomplete
-            )
-          pure $
-            certState
-              & updateDormantDRepExpiries tx currentEpoch
-              & updateVotingDRepExpiries tx currentEpoch (pp ^. ppDRepActivityL)
-              & certDStateL . accountsL %~ drainAccounts withdrawals
+    Empty -> pure certState
     gamma :|> txCert -> do
       certState' <-
         trans @(CERTS era) $ TRC (env, certState, gamma)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -59,7 +59,6 @@ import Cardano.Ledger.Conway.Era (
   LEDGER,
   UTXOW,
   hardforkConwayBootstrapPhase,
-  hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule,
  )
 import Cardano.Ledger.Conway.Governance (
   ConwayEraGov (..),
@@ -395,22 +394,18 @@ conwayLedgerTransitionTRC
           unless (hardforkConwayBootstrapPhase (pp ^. ppProtocolVersionL)) $ do
             runTest $ validateWithdrawalsDelegated accounts tx
 
-          certState' <-
-            if hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule $ pp ^. ppProtocolVersionL
-              then do
-                let withdrawals = tx ^. bodyTxL . withdrawalsTxBodyL
-                Shelley.testIncompleteAndMissingWithdrawals (certState ^. certDStateL . accountsL) withdrawals
-                pure $
-                  certState
-                    & updateDormantDRepExpiries tx curEpochNo
-                    & updateVotingDRepExpiries tx curEpochNo (pp ^. ppDRepActivityL)
-                    & certDStateL . accountsL %~ drainAccounts withdrawals
-              else pure certState
+          let withdrawals = tx ^. bodyTxL . withdrawalsTxBodyL
+          Shelley.testIncompleteAndMissingWithdrawals (certState ^. certDStateL . accountsL) withdrawals
+          let certState' =
+                certState
+                  & updateDormantDRepExpiries tx curEpochNo
+                  & updateVotingDRepExpiries tx curEpochNo (pp ^. ppDRepActivityL)
+                  & certDStateL . accountsL %~ drainAccounts withdrawals
 
           certStateAfterCERTS <-
             trans @(EraRule "CERTS" era) $
               TRC
-                ( CertsEnv tx pp curEpochNo committee committeeProposals
+                ( CertsEnv pp curEpochNo committee committeeProposals
                 , certState'
                 , StrictSeq.fromStrict $ txBody ^. certsTxBodyL
                 )
@@ -479,12 +474,11 @@ validateRefScriptSize pp utxo tx =
   let totalRefScriptSize = txNonDistinctRefScriptsSize utxo tx
       maxRefScriptSizePerTx = fromIntegral @Word32 @Int $ pp ^. ppMaxRefScriptSizePerTxG
    in failureUnless (totalRefScriptSize <= maxRefScriptSizePerTx) $
-        ( ConwayTxRefScriptsSizeTooBig
-            Mismatch
-              { mismatchSupplied = totalRefScriptSize
-              , mismatchExpected = maxRefScriptSizePerTx
-              }
-        )
+        ConwayTxRefScriptsSizeTooBig
+          Mismatch
+            { mismatchSupplied = totalRefScriptSize
+            , mismatchExpected = maxRefScriptSizePerTx
+            }
 
 validateWithdrawalsDelegated ::
   ( EraTx era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/CertsSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/CertsSpec.hs
@@ -12,9 +12,8 @@ module Test.Cardano.Ledger.Conway.Imp.CertsSpec (conwayOnlySpec, spec) where
 
 import Cardano.Ledger.BaseTypes (EpochInterval (..), Mismatch (..))
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Conway (hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule)
 import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Conway.Rules (ConwayCertsPredFailure (..), ConwayLedgerPredFailure (..))
+import Cardano.Ledger.Conway.Rules (ConwayLedgerPredFailure (..))
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.DRep (DRep (..))
 import Cardano.Ledger.Plutus (SLanguage (SPlutusV3), hashPlutusScript)
@@ -34,7 +33,6 @@ conwayOnlySpec = describe "CERTS" $ do
   describe "Withdrawals" $ do
     it "Withdrawing from an unregistered staking address" $ do
       modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
-      pv <- getsPParams @era ppProtocolVersionL
 
       stakeKey <- freshKeyHash
       accountAddress <- getAccountAddressFor $ KeyHashObj stakeKey
@@ -45,11 +43,8 @@ conwayOnlySpec = describe "CERTS" $ do
               & withdrawalsTxBodyL
                 .~ Withdrawals [(accountAddress, Coin 20)]
         notInRewardsFailure =
-          ( if hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule pv
-              then injectFailure . ConwayWithdrawalsMissingAccounts @era
-              else injectFailure . WithdrawalsNotInRewardsCERTS @era
-          )
-            $ Withdrawals [(accountAddress, Coin 20)]
+          (injectFailure . ConwayWithdrawalsMissingAccounts @era) $
+            Withdrawals [(accountAddress, Coin 20)]
        in
         submitBootstrapAware
           (submitTx_ tx)
@@ -72,11 +67,8 @@ conwayOnlySpec = describe "CERTS" $ do
               & withdrawalsTxBodyL
                 .~ Withdrawals [(accountAddress, zero), (registeredAccountAddress, reward)]
         notInRewardsFailure =
-          ( if hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule pv
-              then injectFailure . ConwayWithdrawalsMissingAccounts @era
-              else injectFailure . WithdrawalsNotInRewardsCERTS @era
-          )
-            $ Withdrawals [(accountAddress, zero)]
+          (injectFailure . ConwayWithdrawalsMissingAccounts @era) $
+            Withdrawals [(accountAddress, zero)]
        in
         submitBootstrapAware
           (submitTx_ tx)
@@ -99,7 +91,6 @@ spec = describe "CERTS" $ do
   describe "Withdrawals" $ do
     it "Withdrawing the wrong amount" $ do
       modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
-      pv <- getsPParams @era ppProtocolVersionL
 
       (accountAddress1, reward1, stakeKey1) <- setupAccountAddress
       (accountAddress2, reward2, stakeKey2) <- setupAccountAddress
@@ -120,14 +111,9 @@ spec = describe "CERTS" $ do
                   , (accountAddress2, reward2)
                   ]
         )
-        [ if hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule pv
-            then
-              injectFailure . ConwayIncompleteWithdrawals @era $
-                NEM.singleton accountAddress1 $
-                  Mismatch (reward1 <+> Coin 1) reward1
-            else
-              injectFailure . WithdrawalsNotInRewardsCERTS @era $
-                Withdrawals [(accountAddress1, reward1 <+> Coin 1)]
+        [ injectFailure . ConwayIncompleteWithdrawals @era $
+            NEM.singleton accountAddress1 $
+              Mismatch (reward1 <+> Coin 1) reward1
         ]
 
       submitFailingSubsetTx
@@ -139,14 +125,9 @@ spec = describe "CERTS" $ do
                 .~ Withdrawals
                   [(accountAddress1, zero)]
         )
-        [ if hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule pv
-            then
-              injectFailure . ConwayIncompleteWithdrawals @era $
-                NEM.singleton accountAddress1 $
-                  Mismatch zero reward1
-            else
-              injectFailure . WithdrawalsNotInRewardsCERTS @era $
-                Withdrawals [(accountAddress1, zero)]
+        [ injectFailure . ConwayIncompleteWithdrawals @era $
+            NEM.singleton accountAddress1 $
+              Mismatch zero reward1
         ]
 
 setupAccountAddress ::

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
@@ -97,7 +97,7 @@ instance
   ) =>
   EncCBOR (EntitiesEnv era)
   where
-  encCBOR x@(EntitiesEnv _ _ _ _ _) =
+  encCBOR x@(EntitiesEnv {}) =
     let EntitiesEnv {..} = x
      in encode $
           Rec EntitiesEnv
@@ -277,7 +277,7 @@ dijkstraEntitiesTransition = do
       legacyMode = stAnnTx ^. plutusLegacyModeStAnnTxG
       withdrawals = tx ^. bodyTxL . withdrawalsTxBodyL
       accounts = certState ^. certDStateL . accountsL
-      certsEnv = Conway.CertsEnv tx pp curEpoch committee committeeProposals
+      certsEnv = Conway.CertsEnv pp curEpoch committee committeeProposals
 
   network <- liftSTS $ asks networkId
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubCerts.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubCerts.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -165,7 +164,7 @@ data SubCertsEnv era = SubCertsEnv
   deriving (Generic)
 
 instance EraTx era => EncCBOR (SubCertsEnv era) where
-  encCBOR x@(SubCertsEnv _ _ _ _ _) =
+  encCBOR x@(SubCertsEnv {}) =
     let SubCertsEnv {..} = x
      in encode $
           Rec SubCertsEnv
@@ -188,5 +187,4 @@ conwayToDijkstraSubCertsPredFailure ::
   ) =>
   Conway.ConwayCertsPredFailure era -> DijkstraSubCertsPredFailure era
 conwayToDijkstraSubCertsPredFailure = \case
-  Conway.WithdrawalsNotInRewardsCERTS _ -> error "Impossible: `WithdrawalsNotInRewardsCERTS` for SUBCERTS"
   Conway.CertFailure f -> SubCertFailure (injectFailure @"SUBCERT" f)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Certs.hs
@@ -1,10 +1,8 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE ViewPatterns #-}
 
 -- | Specs necessary to generate, environment, state, and signal
 -- for the CERTS rule
@@ -35,9 +33,8 @@ certsEnvSpec ::
   (EraSpecPParams era, HasSpec (Tx TopTx era)) =>
   Specification (Conway.CertsEnv era)
 certsEnvSpec = constrained $ \ce ->
-  match ce $ \tx pp _currepoch _currcommittee commproposals ->
+  match ce $ \pp _currepoch _currcommittee commproposals ->
     [ satisfies pp pparamsSpec
-    , assert $ tx ==. lit txZero
     , genHint 3 commproposals
     ]
 


### PR DESCRIPTION
# Description

The hardfork flag has served its purpose. Withdrawal and DRep checks are now unconditionally handled in the LEDGER rule. The `WithdrawalsNotInRewardsCERTS` predicate failure in `ConwayCertsPredFailure` is removed along with it.

Fixes #6036 

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
