### PR TITLE
Conformance for starting account balance intervals

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
   subdir: hs
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `*-artifacts` BEFORE MERGE!
-  tag: 8768f57ac991a09171b2f057b9a8fbce8be96590
+  tag: 9b77bb1cc7ea64f11621e51ab4f5d1ebf1f512a7
 
 source-repository-package
   type: git

--- a/flake.lock
+++ b/flake.lock
@@ -222,11 +222,11 @@
     "formal-ledger-specifications": {
       "flake": false,
       "locked": {
-        "lastModified": 1788956565,
-        "narHash": "sha256-5Jpsdsx1S8hWDk/iqVHm1e3xNa2HdF3O3u6dvY4w938=",
+        "lastModified": 1789120061,
+        "narHash": "sha256-ee1+BYVtIhnSO20ShPm19UYDZVAKVlyY2wULR5eXwqg=",
         "owner": "IntersectMBO",
         "repo": "formal-ledger-specifications",
-        "rev": "8768f57ac991a09171b2f057b9a8fbce8be96590",
+        "rev": "9b77bb1cc7ea64f11621e51ab4f5d1ebf1f512a7",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Dijkstra/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Dijkstra/Ledger.hs
@@ -109,6 +109,7 @@ instance SpecTranslate DijkstraEra (TxBody TopTx DijkstraEra) where
         <*> (Agda.MkHSSet <$> toSpecRep (txb ^. guardsTxBodyL))
         <*> toSpecRep (txb ^. directDepositsTxBodyL)
         <*> toSpecRep (txb ^. accountBalanceIntervalsTxBodyL)
+        <*> toSpecRep (txb ^. startingAccountBalanceIntervalsTxBodyL)
 
 instance SpecTranslate DijkstraEra (TxBody SubTx DijkstraEra) where
   type SpecRep DijkstraEra (TxBody SubTx DijkstraEra) = Agda.TxBodySub

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Dijkstra.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Dijkstra.hs
@@ -57,9 +57,7 @@ spec = do
 
             xdescribe "disabled" ConwayCERTS.spec
 
-            xdescribe
-              "disabled until the formal spec models starting account balance intervals"
-              ENTITIES.spec
+            ENTITIES.spec
 
             ShelleyDELEG.spec
             ConwayDELEG.spec


### PR DESCRIPTION
# Description

- Update formal ledger spec
- Revert 2d3f3a2838ab1c97ef13ef36af6e808411b1be31 to reenable ENTITIES tests

Blocked by https://github.com/IntersectMBO/formal-ledger-specifications/pull/1308

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
