### PR TITLE
Execute Plutus scripts from sub-transactions and count their ExUnits

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.17.0.0
 
+* Add `getTotalExUnits` to `AlonzoEraTx`, with the existing own-redeemer total as its default.
+* Deprecate `totExUnits` in favor of `getTotalExUnits`; require `AlonzoEraTx` in `totExUnits`, `alonzoMinFeeTx` and `validateExUnitsTooBigUTxO`.
 * Add `CertificateNotSupported` and `PlutusPurposeNotSupported` constructors to `AlonzoContextError`
 * Stop re-exporting `TxOutSource` from `Cardano.Ledger.Alonzo.Plutus.TxInfo` (it remains available from `Cardano.Ledger.Plutus.TxInfo`)
 * Change `transTxCert` to return `Either (ContextError era) PV1.DCert` instead of `PV1.DCert` and add an `Inject (AlonzoContextError era) (ContextError era)` constraint; unsupported certificates now produce `CertificateNotSupported` instead of a partial `error`
@@ -23,6 +25,7 @@
 ### `testlib`
 
 * Export `makeCollateralInput` and `txWithMaxRedeemers`
+* Use annotated transaction script collection in `impPlutusWithContexts` so phase-2 test expectations include subtransactions.
 * Add `Inject (AlonzoContextError era) (ContextError era)` superclass constraint to the `AlonzoEraTest` type class
 * Add `mkTestLedgerTxInfo` helper
 * Add `Serialise` instance for `PV4.POSIXTimeRange`

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
@@ -36,7 +36,6 @@ import Cardano.Ledger.Alonzo.Rules.Utxo (AlonzoUtxoPredFailure)
 import Cardano.Ledger.Alonzo.Rules.Utxos (AlonzoUtxosPredFailure)
 import Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoUtxowPredFailure)
 import Cardano.Ledger.Alonzo.Scripts (ExUnits (..), OrdExUnits (..), pointWiseExUnits)
-import Cardano.Ledger.Alonzo.Tx (totExUnits)
 import Cardano.Ledger.BaseTypes (Mismatch (..), Relation (..), ShelleyBase)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders
@@ -165,7 +164,7 @@ validateExUnits ::
   ExUnits ->
   Rule (EraRule "BBODY" era) 'Transition ()
 validateExUnits txs ppMax =
