### PR TITLE
Update hackageNix and CHaP for node 11.2 release

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -34,8 +34,8 @@ source-repository-package
 -- NOTE: If you would like to update the above,
 -- see CONTRIBUTING.md#to-update-the-referenced-agda-ledger-spec
 index-state:
-  , hackage.haskell.org 2026-07-15T21:58:35Z
-  , cardano-haskell-packages 2026-08-07T15:03:01Z
+  , hackage.haskell.org 2026-09-02T14:05:07Z
+  , cardano-haskell-packages 2026-09-02T08:49:12Z
 
 packages:
   -- == Byron era ==
@@ -109,8 +109,8 @@ source-repository-package
   type: git
   location: https://github.com/tweag/cardano-cls.git
   subdir: merkle-tree-incremental mempack-scls scls-cbor scls-format scls-core
-  --sha256: sha256-xngnA6A3YNjtPXYLk1vIt/aauvibzuAhngT2sPqJp0g=
-  tag: c0f41e7d3fe8e32316cb8fb8a34d7adddbe0ae0c
+  --sha256: sha256-QEk2npUEgyqlR/85DroIWWsLtxTX9AIC8XL3He2mWNU=
+  tag: 299fbb3958a6d7cd3d23682665157505b28ef5a7
 
 constraints:
   -- Happy version 2.2.1 fails to compile haskell-src-exts
@@ -147,3 +147,9 @@ if impl(ghc >=9.14)
     , serialise:containers
     , serialise:time
 -- cabal-allow-newer end
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-crypto
+  tag: ac2e12a471b735ad80949bcbf0f6f634e5dbef77
+  --sha256: sha256-NvbMk41W2PQy2H91nkG0GtPyGDwia0y6DQNNf9RtoAc=

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Translation/TranslationInstance.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Translation/TranslationInstance.hs
@@ -183,6 +183,8 @@ instance Cborg.Serialise PV4.TxOut
 
 instance Cborg.Serialise PV4.TxInInfo
 
+instance Cborg.Serialise PV4.POSIXTimeRange
+
 instance Cborg.Serialise PV4.TxInfo
 
 instance Cborg.Serialise VersionedTxInfo

--- a/eras/byron/crypto/cardano-crypto-wrapper.cabal
+++ b/eras/byron/crypto/cardano-crypto-wrapper.cabal
@@ -94,8 +94,8 @@ library
     deepseq,
     formatting,
     heapwords,
-    memory,
     nothunks,
+    ram,
     text,
 
 library testlib
@@ -136,7 +136,7 @@ library testlib
     cardano-prelude-test,
     crypton,
     hedgehog >=1.0.4,
-    memory,
+    ram,
 
 test-suite test
   type: exitcode-stdio-1.0

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
@@ -649,11 +649,9 @@ instance EraPlutusTxInfo 'PlutusV4 DijkstraEra where
             { PV4.txInfoInputs = inputsInfo
             , PV4.txInfoOutputs = outputs
             , PV4.txInfoReferenceInputs = refInputsInfo
-            , PV4.txInfoFee =
-                withBothTxLevels txBody (\topTxBody -> transCoinToLovelace (topTxBody ^. feeTxBodyL)) (const 0)
             , PV4.txInfoMint = Conway.transMintValue (txBody ^. mintTxBodyL)
             , PV4.txInfoTxCerts = txCerts
-            , PV4.txInfoValidRange = timeRange
+            , PV4.txInfoValidRange = transPOSIXTimeRange timeRange
             , PV4.txInfoRedeemers = plutusRedeemers
             , PV4.txInfoData = PV3.unsafeFromList $ Alonzo.transTxWitsDatums (ltiTx ^. witsTxL)
             , PV4.txInfoId = Conway.transTxBodyId txBody
@@ -742,8 +740,8 @@ transTxOutV4 txOutSource txOut = do
       }
 
 transTxBodyWithdrawals ::
-  DijkstraEraTxBody era => TxBody l era -> PV4.Map PV4.AccountId PV4.Lovelace
-transTxBodyWithdrawals txb = transMap transAccountAddressToAccountId transCoinToLovelace withdrawals
+  DijkstraEraTxBody era => TxBody l era -> PV4.Map PV4.Credential PV4.Lovelace
+transTxBodyWithdrawals txb = transMap transAccountAddressToCredential transCoinToLovelace withdrawals
   where
     Withdrawals withdrawals = txb ^. withdrawalsTxBodyL
 
