### PR TITLE
TxInfo improvements

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.17.0.0
 
+* Add `CertificateNotSupported` and `PlutusPurposeNotSupported` constructors to `AlonzoContextError`
+* Stop re-exporting `TxOutSource` from `Cardano.Ledger.Alonzo.Plutus.TxInfo` (it remains available from `Cardano.Ledger.Plutus.TxInfo`)
+* Change `transTxCert` to return `Either (ContextError era) PV1.DCert` instead of `PV1.DCert` and add an `Inject (AlonzoContextError era) (ContextError era)` constraint; unsupported certificates now produce `CertificateNotSupported` instead of a partial `error`
+* Change `transTxCertCommon` to return `Either (ContextError era) PV1.DCert` instead of `Maybe PV1.DCert`
+* Change `transPlutusPurpose` to accept `PlutusPurpose AsIxItem era` instead of `AlonzoPlutusPurpose AsIxItem era`; unsupported purposes now produce `PlutusPurposeNotSupported`
 * Add `AlonzoEraTransition` class with a `tcAlonzoGenesisL` lens
 * Change `alonzoInjectCostModels` to accept the `TransitionConfig` of the current era instead of `TransitionConfig AlonzoEra`
 * Switch `toPlutusScriptPurpose` to accept `LedgerTxInfo` instead of `ProtVer`
@@ -17,6 +22,7 @@
 
 ### `testlib`
 
+* Add `Inject (AlonzoContextError era) (ContextError era)` superclass constraint to the `AlonzoEraTest` type class
 * Add `mkTestLedgerTxInfo` helper
 * Add `Serialise` instance for `PV4.POSIXTimeRange`
 * Add `Serialise` instances for `PlutusLedgerApi.V4` script context types

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -22,7 +23,6 @@
 module Cardano.Ledger.Alonzo.Plutus.TxInfo (
   mkPlutusWithContext,
   AlonzoContextError (..),
-  TxOutSource (..),
   transLookupTxOut,
   transTxOut,
   transValidityInterval,
@@ -52,14 +52,18 @@ import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Era (AlonzoEra)
 import Cardano.Ledger.Alonzo.Plutus.Context
 import Cardano.Ledger.Alonzo.Scripts (
-  AlonzoPlutusPurpose (..),
   PlutusScript (..),
   toAsItem,
   toAsPurpose,
  )
 import Cardano.Ledger.Alonzo.TxWits (unTxDatsL)
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO (getSpendingDatum))
-import Cardano.Ledger.BaseTypes (ProtVer (..), StrictMaybe (..), strictMaybeToMaybe)
+import Cardano.Ledger.BaseTypes (
+  ProtVer (..),
+  StrictMaybe (..),
+  kindObjectValue,
+  strictMaybeToMaybe,
+ )
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders (
   Decode (..),
@@ -86,7 +90,7 @@ import Cardano.Slotting.Time (SystemStart)
 import Control.Arrow (left)
 import Control.DeepSeq (NFData)
 import Control.Monad (forM, guard)
-import Data.Aeson (ToJSON (..), pattern String)
+import Data.Aeson (ToJSON (..), (.=), pattern String)
 import Data.ByteString.Short as SBS (fromShort)
 import Data.Foldable as F (Foldable (..))
 import qualified Data.Map.Strict as Map
@@ -131,7 +135,7 @@ mkPlutusWithContext script plutusPurpose lti@LedgerTxInfo {ltiProtVer} txInfoRes
           }
 
 instance EraPlutusTxInfo 'PlutusV1 AlonzoEra where
-  toPlutusTxCert _ _ = pure . transTxCert
+  toPlutusTxCert _ _ = transTxCert
 
   toPlutusScriptPurpose proxy lti = transPlutusPurpose proxy (ltiProtVer lti)
 
@@ -226,36 +230,86 @@ instance EraPlutusContext AlonzoEra where
 data AlonzoContextError era
   = TranslationLogicMissingInput TxIn
   | TimeTranslationPastHorizon Text
-  deriving (Eq, Ord, Show, Generic)
+  | CertificateNotSupported (TxCert era)
+  | PlutusPurposeNotSupported (PlutusPurpose AsItem era)
+  deriving (Generic)
 
-instance Era era => NFData (AlonzoContextError era)
+deriving instance
+  ( Eq (TxCert era)
+  , Eq (PlutusPurpose AsItem era)
+  , EraPParams era
+  ) =>
+  Eq (AlonzoContextError era)
 
-instance Era era => EncCBOR (AlonzoContextError era) where
+deriving instance
+  ( Ord (TxCert era)
+  , Ord (PlutusPurpose AsItem era)
+  , EraPParams era
+  ) =>
+  Ord (AlonzoContextError era)
+
+deriving instance
+  ( Show (TxCert era)
+  , Show (PlutusPurpose AsItem era)
+  , EraPParams era
+  ) =>
+  Show (AlonzoContextError era)
+
+instance
+  ( Era era
+  , NFData (TxCert era)
+  , NFData (PlutusPurpose AsItem era)
+  ) =>
+  NFData (AlonzoContextError era)
+
+instance
+  (Era era, EncCBOR (TxCert era), EncCBOR (PlutusPurpose AsItem era)) =>
+  EncCBOR (AlonzoContextError era)
+  where
   encCBOR = \case
     TranslationLogicMissingInput txIn ->
       encode $ Sum (TranslationLogicMissingInput @era) 1 !> To txIn
     TimeTranslationPastHorizon err ->
       encode $ Sum (TimeTranslationPastHorizon @era) 7 !> To err
+    CertificateNotSupported txCert ->
+      encode $ Sum CertificateNotSupported 9 !> To txCert
+    PlutusPurposeNotSupported purpose ->
+      encode $ Sum PlutusPurposeNotSupported 10 !> To purpose
 
-instance Era era => DecCBOR (AlonzoContextError era) where
+instance
+  ( Era era
+  , DecCBOR (TxCert era)
+  , DecCBOR (PlutusPurpose AsItem era)
+  ) =>
+  DecCBOR (AlonzoContextError era)
+  where
   decCBOR = decode $ Summands "ContextError" $ \case
     1 -> SumD (TranslationLogicMissingInput @era) <! From
     7 -> SumD (TimeTranslationPastHorizon @era) <! From
+    9 -> SumD (CertificateNotSupported @era) <! From
+    10 -> SumD (PlutusPurposeNotSupported @era) <! From
     n -> Invalid n
 
-instance ToJSON (AlonzoContextError era) where
+instance
+  (ToJSON (TxCert era), ToJSON (PlutusPurpose AsItem era)) =>
+  ToJSON (AlonzoContextError era)
+  where
   toJSON = \case
     TranslationLogicMissingInput txin ->
       String $ "Transaction input does not exist in the UTxO: " <> txInToText txin
     TimeTranslationPastHorizon msg ->
       String $ "Time translation requested past the horizon: " <> msg
+    CertificateNotSupported txCert ->
+      kindObjectValue "CertificateNotSupported" ["certificate" .= toJSON txCert]
+    PlutusPurposeNotSupported purpose ->
+      kindObjectValue "PlutusPurposeNotSupported" ["purpose" .= toJSON purpose]
 
 transLookupTxOut ::
-  forall era a.
-  Inject (AlonzoContextError era) a =>
+  forall era.
+  Inject (AlonzoContextError era) (ContextError era) =>
   UTxO era ->
   TxIn ->