-  let txTotal = foldMap totExUnits txs
+  let txTotal = foldMap getTotalExUnits txs
    in pointWiseExUnits (<=) txTotal ppMax
         ?! injectFailure
           ( TooManyExUnits $

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -54,7 +54,7 @@ import Cardano.Ledger.Alonzo.Rules.Utxos (
   UtxosEnv (..),
  )
 import Cardano.Ledger.Alonzo.Scripts (OrdExUnits (..), pointWiseExUnits)
-import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx (..), IsPhase2Valid (..), totExUnits)
+import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx (..), IsPhase2Valid (..))
 import Cardano.Ledger.Alonzo.TxBody (
   AllegraEraTxBody (..),
   AlonzoEraTxBody (..),
@@ -462,10 +462,7 @@ validateWrongNetworkInTxBody netId txBody =
 --
 -- > totExunits tx ≤ maxTxExUnits pp
 validateExUnitsTooBigUTxO ::
-  ( AlonzoEraTxWits era
-  , EraTx era
-  , AlonzoEraPParams era
-  ) =>
+  AlonzoEraTx era =>
   PParams era ->
   Tx l era ->
   Test (AlonzoUtxoPredFailure era)
@@ -476,7 +473,7 @@ validateExUnitsTooBigUTxO pp tx =
   where
     maxTxExUnits = pp ^. ppMaxTxExUnitsL
     -- This sums up the ExUnits for all embedded Plutus Scripts anywhere in the transaction:
-    totalExUnits = totExUnits tx
+    totalExUnits = getTotalExUnits tx
 
 -- | Ensure that number of collaterals does not exceed the allowed @maxCollInputs@ parameter.
 --

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -277,6 +277,11 @@ class
   isValidTxL :: Lens' (Tx TopTx era) IsPhase2Valid
   isValidTxL = isPhase2ValidTxL
 
+  -- | Total declared execution units, including sub-transactions when supported.
+  -- Earlier eras only have the transaction's own redeemers.
+  getTotalExUnits :: Tx l era -> ExUnits
+  getTotalExUnits tx = foldMap snd $ tx ^. witsTxL . rdmrsTxWitsL . unRedeemersL
+
 {-# DEPRECATED isValidTxL "In favor of `isPhase2ValidTxL`" #-}
 
 instance Typeable l => DecCBOR (Annotator (Tx l AlonzoEra)) where
@@ -443,10 +448,7 @@ toCBORForSizeComputation AlonzoTx {atBody, atWits, atAuxData} =
     <> encodeNullStrictMaybe encCBOR atAuxData
 
 alonzoMinFeeTx ::
-  ( EraTx era
-  , AlonzoEraTxWits era
-  , AlonzoEraPParams era
-  ) =>
+  AlonzoEraTx era =>
   PParams era ->
   Tx l era ->
   Coin
@@ -455,13 +457,14 @@ alonzoMinFeeTx pp tx =
     <+> (pp ^. ppTxFeeFixedL)
     <+> txscriptfee (pp ^. ppPricesL) allExunits
   where
-    allExunits = totExUnits tx
+    allExunits = getTotalExUnits tx
 
 totExUnits ::
-  (EraTx era, AlonzoEraTxWits era) =>
+  AlonzoEraTx era =>
   Tx l era ->
   ExUnits
-totExUnits tx = foldMap snd $ tx ^. witsTxL . rdmrsTxWitsL . unRedeemersL
+totExUnits = getTotalExUnits
+{-# DEPRECATED totExUnits "In favor of `getTotalExUnits`" #-}
 
 --------------------------------------------------------------------------------
 -- Serialisation

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -53,7 +53,6 @@ import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
 import Cardano.Ledger.Alonzo.Plutus.Context (ContextError)
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (
-  collectPlutusScriptsWithContext,
   evalPlutusScriptsWithLogs,
   evalTxExUnits,
  )
@@ -73,7 +72,7 @@ import Cardano.Ledger.Alonzo.Scripts (
 import Cardano.Ledger.Alonzo.Tx (ScriptIntegrity, hashScriptIntegrity, mkScriptIntegrity)
 import Cardano.Ledger.Alonzo.TxAuxData (AlonzoTxAuxData)
 import Cardano.Ledger.Alonzo.TxWits (unRedeemersL, unTxDatsL)
-import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded (..))
+import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded (..), plutusScriptsWithContextStAnnTx)
 import Cardano.Ledger.BaseTypes (Globals (..), StrictMaybe (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
@@ -93,6 +92,7 @@ import Cardano.Ledger.Plutus (
   hashPlutusScript,
   plutusLanguage,
  )
+import Cardano.Ledger.Shelley.API.Mempool (mkStAnnTx)
 import Cardano.Ledger.Shelley.LedgerState (
   curPParamsEpochStateL,
   nesEsL,
@@ -483,7 +483,8 @@ impPlutusWithContexts tx = do
   globals <- use impGlobalsL
   pp <- getsNES $ nesEsL . curPParamsEpochStateL
   utxo <- getUTxO
-  case collectPlutusScriptsWithContext (epochInfo globals) (systemStart globals) pp tx utxo of
+  let stAnnTx = mkStAnnTx (epochInfo globals) (systemStart globals) pp utxo mempty tx
+  case plutusScriptsWithContextStAnnTx stAnnTx of
     Left errs ->
       assertFailure $
         "Did not expect to get context translation failures: " ++ unlines (map show $ NonEmpty.toList errs)

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -40,7 +40,6 @@ import Cardano.Ledger.Alonzo.Tx (
   AlonzoTx (AlonzoTx),
   ScriptIntegrity (..),
   hashScriptIntegrity,
-  totExUnits,
  )
 import Cardano.Ledger.Alonzo.TxAuxData (AlonzoTxAuxData (..), mkAlonzoTxAuxData)
 import Cardano.Ledger.Alonzo.TxBody (
@@ -522,7 +521,7 @@ instance EraGen AlonzoEra where
 
   genEraTweakBlock pp txns =
     let txTotal, ppMax :: ExUnits
-        txTotal = foldMap totExUnits txns
+        txTotal = foldMap getTotalExUnits txns
         ppMax = pp ^. ppMaxBlockExUnitsL
      in if pointWiseExUnits (<=) txTotal ppMax
           then pure txns

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/ChainTrace.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/ChainTrace.hs
@@ -21,7 +21,7 @@ import Cardano.Ledger.Alonzo.Plutus.Evaluate (
  )
 import Cardano.Ledger.Alonzo.Rules (BBODY, LEDGER)
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), ExUnits (..), mkPlutusScript)
-import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx (..), IsPhase2Valid (..), totExUnits)
+import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx (..), IsPhase2Valid (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Plutus.Evaluate (PlutusWithContext (..), ScriptResult (..))
 import Cardano.Ledger.Plutus.Language (plutusFromRunnable)
@@ -93,7 +93,7 @@ alonzoSpecificProps SourceSignalTarget {source = chainSt, signal = block} =
             utxoConsumed = not $ u `Map.isSubmapOf` u'
             allScripts = tx ^. witsTxL . scriptTxWitsL
             hasPlutus = if all (isNativeScript @AlonzoEra) allScripts then NoPlutus else HasPlutus
-            totEU = totExUnits tx
+            totEU = getTotalExUnits tx
             nonTrivialExU = exUnitsMem totEU > 0 && exUnitsSteps totEU > 0
             collected =
               -- Note that none of our plutus scripts use validity intervals,

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.15.0.0
 
+* Require `AlonzoEraTx` in `babbageUtxoValidation` so execution limits use the era's total execution units.
 * Encode a wrapped `AlonzoContextError` under tag 8 in `BabbageContextError`, and add `TxCert era` and `PlutusPurpose AsItem era` constraints to its `NFData` and `EncCBOR` instances
 * Add `DecCBOR (TxCert era)` and `DecCBOR (PlutusPurpose AsItem era)` constraints to the `DecCBOR (BabbageContextError era)` instance
 * Add `AlonzoEraTransition` instance for `BabbageEra`

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -341,7 +341,7 @@ babbageUtxoValidation ::
   forall era.
   ( EraUTxO era
   , BabbageEraTxBody era
-  , AlonzoEraTxWits era
+  , AlonzoEraTx era
   , InjectRuleFailure "UTXO" Shelley.ShelleyUtxoPredFailure era
   , InjectRuleFailure "UTXO" Allegra.AllegraUtxoPredFailure era
   , InjectRuleFailure "UTXO" Alonzo.AlonzoUtxoPredFailure era

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.24.0.0
 
+* Require `AlonzoEraTx` in `getConwayMinFeeTx` so script fees use the era's total execution units.
 * Remove `transPlutusPurposeV1V2`, superseded by `Alonzo.transPlutusPurpose`
 * No longer export the `CertificateNotSupported` and `PlutusPurposeNotSupported` constructors of `ConwayContextError`, in favor of the same cases defined in Alonzo.
 * Add `conwayInjectIntoTestState`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
@@ -98,8 +98,7 @@ conwayTxL :: Lens' (Tx l ConwayEra) (AlonzoTx l ConwayEra)
 conwayTxL = lens unConwayTx (\x y -> x {unConwayTx = y})
 
 getConwayMinFeeTx ::
-  ( EraTx era
-  , AlonzoEraTxWits era
+  ( AlonzoEraTx era
   , ConwayEraPParams era
   ) =>
   PParams era ->

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.4.0.0
 
+* Evaluate Plutus scripts and propagate script collection errors across the full transaction batch.
+* Include subtransaction execution units in transaction and block limits and minimum script fees.
 * Remove `WithdrawalsExceedAccountBalance` constructor from `DijkstraUtxoPredFailure`
 * Add `WithdrawalAccountsMissingFromOriginal` constructor to `EntitiesPredFailure`
 * Rename `EntitiesPredFailure` constructors:
@@ -95,6 +97,7 @@
 
 ### `testlib`
 
+* Preserve explicitly supplied redeemers when fixing up subtransactions.
 * Add `InjectRuleFailure "LEDGER" DijkstraSubUtxowPredFailure era` as a superclass of `DijkstraEraImp`
 * Add `mkTopTxWithSubTxs`, `traverseSubTxs` and `withPostFixupSubTxs`
 * Add `Test.Cardano.Ledger.Dijkstra.Imp.SubUtxowSpec`

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
@@ -39,6 +39,7 @@ import Cardano.Ledger.Alonzo.Tx (
   AlonzoEraTx,
   IsPhase2Valid (..),
  )
+import Cardano.Ledger.Alonzo.TxWits (AlonzoEraTxWits (..), unRedeemersL)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..), integralToBounded)
 import Cardano.Ledger.Binary (
   Annotator,
@@ -336,6 +337,13 @@ dijkstraTxL = lens unDijkstraTx (\x y -> x {unDijkstraTx = y})
 instance AlonzoEraTx DijkstraEra where
   isPhase2ValidTxL = dijkstraTxL . isPhase2ValidDijkstraTxL
   {-# INLINE isPhase2ValidTxL #-}
+
+  getTotalExUnits tx =
+    foldMap snd (tx ^. witsTxL . rdmrsTxWitsL . unRedeemersL)
+      <> withBothTxLevels
+        tx
+        (\topTx -> foldMap getTotalExUnits (topTx ^. bodyTxL . subTransactionsTxBodyL))
+        (const mempty)
 
 instance Typeable l => DecCBOR (Annotator (Tx l DijkstraEra)) where
   decCBOR = fmap MkDijkstraTx <$> decCBOR

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
@@ -246,7 +246,13 @@ plutusScriptsWithContextDijkstraStAnnTx ::
 plutusScriptsWithContextDijkstraStAnnTx stAnnTx =
   withBothTxLevels
     stAnnTx
-    (\DijkstraStAnnTopTx {dsattPlutusScriptsWithContext} -> dsattPlutusScriptsWithContext)
+    ( \DijkstraStAnnTopTx {dsattPlutusScriptsWithContext, dsattSubTransactions} ->
+        -- Evaluate the whole batch together, after all phase-1 checks have passed.
+        -- Collection errors in a sub-transaction must also reject the batch.
+        concat
+          <$> sequence
+            (dsattPlutusScriptsWithContext : map dsastPlutusScriptsWithContext dsattSubTransactions)
+    )
     (\DijkstraStAnnSubTx {dsastPlutusScriptsWithContext} -> dsastPlutusScriptsWithContext)
 
 plutusLanguagesUsedDijkstraStAnnTx ::

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/SubUtxowSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/SubUtxowSpec.hs
@@ -11,9 +11,10 @@ module Test.Cardano.Ledger.Dijkstra.Imp.SubUtxowSpec (spec) where
 
 import Cardano.Ledger.Address (bootstrapKeyHash)
 import Cardano.Ledger.Allegra.Scripts (AllegraEraScript (..))
+import Cardano.Ledger.Alonzo.Plutus.Context (CollectError (..))
 import Cardano.Ledger.Alonzo.Scripts (eraLanguages)
 import Cardano.Ledger.Alonzo.TxWits (unRedeemersL, unTxDatsL)
-import Cardano.Ledger.BaseTypes (Mismatch (..), SlotNo (..), StrictMaybe (..))
+import Cardano.Ledger.BaseTypes (Inject (..), Mismatch (..), SlotNo (..), StrictMaybe (..))
 import Cardano.Ledger.Conway.Governance (
   GovAction (..),
   GovActionId,
@@ -22,10 +23,12 @@ import Cardano.Ledger.Conway.Governance (
   VotingProcedure (..),
   VotingProcedures (..),
  )
+import qualified Cardano.Ledger.Conway.Rules as Conway
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..), credKeyHashWitness)
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Rules (DijkstraSubUtxowPredFailure (..))
+import Cardano.Ledger.Dijkstra.TxInfo (DijkstraContextError (..))
 import Cardano.Ledger.Keys (asWitness, witVKeyHash)
 import Cardano.Ledger.Plutus (
   Data (..),
@@ -260,9 +263,10 @@ spec = describe "SUBUTXOW" $ do
                        )
             txInAt 0
               <$> withPostFixup (rederiveAddrTxWits . resetTxOutDataHash) (submitTx tx)
-          submitFailingTx
+          submitFailingLegacySubTx
+            lang
             (mkTopTxWithSubTxs [mkBasicTx $ mkBasicTxBody & inputsTxBodyL .~ [txIn]])
-            [injectFailure . SubUnspendableUTxONoDatumHash @era $ NES.singleton txIn]
+            (SubUnspendableUTxONoDatumHash @era $ NES.singleton txIn)
 
   forM_ (eraLanguages @era) $ \lang ->
     withSLanguage lang $ \slang ->
@@ -275,9 +279,10 @@ spec = describe "SUBUTXOW" $ do
           txIn <- produceScript redeemerSameAsDatumHash
           let missingDatum = hashData @era (Data (P.I 3))
           withPostFixupSubTxs (fixupResetAddrWits . (witsTxL . datsTxWitsL .~ mempty)) $
-            submitFailingTx
+            submitFailingLegacySubTx
+              lang
               (mkTopTxWithSubTxs [scriptSpendingSubTx txIn])
-              [injectFailure $ SubMissingRequiredDatums @era (NES.singleton missingDatum) []]
+              (SubMissingRequiredDatums @era (NES.singleton missingDatum) [])
 
         it "SubNotAllowedSupplementalDatums" $ do
           txIn <- produceScript redeemerSameAsDatumHash
@@ -289,11 +294,10 @@ spec = describe "SUBUTXOW" $ do
                         %~ Map.insert extraDatumHash extraDatum
                     )
           withPostFixupSubTxs addExtraDatum $
-            submitFailingTx
+            submitFailingLegacySubTx
+              lang
               (mkTopTxWithSubTxs [scriptSpendingSubTx txIn])
-              [ injectFailure $
-                  SubNotAllowedSupplementalDatums @era (NES.singleton extraDatumHash) []
-              ]
+              (SubNotAllowedSupplementalDatums @era (NES.singleton extraDatumHash) [])
 
         it "SubMissingRedeemers" $ do
           txIn <- produceScript redeemerSameAsDatumHash
@@ -301,7 +305,8 @@ spec = describe "SUBUTXOW" $ do
           withPostFixupSubTxs (fixupResetAddrWits . (witsTxL . rdmrsTxWitsL .~ mempty)) $
             submitFailingTx
               (mkTopTxWithSubTxs [scriptSpendingSubTx txIn])
-              [ injectFailure $
+              [ injectFailure $ Conway.CollectErrors [NoRedeemer missingRedeemer]
+              , injectFailure $
                   SubMissingRedeemers @era [(missingRedeemer, redeemerSameAsDatumHash)]
               ]
 
@@ -315,9 +320,10 @@ spec = describe "SUBUTXOW" $ do
                         %~ Map.insert extraPurpose (redeemerData, ExUnits 0 0)
                     )
           withPostFixupSubTxs addExtraRedeemer $
-            submitFailingTx
+            submitFailingLegacySubTx
+              lang
               (mkTopTxWithSubTxs [scriptSpendingSubTx txIn])
-              [injectFailure $ SubExtraRedeemers @era [extraPurpose]]
+              (SubExtraRedeemers @era [extraPurpose])
 
         describe "SubScriptIntegrityHashMismatch" $ do
           let testHashMismatch badHash = do
@@ -337,22 +343,20 @@ spec = describe "SUBUTXOW" $ do
                   rederiveAddrTxWits $
                     fixedUpTx & bodyTxL . subTransactionsTxBodyL .~ OMap.singleton badSubTx
                 withNoFixup $
-                  submitFailingTx
-                    badTopTx
-                    [ injectFailure $
-                        SubScriptIntegrityHashMismatch @era
-                          Mismatch {mismatchSupplied = badHash, mismatchExpected = goodHash}
-                          (originalBytes <$> expectedIntegrity)
-                    ]
+                  submitFailingLegacySubTx lang badTopTx $
+                    SubScriptIntegrityHashMismatch @era
+                      Mismatch {mismatchSupplied = badHash, mismatchExpected = goodHash}
+                      (originalBytes <$> expectedIntegrity)
           it "the supplied hash is wrong" $ testHashMismatch . SJust =<< arbitrary
           it "the supplied hash is missing" $ testHashMismatch SNothing
 
         it "SubMalformedScriptWitnesses" $ do
           let scriptHash = hashPlutusScript $ asSLanguage slang malformedPlutus
           txIn <- produceScript scriptHash
-          submitFailingTx
+          submitFailingLegacySubTx
+            lang
             (mkTopTxWithSubTxs [scriptSpendingSubTx txIn])
-            [injectFailure . SubMalformedScriptWitnesses @era $ NES.singleton scriptHash]
+            (SubMalformedScriptWitnesses @era $ NES.singleton scriptHash)
 
         disableInConformanceIt "SubMalformedReferenceScripts" $ do
           script <- fromPlutusScript <$> mkPlutusScript (asSLanguage slang malformedPlutus)
@@ -380,6 +384,27 @@ spec = describe "SUBUTXOW" $ do
           submitFailingTx
             (mkTopTxWithSubTxs [subTx])
             [injectFailure $ SubInvalidMetadata @era]
+
+-- Legacy sub-transaction scripts also fail context translation, independently
+-- of the SUBUTXOW predicate under test. Fixup can change the sub-transaction id.
+submitFailingLegacySubTx ::
+  forall era.
+  DijkstraEraImp era =>
+  Language ->
+  Tx TopTx era ->
+  DijkstraSubUtxowPredFailure era ->
+  ImpTestM era ()
+submitFailingLegacySubTx lang tx expectedFailure =
+  submitFailingTxM tx $ \fixedUpTx ->
+    case OMap.elems $ fixedUpTx ^. bodyTxL . subTransactionsTxBodyL of
+      [subTx] ->
+        pure
+          [ injectFailure $
+              Conway.CollectErrors
+                [BadTranslation . inject $ UnsupportedScriptInSubTx @era lang (txIdTx subTx)]
+          , injectFailure expectedFailure
+          ]
+      _ -> assertFailure "Expected exactly one sub-transaction"
 
 -- | Every distinct reason a sub-transaction requires a key witness,
 -- paired with a sub-transaction that requires it and the key hash whose

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxowSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxowSpec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -12,7 +13,8 @@ module Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec (spec) where
 import Cardano.Ledger.Alonzo.Plutus.Context (CollectError (..))
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
 import Cardano.Ledger.Alonzo.TxWits (unRedeemersL)
-import Cardano.Ledger.BaseTypes (Inject (..), StrictMaybe (..))
+import Cardano.Ledger.BaseTypes (Inject (..), Mismatch (..), StrictMaybe (..))
+import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Rules (ConwayUtxosPredFailure (..))
 import qualified Cardano.Ledger.Conway.Rules as Conway
 import Cardano.Ledger.Core
@@ -25,6 +27,8 @@ import Cardano.Ledger.Plutus (
   Data,
   ExUnits (..),
   Language (..),
+  OrdExUnits (..),
+  Plutus,
   SLanguage (..),
   hashPlutusScript,
  )
@@ -38,7 +42,7 @@ import Test.Cardano.Ledger.Alonzo.Arbitrary (alwaysSucceeds)
 import Test.Cardano.Ledger.Core.Utils (txInAt)
 import Test.Cardano.Ledger.Dijkstra.ImpTest
 import Test.Cardano.Ledger.Imp.Common
-import Test.Cardano.Ledger.Plutus.Examples (alwaysSucceedsNoDatum)
+import Test.Cardano.Ledger.Plutus.Examples (alwaysFailsNoDatum, alwaysSucceedsNoDatum)
 
 spec ::
   forall era.
@@ -213,3 +217,61 @@ spec = describe "UTXOW" $ do
               ]
         ]
       submitTx_ tx
+
+  describe "Sub-transaction Plutus evaluation" $ do
+    it "Evaluates every sub-transaction script during phase 2" $ do
+      passingSubTx <- mkPlutusSpendingTx $ alwaysSucceedsNoDatum SPlutusV4
+      failingSubTx <- mkPlutusSpendingTx $ alwaysFailsNoDatum SPlutusV4
+      submitPhase2Invalid_ =<< withSubTransactions [passingSubTx, failingSubTx]
+
+    -- See: https://github.com/IntersectMBO/formal-ledger-specifications/issues/723
+    disableInConformanceIt "Enforces the transaction budget across sub-transactions" $ do
+      subA <- mkPlutusSpendingTx $ alwaysSucceedsNoDatum SPlutusV4
+      subB <- mkPlutusSpendingTx $ alwaysSucceedsNoDatum SPlutusV4
+      tx <- withSubTransactions [subA, subB]
+      let limit = ExUnits 1_500_000 200_000_000
+      modifyPParams $ ppMaxTxExUnitsL .~ limit
+      submitFailingTx
+        tx
+        [ injectFailure $
+            Alonzo.ExUnitsTooBigUTxO $
+              Mismatch
+                { mismatchSupplied = OrdExUnits $ ExUnits 2_000_000 200_000_000
+                , mismatchExpected = OrdExUnits limit
+                }
+        ]
+
+-- Reference scripts avoid the unfinished PlutusV4 witness serialization.
+mkPlutusSpendingTx ::
+  forall era.
+  DijkstraEraImp era =>
+  Plutus 'PlutusV4 ->
+  ImpTestM era (Tx SubTx era)
+mkPlutusSpendingTx plutus = do
+  script <- fromPlutusScript <$> mkPlutusScript plutus
+  txIn <- produceScript $ hashPlutusScript plutus
+  refAddr <- freshKeyAddrNoPtr_
+  refTx <-
+    submitTx $
+      mkBasicTx mkBasicTxBody
+        & bodyTxL . outputsTxBodyL
+          .~ [mkBasicTxOut refAddr mempty & referenceScriptTxOutL .~ SJust script]
+  redeemer <- arbitrary @(Data era)
+  fixupPPHash $
+    mkBasicTx mkBasicTxBody
+      & bodyTxL . inputsTxBodyL .~ [txIn]
+      & bodyTxL . referenceInputsTxBodyL .~ [txInAt 0 refTx]
+      & witsTxL . rdmrsTxWitsL . unRedeemersL
+        .~ Map.singleton (mkSpendingPurpose $ AsIx 0) (redeemer, ExUnits 1_000_000 100_000_000)
+
+withSubTransactions ::
+  DijkstraEraImp era =>
+  [Tx SubTx era] ->
+  ImpTestM era (Tx TopTx era)
+withSubTransactions subTxs = do
+  collateralAddr <- freshKeyAddrNoPtr_
+  collateral <- sendCoinTo collateralAddr $ Coin 30_000_000
+  pure $
+    mkBasicTx mkBasicTxBody
+      & bodyTxL . subTransactionsTxBodyL .~ OMap.fromFoldable subTxs
+      & bodyTxL . collateralInputsTxBodyL .~ [collateral]

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
@@ -333,9 +333,13 @@ fixupSubTransactions tx = impAnn "fixupSubTransactions" $ do
         >=> fixupOutputDatums
         >=> fixupDatums
         >=> fixupTxOuts
-        >=> txWithMaxRedeemers
+        >=> addMissingRedeemers
         >=> fixupPPHash
         >=> updateAddrTxWits
+    addMissingRedeemers subTx = do
+      let originalRedeemers = subTx ^. witsTxL . rdmrsTxWitsL
+      withMaxRedeemers <- txWithMaxRedeemers subTx
+      pure $ withMaxRedeemers & witsTxL . rdmrsTxWitsL %~ (originalRedeemers <>)
     addSubTxIn subTx
       | not (Set.null (subTx ^. bodyTxL . inputsTxBodyL)) = pure subTx
       | otherwise = do

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoAPI.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoAPI.hs
@@ -17,7 +17,7 @@
 
 module Test.Cardano.Ledger.Examples.AlonzoAPI (tests, defaultPParams) where
 
-import Cardano.Ledger.Alonzo.Tx (alonzoMinFeeTx, hashData)
+import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx, alonzoMinFeeTx, hashData)
 import Cardano.Ledger.Alonzo.TxWits (AlonzoEraTxWits (..), TxDats (..), unTxDatsL)
 import Cardano.Ledger.BaseTypes (ProtVer (..), inject)
 import Cardano.Ledger.Coin (Coin (..), CompactForm (CompactCoin))
@@ -81,8 +81,7 @@ tests =
 testEstimateMinFee ::
   forall era.
   ( Reflect era
-  , AlonzoEraTxWits era
-  , AlonzoEraTxBody era
+  , AlonzoEraTx era
   , EraModel era
   ) =>
   Expectation


### PR DESCRIPTION
## Description 
Dijkstra’s batch validation skips Plutus execution for subtransactions which critically allows spending validators and minting policies to bypass enforcement. Their execution budgets are also omitted from transaction and block limits and script fees. In this state, Plutus-locked funds would be at risk through Dijsktra subtransactions. Top-level Plutus evaluation, native-script checks, and other ledger rules still applied, but suppose funds are locked by a validator pending some approval like checking an escrow payment, a subtransaction could consume those funds and send their value elsewhere without approval. Native script enforcement survives in subtransactions. 

Collected script contexts and collection errors across the full batch, and include subtransaction budgets in execution limits and fees. Earlier eras retain their existing accounting.

Added two ledger regression tests covering subtransaction script evaluation and aggregate transaction budgets.

108 UTXOW-related examples passed, including both new regressions.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] Self-reviewed the diff.


N/A
- [] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).