@@ -790,11 +788,25 @@ transTxBodyRequiredTopLevelGuards txb = transMap transCred (fmap transDatum . st
 transAccountAddressToAccountId :: AccountAddress -> PV4.AccountId
 transAccountAddressToAccountId (AccountAddress _ (AccountId c)) = PV4.AccountId $ transCred c
 
+transAccountAddressToCredential :: AccountAddress -> PV4.Credential
+transAccountAddressToCredential (AccountAddress _ (AccountId c)) = transCred c
+
 transTxBodyDirectDeposits ::
-  DijkstraEraTxBody era => TxBody l era -> PV4.Map PV4.AccountId PV4.Lovelace
-transTxBodyDirectDeposits txb = transMap transAccountAddressToAccountId transCoinToLovelace deposits
+  DijkstraEraTxBody era => TxBody l era -> PV4.Map PV4.Credential PV4.Lovelace
+transTxBodyDirectDeposits txb = transMap transAccountAddressToCredential transCoinToLovelace deposits
   where
     DirectDeposits deposits = txb ^. directDepositsTxBodyL
+
+transPOSIXTimeRange :: PV1.POSIXTimeRange -> PV4.POSIXTimeRange
+transPOSIXTimeRange (PV1.Interval (PV1.LowerBound lo _) (PV1.UpperBound hi _)) =
+  PV4.POSIXTimeRange
+    { PV4.fromInclusive = case lo of
+        PV1.Finite t -> Just t
+        _ -> Nothing
+    , PV4.untilExclusive = case hi of
+        PV1.Finite t -> Just t
+        _ -> Nothing
+    }
 
 transAccountBalanceInterval :: AccountBalanceInterval era -> PV4.AccountBalanceInterval
 transAccountBalanceInterval = \case

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TxInfoSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TxInfoSpec.hs
@@ -281,7 +281,7 @@ spec = describe "TxInfo" $ do
               `shouldBeRight` PV4.TxInfo
                 { PV4.txInfoWithdrawals = PV4.unsafeFromList []
                 , PV4.txInfoVotes = PV4.unsafeFromList []
-                , PV4.txInfoValidRange = PV4.always
+                , PV4.txInfoValidRange = PV4.POSIXTimeRange Nothing Nothing
                 , PV4.txInfoTxCerts = []
                 , PV4.txInfoTreasuryDonation = PV4.Lovelace 0
                 , PV4.txInfoSubTxIx = Nothing
@@ -315,7 +315,6 @@ spec = describe "TxInfo" $ do
                     ]
                 , PV4.txInfoId = PV4.TxId $ transSafeHash txBodyHash
                 , PV4.txInfoGuards = []
-                , PV4.txInfoFee = PV4.Lovelace 0
                 , PV4.txInfoDirectDeposits = PV4.unsafeFromList []
                 , PV4.txInfoData = PV4.unsafeFromList []
                 , PV4.txInfoCurrentTreasuryAmount = Nothing

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -84,7 +84,7 @@ library
     base >=4.18 && <5,
     base16-bytestring,
     bytestring,
-    cardano-crypto-class >=2.3 && <2.6,
+    cardano-crypto-class >=2.3 && <2.7,
     cardano-data ^>=1.3.2,
     cardano-ledger-allegra ^>=1.10,
     cardano-ledger-binary >=1.4,

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -119,7 +119,7 @@ library
     base >=4.18 && <5,
     bytestring,
     cardano-base >=0.1.1.0,
-    cardano-crypto-class >=2.3 && <2.6,
+    cardano-crypto-class >=2.3 && <2.7,
     cardano-crypto-wrapper,
     cardano-data ^>=1.3.2,
     cardano-ledger-binary ^>=1.10,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1786548406,
-        "narHash": "sha256-ulRkDpM4ajVofbnagpi3bO3MyDEL7yOdZ6rIw5te+y0=",
+        "lastModified": 1788340313,
+        "narHash": "sha256-JhRJSoyPPXPUA2IwcrR+oK5JJCwv326IPkyGBLz8g08=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "452420d4a4366a770e5785f9035d3b14639bf4d9",
+        "rev": "2e648337e75e3ccc137644ecf351af9018b38621",
         "type": "github"
       },
       "original": {
@@ -81,6 +81,23 @@
         "owner": "haskell",
         "ref": "3.6",
         "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cardano-crypto-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1785137178,
+        "narHash": "sha256-NvbMk41W2PQy2H91nkG0GtPyGDwia0y6DQNNf9RtoAc=",
+        "owner": "input-output-hk",
+        "repo": "cardano-crypto",
+        "rev": "ac2e12a471b735ad80949bcbf0f6f634e5dbef77",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-crypto",
+        "rev": "ac2e12a471b735ad80949bcbf0f6f634e5dbef77",
         "type": "github"
       }
     },