-  Either a (TxOut era)
+  Either (ContextError era) (TxOut era)
 transLookupTxOut (UTxO utxo) txIn =
   case Map.lookup txIn utxo of
     Nothing -> Left $ inject $ TranslationLogicMissingInput @era txIn
@@ -263,13 +317,13 @@ transLookupTxOut (UTxO utxo) txIn =
 
 -- | Translate a validity interval to POSIX time
 transValidityInterval ::
-  forall proxy era a.
-  Inject (AlonzoContextError era) a =>
+  forall proxy era.
+  Inject (AlonzoContextError era) (ContextError era) =>
   proxy era ->
   EpochInfo (Either Text) ->
   SystemStart ->
   ValidityInterval ->
-  Either a PV1.POSIXTimeRange
+  Either (ContextError era) PV1.POSIXTimeRange
 transValidityInterval _ epochInfo systemStart = \case
   ValidityInterval SNothing SNothing -> pure PV1.always
   ValidityInterval (SJust i) SNothing -> PV1.from <$> transSlotToPOSIXTime i
@@ -363,43 +417,53 @@ transValue (MaryValue c m) = transCoinToValue c <> transMultiAsset m
 -- =============================================
 -- translate fields like TxCert, Withdrawals, and similar
 
-transTxCert :: (ShelleyEraTxCert era, AtMostEra "Babbage" era) => TxCert era -> PV1.DCert
-transTxCert txCert =
-  case transTxCertCommon txCert of
-    Just cert -> cert
-    Nothing ->
-      case txCert of
-        GenesisDelegTxCert {} -> PV1.DCertGenesis
-        MirTxCert {} -> PV1.DCertMir
-        _ -> error "Impossible: All certificates should have been accounted for"
+transTxCert ::
+  ( ShelleyEraTxCert era
+  , AtMostEra "Babbage" era
+  , Inject (AlonzoContextError era) (ContextError era)
+  ) =>
+  TxCert era -> Either (ContextError era) PV1.DCert
+transTxCert = \case
+  GenesisDelegTxCert {} -> Right PV1.DCertGenesis
+  MirTxCert {} -> Right PV1.DCertMir
+  txCert -> transTxCertCommon txCert
 
 -- | Just like `transTxCert`, but do not translate certificates that were deprecated in Conway
-transTxCertCommon :: ShelleyEraTxCert era => TxCert era -> Maybe PV1.DCert
+transTxCertCommon ::
+  ( ShelleyEraTxCert era
+  , Inject (AlonzoContextError era) (ContextError era)
+  ) =>
+  TxCert era -> Either (ContextError era) PV1.DCert
 transTxCertCommon = \case
   RegTxCert stakeCred ->
-    Just $ PV1.DCertDelegRegKey (PV1.StakingHash (transCred stakeCred))
+    Right $ PV1.DCertDelegRegKey (PV1.StakingHash (transCred stakeCred))
   UnRegTxCert stakeCred ->
-    Just $ PV1.DCertDelegDeRegKey (PV1.StakingHash (transCred stakeCred))
+    Right $ PV1.DCertDelegDeRegKey (PV1.StakingHash (transCred stakeCred))
   DelegStakeTxCert stakeCred keyHash ->
-    Just $ PV1.DCertDelegDelegate (PV1.StakingHash (transCred stakeCred)) (transKeyHash keyHash)
+    Right $ PV1.DCertDelegDelegate (PV1.StakingHash (transCred stakeCred)) (transKeyHash keyHash)
   RegPoolTxCert (StakePoolParams {sppId, sppVrf}) ->
-    Just $
+    Right $
       PV1.DCertPoolRegister
         (transKeyHash sppId)
         (PV1.PubKeyHash (PV1.toBuiltin (hashToBytes (unVRFVerKeyHash sppVrf))))
   RetirePoolTxCert poolId retireEpochNo ->
-    Just $ PV1.DCertPoolRetire (transKeyHash poolId) (transEpochNo retireEpochNo)
-  _ -> Nothing
+    Right $ PV1.DCertPoolRetire (transKeyHash poolId) (transEpochNo retireEpochNo)
+  txCert -> Left $ inject $ CertificateNotSupported txCert
 
 transPlutusPurpose ::
-  (EraPlutusTxInfo l era, PlutusTxCert l ~ PV1.DCert) =>
+  forall l era proxy.
+  ( PlutusTxCert l ~ PV1.DCert
+  , EraPlutusTxInfo l era
+  , Inject (AlonzoContextError era) (ContextError era)
+  ) =>
   proxy l ->
   ProtVer ->
-  AlonzoPlutusPurpose AsIxItem era ->
+  PlutusPurpose AsIxItem era ->
   Either (ContextError era) PV1.ScriptPurpose
 transPlutusPurpose proxy pv = \case
-  AlonzoSpending (AsIxItem _ txIn) -> pure $ PV1.Spending (transTxIn txIn)
-  AlonzoMinting (AsIxItem _ policyId) -> pure $ PV1.Minting (transPolicyID policyId)
-  AlonzoCertifying (AsIxItem _ txCert) -> PV1.Certifying <$> toPlutusTxCert proxy pv txCert
-  AlonzoWithdrawing (AsIxItem _ accountAddress) ->
+  SpendingPurpose (AsIxItem _ txIn) -> pure $ PV1.Spending (transTxIn txIn)
+  MintingPurpose (AsIxItem _ policyId) -> pure $ PV1.Minting (transPolicyID policyId)
+  CertifyingPurpose (AsIxItem _ txCert) -> PV1.Certifying <$> toPlutusTxCert proxy pv txCert
+  WithdrawingPurpose (AsIxItem _ accountAddress) ->
     pure $ PV1.Rewarding (PV1.StakingHash (transAccountAddress accountAddress))
+  purpose -> Left $ inject $ PlutusPurposeNotSupported @era $ hoistPlutusPurpose toAsItem purpose

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
@@ -335,7 +335,10 @@ instance
   where
   arbitrary = genericArbitraryU
 
-instance Era era => Arbitrary (AlonzoContextError era) where
+instance
+  (Era era, Arbitrary (TxCert era), Arbitrary (PlutusPurpose AsItem era)) =>
+  Arbitrary (AlonzoContextError era)
+  where
   arbitrary = genericArbitraryU
 
 instance

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Era.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Era.hs
@@ -14,8 +14,9 @@ module Test.Cardano.Ledger.Alonzo.Era (
 import Cardano.Ledger.Alonzo
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Plutus.Context
+import Cardano.Ledger.Alonzo.Plutus.TxInfo
 import Cardano.Ledger.Alonzo.UTxO
-import Cardano.Ledger.BaseTypes (ProtVer)
+import Cardano.Ledger.BaseTypes (Inject, ProtVer)
 import Cardano.Ledger.Plutus (Language (..))
 import Cardano.Ledger.State
 import Cardano.Slotting.EpochInfo (EpochInfo)
@@ -48,6 +49,7 @@ class
   , Script era ~ AlonzoScript era
   , EraPlutusTxInfo PlutusV1 era
   , Arbitrary (PlutusPurpose AsIx era)
+  , Inject (AlonzoContextError era) (ContextError era)
   ) =>
   AlonzoEraTest era
 

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
@@ -168,7 +168,7 @@ instance ToExpr (SupportedPlutusRunnable era) where
   toExpr (SupportedPlutusRunnable spr) = toExpr spr
 
 -- Plutus/TxInfo