@@ -308,11 +325,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1784153046,
-        "narHash": "sha256-W6/dzXu2M1bIJI2zIWkcd7npfzxDKyHS2ALhm4KhHOQ=",
+        "lastModified": 1788358854,
+        "narHash": "sha256-NIF+y/9ctwQILbHsCZCOFN7dxuwWXKnFn5T0+ya49+Y=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "4740f5a1e2c33fdde1fcea79d3063289c82db1e0",
+        "rev": "04149d44d879f7115282c442f8904b5eb5a78c4e",
         "type": "github"
       },
       "original": {
@@ -872,6 +889,7 @@
     "root": {
       "inputs": {
         "CHaP": "CHaP",
+        "cardano-crypto-src": "cardano-crypto-src",
         "cardano-ledger-release-tool": "cardano-ledger-release-tool",
         "cardano-mainnet-mirror": "cardano-mainnet-mirror",
         "flake-compat": "flake-compat",

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,12 @@
       url = "github:IntersectMBO/formal-ledger-specifications";
       flake = false;
     };
+
+    cardano-crypto-src = {
+      url =
+        "github:input-output-hk/cardano-crypto/ac2e12a471b735ad80949bcbf0f6f634e5dbef77";
+      flake = false;
+    };
   };
 
   outputs = inputs:
@@ -96,6 +102,8 @@
             "https://chap.intersectmbo.org/" = inputs.CHaP;
             "https://github.com/IntersectMBO/formal-ledger-specifications.git" =
               inputs.formal-ledger-specifications;
+            "https://github.com/input-output-hk/cardano-crypto" =
+              inputs.cardano-crypto-src;
           };
           cabalProjectLocal = ''
             repository cardano-haskell-packages-local

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -119,7 +119,7 @@ library
     bytestring >=0.10 && <0.11.3 || >=0.11.4,
     cardano-base >=0.1.6,
     cardano-crypto,
-    cardano-crypto-class >=2.4 && <2.6,
+    cardano-crypto-class >=2.4 && <2.7,
     cardano-crypto-wrapper,
     cardano-data >=1.3,
     cardano-ledger-binary ^>=1.10,

--- a/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
+++ b/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
@@ -45,7 +45,7 @@ library
       -Wredundant-constraints
   build-depends:
     base >=4.18 && <5,
-    cardano-crypto-class >=2.5 && <2.6,
+    cardano-crypto-class >=2.5 && <2.7,
     cardano-ledger-allegra >=1.10,
     cardano-ledger-alonzo >=1.16,
     cardano-ledger-babbage >=1.13.1,

--- a/libs/cardano-protocol/cardano-protocol.cabal
+++ b/libs/cardano-protocol/cardano-protocol.cabal
@@ -42,7 +42,7 @@ library
     bytestring,
     cardano-base >=0.1.2,
     cardano-binary,
-    cardano-crypto-class >=2.5 && <2.6,
+    cardano-crypto-class >=2.5 && <2.7,
     cardano-crypto-praos ^>=2.2,
     cardano-ledger-binary >=1.8,
     cardano-ledger-core >=1.21,

--- a/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor/Source/V4.hs
+++ b/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor/Source/V4.hs
@@ -163,7 +163,7 @@ purposeIsWellformedNoDatumQ =
               -- this later:
               --
               -- null $ P.filter (propProc P.==) $ PV4.txInfoProposalProcedures txInfo
-              PV4D.WithdrawingScript account -> PAMD.member account infoWithdrawals
+              PV4D.WithdrawingScript (PV4D.AccountId cred) -> PAMD.member cred infoWithdrawals
               PV4D.GuardingScript ix topTxInfo ->
                 (PV4D.ScriptCredential sh P.== infoGuards PLD.!! ix)
                   P.&& (P.isJust infoSubTxIx P.== P.isNothing topTxInfo)


### PR DESCRIPTION
# Description

* Update hackageNix and CHaP
* Add cardano-crypto SRP
* Fix removed PV4.txInfoFee from plutus
* Update cardano-crypto-class bounds to ^>=2.6
* Transition memory→ram-->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