-instance ToExpr (AlonzoContextError era)
+instance (ToExpr (TxCert era), ToExpr (PlutusPurpose AsItem era)) => ToExpr (AlonzoContextError era)
 
 instance
   ( ToExpr (ContextError era)

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.15.0.0
 
+* Encode a wrapped `AlonzoContextError` under tag 8 in `BabbageContextError`, and add `TxCert era` and `PlutusPurpose AsItem era` constraints to its `NFData` and `EncCBOR` instances
+* Add `DecCBOR (TxCert era)` and `DecCBOR (PlutusPurpose AsItem era)` constraints to the `DecCBOR (BabbageContextError era)` instance
 * Add `AlonzoEraTransition` instance for `BabbageEra`
 * Add `FromJSON` instance for `BabbageTxOut era`
 * Change `toPlutusV2Args` to accept `LedgerTxInfo era` argument instead of `ProtVer` and `Maybe (Data era)`

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
@@ -58,7 +58,7 @@ import Cardano.Ledger.BaseTypes (
   isSJust,
   kindObjectValue,
  )
-import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
+import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..), natVersion, withCurrentEncodingVersion)
 import Cardano.Ledger.Binary.Coders (
   Decode (..),
   Encode (..),
@@ -87,7 +87,6 @@ import Cardano.Ledger.Plutus.TxInfo (
  )
 import Cardano.Ledger.State (UTxO (..))
 import Cardano.Ledger.TxIn (TxIn (..), txInToText)
-import Control.Arrow (left)
 import Control.DeepSeq (NFData)
 import Control.Monad (unless, when, zipWithM)
 import Data.Aeson (ToJSON (..), (.=), pattern String)
@@ -161,7 +160,8 @@ transTxOutV2 txOutSource txOut = do
 -- | Given a TxIn, look it up in the UTxO. If it exists, translate it to the V1 context
 transTxInInfoV1 ::
   forall era.
-  ( Inject (BabbageContextError era) (ContextError era)
+  ( Inject (Alonzo.AlonzoContextError era) (ContextError era)
+  , Inject (BabbageContextError era) (ContextError era)
   , Value era ~ MaryValue
   , BabbageEraTxOut era
   ) =>
@@ -169,14 +169,15 @@ transTxInInfoV1 ::
   TxIn ->
   Either (ContextError era) PV1.TxInInfo
 transTxInInfoV1 utxo txIn = do
-  txOut <- left (inject . AlonzoContextError @era) $ Alonzo.transLookupTxOut utxo txIn
+  txOut <- Alonzo.transLookupTxOut utxo txIn
   plutusTxOut <- transTxOutV1 (TxOutFromInput txIn) txOut
   Right (PV1.TxInInfo (transTxIn txIn) plutusTxOut)
 
 -- | Given a TxIn, look it up in the UTxO. If it exists, translate it to the V2 context
 transTxInInfoV2 ::
   forall era.
-  ( Inject (BabbageContextError era) (ContextError era)
+  ( Inject (Alonzo.AlonzoContextError era) (ContextError era)
+  , Inject (BabbageContextError era) (ContextError era)
   , Value era ~ MaryValue
   , BabbageEraTxOut era
   ) =>
@@ -184,7 +185,7 @@ transTxInInfoV2 ::
   TxIn ->
   Either (ContextError era) PV2.TxInInfo
 transTxInInfoV2 utxo txIn = do
-  txOut <- left (inject . AlonzoContextError @era) $ Alonzo.transLookupTxOut utxo txIn
+  txOut <- Alonzo.transLookupTxOut utxo txIn
   plutusTxOut <- transTxOutV2 (TxOutFromInput txIn) txOut
   Right (PV2.TxInInfo (transTxIn txIn) plutusTxOut)
 
@@ -273,29 +274,55 @@ deriving instance
   (Show (AlonzoContextError era), Show (PlutusPurpose AsIx era)) =>
   Show (BabbageContextError era)
 
-instance (Era era, NFData (PlutusPurpose AsIx era)) => NFData (BabbageContextError era)
+instance
+  ( Era era
+  , NFData (TxCert era)
+  , NFData (PlutusPurpose AsIx era)
+  , NFData (PlutusPurpose AsItem era)
+  ) =>
+  NFData (BabbageContextError era)
 
 instance Inject (AlonzoContextError era) (BabbageContextError era) where
   inject = AlonzoContextError
 
-instance (Era era, EncCBOR (PlutusPurpose AsIx era)) => EncCBOR (BabbageContextError era) where
-  encCBOR = \case
-    ByronTxOutInContext txOutSource ->
-      encode $ Sum (ByronTxOutInContext @era) 0 !> To txOutSource
-    AlonzoContextError (TranslationLogicMissingInput txIn) ->
-      encode $ Sum (TranslationLogicMissingInput @era) 1 !> To txIn
-    RedeemerPointerPointsToNothing ptr ->
-      encode $ Sum RedeemerPointerPointsToNothing 2 !> To ptr
-    InlineDatumsNotSupported txOutSource ->
-      encode $ Sum (InlineDatumsNotSupported @era) 4 !> To txOutSource
-    ReferenceScriptsNotSupported txOutSource ->
-      encode $ Sum (ReferenceScriptsNotSupported @era) 5 !> To txOutSource
-    ReferenceInputsNotSupported txIns ->
-      encode $ Sum (ReferenceInputsNotSupported @era) 6 !> To txIns
-    AlonzoContextError (TimeTranslationPastHorizon err) ->
-      encode $ Sum TimeTranslationPastHorizon 7 !> To err
+instance
+  ( Era era
+  , EncCBOR (TxCert era)
+  , EncCBOR (PlutusPurpose AsIx era)
+  , EncCBOR (PlutusPurpose AsItem era)
+  ) =>
+  EncCBOR (BabbageContextError era)
+  where
+  encCBOR contextError = withCurrentEncodingVersion $ \currentVersion ->
+    let isPreDijkstraEra = currentVersion < natVersion @12
+     in case contextError of
+          ByronTxOutInContext txOutSource ->
+            encode $ Sum (ByronTxOutInContext @era) 0 !> To txOutSource
+          AlonzoContextError (TranslationLogicMissingInput txIn)
+            | isPreDijkstraEra ->
+                encode $ Sum (TranslationLogicMissingInput @era) 1 !> To txIn
+          RedeemerPointerPointsToNothing ptr ->
+            encode $ Sum RedeemerPointerPointsToNothing 2 !> To ptr
+          InlineDatumsNotSupported txOutSource ->
+            encode $ Sum (InlineDatumsNotSupported @era) 4 !> To txOutSource
+          ReferenceScriptsNotSupported txOutSource ->
+            encode $ Sum (ReferenceScriptsNotSupported @era) 5 !> To txOutSource
+          ReferenceInputsNotSupported txIns ->
+            encode $ Sum (ReferenceInputsNotSupported @era) 6 !> To txIns
+          AlonzoContextError (TimeTranslationPastHorizon err)
+            | isPreDijkstraEra ->
+                encode $ Sum TimeTranslationPastHorizon 7 !> To err
+          AlonzoContextError alonzoError ->
+            encode $ Sum AlonzoContextError 8 !> To alonzoError
 
-instance (Era era, DecCBOR (PlutusPurpose AsIx era)) => DecCBOR (BabbageContextError era) where
+instance
+  ( Era era
+  , DecCBOR (TxCert era)
+  , DecCBOR (PlutusPurpose AsIx era)
+  , DecCBOR (PlutusPurpose AsItem era)
+  ) =>
+  DecCBOR (BabbageContextError era)
+  where
   decCBOR = decode $ Summands "ContextError" $ \case
     0 -> SumD ByronTxOutInContext <! From
     1 -> SumD (AlonzoContextError . TranslationLogicMissingInput) <! From
@@ -304,9 +331,16 @@ instance (Era era, DecCBOR (PlutusPurpose AsIx era)) => DecCBOR (BabbageContextE
     5 -> SumD ReferenceScriptsNotSupported <! From
     6 -> SumD ReferenceInputsNotSupported <! From
     7 -> SumD (AlonzoContextError . TimeTranslationPastHorizon) <! From
+    8 -> SumD AlonzoContextError <! From
     n -> Invalid n
 
-instance ToJSON (PlutusPurpose AsIx era) => ToJSON (BabbageContextError era) where
+instance
+  ( ToJSON (TxCert era)
+  , ToJSON (PlutusPurpose AsIx era)
+  , ToJSON (PlutusPurpose AsItem era)
+  ) =>
+  ToJSON (BabbageContextError era)
+  where
   toJSON = \case
     AlonzoContextError err -> toJSON err
     ByronTxOutInContext txOutSource ->
@@ -323,7 +357,7 @@ instance ToJSON (PlutusPurpose AsIx era) => ToJSON (BabbageContextError era) whe
           <> T.intercalate ", " (map txInToText (Set.toList txIns))
 
 instance EraPlutusTxInfo 'PlutusV1 BabbageEra where
-  toPlutusTxCert _ _ = pure . Alonzo.transTxCert
+  toPlutusTxCert _ _ = Alonzo.transTxCert
 
   toPlutusScriptPurpose proxy lti = Alonzo.transPlutusPurpose proxy (ltiProtVer lti)
 
@@ -365,7 +399,7 @@ instance EraPlutusTxInfo 'PlutusV1 BabbageEra where
   toPlutusTxInInfo _ = transTxInInfoV1
 
 instance EraPlutusTxInfo 'PlutusV2 BabbageEra where
-  toPlutusTxCert _ _ = pure . Alonzo.transTxCert
+  toPlutusTxCert _ _ = Alonzo.transTxCert
 
   toPlutusScriptPurpose proxy lti = Alonzo.transPlutusPurpose proxy (ltiProtVer lti)
 

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Arbitrary.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Arbitrary.hs
@@ -85,7 +85,9 @@ instance Arbitrary TxOutSource where
 
 instance
   ( Era era
+  , Arbitrary (TxCert era)
   , Arbitrary (PlutusPurpose AsIx era)
+  , Arbitrary (PlutusPurpose AsItem era)
   ) =>
   Arbitrary (BabbageContextError era)
   where

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxosSpec.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxosSpec.hs
@@ -10,9 +10,6 @@
 module Test.Cardano.Ledger.Babbage.Imp.UtxosSpec (spec) where
 
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (CollectError (BadTranslation))
-import Cardano.Ledger.Alonzo.Plutus.TxInfo (
-  TxOutSource (..),
- )
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
 import Cardano.Ledger.Alonzo.Scripts (eraLanguages)
 import Cardano.Ledger.Babbage (BabbageEra)
@@ -55,6 +52,9 @@ import Cardano.Ledger.Plutus (
   hashPlutusScript,
   mkInlineDatum,
   withSLanguage,
+ )
+import Cardano.Ledger.Plutus.TxInfo (
+  TxOutSource (..),
  )
 import Cardano.Ledger.Shelley.Scripts (pattern RequireAllOf)
 import Lens.Micro

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/TreeDiff.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/TreeDiff.hs
@@ -32,7 +32,12 @@ import Test.Cardano.Ledger.Alonzo.TreeDiff
 instance ToExpr (PlutusScript BabbageEra)
 
 -- PlutusContext
-instance ToExpr (PlutusPurpose AsIx era) => ToExpr (BabbageContextError era)
+instance
+  ( ToExpr (TxCert era)
+  , ToExpr (PlutusPurpose AsIx era)
+  , ToExpr (PlutusPurpose AsItem era)
+  ) =>
+  ToExpr (BabbageContextError era)
 
 -- PParams
 instance ToExpr (BabbagePParams StrictMaybe era)

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/TxInfoSpec.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/TxInfoSpec.hs
@@ -17,7 +17,7 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
   PlutusTxInfo,
   toPlutusTxInfoForPurpose,
  )
-import Cardano.Ledger.Alonzo.Plutus.TxInfo (AlonzoContextError (..), TxOutSource (..))
+import Cardano.Ledger.Alonzo.Plutus.TxInfo (AlonzoContextError (..))
 import Cardano.Ledger.Alonzo.Scripts (AsPurpose (..))
 import Cardano.Ledger.Alonzo.UTxO
 import Cardano.Ledger.Babbage.Core
@@ -37,6 +37,7 @@ import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
 import Cardano.Ledger.Mary.Value (MaryValue)
 import Cardano.Ledger.Plutus.Data (Data (..), Datum (..), dataToBinaryData)
 import Cardano.Ledger.Plutus.Language (Language (..), SLanguage (..))
+import Cardano.Ledger.Plutus.TxInfo (TxOutSource (..))
 import Cardano.Ledger.State (EraUTxO (..), UTxO (..))
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..), mkTxInPartial)
 import Cardano.Slotting.EpochInfo (EpochInfo, fixedEpochInfo)

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.24.0.0
 
+* Remove `transPlutusPurposeV1V2`, superseded by `Alonzo.transPlutusPurpose`
+* No longer export the `CertificateNotSupported` and `PlutusPurposeNotSupported` constructors of `ConwayContextError`, in favor of the same cases defined in Alonzo.
 * Add `conwayInjectIntoTestState`
 * Add `AlonzoEraTransition` as a superclass of `ConwayEraTransition`
 * Add `AlonzoEraTransition` instance for `ConwayEra`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
@@ -17,7 +17,14 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Conway.TxInfo (
-  ConwayContextError (..),
+  ConwayContextError (
+    BabbageContextError,
+    CurrentTreasuryFieldNotSupported,
+    VotingProceduresFieldNotSupported,
+    ProposalProceduresFieldNotSupported,
+    TreasuryDonationFieldNotSupported,
+    ReferenceInputsNotDisjointFromInputs
+  ),
   ConwayEraPlutusTxInfo (..),
   transTxBodyWithdrawals,
   transTxCert,
@@ -38,7 +45,6 @@ module Cardano.Ledger.Conway.TxInfo (
   transVoter,
   toPlutusV3Args,
   transTxCertV1V2,
-  transPlutusPurposeV1V2,
   transPlutusPurposeV3,
   guardConwayFeaturesForPlutusV1V2,
   transTxInInfoV3,
@@ -51,23 +57,14 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
   EraPlutusContext (..),
   EraPlutusTxInfo (..),
   LedgerTxInfo (..),
-  PlutusTxCert,
   PlutusTxInfoResult (..),
   SupportedLanguage (..),
   SupportedPlutusRunnable (..),
   lookupTxInfoResultImpossible,
  )
-import Cardano.Ledger.Alonzo.Plutus.TxInfo (
-  AlonzoContextError (..),
-  TxOutSource (..),
- )
 import qualified Cardano.Ledger.Alonzo.Plutus.TxInfo as Alonzo
-import Cardano.Ledger.Alonzo.Scripts (AlonzoPlutusPurpose (..), toAsItem)
+import Cardano.Ledger.Alonzo.Scripts (toAsItem)
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO (..))
-import Cardano.Ledger.Babbage.TxInfo (
-  BabbageContextError (..),
-  transTxOutV2,
- )
 import qualified Cardano.Ledger.Babbage.TxInfo as Babbage
 import Cardano.Ledger.BaseTypes (
   Inject (..),
@@ -121,6 +118,7 @@ import Cardano.Ledger.Plutus.Language (
  )
 import Cardano.Ledger.Plutus.ToPlutusData (ToPlutusData (..))
 import Cardano.Ledger.Plutus.TxInfo (
+  TxOutSource (..),
   slotToPOSIXTime,
   transAccountAddress,
   transBoundedRational,
@@ -185,8 +183,9 @@ instance EraPlutusContext ConwayEra where
   lookupTxInfoResult SPlutusV3 (ConwayTxInfoResult _ _ tirPlutusV3) = tirPlutusV3
   lookupTxInfoResult slang _ = lookupTxInfoResultImpossible slang
 
+-- TODO: Remove `CertificateNotSupported` and `PlutusPurposeNotSupported` once in Dijkstra era
 data ConwayContextError era
-  = BabbageContextError (BabbageContextError era)
+  = BabbageContextError (Babbage.BabbageContextError era)
   | CertificateNotSupported (TxCert era)
   | PlutusPurposeNotSupported (PlutusPurpose AsItem era)
   | CurrentTreasuryFieldNotSupported Coin
@@ -197,7 +196,7 @@ data ConwayContextError era
   deriving (Generic)
 
 deriving instance
-  ( Eq (BabbageContextError era)
+  ( Eq (Babbage.BabbageContextError era)
   , Eq (TxCert era)
   , Eq (PlutusPurpose AsItem era)
   , Eq (PlutusPurpose AsIx era)
@@ -206,7 +205,7 @@ deriving instance
   Eq (ConwayContextError era)
 
 deriving instance
-  ( Ord (BabbageContextError era)
+  ( Ord (Babbage.BabbageContextError era)
   , Ord (TxCert era)
   , Ord (PlutusPurpose AsItem era)
   , Ord (PlutusPurpose AsIx era)
@@ -215,7 +214,7 @@ deriving instance
   Ord (ConwayContextError era)
 
 deriving instance
-  ( Show (BabbageContextError era)
+  ( Show (Babbage.BabbageContextError era)
   , Show (TxCert era)
   , Show (PlutusPurpose AsItem era)
   , Show (PlutusPurpose AsIx era)
@@ -223,11 +222,14 @@ deriving instance
   ) =>
   Show (ConwayContextError era)
 
-instance Inject (BabbageContextError era) (ConwayContextError era) where
+instance Inject (Babbage.BabbageContextError era) (ConwayContextError era) where
   inject = BabbageContextError
 
-instance Inject (AlonzoContextError era) (ConwayContextError era) where
-  inject = BabbageContextError . inject
+instance Inject (Alonzo.AlonzoContextError era) (ConwayContextError era) where
+  inject = \case
+    Alonzo.CertificateNotSupported txCert -> CertificateNotSupported txCert
+    Alonzo.PlutusPurposeNotSupported purpose -> PlutusPurposeNotSupported purpose
+    alonzoContextError -> BabbageContextError $ inject alonzoContextError
 
 instance
   ( EraPParams era
@@ -246,7 +248,7 @@ instance
   EncCBOR (ConwayContextError era)
   where
   encCBOR = \case
-    -- We start at tag 8, just in case to avoid clashes with previous eras.
+    -- We start at tag 8, to disambiguate with previous eras, but it is not necessary.
     BabbageContextError babbageContextError ->
       encode $ Sum BabbageContextError 8 !> To babbageContextError
     CertificateNotSupported txCert ->
@@ -322,7 +324,7 @@ instance
 -- If the transaction contains any Byron addresses or Babbage features, return Left.
 transTxOutV1 ::
   forall era.
-  ( Inject (BabbageContextError era) (ContextError era)
+  ( Inject (Babbage.BabbageContextError era) (ContextError era)
   , Value era ~ MaryValue
   , BabbageEraTxOut era
   ) =>
@@ -331,15 +333,16 @@ transTxOutV1 ::
   Either (ContextError era) PV1.TxOut
 transTxOutV1 txOutSource txOut = do
   when (isSJust (txOut ^. dataTxOutL)) $ do
-    Left $ inject $ InlineDatumsNotSupported @era txOutSource
+    Left $ inject $ Babbage.InlineDatumsNotSupported @era txOutSource
   case Alonzo.transTxOut txOut of
-    Nothing -> Left $ inject $ ByronTxOutInContext @era txOutSource
+    Nothing -> Left $ inject $ Babbage.ByronTxOutInContext @era txOutSource
     Just plutusTxOut -> Right plutusTxOut
 
 -- | Given a TxIn, look it up in the UTxO. If it exists, translate it to the V1 context
 transTxInInfoV1 ::
   forall era.
-  ( Inject (BabbageContextError era) (ContextError era)
+  ( Inject (Alonzo.AlonzoContextError era) (ContextError era)
+  , Inject (Babbage.BabbageContextError era) (ContextError era)
   , Value era ~ MaryValue
   , BabbageEraTxOut era
   ) =>
@@ -347,14 +350,15 @@ transTxInInfoV1 ::
   TxIn ->
   Either (ContextError era) PV1.TxInInfo
 transTxInInfoV1 utxo txIn = do
-  txOut <- left (inject . AlonzoContextError @era) $ Alonzo.transLookupTxOut utxo txIn
+  txOut <- Alonzo.transLookupTxOut utxo txIn
   plutusTxOut <- transTxOutV1 (TxOutFromInput txIn) txOut
   Right (PV1.TxInInfo (TxInfo.transTxIn txIn) plutusTxOut)
 
 -- | Given a TxIn, look it up in the UTxO. If it exists, translate it to the V3 context
 transTxInInfoV3 ::
   forall era.
-  ( Inject (BabbageContextError era) (ContextError era)
+  ( Inject (Alonzo.AlonzoContextError era) (ContextError era)
+  , Inject (Babbage.BabbageContextError era) (ContextError era)
   , Value era ~ MaryValue
   , BabbageEraTxOut era
   ) =>
@@ -362,8 +366,8 @@ transTxInInfoV3 ::
   TxIn ->
   Either (ContextError era) PV3.TxInInfo
 transTxInInfoV3 utxo txIn = do
-  txOut <- left (inject . AlonzoContextError @era) $ Alonzo.transLookupTxOut utxo txIn
-  plutusTxOut <- transTxOutV2 (TxOutFromInput txIn) txOut
+  txOut <- Alonzo.transLookupTxOut utxo txIn
+  plutusTxOut <- Babbage.transTxOutV2 (TxOutFromInput txIn) txOut
   Right (PV3.TxInInfo (transTxIn txIn) plutusTxOut)
 
 guardConwayFeaturesForPlutusV1V2 ::
@@ -400,7 +404,7 @@ guardConwayFeaturesForPlutusV1V2 tx = do
 transTxCertV1V2 ::
   ( ShelleyEraTxCert era
   , ConwayEraTxCert era
-  , Inject (ConwayContextError era) (ContextError era)
+  , Inject (Alonzo.AlonzoContextError era) (ContextError era)
   ) =>
   TxCert era ->
   Either (ContextError era) PV1.DCert
@@ -409,14 +413,12 @@ transTxCertV1V2 = \case
     Right $ PV1.DCertDelegRegKey (PV1.StakingHash (transCred stakeCred))
   UnRegDepositTxCert stakeCred _refund ->
     Right $ PV1.DCertDelegDeRegKey (PV1.StakingHash (transCred stakeCred))
-  txCert
-    | Just dCert <- Alonzo.transTxCertCommon txCert -> Right dCert
-    | otherwise -> Left $ inject $ CertificateNotSupported txCert
+  txCert -> Alonzo.transTxCertCommon txCert
 
 instance EraPlutusTxInfo 'PlutusV1 ConwayEra where
   toPlutusTxCert _ _ = transTxCertV1V2
 
-  toPlutusScriptPurpose proxy lti = transPlutusPurposeV1V2 proxy (ltiProtVer lti)
+  toPlutusScriptPurpose proxy lti = Alonzo.transPlutusPurpose proxy (ltiProtVer lti)
 
   toPlutusTxInfo proxy LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} =
     PlutusTxInfoResult $ withTopTxLevelOnly ltiTx $ \tx -> do
@@ -456,7 +458,7 @@ instance EraPlutusTxInfo 'PlutusV1 ConwayEra where
 instance EraPlutusTxInfo 'PlutusV2 ConwayEra where
   toPlutusTxCert _ _ = transTxCertV1V2
 
-  toPlutusScriptPurpose proxy lti = transPlutusPurposeV1V2 proxy (ltiProtVer lti)
+  toPlutusScriptPurpose proxy lti = Alonzo.transPlutusPurpose proxy (ltiProtVer lti)
 
   toPlutusTxInfo proxy lti@LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} =
     PlutusTxInfoResult $ withTopTxLevelOnly ltiTx $ \tx -> do
@@ -644,7 +646,7 @@ transDRep = \case
 transPlutusPurposeV3 ::
   forall era proxy.
   ( ConwayEraPlutusTxInfo 'PlutusV3 era
-  , Inject (ConwayContextError era) (ContextError era)
+  , Inject (Alonzo.AlonzoContextError era) (ContextError era)
   ) =>
   proxy 'PlutusV3 ->
   ProtVer ->
@@ -659,7 +661,8 @@ transPlutusPurposeV3 proxy pv = \case
   VotingPurpose (AsIxItem _ voter) -> pure $ PV3.Voting (transVoter voter)
   ProposingPurpose (AsIxItem ix proposal) ->
     pure $ PV3.Proposing (toInteger ix) (transProposal proxy proposal)
-  purpose -> Left $ inject $ PlutusPurposeNotSupported @era $ hoistPlutusPurpose toAsItem purpose
+  purpose ->
+    Left $ inject $ Alonzo.PlutusPurposeNotSupported @era $ hoistPlutusPurpose toAsItem purpose
 
 transVoter :: Voter -> PV3.Voter
 transVoter = \case
@@ -738,23 +741,6 @@ transProposal proxy ProposalProcedure {pProcDeposit, pProcReturnAddr, pProcGovAc
     , PV3.ppGovernanceAction = transGovAction proxy pProcGovAction
     }
 
-transPlutusPurposeV1V2 ::
-  forall l era proxy.
-  ( PlutusTxCert l ~ PV2.DCert
-  , EraPlutusTxInfo l era
-  , Inject (ConwayContextError era) (ContextError era)
-  ) =>
-  proxy l ->
-  ProtVer ->
-  PlutusPurpose AsIxItem era ->
-  Either (ContextError era) PV2.ScriptPurpose
-transPlutusPurposeV1V2 proxy pv = \case
-  SpendingPurpose asIxItem -> Alonzo.transPlutusPurpose proxy pv $ AlonzoSpending asIxItem
-  MintingPurpose asIxItem -> Alonzo.transPlutusPurpose proxy pv $ AlonzoMinting asIxItem
-  CertifyingPurpose asIxItem -> Alonzo.transPlutusPurpose proxy pv $ AlonzoCertifying asIxItem
-  WithdrawingPurpose asIxItem -> Alonzo.transPlutusPurpose proxy pv $ AlonzoWithdrawing asIxItem
-  purpose -> Left $ inject $ PlutusPurposeNotSupported @era $ hoistPlutusPurpose toAsItem purpose
-
 transProtVer :: ProtVer -> PV3.ProtocolVersion
 transProtVer (ProtVer major minor) =
   PV3.ProtocolVersion (toInteger (getVersion32 major)) (toInteger minor)
@@ -810,7 +796,7 @@ instance ConwayEraPlutusTxInfo 'PlutusV3 ConwayEra where
 -- | Translate a validity interval to POSIX time
 transValidityInterval ::
   forall proxy era.
-  Inject (AlonzoContextError era) (ContextError era) =>
+  Inject (Alonzo.AlonzoContextError era) (ContextError era) =>
   proxy era ->
   EpochInfo (Either Text) ->
   SystemStart ->
@@ -832,14 +818,14 @@ transValidityInterval era epochInfo systemStart = \case
 
 transSlotToPOSIXTime ::
   forall era proxy.
-  Inject (AlonzoContextError era) (ContextError era) =>
+  Inject (Alonzo.AlonzoContextError era) (ContextError era) =>
   proxy era ->
   EpochInfo (Either Text) ->
   SystemStart ->
   SlotNo ->
   Either (ContextError era) PV3.POSIXTime
 transSlotToPOSIXTime _ epochInfo systemStart =
-  left (inject . TimeTranslationPastHorizon @era)
+  left (inject . Alonzo.TimeTranslationPastHorizon @era)
     . slotToPOSIXTime epochInfo systemStart
 
 checkReferenceInputsNotDisjointFromInputs ::

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxosSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxosSpec.hs
@@ -15,6 +15,7 @@ import Cardano.Ledger.Allegra.Scripts (
  )
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext (..))
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (CollectError (..))
+import qualified Cardano.Ledger.Alonzo.Plutus.TxInfo as Alonzo
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
 import Cardano.Ledger.Alonzo.Scripts (eraLanguages)
 import Cardano.Ledger.Babbage (BabbageEra)
@@ -308,7 +309,7 @@ conwayFeaturesPlutusV1V2FailureSpec = do
                     Alonzo.CollectErrors
                       [ BadTranslation $
                           inject $
-                            CertificateNotSupported badCert
+                            Alonzo.CertificateNotSupported badCert
                       ]
                 )
         describe "DelegTxCert" $ do

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -34,7 +34,7 @@
   - `dueCertState` -> `ueOriginalCertState`
   - `dueOriginalUtxo` -> `ueOriginalUtxo`
 * Add `ScriptHashNotFoundForPurpose` constructor to `DijkstraContextError`
-* Change `PointerPresentInOutput` constructor of `DijkstraContextError` to contain a `NonEmptySet TxOutSource` instead of `NonEmpty (TxOut era)`
+* Change `PointerPresentInOutput` constructor of `DijkstraContextError` to contain a `TxOutSource` instead of `NonEmpty (TxOut era)`
 * Add `udppPlutusV4CostModel` field to `UpgradeDijkstraPParams`
 * Add `HKDSemialign` constraint to `upgradeDijkstraPParams`
 * Add `EncCBOR`, `ToCBOR` for `Block`

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -445,7 +445,7 @@ dijkstraUtxoTransition = do
   validateNoPtrInCollateralReturn txBody
 
   {- txsize tx ≤ maxTxSize pp -}
-  runTestOnSignal $ Shelley.validateMaxTxSizeUTxO pp tx
+  runTest $ Shelley.validateMaxTxSizeUTxO pp tx
 
   {- totExunits tx ≤ maxTxExUnits pp -}
   runTest $ Alonzo.validateExUnitsTooBigUTxO pp tx

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
@@ -127,8 +127,6 @@ import qualified Data.Map.NonEmpty as NEMap
 import qualified Data.Map.Strict as Map
 import Data.Proxy (Proxy (..))
 import qualified Data.Set as Set
-import Data.Set.NonEmpty (NonEmptySet)
-import qualified Data.Set.NonEmpty as NES
 import Data.Text (Text)
 import GHC.Generics (Generic)
 import Lens.Micro ((^.))
@@ -142,7 +140,7 @@ data DijkstraContextError era
   | -- | Failure translating sub-transactions for Guarding purpose at the top level
     SubTxContextError TxId (ContextError era)
   | -- | From Dijkstra onwards, attempt to use a script when there are stake ref pointers present in any outputs will result in this failure
-    PointerPresentInOutput (NonEmptySet TxOutSource)
+    PointerPresentInOutput TxOutSource
   | -- | Attempt to use PlutusV1-V3 in a sub-transaction will result in this failure
     UnsupportedScriptInSubTx Language TxId
   | -- | Attempt to use PlutusV1-V3 with non-empty direct deposits will result in this failure
@@ -582,29 +580,11 @@ instance EraPlutusTxInfo 'PlutusV4 DijkstraEra where
       inputsInfo <- mapM (transTxInInfoV4 ltiUTxO) (Set.toList txInputs)
       refInputsInfo <- mapM (transTxInInfoV4 ltiUTxO) (Set.toList refInputs)
       Conway.checkReferenceInputsNotDisjointFromInputs txBody
-      let
-        accErrors acc (ix, txOut) =
-          let res = transTxOutV4 (TxOutFromOutput ix) txOut
-           in case acc of
-                Right l -> case res of
-                  Right x -> Right $ x : l
-                  Left e -> Left e
-                Left (PointerPresentInOutput errs)
-                  -- If the accumulator contains a PointerPresentInOutput, then
-                  -- continue translating to collect all the other PointerPresentInOutput
-                  -- failures
-                  | Left (PointerPresentInOutput err) <- res ->
-                      Left . PointerPresentInOutput $ err <> errs
-                Left e -> Left e
       outputs <-
-        reverse
-          <$>
-          -- Use foldl here to collect errors from left to right (leftmost failure
-          -- takes precedence)
-          foldl'
-            accErrors
-            (Right mempty)
-            ([minBound ..] `zip` F.toList (txBody ^. outputsTxBodyL))
+        zipWithM
+          (transTxOutV4 . TxOutFromOutput)
+          [minBound ..]
+          (F.toList (txBody ^. outputsTxBodyL))
       txCerts <- Alonzo.transTxBodyCerts proxy ltiProtVer txBody
       plutusRedeemers <- Babbage.transTxRedeemers proxy lti
       let
@@ -689,7 +669,7 @@ transTxOutV4 txOutSource txOut = do
         PV4.Address (transCred pCred) <$> case stakeRef of
           StakeRefBase sCred -> Right . Just $ transCredToAccountId sCred
           StakeRefNull -> Right Nothing
-          StakeRefPtr _ -> Left . inject . PointerPresentInOutput @era $ NES.singleton txOutSource
+          StakeRefPtr _ -> Left . inject $ PointerPresentInOutput @era txOutSource
       AddrBootstrap _ -> Left . inject $ Babbage.ByronTxOutInContext @era txOutSource
   pure $
     PV4.TxOut

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
@@ -40,7 +40,6 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
   SupportedLanguage (..),
   SupportedPlutusRunnable (..),
  )
-import Cardano.Ledger.Alonzo.Plutus.TxInfo (transPolicyID, transValue)
 import qualified Cardano.Ledger.Alonzo.Plutus.TxInfo as Alonzo
 import Cardano.Ledger.Alonzo.Scripts (toAsItem, toAsIx)
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO (..))
@@ -117,7 +116,6 @@ import Cardano.Slotting.Time (SystemStart)
 import Control.DeepSeq (NFData)
 import Control.Monad (unless, zipWithM)
 import Data.Aeson (KeyValue (..), ToJSON (..))
-import Data.Bifunctor (Bifunctor (..))
 import Data.Foldable (Foldable (..))
 import qualified Data.Foldable as F
 import Data.List.NonEmpty (NonEmpty (..))
@@ -274,10 +272,10 @@ instance Inject (ConwayContextError era) (DijkstraContextError era) where
   inject = ConwayContextError
 
 instance Inject (Babbage.BabbageContextError era) (DijkstraContextError era) where
-  inject = ConwayContextError . inject
+  inject = ConwayContextError . Conway.BabbageContextError
 
 instance Inject (Alonzo.AlonzoContextError era) (DijkstraContextError era) where
-  inject = ConwayContextError . inject
+  inject = ConwayContextError . Conway.BabbageContextError . Babbage.AlonzoContextError
 
 instance EraPlutusContext DijkstraEra where
   type ContextError DijkstraEra = DijkstraContextError DijkstraEra
@@ -316,7 +314,7 @@ instance EraPlutusContext DijkstraEra where
 instance EraPlutusTxInfo 'PlutusV1 DijkstraEra where
   toPlutusTxCert _ _ = transTxCertV1V2
 
-  toPlutusScriptPurpose proxy lti = Conway.transPlutusPurposeV1V2 proxy (ltiProtVer lti)
+  toPlutusScriptPurpose proxy lti = Alonzo.transPlutusPurpose proxy (ltiProtVer lti)
 
   toPlutusTxInfo proxy LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} =
     flip (withBothTxLevels ltiTx) transFailUnsupportedScriptInSubTx $ \tx -> PlutusTxInfoResult $ do
@@ -355,7 +353,7 @@ instance EraPlutusTxInfo 'PlutusV1 DijkstraEra where
 
 transTxCertV1V2 ::
   ( ConwayEraTxCert era
-  , Inject (ConwayContextError era) (ContextError era)
+  , Inject (Alonzo.AlonzoContextError era) (ContextError era)
   ) =>
   TxCert era ->
   Either (ContextError era) PV1.DCert
@@ -373,12 +371,12 @@ transTxCertV1V2 = \case
         (PV1.PubKeyHash (PV1.toBuiltin (hashToBytes (unVRFVerKeyHash sppVrf))))
   RetirePoolTxCert poolId retireEpochNo ->
     Right $ PV1.DCertPoolRetire (transKeyHash poolId) (transEpochNo retireEpochNo)
-  txCert -> Left $ inject $ CertificateNotSupported txCert
+  txCert -> Left $ inject $ Alonzo.CertificateNotSupported txCert
 
 instance EraPlutusTxInfo 'PlutusV2 DijkstraEra where
   toPlutusTxCert _ _ = transTxCertV1V2
 
-  toPlutusScriptPurpose proxy lti = Conway.transPlutusPurposeV1V2 proxy (ltiProtVer lti)
+  toPlutusScriptPurpose proxy lti = Alonzo.transPlutusPurpose proxy (ltiProtVer lti)
 
   toPlutusTxInfo proxy lti@LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} =
     flip (withBothTxLevels ltiTx) transFailUnsupportedScriptInSubTx $ \tx -> PlutusTxInfoResult $ do
@@ -626,6 +624,7 @@ transTxInInfoV4 ::
   forall era.
   ( BabbageEraTxOut era
   , Value era ~ MaryValue
+  , Inject (Alonzo.AlonzoContextError era) (ContextError era)
   , Inject (Babbage.BabbageContextError era) (ContextError era)
   , Inject (DijkstraContextError era) (ContextError era)
   ) =>
@@ -633,7 +632,7 @@ transTxInInfoV4 ::
   TxIn ->
   Either (ContextError era) PV4.TxInInfo
 transTxInInfoV4 utxo txIn = do
-  txOut <- first (inject . Babbage.AlonzoContextError @era) $ Alonzo.transLookupTxOut utxo txIn
+  txOut <- Alonzo.transLookupTxOut utxo txIn
   plutusTxOut <- transTxOutV4 (TxOutFromInput txIn) txOut
   Right (PV4.TxInInfo (transTxInV4 txIn) plutusTxOut)
 
@@ -649,7 +648,7 @@ transTxOutV4 ::
   Either (ContextError era) PV4.TxOut
 transTxOutV4 txOutSource txOut = do
   let
-    val = transValue $ txOut ^. valueTxOutL
+    val = Alonzo.transValue $ txOut ^. valueTxOutL
     referenceScript = Babbage.transReferenceScript $ txOut ^. referenceScriptTxOutL
     datum =
       case txOut ^. datumTxOutF of
@@ -818,7 +817,7 @@ transPlutusPurposeV4 ::
   forall era proxy.
   ( DijkstraEraScript era
   , ConwayEraPlutusTxInfo PlutusV4 era
-  , Inject (ConwayContextError era) (ContextError era)
+  , Inject (Alonzo.AlonzoContextError era) (ContextError era)
   , Inject (DijkstraContextError era) (ContextError era)
   ) =>
   proxy 'PlutusV4 ->
@@ -836,7 +835,7 @@ transPlutusPurposeV4 proxy lti plutusPurpose = do
   case plutusPurpose of
     SpendingPurpose (AsIxItem _ (TxIn txId (TxIx ix))) ->
       pure . PV4.Spending sh $ PV4.TxOutRef (transTxId txId) (toInteger ix)
-    MintingPurpose (AsIxItem _ pId) -> pure . PV4.Minting sh $ transPolicyID pId
+    MintingPurpose (AsIxItem _ pId) -> pure . PV4.Minting sh $ Alonzo.transPolicyID pId
     CertifyingPurpose (AsIxItem ix cert) ->
       PV4.Certifying sh (toInteger ix) <$> toPlutusTxCert proxy pv cert
     WithdrawingPurpose (AsIxItem _ (AccountAddress _ (AccountId c))) ->
@@ -845,4 +844,5 @@ transPlutusPurposeV4 proxy lti plutusPurpose = do
     ProposingPurpose (AsIxItem ix proc) ->
       pure $ PV4.Proposing sh (toInteger ix) (transProposal proxy proc)
     GuardingPurpose (AsIxItem ix _) -> pure $ PV4.Guarding sh (toInteger ix)
-    _ -> Left $ inject $ PlutusPurposeNotSupported @era $ hoistPlutusPurpose toAsItem plutusPurpose
+    _ ->
+      Left $ inject $ Alonzo.PlutusPurposeNotSupported @era $ hoistPlutusPurpose toAsItem plutusPurpose

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TxInfoSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TxInfoSpec.hs
@@ -53,10 +53,8 @@ import Control.Monad.Trans.Fail.String (errorFail)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.NonEmpty as NEM
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromJust)
 import qualified Data.OSet.Strict as OSet
 import Data.Proxy (Proxy (..))
-import qualified Data.Set.NonEmpty as NES
 import Lens.Micro ((&), (.~))
 import qualified PlutusLedgerApi.V4 as PV4
 import Test.Cardano.Ledger.Alonzo.Era (mkTestLedgerTxInfo)
@@ -108,31 +106,7 @@ spec = describe "TxInfo" $ do
         ledgerTxInfo = mkLocalLedgerTxInfo utxo tx
       pure $
         toPlutusTxInfoForPurpose SPlutusV4 ledgerTxInfo (SpendingPurpose AsPurpose)
-          `shouldBeLeft` inject (PointerPresentInOutput @era (NES.singleton . TxOutFromOutput $ TxIx 0))
-    prop "Collects all Ptr sources when multiple outputs have pointers" $ do
-      pc0 <- arbitrary
-      pc1 <- arbitrary
-      pc2 <- arbitrary
-      ptr0 <- arbitrary
-      ptr2 <- arbitrary
-      stakeCred <- arbitrary
-      val0 <- arbitrary
-      val1 <- arbitrary
-      val2 <- arbitrary
-      let
-        txOuts =
-          [ mkBasicTxOut (Addr Testnet pc0 (StakeRefPtr ptr0)) val0
-          , mkBasicTxOut (Addr Testnet pc1 (StakeRefBase stakeCred)) val1
-          , mkBasicTxOut (Addr Testnet pc2 (StakeRefPtr ptr2)) val2
-          ]
-        tx = mkBasicTx @era @TopTx $ mkBasicTxBody & outputsTxBodyL .~ txOuts
-        ledgerTxInfo = mkLocalLedgerTxInfo mempty tx
-      pure $
-        toPlutusTxInfoForPurpose SPlutusV4 ledgerTxInfo (SpendingPurpose AsPurpose)
-          `shouldBeLeft` inject
-            ( PointerPresentInOutput @era . fromJust $
-                NES.fromSet [TxOutFromOutput $ TxIx 0, TxOutFromOutput $ TxIx 2]
-            )
+          `shouldBeLeft` inject (PointerPresentInOutput @era (TxOutFromOutput $ TxIx 0))
     prop "Fails translation when Byron addresses present in outputs" $ do
       ba0 <- arbitrary
       ba2 <- arbitrary
@@ -170,10 +144,7 @@ spec = describe "TxInfo" $ do
         ledgerTxInfo = mkLocalLedgerTxInfo mempty tx
       pure $
         toPlutusTxInfoForPurpose SPlutusV4 ledgerTxInfo (SpendingPurpose AsPurpose)
-          `shouldBeLeft` inject
-            ( PointerPresentInOutput @era . fromJust $
-                NES.fromSet [TxOutFromOutput $ TxIx 0, TxOutFromOutput $ TxIx 2]
-            )
+          `shouldBeLeft` inject (PointerPresentInOutput @era (TxOutFromOutput $ TxIx 0))
     prop "Translates outputs in the order they appear in the TxBody" $ do
       pc0 <- arbitrary
       pc1 <- arbitrary


### PR DESCRIPTION
# Description

This is a PR that cleans up some parts of translation and copies some translation failures into Alonzo, so we can remove current ones when we get into Dijkstra and reduce duplication when that happens.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
